### PR TITLE
fix(local-exec): avoid creation of exec id for dry-run

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/execdb.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/execdb.py
@@ -165,25 +165,5 @@ class ExecutionDB:
         return dict(self._jobs)
 
 
-def write_job(job: JobData) -> None:
-    db = ExecutionDB()
-    db.write_job(job)
-
-
-def get_job(job_id: str) -> Optional[JobData]:
-    db = ExecutionDB()
-    return db.get_job(job_id)
-
-
-def get_jobs(invocation_id: str) -> Dict[str, JobData]:
-    db = ExecutionDB()
-    return db.get_jobs(invocation_id)
-
-
-def get_all_jobs() -> Dict[str, JobData]:
-    db = ExecutionDB()
-    return db.get_all_jobs()
-
-
 # Ensure all the paths
 _DB = ExecutionDB()

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
@@ -185,26 +185,6 @@ class LocalExecutor(BaseExecutor):
             run_all_sequentially_sh_content
         )
 
-        # Save launched jobs metadata
-        db = ExecutionDB()
-        for job_id, task, evaluation_task in zip(
-            job_ids, cfg.evaluation.tasks, evaluation_tasks
-        ):
-            db.write_job(
-                job=JobData(
-                    invocation_id=invocation_id,
-                    job_id=job_id,
-                    timestamp=time.time(),
-                    executor="local",
-                    data={
-                        "output_dir": str(evaluation_task["output_dir"]),
-                        "container": evaluation_task["container_name"],
-                        "eval_image": evaluation_task["eval_image"],
-                    },
-                    config=OmegaConf.to_object(cfg),
-                )
-            )
-
         if dry_run:
             print("\n\n=============================================\n\n")
             print(f"DRY RUN: Scripts prepared and saved to {output_dir}")
@@ -224,6 +204,26 @@ class LocalExecutor(BaseExecutor):
                         print(f.read())
             print("\nTo execute, run without --dry-run")
             return invocation_id
+
+        # Save launched jobs metadata
+        db = ExecutionDB()
+        for job_id, task, evaluation_task in zip(
+            job_ids, cfg.evaluation.tasks, evaluation_tasks
+        ):
+            db.write_job(
+                job=JobData(
+                    invocation_id=invocation_id,
+                    job_id=job_id,
+                    timestamp=time.time(),
+                    executor="local",
+                    data={
+                        "output_dir": str(evaluation_task["output_dir"]),
+                        "container": evaluation_task["container_name"],
+                        "eval_image": evaluation_task["eval_image"],
+                    },
+                    config=OmegaConf.to_object(cfg),
+                )
+            )
 
         # Launch bash scripts with Popen for non-blocking execution.
         # To ensure subprocess continues after python exits:

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_execdb.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_execdb.py
@@ -25,9 +25,6 @@ from nemo_evaluator_launcher.common.execdb import (
     JobData,
     generate_invocation_id,
     generate_job_id,
-    get_job,
-    get_jobs,
-    write_job,
 )
 
 
@@ -78,7 +75,7 @@ def test_write_and_get_job(mock_execdb):
     )
 
     # Write job
-    write_job(job)
+    ExecutionDB().write_job(job)
 
     # Verify job was written to file
     assert execdb.EXEC_DB_FILE.exists()
@@ -95,7 +92,7 @@ def test_write_and_get_job(mock_execdb):
         assert "timestamp" in record
 
     # Get job and verify
-    result = get_job(job_id)
+    result = ExecutionDB().get_job(job_id)
     assert result is not None
     assert isinstance(result, JobData)
     assert result.invocation_id == invocation_id
@@ -119,7 +116,7 @@ def test_write_job_with_null_job_id(mock_execdb):
     )
 
     # Write job
-    write_job(job)
+    ExecutionDB().write_job(job)
 
     # Verify job was written to file
     with open(execdb.EXEC_DB_FILE, "r") as f:
@@ -133,7 +130,7 @@ def test_write_job_with_null_job_id(mock_execdb):
 
 def test_get_nonexistent_job(mock_execdb):
     """Test getting a job that doesn't exist."""
-    result = get_job("job-nonexistent")
+    result = ExecutionDB().get_job("job-nonexistent")
     assert result is None
 
 
