### PR TITLE
fix(executors): migrate to eval-factory cmd

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
@@ -75,12 +75,12 @@ def get_eval_factory_command(
     create_file_cmd = _yaml_to_echo_command(
         yaml.safe_dump(config_fields), "config_ef.yaml"
     )
-    nv_eval_command = f"""nv_eval run_eval --model_id {model_id} --model_type {model_type} --eval_type {eval_type} --model_url {model_url} --api_key_name API_KEY --output_dir /results --run_config config_ef.yaml"""
+    eval_command = f"""eval-factory run_eval --model_id {model_id} --model_type {model_type} --eval_type {eval_type} --model_url {model_url} --api_key_name API_KEY --output_dir /results --run_config config_ef.yaml"""
 
     if overrides:
-        nv_eval_command = f"{nv_eval_command} --overrides {overrides_str}"
+        eval_command = f"{eval_command} --overrides {overrides_str}"
 
-    return create_file_cmd + " && " + "cat config_ef.yaml && " + nv_eval_command
+    return create_file_cmd + " && " + "cat config_ef.yaml && " + eval_command
 
 
 def get_endpoint_url(

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -105,9 +105,7 @@ class TestSlurmExecutorFeatures:
             }
             mock_get_health.return_value = "http://localhost:8000/health"
             mock_get_endpoint.return_value = "http://localhost:8000/v1"
-            mock_get_eval_command.return_value = (
-                "nemo_evaluator_launcher run_eval --test"
-            )
+            mock_get_eval_command.return_value = "eval-factory run_eval --test"
             mock_get_model_name.return_value = "test-model"
 
             yield {


### PR DESCRIPTION
It unblocks us to use new Eval Factory containers in the launcher — they don't have `nv-eval`/`nv_eval` alias anymore.