### PR TITLE
fix: add code to shutdown Ray server in nemo-run script

### DIFF
--- a/scripts/evaluation_with_nemo_run.py
+++ b/scripts/evaluation_with_nemo_run.py
@@ -352,7 +352,10 @@ def main():
     )
 
     eval_fn = run.Partial(
-        wait_and_evaluate, target_cfg=eval_target, eval_cfg=eval_config, serving_backend=args.serving_backend
+        wait_and_evaluate,
+        target_cfg=eval_target,
+        eval_cfg=eval_config,
+        serving_backend=args.serving_backend,
     )
     # [snippet-config-end]
 

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -45,4 +45,5 @@ def wait_and_evaluate(target_cfg, eval_cfg, serving_backend="pytriton"):
 
     return result
 
+
 # [snippet-end]


### PR DESCRIPTION
Adds helper code to shut down Ray server when being run with nemo-run script, since it does not shut down automatically unlike Triton. Without this, it leads to GPU resources still being subscribed on clusters and causing wastage.