### PR TITLE
chore(ui): disable color on non-TTY destinations

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/logging_utils.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/logging_utils.py
@@ -271,6 +271,9 @@ def _configure_structlog() -> None:
         structlog.processors.UnicodeDecoder(),
     ]
 
+    # Check if stderr is a TTY to determine if colors should be enabled
+    colors_enabled = sys.stderr.isatty()
+
     logging.config.dictConfig(
         {
             "version": 1,
@@ -281,7 +284,7 @@ def _configure_structlog() -> None:
                     "()": "structlog.stdlib.ProcessorFormatter",
                     "processors": [
                         *shared_processors,
-                        MainConsoleRenderer(colors=True),
+                        MainConsoleRenderer(colors=colors_enabled),
                     ],
                 },
                 # Formatter for plain file output

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/printing_utils.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/printing_utils.py
@@ -28,6 +28,7 @@ USAGE:
 """
 
 import os
+import sys
 
 # If this env var is set, it will override a more standard "LOG_LEVEL". If
 # both are unset, default would be used.
@@ -35,9 +36,15 @@ _DISABLE_COLOR_ENV_VAR = "NEMO_EVALUATOR_DISABLE_COLOR"
 
 
 def _is_color_disabled():
+    # Check environment variable first
     env_var = os.environ.get(_DISABLE_COLOR_ENV_VAR, "0").lower()
 
     if "1" in env_var or "yes" in env_var or "y" in env_var or "true" in env_var:
+        return True
+
+    # If not explicitly disabled, check if stdout is a TTY
+    # Colors are disabled if output is not a TTY
+    if not sys.stdout.isatty():
         return True
 
     return False

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_logging_utils.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_logging_utils.py
@@ -250,3 +250,39 @@ class TestRedactProcessor:
 
         # Normal sensitive keys should still be redacted
         assert self._is_masked(red["api_token"], original["api_token"])
+
+
+class TestMainConsoleRenderer:
+    """Test cases for MainConsoleRenderer color functionality."""
+
+    def test_colors_disabled(self):
+        """Test that colors are disabled when colors=False."""
+        from nemo_evaluator_launcher.common.logging_utils import MainConsoleRenderer
+
+        renderer = MainConsoleRenderer(colors=False)
+
+        event_dict = {
+            "timestamp": "2025-01-01T12:00:00.000",
+            "event": "test message",
+            "level": "info",
+        }
+        output = renderer(None, "info", event_dict)
+
+        # Should not contain ANSI color codes
+        assert "\033[" not in output
+
+    def test_colors_enabled(self):
+        """Test that colors are enabled when colors=True."""
+        from nemo_evaluator_launcher.common.logging_utils import MainConsoleRenderer
+
+        renderer = MainConsoleRenderer(colors=True)
+
+        event_dict = {
+            "timestamp": "2025-01-01T12:00:00.000",
+            "event": "test message",
+            "level": "info",
+        }
+        output = renderer(None, "info", event_dict)
+
+        # Should contain ANSI color codes
+        assert "\033[" in output

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_printing_utils.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_printing_utils.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for printing_utils.py functionality."""
+
+import os
+import sys
+from unittest.mock import patch
+
+
+class TestPrintingUtilsColors:
+    """Test cases for printing utils color functionality."""
+
+    def test_colors_disabled_when_not_tty(self):
+        """Test that colors are disabled when stdout is not a TTY."""
+        with patch.object(sys.stdout, "isatty", return_value=False):
+            # Reload module to pick up the TTY check
+            import importlib
+
+            import nemo_evaluator_launcher.common.printing_utils as printing_utils
+
+            importlib.reload(printing_utils)
+
+            output = printing_utils.red("test")
+            # Should not contain ANSI color codes
+            assert "\033[" not in output
+            assert output == "test"
+
+    def test_colors_enabled_when_tty(self):
+        """Test that colors are enabled when stdout is a TTY."""
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            with patch.dict(os.environ, {}, clear=True):
+                # Reload module to pick up the TTY check
+                import importlib
+
+                import nemo_evaluator_launcher.common.printing_utils as printing_utils
+
+                importlib.reload(printing_utils)
+
+                output = printing_utils.red("test")
+                # Should contain ANSI color codes
+                assert "\033[" in output
+
+    def test_env_var_disables_colors(self, monkeypatch):
+        """Test that environment variable can disable colors even when TTY."""
+        monkeypatch.setenv("NEMO_EVALUATOR_DISABLE_COLOR", "1")
+        with patch.object(sys.stdout, "isatty", return_value=True):
+            # Reload module to pick up the env var
+            import importlib
+
+            import nemo_evaluator_launcher.common.printing_utils as printing_utils
+
+            importlib.reload(printing_utils)
+
+            output = printing_utils.red("test")
+            # Should not contain ANSI color codes due to env var
+            assert "\033[" not in output
+            assert output == "test"
+
+        monkeypatch.delenv("NEMO_EVALUATOR_DISABLE_COLOR", raising=False)

--- a/packages/nemo-evaluator/src/nemo_evaluator/logging/utils.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/logging/utils.py
@@ -245,6 +245,9 @@ def _configure_structlog(log_dir: str = None) -> None:
         structlog.processors.UnicodeDecoder(),
     ]
 
+    # Check if stderr is a TTY to determine if colors should be enabled
+    colors_enabled = sys.stderr.isatty()
+
     logging.config.dictConfig(
         {
             "version": 1,
@@ -257,7 +260,7 @@ def _configure_structlog(log_dir: str = None) -> None:
                         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
                         custom_timestamper,
                         *shared_processors,
-                        MainConsoleRenderer(colors=True),
+                        MainConsoleRenderer(colors=colors_enabled),
                     ],
                 },
                 # Formatter for plain file output

--- a/packages/nemo-evaluator/tests/unit_tests/logging/__init__.py
+++ b/packages/nemo-evaluator/tests/unit_tests/logging/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/packages/nemo-evaluator/tests/unit_tests/logging/test_utils.py
+++ b/packages/nemo-evaluator/tests/unit_tests/logging/test_utils.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test module for logging utils."""
+
+from nemo_evaluator.logging.utils import MainConsoleRenderer
+
+
+def test_colors_disabled():
+    """Test that colors are disabled when colors=False."""
+    renderer = MainConsoleRenderer(colors=False)
+
+    event_dict = {
+        "timestamp": "2025-01-01T12:00:00.000",
+        "event": "test message",
+        "level": "info",
+    }
+    output = renderer(None, "info", event_dict)
+
+    # Should not contain ANSI color codes
+    assert "\033[" not in output
+
+
+def test_colors_enabled():
+    """Test that colors are enabled when colors=True."""
+    renderer = MainConsoleRenderer(colors=True)
+
+    event_dict = {
+        "timestamp": "2025-01-01T12:00:00.000",
+        "event": "test message",
+        "level": "info",
+    }
+    output = renderer(None, "info", event_dict)
+
+    # Should contain ANSI color codes
+    assert "\033[" in output


### PR DESCRIPTION
This disables colors on non-TTY outputs (standard practice for tools) in both launcher and core. It's needed since we're starting to put log files into the buckets and they are unreadable with ANSI escapes.

<img width="3429" height="1326" alt="520200136-e9932c51-ca52-4b60-8335-ac5bc1aed7f3" src="https://github.com/user-attachments/assets/84ce4845-80e6-4eac-82e3-5b51eee97300" />

<img width="1720" height="1310" alt="image" src="https://github.com/user-attachments/assets/35bf0c88-c67d-4b5b-a8aa-478d3d400f62" />