@@ -166,14 +163,14 @@ def test_load_existing_jobs(mock_execdb):
     _ = ExecutionDB()
 
     # Verify jobs are loaded
-    result1 = get_job("job-22222222")
+    result1 = ExecutionDB().get_job("job-22222222")
     assert result1 is not None
     assert isinstance(result1, JobData)
     assert result1.invocation_id == "inv-11111111"
     assert result1.executor == "local"
     assert result1.data == {"test": "data1"}
 
-    result2 = get_job("job-44444444")
+    result2 = ExecutionDB().get_job("job-44444444")
     assert result2 is not None
     assert isinstance(result2, JobData)
     assert result2.invocation_id == "inv-33333333"
@@ -195,8 +192,8 @@ def test_load_existing_jobs_with_invalid_json(mock_execdb):
 
     _ = ExecutionDB()
 
-    assert get_job("job-22222222") is not None
-    assert get_job("job-44444444") is not None
+    assert ExecutionDB().get_job("job-22222222") is not None
+    assert ExecutionDB().get_job("job-44444444") is not None
 
 
 def test_multiple_jobs_same_id(mock_execdb):
@@ -218,10 +215,10 @@ def test_multiple_jobs_same_id(mock_execdb):
         data={"data": "second"},
     )
 
-    write_job(job1)
-    write_job(job2)
+    ExecutionDB().write_job(job1)
+    ExecutionDB().write_job(job2)
 
-    result = get_job(job_id)
+    result = ExecutionDB().get_job(job_id)
     assert result is not None
     assert isinstance(result, JobData)
     assert result.executor == "gitlab"
@@ -241,9 +238,9 @@ def test_empty_data(mock_execdb):
         executor="local",
         data={},
     )
-    write_job(job)
+    ExecutionDB().write_job(job)
 
-    result = get_job("job-87654321")
+    result = ExecutionDB().get_job("job-87654321")
     assert result is not None
     assert isinstance(result, JobData)
     assert result.data == {}
@@ -274,12 +271,12 @@ def test_get_jobs_by_invocation_id(mock_execdb):
         data={"task": "task3"},
     )
 
-    write_job(job1)
-    write_job(job2)
-    write_job(job3)
+    ExecutionDB().write_job(job1)
+    ExecutionDB().write_job(job2)
+    ExecutionDB().write_job(job3)
 
     # Get jobs for the specific invocation
-    jobs = get_jobs(invocation_id)
+    jobs = ExecutionDB().get_jobs(invocation_id)
 
     assert len(jobs) == 2
     assert generate_job_id(invocation_id, 0) in jobs
@@ -292,7 +289,7 @@ def test_get_jobs_by_invocation_id(mock_execdb):
 
 def test_get_jobs_nonexistent_invocation(mock_execdb):
     """Test getting jobs for a nonexistent invocation."""
-    jobs = get_jobs("inv-nonexistent")
+    jobs = ExecutionDB().get_jobs("inv-nonexistent")
     assert jobs == {}
 
 
@@ -326,7 +323,7 @@ def test_invocation_mapping_consistency(mock_execdb):
     assert generate_job_id(invocation_id, 1) in job_ids
 
     # Check that jobs can be retrieved
-    jobs = get_jobs(invocation_id)
+    jobs = ExecutionDB().get_jobs(invocation_id)
     assert len(jobs) == 2
     assert generate_job_id(invocation_id, 0) in jobs
     assert generate_job_id(invocation_id, 1) in jobs

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_local_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_local_executor.py
@@ -88,28 +88,8 @@ class TestLocalExecutorDryRun:
         }
 
     @pytest.fixture
-    def mock_run_template(self):
-        """Mock run template content."""
-        return """
-# Mock template for testing
-{% for task in evaluation_tasks %}
-echo "Running task: {{ task.job_id }}"
-echo "Container: {{ task.container_name }}"
-echo "Image: {{ task.eval_image }}"
-echo "Command: {{ task.eval_factory_command }}"
-echo "Output dir: {{ task.output_dir }}"
-{% for env_var in task.env_vars %}
-echo "Env: {{ env_var }}"
-{% endfor %}
-{% if auto_export_destinations %}
-echo "Auto-export destinations: {{ auto_export_destinations|join(',') }}"
-{% endif %}
-echo "Invocation ID: {{ invocation_id }}"
-{% endfor %}
-""".strip()
-
     def test_execute_eval_dry_run_basic(
-        self, mock_execdb, sample_config, mock_tasks_mapping, mock_run_template, tmpdir
+        self, mock_execdb, sample_config, mock_tasks_mapping, tmpdir
     ):
         """Test basic dry run execution."""
         # Set up environment variable that the config references
