### PR TITLE
feat(interceptors): reasoning content migration

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/reasoning_interceptor.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/reasoning_interceptor.py
@@ -65,6 +65,10 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
         add_reasoning: bool = Field(
             default=True, description="Whether to add reasoning information"
         )
+        migrate_reasoning_content: bool = Field(
+            default=False,
+            description="If reasoning traces are found in `reasoning_content`, they will be moved to `content` field end surrounded by start_reasoning_token and end_reasoning_token",
+        )
         enable_reasoning_tracking: bool = Field(
             default=True, description="Enable reasoning tracking and logging"
         )
@@ -92,6 +96,7 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
     end_reasoning_token: str
     start_reasoning_token: str | None
     add_reasoning: bool
+    migrate_reasoning_content: bool
     enable_reasoning_tracking: bool
     include_if_not_finished: bool
     enable_caching: bool
@@ -110,6 +115,7 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
         self.end_reasoning_token = params.end_reasoning_token
         self.start_reasoning_token = params.start_reasoning_token
         self.add_reasoning = params.add_reasoning
+        self.migrate_reasoning_content = params.migrate_reasoning_content
         self.enable_reasoning_tracking = params.enable_reasoning_tracking
         self.include_if_not_finished = params.include_if_not_finished
         self.stats_file_saving_interval = params.stats_file_saving_interval
@@ -150,6 +156,7 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
             end_reasoning_token=self.end_reasoning_token,
             start_reasoning_token=self.start_reasoning_token,
             add_reasoning=self.add_reasoning,
+            migrate_reasoning_content=self.migrate_reasoning_content,
             enable_reasoning_tracking=self.enable_reasoning_tracking,
             include_if_not_finished=self.include_if_not_finished,
             stats_file_saving_interval=self.stats_file_saving_interval,
@@ -355,13 +362,47 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
         ).strip("\n")
         return cleaned_content
 
+    def _migrate_reasoning_content(self, msg: dict):
+        modified_msg = msg.copy()
+        if (
+            "reasoning_content" in msg
+            and msg["reasoning_content"]
+            and msg["reasoning_content"].strip()
+        ):
+            reasoning_content = msg["reasoning_content"]
+            content = msg.get("content", "")
+            updated_message_content = (
+                self.start_reasoning_token
+                + reasoning_content
+                + self.end_reasoning_token
+                + content
+            )
+            modified_msg["content"] = updated_message_content
+            return modified_msg
+        else:
+            return msg
+
     @final
     def intercept_response(
         self, resp: AdapterResponse, context: AdapterGlobalContext
     ) -> AdapterResponse:
         """Remove reasoning tokens from assistant message content in the response and track reasoning info."""
         if not self.add_reasoning:
-            self.logger.debug("Reasoning processing disabled, returning response as-is")
+            if self.migrate_reasoning_content:
+                self.logger.debug(
+                    "Reasoning processing disabled, but migrating `reasoning_content` back to `content`."
+                )
+                response_data = resp.r.json()
+                for choice in response_data["choices"]:
+                    msg = choice.get("message")
+                    modified_msg = self._migrate_reasoning_content(msg)
+                    msg.update(modified_msg)
+
+                resp.r._content = json.dumps(response_data).encode()
+            else:
+                self.logger.debug(
+                    "Reasoning processing disabled, returning response as-is"
+                )
             return resp
 
         try:

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_reasoning.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_reasoning.py
@@ -174,6 +174,7 @@ def test_reasoning_responses(
             "<think>This is my reasoning process that should be migrated</think>Here's my final answer.",
         ),
         ("", "Here's my final answer.", "Here's my final answer."),
+        (None, "Here's my final answer.", "Here's my final answer."),
     ],
 )
 def test_migration(
@@ -209,9 +210,9 @@ def test_migration(
     response = requests.post(url, json=data)
 
     assert response.status_code == 200
-    cleaned_data = response.json()
-    cleaned_content = cleaned_data["choices"][0]["message"]["content"]
-    assert cleaned_content == expected_content
+    migrated_data = response.json()
+    migrated_content = migrated_data["choices"][0]["message"]["content"]
+    assert migrated_content == expected_content
 
 
 def test_multiple_choices(


### PR DESCRIPTION
Some deployments put reasoning traces into `reasoning_content` field and a clean response in `content`. Some harnesses require reasoning traces to be present but many are not prepared to use `reasoning_content`. The proposed change to the reasoning interceptor allows to take `reasoning_content` back to `content`