### PR TITLE
chore: add info cmd to run sumamry

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/run.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/run.py
@@ -205,6 +205,10 @@ class Cmd:
                 + f"nemo-evaluator-launcher status {invocation_id}"
             )
             print(
+                bold(cyan("To view job info: "))
+                + f"nemo-evaluator-launcher info {invocation_id}"
+            )
+            print(
                 bold(cyan("To kill all jobs: "))
                 + f"nemo-evaluator-launcher kill {invocation_id}"
             )


### PR DESCRIPTION
Example:
...
To check status: nemo-evaluator-launcher status <invoc_id>
To view job info: nemo-evaluator-launcher info <invoc_id>
To kill all jobs: nemo-evaluator-launcher kill <invoc_id>
To kill individual jobs:
  nemo-evaluator-launcher kill <invoc_id.0>  # ifeval
....