@@ -128,7 +108,6 @@ echo "Invocation ID: {{ invocation_id }}"
                 patch(
                     "nemo_evaluator_launcher.executors.local.executor.get_eval_factory_command"
                 ) as mock_get_command,
-                patch("builtins.open", mock_open(read_data=mock_run_template)),
                 patch("builtins.print") as mock_print,
             ):
                 # Configure mocks
@@ -195,19 +174,6 @@ echo "Invocation ID: {{ invocation_id }}"
                 dry_run_messages = [msg for msg in print_calls if "DRY RUN" in str(msg)]
                 assert len(dry_run_messages) > 0
 
-                # Verify database entries were created
-                db = ExecutionDB()
-                jobs = db.get_jobs(invocation_id)
-                assert len(jobs) == 2  # Two tasks
-
-                # Verify job data structure
-                for job_id, job_data in jobs.items():
-                    assert job_data.invocation_id == invocation_id
-                    assert job_data.executor == "local"
-                    assert "output_dir" in job_data.data
-                    assert "container" in job_data.data
-                    assert "eval_image" in job_data.data
-
         finally:
             # Clean up environment
             for env_var in ["TEST_API_KEY", "GLOBAL_VALUE", "TASK_VALUE"]:
@@ -215,7 +181,7 @@ echo "Invocation ID: {{ invocation_id }}"
                     del os.environ[env_var]
 
     def test_execute_eval_dry_run_env_var_validation(
-        self, sample_config, mock_tasks_mapping, mock_run_template
+        self, sample_config, mock_tasks_mapping
     ):
         """Test that missing environment variables are properly validated."""
         # Don't set the required environment variables
@@ -227,7 +193,6 @@ echo "Invocation ID: {{ invocation_id }}"
             patch(
                 "nemo_evaluator_launcher.executors.local.executor.get_task_from_mapping"
             ) as mock_get_task,
-            patch("builtins.open", mock_open(read_data=mock_run_template)),
         ):
             mock_load_mapping.return_value = mock_tasks_mapping
 
@@ -246,7 +211,7 @@ echo "Invocation ID: {{ invocation_id }}"
                 LocalExecutor.execute_eval(sample_config, dry_run=True)
 
     def test_execute_eval_dry_run_required_task_env_vars(
-        self, sample_config, mock_tasks_mapping, mock_run_template
+        self, sample_config, mock_tasks_mapping
     ):
         """Test validation of required task-specific environment variables."""
         # Set some but not all required env vars
@@ -262,7 +227,6 @@ echo "Invocation ID: {{ invocation_id }}"
                 patch(
                     "nemo_evaluator_launcher.executors.local.executor.get_task_from_mapping"
                 ) as mock_get_task,
-                patch("builtins.open", mock_open(read_data=mock_run_template)),
             ):
                 mock_load_mapping.return_value = mock_tasks_mapping
 
@@ -288,73 +252,6 @@ echo "Invocation ID: {{ invocation_id }}"
                 if env_var in os.environ:
                     del os.environ[env_var]
 
