### PR TITLE
fix(export-remote): use .log suffix for slurm logs to render them in MLFlow UI

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -531,7 +531,7 @@ def _create_slurm_sbatch_script(
     )
     s += "#SBATCH --job-name {}\n".format(job_name)
     s += "#SBATCH --exclusive\n"
-    s += "#SBATCH --output {}\n".format(remote_task_subdir / "logs" / "slurm-%A.out")
+    s += "#SBATCH --output {}\n".format(remote_task_subdir / "logs" / "slurm-%A.log")
     s += "\n"
     s += f'TASK_DIR="{str(remote_task_subdir)}"\n'
     s += "\n"
@@ -696,7 +696,7 @@ def _create_slurm_sbatch_script(
         s += "--no-container-mount-home "
 
     s += "--container-mounts {} ".format(",".join(evaluation_mounts_list))
-    s += "--output {} ".format(remote_task_subdir / "logs" / "client-%A.out")
+    s += "--output {} ".format(remote_task_subdir / "logs" / "client-%A.log")
     s += "bash -c '\n"
     s += eval_factory_command
     s += "'\n\n"
@@ -818,7 +818,7 @@ def _generate_auto_export_section(
         s += "--no-container-mount-home "
 
     s += f"--container-mounts {remote_task_subdir}/artifacts:{remote_task_subdir}/artifacts,{remote_task_subdir}/logs:{remote_task_subdir}/logs "
-    s += "--output {} ".format(remote_task_subdir / "logs" / "export-%A.out")
+    s += "--output {} ".format(remote_task_subdir / "logs" / "export-%A.log")
     s += "    bash -c '\n"
     # FIXME(martas): would be good to install specific version
     s += "        pip install nemo-evaluator-launcher[all]\n"
@@ -1336,7 +1336,7 @@ def _generate_deployment_srun_command(
         s += "--container-mounts {} ".format(",".join(deployment_mounts_list))
     if not cfg.execution.get("mounts", {}).get("mount_home", True):
         s += "--no-container-mount-home "
-    s += "--output {} ".format(remote_task_subdir / "logs" / "server-%A-%t.out")
+    s += "--output {} ".format(remote_task_subdir / "logs" / "server-%A-%t.log")
 
     deployment_env_var_names = list(
         cfg.execution.get("env_vars", {}).get("deployment", {})
@@ -1439,7 +1439,7 @@ def _generate_haproxy_srun_command(cfg, remote_task_subdir):
     s += "--nodes 1 --ntasks 1 "
     s += f"--container-image {cfg.execution.get('proxy', {}).get('image', 'haproxy:latest')} "
     s += f"--container-mounts {remote_task_subdir}/proxy.cfg:/usr/local/etc/haproxy/haproxy.cfg:ro "
-    s += f"--output {remote_task_subdir}/logs/proxy-%A.out "
+    s += f"--output {remote_task_subdir}/logs/proxy-%A.log "
     s += "haproxy -f /usr/local/etc/haproxy/haproxy.cfg &\n"
     s += "PROXY_PID=$!  # capture the PID of the proxy background srun process\n"
     s += 'echo "Proxy started with PID: $PROXY_PID"\n\n'


### PR DESCRIPTION
Files with `.out` suffix are treated as binary and you cannot view them in MLFlow. `.log` files on the other hand are treated as text files and render correctly, e.g.:

<img width="1734" height="783" alt="image" src="https://github.com/user-attachments/assets/2963723d-ff61-4908-8584-0eead3c83698" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log file naming convention for SLURM operations to use `.log` extension instead of `.out`.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->