### PR TITLE
feat(export): add .txt to log filename for preview in MLflow UI

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
@@ -395,8 +395,10 @@ class MLflowExporter(BaseExporter):
                 for p in logs_dir.iterdir():
                     if p.is_file():
                         rel = p.name
+                        # add .txt to filename for preview in MLflow UI
                         mlflow.log_artifact(
-                            str(p), artifact_path=f"{artifact_path}/logs"
+                            str(p),
+                            artifact_path=f"{artifact_path}/logs/{rel}.txt",
                         )
                         logged_names.append(f"logs/{rel}")
                         logger.debug(f"mlflow upload log: {rel}")


### PR DESCRIPTION
We save files with `.out` or `.log` extensions and they are treated as binary by MLFlow. With `.txt` suffix logs can be viewed in UI.