### PR TITLE
fix(docs): fixes level of adapter_config in yaml hierarchy

### DIFF
--- a/packages/nemo-evaluator-launcher/examples/local_limit_samples.yaml
+++ b/packages/nemo-evaluator-launcher/examples/local_limit_samples.yaml
@@ -40,19 +40,19 @@ target:
 
 # specify the benchmarks to evaluate
 evaluation:
-  nemo_evaluator_config:  # global config settings that apply to all tasks
+  nemo_evaluator_config: # global config settings that apply to all tasks
     config:
       params:
-        request_timeout: 3600  # timeout for API requests in seconds
-        parallelism: 1  # number of parallel requests
-        limit_samples: 5  # TEST ONLY: Limits all benchmarks to 10 samples total for quick testing
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: false  # if true, strips reasoning tokens anc collects reasoning stats
-            use_system_prompt: true  # enables custom system prompt
-            custom_system_prompt: >-
-              "Think step by step."
+        request_timeout: 3600 # timeout for API requests in seconds
+        parallelism: 1 # number of parallel requests
+        limit_samples: 5 # TEST ONLY: Limits all benchmarks to 10 samples total for quick testing
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: false # if true, strips reasoning tokens anc collects reasoning stats
+          use_system_prompt: true # enables custom system prompt
+          custom_system_prompt: >-
+            "Think step by step."
   tasks:
     - name: gpqa_diamond
       env_vars:

--- a/packages/nemo-evaluator-launcher/examples/local_llama_3_1_8b_instruct.yaml
+++ b/packages/nemo-evaluator-launcher/examples/local_llama_3_1_8b_instruct.yaml
@@ -43,13 +43,13 @@ evaluation:
       params:
         request_timeout: 3600 # timeout for API requests in seconds
         parallelism: 1 # number of parallel requests
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: false # if true, strips reasoning tokens and collects reasoning stats
-            use_system_prompt: true # enables custom system prompt
-            custom_system_prompt: >-
-              "Think step by step."
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: false # if true, strips reasoning tokens and collects reasoning stats
+          use_system_prompt: true # enables custom system prompt
+          custom_system_prompt: >-
+            "Think step by step."
   tasks:
     - name: ifeval # use the default benchmark configuration
     - name: gpqa_diamond
@@ -70,8 +70,8 @@ evaluation:
             max_new_tokens: 2048 # maximum tokens to generate
             extra:
               n_samples: 5 # sample 5 predictions per prompt
-          target:
-            api_endpoint:
-              adapter_config:
-                custom_system_prompt: >-
-                  "You must only provide the code implementation"
+        target:
+          api_endpoint:
+            adapter_config:
+              custom_system_prompt: >-
+                "You must only provide the code implementation"

--- a/packages/nemo-evaluator-launcher/examples/local_llama_3_1_8b_instruct_limit_samples.yaml
+++ b/packages/nemo-evaluator-launcher/examples/local_llama_3_1_8b_instruct_limit_samples.yaml
@@ -39,41 +39,41 @@ target:
 
 # specify the benchmarks to evaluate
 evaluation:
-  nemo_evaluator_config:  # global config settings that apply to all tasks
+  nemo_evaluator_config: # global config settings that apply to all tasks
     config:
       params:
-        request_timeout: 3600  # timeout for API requests in seconds
-        parallelism: 1  # number of parallel requests
-        limit_samples: 10  # limit number of samples for quick testing
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: false  # if true, strips reasoning tokens and collects reasoning stats
-            use_system_prompt: true  # enables custom system prompt
-            custom_system_prompt: >-
-              "Think step by step."
+        request_timeout: 3600 # timeout for API requests in seconds
+        parallelism: 1 # number of parallel requests
+        limit_samples: 10 # limit number of samples for quick testing
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: false # if true, strips reasoning tokens and collects reasoning stats
+          use_system_prompt: true # enables custom system prompt
+          custom_system_prompt: >-
+            "Think step by step."
   tasks:
-    - name: ifeval  # use the default benchmark configuration
+    - name: ifeval # use the default benchmark configuration
     - name: gpqa_diamond
-      nemo_evaluator_config:  # task-specific configuration for gpqa_diamond
+      nemo_evaluator_config: # task-specific configuration for gpqa_diamond
         config:
           params:
-            temperature: 0.6  # sampling temperature
-            top_p: 0.95  # nucleus sampling parameter
-            max_new_tokens: 8192  # maximum tokens to generate
+            temperature: 0.6 # sampling temperature
+            top_p: 0.95 # nucleus sampling parameter
+            max_new_tokens: 8192 # maximum tokens to generate
       env_vars:
         HF_TOKEN: HF_TOKEN_FOR_GPQA_DIAMOND # Click request access for GPQA-Diamond: https://huggingface.co/datasets/Idavidrein/gpqa
     - name: mbpp
-      nemo_evaluator_config:  # task-specific configuration for mbpp
+      nemo_evaluator_config: # task-specific configuration for mbpp
         config:
           params:
-            temperature: 0.2  # sampling temperature
-            top_p: 0.95  # nucleus sampling parameter
-            max_new_tokens: 2048  # maximum tokens to generate
+            temperature: 0.2 # sampling temperature
+            top_p: 0.95 # nucleus sampling parameter
+            max_new_tokens: 2048 # maximum tokens to generate
             extra:
-              n_samples: 5  # sample 5 predictions per prompt
-          target:
-            api_endpoint:
-              adapter_config:
-                custom_system_prompt: >-
-                  "You must only provide the code implementation"
+              n_samples: 5 # sample 5 predictions per prompt
+        target:
+          api_endpoint:
+            adapter_config:
+              custom_system_prompt: >-
+                "You must only provide the code implementation"

--- a/packages/nemo-evaluator-launcher/examples/local_nvidia_nemotron_nano_9b_v2.yaml
+++ b/packages/nemo-evaluator-launcher/examples/local_nvidia_nemotron_nano_9b_v2.yaml
@@ -40,19 +40,19 @@ target:
 
 # specify the benchmarks to evaluate
 evaluation:
-  nemo_evaluator_config:  # global config settings that apply to all tasks
+  nemo_evaluator_config: # global config settings that apply to all tasks
     config:
       params:
-        request_timeout: 3600  # timeout for API requests in seconds
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: false  # if true, strips reasoning tokens and collects reasoning stats
-            use_system_prompt: false  # disables custom system prompt
+        request_timeout: 3600 # timeout for API requests in seconds
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: false # if true, strips reasoning tokens and collects reasoning stats
+          use_system_prompt: false # disables custom system prompt
   tasks:
     - name: simple_evals.mmlu_pro
-      nemo_evaluator_config:  # task-specific configuration for mmlu_pro
+      nemo_evaluator_config: # task-specific configuration for mmlu_pro
         config:
           params:
-            limit_samples: 10  # TEST ONLY: Limits all benchmarks to 10 samples total for quick testing
-            parallelism: 1  # number of parallel requests
+            limit_samples: 10 # TEST ONLY: Limits all benchmarks to 10 samples total for quick testing
+            parallelism: 1 # number of parallel requests

--- a/packages/nemo-evaluator-launcher/examples/slurm_llama_3_1_8b_instruct.yaml
+++ b/packages/nemo-evaluator-launcher/examples/slurm_llama_3_1_8b_instruct.yaml
@@ -59,41 +59,41 @@ deployment:
 
 # specify the benchmarks to evaluate
 evaluation:
-  nemo_evaluator_config:  # global config settings that apply to all tasks
+  nemo_evaluator_config: # global config settings that apply to all tasks
     config:
       params:
-        request_timeout: 3600  # timeout for API requests in seconds
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: false  # if true, strips reasoning tokens and collects reasoning stats
-            use_system_prompt: true  # enables custom system prompt
-            custom_system_prompt: >-
-              "Think step by step."
+        request_timeout: 3600 # timeout for API requests in seconds
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: false # if true, strips reasoning tokens and collects reasoning stats
+          use_system_prompt: true # enables custom system prompt
+          custom_system_prompt: >-
+            "Think step by step."
   tasks:
-    - name: ifeval  # use the default benchmark configuration
+    - name: ifeval # use the default benchmark configuration
     - name: gpqa_diamond
-      nemo_evaluator_config:  # task-specific configuration for gpqa_diamond
+      nemo_evaluator_config: # task-specific configuration for gpqa_diamond
         config:
           params:
