### PR TITLE
feat(cmd): wrap ef config into config

### DIFF
--- a/docs/about/key-features.md
+++ b/docs/about/key-features.md
@@ -11,14 +11,14 @@ NeMo Evaluator SDK delivers comprehensive AI model evaluation through a dual-lib
 Run evaluations anywhere with unified configuration and monitoring:
 
 - **Local Execution**: Docker-based evaluation on your workstation
-- **HPC Clusters**: Slurm integration for large-scale parallel evaluation  
+- **HPC Clusters**: Slurm integration for large-scale parallel evaluation
 - **Cloud Platforms**: Lepton AI and custom cloud backend support
 - **Hybrid Workflows**: Mix local development with cloud production
 
 ```bash
 # Single command, multiple backends
 nemo-evaluator-launcher run --config-dir packages/nemo-evaluator-launcher/examples --config-name local_llama_3_1_8b_instruct
-nemo-evaluator-launcher run --config-dir packages/nemo-evaluator-launcher/examples --config-name slurm_llama_3_1_8b_instruct  
+nemo-evaluator-launcher run --config-dir packages/nemo-evaluator-launcher/examples --config-name slurm_llama_3_1_8b_instruct
 nemo-evaluator-launcher run --config-dir packages/nemo-evaluator-launcher/examples --config-name lepton_vllm_llama_3_1_8b_instruct
 ```
 
@@ -85,14 +85,14 @@ Pre-built NGC containers guarantee reproducible results across environments:
   - CUDA code evaluation
   - [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/compute-eval)
   - {{ docker_compose_latest }}
-  - cccl_problems, combined_problems, cuda_problems 
+  - cccl_problems, combined_problems, cuda_problems
 * - **garak**
   - Security and robustness testing
   - [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/garak)
   - {{ docker_compose_latest }}
   - garak
-* - **genai-perf** 
-  - GenAI performance benchmarking 
+* - **genai-perf**
+  - GenAI performance benchmarking
   - [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/genai-perf)
   - {{ docker_compose_latest }}
   - genai_perf_generation, genai_perf_summarization
@@ -131,11 +131,11 @@ Pre-built NGC containers guarantee reproducible results across environments:
   - [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/mtbench)
   - {{ docker_compose_latest }}
   - mtbench, mtbench-cor1
-* - **nemo-skills** 
+* - **nemo-skills**
   - Language model benchmarks (science, math, agentic)
   - [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/nemo_skills)
   - {{ docker_compose_latest }}
-  - ns_aime2024, ns_aime2025, ns_aime2025_ef, ns_bfcl_v3, ns_gpqa, ns_gpqa_ef, ns_hle, ns_livecodebench, ns_mmlu, ns_mmlu_pro 
+  - ns_aime2024, ns_aime2025, ns_aime2025_ef, ns_bfcl_v3, ns_gpqa, ns_gpqa_ef, ns_hle, ns_livecodebench, ns_mmlu, ns_mmlu_pro
 * - **rag_retriever_eval**
   - RAG system evaluation
   - [NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/rag_retriever_eval)
@@ -189,17 +189,17 @@ target:
         - name: system_message
           config:
             system_message: "You are a helpful AI assistant. Think step by step."
-        
+
         # Request logging interceptor
         - name: request_logging
           config:
             max_requests: 1000
-        
+
         # Caching interceptor
         - name: caching
           config:
             cache_dir: "./evaluation_cache"
-        
+
         # Communication with http://localhost:8080/v1/completions/
         -name: endpoint
 
@@ -208,12 +208,12 @@ target:
           config:
             start_reasoning_token: "<think>"
             end_reasoning_token: "</think>"
-        
+
         # Response logging interceptor
         - name: response_logging
           config:
             max_responses: 1000
