### PR TITLE
Awarno/increase server readiness timeout

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/server.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/server.py
@@ -79,7 +79,7 @@ def is_port_open(host: str, port: int, timeout: float = 0.5) -> bool:
 
 
 def wait_for_server(
-    host: str, port: int, max_wait: float = 10, interval: float = 0.2
+    host: str, port: int, max_wait: float = 300, interval: float = 0.2
 ) -> bool:
     """Wait for server to be ready with timeout.
 


### PR DESCRIPTION
- **Increased** server wait time from **10 s → 300 s**.  
- **Removed** unused `_calculate_inference_time()` method from `ResponseStatsInterceptor`.  
- **Optimized startup** by loading a single aggregated snapshot (instant startup, fast) instead of loading all individual reasoning request stats and processing them to get the aggregated.
