### PR TITLE
Ensure the build-docs job saves the html as an artifact

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -22,4 +22,4 @@ on:
 
 jobs:
   build-docs:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.41.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.48.0


### PR DESCRIPTION
Ensure the build-docs job saves the html as an artifact

The updated build-docs version will handle this automatically.