-        
+
         # Progress tracking interceptor
         - name: progress_tracking
 ```
@@ -241,7 +241,7 @@ Direct access to specialized evaluation containers through [NGC Catalog](https:/
 # Academic benchmarks
 docker run --rm -it --gpus all nvcr.io/nvidia/eval-factory/simple-evals:{{ docker_compose_latest }}
 
-# Code generation evaluation  
+# Code generation evaluation
 docker run --rm -it --gpus all nvcr.io/nvidia/eval-factory/bigcode-evaluation-harness:{{ docker_compose_latest }}
 
 # Safety and security testing
@@ -254,7 +254,7 @@ docker run --rm -it --gpus all nvcr.io/nvidia/eval-factory/vlmevalkit:{{ docker_
 ### Reproducible Evaluation Environments
 Every container provides:
 - **Fixed dependencies**: Locked versions for consistent results
-- **Pre-configured frameworks**: Ready-to-run evaluation harnesses  
+- **Pre-configured frameworks**: Ready-to-run evaluation harnesses
 - **Isolated execution**: No dependency conflicts between evaluations
 - **Version tracking**: Tagged releases for exact reproducibility
 
@@ -351,12 +351,12 @@ Add your own evaluation frameworks using Framework Definition Files:
 framework:
   name: my_custom_eval
   description: Custom evaluation for domain-specific tasks
-  
+
 defaults:
   command: >-
     python custom_eval.py --model {{target.api_endpoint.model_id}}
     --task {{config.params.task}} --output {{config.output_dir}}
-    
+
 evaluations:
   - name: domain_specific_task
     description: Evaluate domain-specific capabilities
@@ -383,28 +383,28 @@ target:
         - name: system_message
           config:
             system_message: "You are an expert AI assistant specialized in this domain."
-        
+
         # Request logging interceptor
         - name: request_logging
           config:
             max_requests: 5000
-        
+
         # Caching interceptor
         - name: caching
           config:
             cache_dir: "./production_cache"
-        
+
         # Reasoning interceptor
         - name: reasoning
           config:
             start_reasoning_token: "<think>"
             end_reasoning_token: "</think>"
-        
+
         # Response logging interceptor
         - name: response_logging
           config:
             max_responses: 5000
-        
+
         # Progress tracking interceptor
         - name: progress_tracking
           config:
@@ -426,7 +426,7 @@ nemo-evaluator-launcher run \
 
 **Safety Containers Available:**
 - **safety-harness**: Content safety evaluation using NemoGuard judge models
-- **garak**: Security vulnerability scanning and prompt injection detection  
+- **garak**: Security vulnerability scanning and prompt injection detection
 - **agentic_eval**: Tool usage and planning evaluation for agentic AI systems
 
 ##  **Monitoring and Observability**

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -42,6 +42,7 @@ from nemo_evaluator_launcher.common.helpers import (
     get_api_key_name,
     get_endpoint_url,
     get_eval_factory_command,
+    get_eval_factory_config,
     get_eval_factory_dataset_size_from_run_config,
     get_health_url,
     get_timestamp_string,
@@ -453,7 +454,15 @@ def _create_slurm_sbatch_script(
     # get task from mapping, overrides, urls
     tasks_mapping = load_tasks_mapping()
     task_definition = get_task_from_mapping(task.name, tasks_mapping)
-    health_url = get_health_url(cfg, get_endpoint_url(cfg, task, task_definition))
+
+    # Create merged config for get_endpoint_url
+    merged_nemo_evaluator_config = get_eval_factory_config(cfg, task)
+    health_url = get_health_url(
+        cfg,
+        get_endpoint_url(
+            cfg, merged_nemo_evaluator_config, task_definition["endpoint_type"]
+        ),
+    )
 
     # TODO(public release): convert to template
     s = "#!/bin/bash\n"


### PR DESCRIPTION
Wrap all the config infor ef_config, removing intransparency regarding overrides. 

Add the deprecation warning and deprecation guard (will start fainiling CI in Dec'25) about old-style overrides

Example of the logging output
```
[I 2025-10-24T01:13:38.637] Created launcher config cfg={'execution': {'type': 'local', 'output_dir': 'llama_3_1_8b_instruct_results', 'extra_docker_args': '', 'mode': 'sequential'}, 'deployment': {'type': 'none'}, 'target': {'api_endpoint': {'model_id': 'meta/llama-3.1-8b-instruct', 'url': 'https://integrate.api.nvidia.com/v1/chat/completions', 'api_key_name': 'NVIDIA_API_KEY'}}, 'evaluation': {'nemo_evaluator_config': {'config': {'output_dir': '/results_overriden', 'params': {'request_timeout': 3600, 'parallelism': 5, 'limit_samples': 5}, 'target': {'api_endpoint': {'adapter_config': {'use_response_logging': True, 'use_request_logging': True}}}}}, 'tasks': [{'name': 'aime_2025_nemo', 'nemo_evaluator_config': {'config': {'params': {'temperature': 0.6, 'top_p': 0.95, 'max_new_tokens': 8192}}}}]}}
[I 2025-10-24T01:13:38.639] Generated command cmd=echo "Y29uZmlnOgogIG91dHB1dF9kaXI6IC9yZXN1bHRzX292ZXJyaWRlbgogIHBhcmFtczoKICAgIGxpbWl0X3NhbXBsZXM6IDUKICAgIG1heF9uZXdfdG9rZW5zOiA4MTkyCiAgICBwYXJhbGxlbGlzbTogNQogICAgcmVxdWVzdF90aW1lb3V0OiAzNjAwCiAgICB0ZW1wZXJhdHVyZTogMC42CiAgICB0b3BfcDogMC45NQogIHRhcmdldDoKICAgIGFwaV9lbmRwb2ludDoKICAgICAgYWRhcHRlcl9jb25maWc6CiAgICAgICAgdXNlX3JlcXVlc3RfbG9nZ2luZzogdHJ1ZQogICAgICAgIHVzZV9yZXNwb25zZV9sb2dnaW5nOiB0cnVlCiAgdHlwZTogYWltZV8yMDI1X25lbW8KdGFyZ2V0OgogIGFwaV9lbmRwb2ludDoKICAgIGFwaV9rZXk6IEFQSV9LRVkKICAgIG1vZGVsX2lkOiBtZXRhL2xsYW1hLTMuMS04Yi1pbnN0cnVjdAogICAgdHlwZTogY2hhdAogICAgdXJsOiBodHRwczovL2ludGVncmF0ZS5hcGkubnZpZGlhLmNvbS92MS9jaGF0L2NvbXBsZXRpb25zCg==" | base64 -d > config_ef.yaml && cmd=$(command -v nemo-evaluator >/dev/null 2>&1 && echo nemo-evaluator || echo eval-factory) && $cmd run_eval --run_config config_ef.yaml
debug=
# Contents of config_ef.yaml
# config:
#   output_dir: /results_overriden
#   params:
#     limit_samples: 5
#     max_new_tokens: 8192
#     parallelism: 5
#     request_timeout: 3600
#     temperature: 0.6
#     top_p: 0.95
#   target:
#     api_endpoint:
#       adapter_config:
#         use_request_logging: true
#         use_response_logging: true
#   type: aime_2025_nemo
# target:
#   api_endpoint:
#     api_key: API_KEY
#     model_id: meta/llama-3.1-8b-instruct
#     type: chat
#     url: https://integrate.api.nvidia.com/v1/chat/completions

```