### PR TITLE
fix(missing-env-var): fix missing env var

### DIFF
--- a/packages/nemo-evaluator-launcher/examples/local_auto_export_llama_3_1_8b_instruct.yaml
+++ b/packages/nemo-evaluator-launcher/examples/local_auto_export_llama_3_1_8b_instruct.yaml
@@ -92,4 +92,4 @@ deployment:
 
 evaluation:
   tasks:
-    - name: simple_evals.gpqa_diamond
+    - name: ifeval


### PR DESCRIPTION
The gated GPQA now uses ifeval (previously there was a missing environment variable error). We could fix it by adding this environment variable, but we already have a GPQA example in other places.