-            temperature: 0.6  # sampling temperature
-            top_p: 0.95  # nucleus sampling parameter
-            max_new_tokens: 8192  # maximum tokens to generate
-            parallelism: 32  # number of parallel requests
+            temperature: 0.6 # sampling temperature
+            top_p: 0.95 # nucleus sampling parameter
+            max_new_tokens: 8192 # maximum tokens to generate
+            parallelism: 32 # number of parallel requests
       env_vars:
         HF_TOKEN: HF_TOKEN_FOR_GPQA_DIAMOND # Click request access for GPQA-Diamond: https://huggingface.co/datasets/Idavidrein/gpqa
     - name: mbpp
-      nemo_evaluator_config:  # task-specific configuration for mbpp
+      nemo_evaluator_config: # task-specific configuration for mbpp
         config:
           params:
-            temperature: 0.2  # sampling temperature
-            top_p: 0.95  # nucleus sampling parameter
-            max_new_tokens: 2048  # maximum tokens to generate
-            parallelism: 32  # number of parallel requests
+            temperature: 0.2 # sampling temperature
+            top_p: 0.95 # nucleus sampling parameter
+            max_new_tokens: 2048 # maximum tokens to generate
+            parallelism: 32 # number of parallel requests
             extra:
-              n_samples: 5  # sample 5 predictions per prompt
-          target:
-            api_endpoint:
-              adapter_config:
-                custom_system_prompt: >-
-                  "You must only provide the code implementation"
+              n_samples: 5 # sample 5 predictions per prompt
+        target:
+          api_endpoint:
+            adapter_config:
+              custom_system_prompt: >-
+                "You must only provide the code implementation"

--- a/packages/nemo-evaluator-launcher/examples/slurm_llama_3_1_8b_instruct_hf.yaml
+++ b/packages/nemo-evaluator-launcher/examples/slurm_llama_3_1_8b_instruct_hf.yaml
@@ -61,16 +61,16 @@ deployment:
 
 # specify the benchmarks to evaluate
 evaluation:
-  nemo_evaluator_config:  # global config settings that apply to all tasks
+  nemo_evaluator_config: # global config settings that apply to all tasks
     config:
       params:
-        request_timeout: 3600  # timeout for API requests in seconds
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: false  # if true, strips reasoning tokens and collects reasoning stats
-            use_system_prompt: true  # enables custom system prompt
-            custom_system_prompt: >-
-              "Think step by step."
+        request_timeout: 3600 # timeout for API requests in seconds
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: false # if true, strips reasoning tokens and collects reasoning stats
+          use_system_prompt: true # enables custom system prompt
+          custom_system_prompt: >-
+            "Think step by step."
   tasks:
-    - name: ifeval  # use the default benchmark configuration
+    - name: ifeval # use the default benchmark configuration

--- a/packages/nemo-evaluator-launcher/examples/slurm_no_deployment_llama_3_1_8b_instruct.yaml
+++ b/packages/nemo-evaluator-launcher/examples/slurm_no_deployment_llama_3_1_8b_instruct.yaml
@@ -48,40 +48,40 @@ target:
 
 # specify the benchmarks to evaluate
 evaluation:
-  nemo_evaluator_config:  # global config settings that apply to all tasks
+  nemo_evaluator_config: # global config settings that apply to all tasks
     config:
       params:
-        request_timeout: 3600  # timeout for API requests in seconds
-        parallelism: 1  # number of parallel requests
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: false  # if true, strips reasoning tokens and collects reasoning stats
-            use_system_prompt: true  # enables custom system prompt
-            custom_system_prompt: >-
-              "Think step by step."
+        request_timeout: 3600 # timeout for API requests in seconds
+        parallelism: 1 # number of parallel requests
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: false # if true, strips reasoning tokens and collects reasoning stats
+          use_system_prompt: true # enables custom system prompt
+          custom_system_prompt: >-
+            "Think step by step."
   tasks:
-    - name: ifeval  # use the default benchmark configuration
+    - name: ifeval # use the default benchmark configuration
     - name: gpqa_diamond
-      nemo_evaluator_config:  # task-specific configuration for gpqa_diamond
+      nemo_evaluator_config: # task-specific configuration for gpqa_diamond
         config:
           params:
