### PR TITLE
fix(cli): change entrypoint name from eval-factory to nemo-evaluator

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
@@ -75,7 +75,7 @@ def get_eval_factory_command(
     create_file_cmd = _yaml_to_echo_command(
         yaml.safe_dump(config_fields), "config_ef.yaml"
     )
-    eval_command = f"""eval-factory run_eval --model_id {model_id} --model_type {model_type} --eval_type {eval_type} --model_url {model_url} --api_key_name API_KEY --output_dir /results --run_config config_ef.yaml"""
+    eval_command = f"""cmd=$([ -x $(command -v nemo-evaluator) ] && echo 'nemo-evaluator' || echo 'eval-factory') $cmd run_eval --model_id {model_id} --model_type {model_type} --eval_type {eval_type} --model_url {model_url} --api_key_name API_KEY --output_dir /results --run_config config_ef.yaml"""
 
     if overrides:
         eval_command = f"{eval_command} --overrides {overrides_str}"

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -105,7 +105,7 @@ class TestSlurmExecutorFeatures:
             }
             mock_get_health.return_value = "http://localhost:8000/health"
             mock_get_endpoint.return_value = "http://localhost:8000/v1"
-            mock_get_eval_command.return_value = "eval-factory run_eval --test"
+            mock_get_eval_command.return_value = "nemo-evaluator run_eval --test"
             mock_get_model_name.return_value = "test-model"
 
             yield {

--- a/packages/nemo-evaluator/pyproject.toml
+++ b/packages/nemo-evaluator/pyproject.toml
@@ -81,6 +81,7 @@ docs = [
 nemo_evaluator_example = "nemo_evaluator.cli.example:main"
 nemo-evaluator-example = "nemo_evaluator.cli.example:main"
 eval-factory = "nemo_evaluator.core.entrypoint:run_eval"
+nemo-evaluator = "nemo_evaluator.core.entrypoint:run_eval"
 
 [tool.coverage.run]
 concurrency = ["thread", "multiprocessing"]

--- a/packages/nemo-evaluator/src/nemo_evaluator/core/entrypoint.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/core/entrypoint.py
@@ -148,6 +148,14 @@ def run(args) -> None:
 def run_eval() -> None:
     args = get_args()
 
+    if sys.argv[0].endswith("eval-factory"):
+        from nemo_evaluator.logging import get_logger
+
+        logger = get_logger(__name__)
+        logger.warning(
+            "You appear to be using a deprecated eval_factory command. Please use nemo-evaluator instead with the same arguments. eval-factory command is going to be removed before 25.12 containers are released."
+        )
+
     if args.command == "ls":
         show_available_tasks()
     elif args.command == "run_eval":

--- a/tests/integration_tests/eval_factory/test_interceptor_integration.py
+++ b/tests/integration_tests/eval_factory/test_interceptor_integration.py
@@ -102,7 +102,7 @@ class TestInterceptorIntegration:
 
         with tempfile.TemporaryDirectory() as temp_dir:
             cmd = [
-                "eval-factory",
+                "nemo-evaluator",
                 "run_eval",
                 "--eval_type",
                 "mmlu_pro",
@@ -187,7 +187,7 @@ class TestInterceptorIntegration:
             cache_dir = f"{output_dir}/cache"
 
         return [
-            "eval-factory",
+            "nemo-evaluator",
             "run_eval",
             "--eval_type",
             "mmlu_pro",


### PR DESCRIPTION
This MR changes `nemo-evaluator` entrypoint from `eval-factory` to `nemo-evaluator`. 

To facilitate backward compatibility we take the following measures:
1. We keep `eval-factory` entrypoint with deprecation warning in `nemo-evaluator`
2. We use either entrypoint in `nemo-evaluator-launcher`, with preference (first-matching) for `nemo-evaluator`