### PR TITLE
docs: Links valid & false positives: add to list

### DIFF
--- a/docs/false_positives.json
+++ b/docs/false_positives.json
@@ -1,4 +1,28 @@
 {
+  "filename": "nemo-fw/evaluation-doc.md",
+  "lineno": 154,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://github.com/NVIDIA-NeMo/Evaluator/blob/main/scripts/evaluation_with_nemo_run.py#L267",
+  "info": "Anchor 'L267' not found"
+}
+{
+  "filename": "nemo-fw/evaluation-hf.md",
+  "lineno": 26,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://github.com/NVIDIA-NeMo/Export-Deploy?tab=readme-ov-file#install-tensorrt-llm-vllm-or-trt-onnx-backend:~:text=cd%20/opt/Export%2DDeploy%0Auv%20sync%20%2D%2Dinexact%20%2D%2Dlink%2Dmode%20symlink%20%2D%2Dlocked%20%2D%2Dextra%20vllm%20%24(cat%20/opt/uv_args.txt)",
+  "info": "Anchor 'install-tensorrt-llm-vllm-or-trt-onnx-backend%3A~%3Atext%3Dcd%20/opt/Export-Deploy%0Auv%20sync%20--inexact%20--link-mode%20symlink%20--locked%20--extra%20vllm%20%24%28cat%20/opt/uv_args.txt%29' not found"
+}
+{
+  "filename": "nemo-fw/evaluation-hf.md",
+  "lineno": 33,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://github.com/NVIDIA-NeMo/Export-Deploy?tab=readme-ov-file#install-tensorrt-llm-vllm-or-trt-onnx-backend:~:text=Install%20TransformerEngine%20%2B%20vLLM",
+  "info": "Anchor 'install-tensorrt-llm-vllm-or-trt-onnx-backend%3A~%3Atext%3DInstall%20TransformerEngine%20%2B%20vLLM' not found"
+}
+{
   "filename": "deployment/bring-your-own-endpoint/hosted-services.md",
   "lineno": 158,
   "status": "broken",
@@ -6,3 +30,12 @@
   "uri": "https://platform.openai.com/docs/models",
   "info": "403 Client Error: Forbidden for url: https://platform.openai.com/docs/models"
 }
+{
+  "filename": "nemo-fw/evaluation-doc.md",
+  "lineno": 154,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://github.com/NVIDIA-NeMo/Evaluator/blob/main/scripts/evaluation_with_nemo_run.py#L232",
+  "info": "Anchor 'L232' not found"
+}
+


### PR DESCRIPTION
Summary
The Problem:
**The automated link checker reported 5 broken links, but they all work fine in a web browser.**

Why They Failed:
**GitHub line anchors (#L232, #L267) - Automated tools struggle to verify these**
Complex text fragments (Export-Deploy links with :~:text=) - Advanced URL syntax that checkers can't validate
**403 Forbidden (OpenAI docs) - Site blocks automated requests but allows browsers**
**Rate-limiting tools**

The Fix:
Created docs/false_positives.json with all 5 links. The build workflow will now skip checking these specific links since they're known to work but fail automated validation.

File Format:
The file uses newline-delimited JSON (NDJSON) - each link is a separate JSON object on its own line, which is what the FW-CI-templates workflow expects.
The "Check for Unknown broken links" job should now pass