### PR TITLE
fix: fix integration test automated run

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -159,7 +159,6 @@ jobs:
 
   cicd-integration-tests:
     needs:
-      - pre-flight
       - cicd-unit-tests-nemo-evaluator
     runs-on: self-hosted-nemo
     if: |


### PR DESCRIPTION
Integration tests triggering: 
Plan : to skip them for PRs, but we wanted to run them on main and I'd like to be able to trigger them manually too

This would now satisfies requirements:
Req 1a: PRs with /ok to test xyz will SKIP integration tests (they use push events to pull-request/* branches, not schedule or workflow_dispatch)
Req 1b: Merges to main won't automatically run integration tests (also push events), but scheduled runs will catch them
Req 2: Manual workflow_dispatch triggers from any branch will run integration tests
Req 3: No more environment protection errors when triggering from feature branches

The key insight is that by checking github.event_name directly instead of relying on is_ci_workload, we:
- Don't require the workflow to be on main branch for manual triggers
- Explicitly exclude PR runs (which are push events)
- Allow scheduled runs to work as before

<img width="1062" height="400" alt="image" src="https://github.com/user-attachments/assets/bc85561c-5b47-4cf3-bed0-8e4de8c8687f" />

<img width="324" height="267" alt="image" src="https://github.com/user-attachments/assets/4830137b-ef9a-45f5-b05f-c082c0dd0d56" />



Fixed integration tests triggering logic:
- Skip on PRs (including /ok to test)
- Run on main branch pushes (when PRs merge)
- Run on scheduled cron jobs (daily)
- Run on manual workflow_dispatch triggers (from any branch)



Tested: 
For:
- Use workflow from: pablo-garay/fix-integration-test-automated-run2
- Branch to run tests on: pablo-garay/fix-integration-test-automated-run2
https://github.com/NVIDIA-NeMo/Evaluator/actions/runs/19550694641
another test: https://github.com/NVIDIA-NeMo/Evaluator/actions/runs/19552356088/job/55986938425