-            temperature: 0.6  # sampling temperature
-            top_p: 0.95  # nucleus sampling parameter
-            max_new_tokens: 8192  # maximum tokens to generate
+            temperature: 0.6 # sampling temperature
+            top_p: 0.95 # nucleus sampling parameter
+            max_new_tokens: 8192 # maximum tokens to generate
       env_vars:
         HF_TOKEN: HF_TOKEN_FOR_GPQA_DIAMOND # Click request access for GPQA-Diamond: https://huggingface.co/datasets/Idavidrein/gpqa
     - name: mbpp
-      nemo_evaluator_config:  # task-specific configuration for mbpp
+      nemo_evaluator_config: # task-specific configuration for mbpp
         config:
           params:
-            temperature: 0.2  # sampling temperature
-            top_p: 0.95  # nucleus sampling parameter
-            max_new_tokens: 2048  # maximum tokens to generate
+            temperature: 0.2 # sampling temperature
+            top_p: 0.95 # nucleus sampling parameter
+            max_new_tokens: 2048 # maximum tokens to generate
             extra:
-              n_samples: 5  # sample 5 predictions per prompt
-          target:
-            api_endpoint:
-              adapter_config:
-                custom_system_prompt: >-
-                  "You must only provide the code implementation"
+              n_samples: 5 # sample 5 predictions per prompt
+        target:
+          api_endpoint:
+            adapter_config:
+              custom_system_prompt: >-
+                "You must only provide the code implementation"

--- a/packages/nemo-evaluator-launcher/examples/slurm_no_deployment_llama_nemotron_super_v1_nemotron_benchmarks.yaml
+++ b/packages/nemo-evaluator-launcher/examples/slurm_no_deployment_llama_nemotron_super_v1_nemotron_benchmarks.yaml
@@ -48,22 +48,22 @@ target:
 
 # specify the benchmarks to evaluate
 evaluation:
-  nemo_evaluator_config:  # global config settings that apply to all tasks
+  nemo_evaluator_config: # global config settings that apply to all tasks
     config:
       # apply recommended sampling parameters for reasoning-on mode
       params:
-        temperature: 0.6  # sampling temperature
-        top_p: 0.95  # nucleus sampling parameter
-        max_new_tokens: 65536  # maximum tokens to generate (large for reasoning)
-        parallelism: 1  # number of parallel requests
-        request_timeout: 3600  # timeout for API requests in seconds
-      target:
-        api_endpoint:
-          adapter_config:
-            use_reasoning: true  # if true, strips reasoning tokens and collects reasoning stats
-            use_system_prompt: true  # enables custom system prompt
-            custom_system_prompt: >-  # turn on thinking mode
-              "detailed thinking on"
+        temperature: 0.6 # sampling temperature
+        top_p: 0.95 # nucleus sampling parameter
+        max_new_tokens: 65536 # maximum tokens to generate (large for reasoning)
+        parallelism: 1 # number of parallel requests
+        request_timeout: 3600 # timeout for API requests in seconds
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: true # if true, strips reasoning tokens and collects reasoning stats
+          use_system_prompt: true # enables custom system prompt
+          custom_system_prompt: >- # turn on thinking mode
+            "detailed thinking on"
   tasks:
     - name: gpqa_diamond_nemo
       env_vars:
@@ -79,16 +79,16 @@ evaluation:
 
     - name: livecodebench_0824_0225
 
-    - name: ifeval  # evaluated in reasoning-off mode
-      nemo_evaluator_config:  # task-specific configuration for ifeval
+    - name: ifeval # evaluated in reasoning-off mode
+      nemo_evaluator_config: # task-specific configuration for ifeval
         config:
           params:
-            temperature: 0  # deterministic generation
-            top_p: 1e-5  # minimal sampling
-            max_new_tokens: 4096  # maximum tokens to generate
-          target:
-            api_endpoint:
-              adapter_config:
-                use_system_prompt: true  # enables custom system prompt
-                custom_system_prompt: >-  # turn off thinking mode
-                  "detailed thinking off"
+            temperature: 0 # deterministic generation
+            top_p: 1e-5 # minimal sampling
+            max_new_tokens: 4096 # maximum tokens to generate
+        target:
+          api_endpoint:
+            adapter_config:
+              use_system_prompt: true # enables custom system prompt
+              custom_system_prompt: >- # turn off thinking mode
+                "detailed thinking off"


### PR DESCRIPTION
This fixes the example docs: moves `nemo_evaluator_config.config.target` to `nemo_evaluator_config.target`