### PR TITLE
fix(config): type slurm

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/slurm/default.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/slurm/default.yaml
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 # Each slurm cluster has its own flavour, below we provide some defaults that might meet one's needs.
+
+# Executor is chosen based on this field
+type: slurm
+
 hostname: ???
 username: ${oc.env:USER}
 account: ???


### PR DESCRIPTION
The executor is chosen based on this field https://github.com/NVIDIA-NeMo/Eval/blob/3e284b24886d23395da17cbb410972cc394da1fc/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/api/functional.py#L99