-    def test_execute_eval_dry_run_custom_container(
-        self, mock_execdb, sample_config, mock_tasks_mapping, mock_run_template, tmpdir
-    ):
-        """Test that custom container images are handled correctly."""
-        # Set up all required environment variables
-        os.environ["TEST_API_KEY"] = "test_key_value"
-        os.environ["GLOBAL_VALUE"] = "global_env_value"
-        os.environ["TASK_VALUE"] = "task_env_value"
-
-        try:
-            with (
-                patch(
-                    "nemo_evaluator_launcher.executors.local.executor.load_tasks_mapping"
-                ) as mock_load_mapping,
-                patch(
-                    "nemo_evaluator_launcher.executors.local.executor.get_task_from_mapping"
-                ) as mock_get_task,
-                patch(
-                    "nemo_evaluator_launcher.executors.local.executor.get_eval_factory_command"
-                ) as mock_get_command,
-                patch("builtins.open", mock_open(read_data=mock_run_template)),
-                patch("builtins.print"),
-            ):
-                mock_load_mapping.return_value = mock_tasks_mapping
-
-                def mock_get_task_side_effect(task_name, mapping):
-                    for (harness, name), definition in mapping.items():
-                        if name == task_name:
-                            return definition
-                    raise KeyError(f"Task {task_name} not found")
-
-                mock_get_task.side_effect = mock_get_task_side_effect
-                mock_get_command.return_value = (
-                    "nemo-evaluator-launcher --task test_command"
-                )
-
-                # Execute dry run
-                invocation_id = LocalExecutor.execute_eval(sample_config, dry_run=True)
-
-                # Verify database entries include correct container images
-                db = ExecutionDB()
-                jobs = db.get_jobs(invocation_id)
-
-                # Find job data for each task
-                task1_job = None
-                task2_job = None
-                for job_id, job_data in jobs.items():
-                    if "test_task_1" in job_data.data["output_dir"]:
-                        task1_job = job_data
-                    elif "test_task_2" in job_data.data["output_dir"]:
-                        task2_job = job_data
-
-                assert task1_job is not None
-                assert task2_job is not None
-
-                # test_task_1 should use default container from mapping
-                assert "test-container:latest" in task1_job.data["eval_image"]
-
-                # test_task_2 should use custom container from config
-                assert task2_job.data["eval_image"] == "custom-container:v2.0"
-
-        finally:
-            # Clean up environment
-            for env_var in ["TEST_API_KEY", "GLOBAL_VALUE", "TASK_VALUE"]:
-                if env_var in os.environ:
-                    del os.environ[env_var]
-
     def test_execute_eval_deployment_type_validation(self, sample_config):
         """Test that non-'none' deployment types raise NotImplementedError."""
         # Change deployment type to something other than 'none'
@@ -362,58 +259,6 @@ echo "Invocation ID: {{ invocation_id }}"
 
         with pytest.raises(NotImplementedError, match="type slurm is not implemented"):
             LocalExecutor.execute_eval(sample_config, dry_run=True)
-
-    def test_execute_eval_dry_run_no_auto_export(
-        self, sample_config, mock_tasks_mapping, mock_run_template, tmpdir
-    ):
-        """Test dry run without auto-export configuration."""
-        # Remove auto_export from config
-        del sample_config.execution.auto_export
-
-        # Set up environment variables
-        os.environ["TEST_API_KEY"] = "test_key_value"
-        os.environ["GLOBAL_VALUE"] = "global_env_value"
-        os.environ["TASK_VALUE"] = "task_env_value"
-
-        try:
-            with (
-                patch(
-                    "nemo_evaluator_launcher.executors.local.executor.load_tasks_mapping"
-                ) as mock_load_mapping,
-                patch(
-                    "nemo_evaluator_launcher.executors.local.executor.get_task_from_mapping"
-                ) as mock_get_task,
-                patch(
-                    "nemo_evaluator_launcher.executors.local.executor.get_eval_factory_command"
-                ) as mock_get_command,
-                patch("builtins.open", mock_open(read_data=mock_run_template)),
-                patch("builtins.print"),
-            ):
-                mock_load_mapping.return_value = mock_tasks_mapping
-
-                def mock_get_task_side_effect(task_name, mapping):
-                    for (harness, name), definition in mapping.items():
-                        if name == task_name:
-                            return definition
-                    raise KeyError(f"Task {task_name} not found")
-
-                mock_get_task.side_effect = mock_get_task_side_effect
-                mock_get_command.return_value = (
-                    "nemo-evaluator-launcher --task test_command"
-                )
-
-                # Should execute successfully without auto-export
-                invocation_id = LocalExecutor.execute_eval(sample_config, dry_run=True)
-
-                # Verify invocation ID is valid
-                assert isinstance(invocation_id, str)
-                assert len(invocation_id) == 8
-
-        finally:
-            # Clean up environment
-            for env_var in ["TEST_API_KEY", "GLOBAL_VALUE", "TASK_VALUE"]:
-                if env_var in os.environ:
-                    del os.environ[env_var]
 
 
 class TestLocalExecutorGetStatus:


### PR DESCRIPTION
* this avoids creating job ids and invocation ids for eval db when dry-run is requested
* fixes number of bad or useless tests