### PR TITLE
feat: add api_key_value field for literal API key support

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/api/api_dataclasses.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/api/api_dataclasses.py
@@ -54,6 +54,10 @@ class ApiEndpoint(BaseModel):
         description="Name of the environment variable that stores API key for the model",
         default=None,
     )
+    api_key_value: Optional[str] = Field(
+        description="Literal API key value for authentication. Use this to pass the API key directly instead of via an environment variable. Cannot be used together with 'api_key_name'.",
+        default=None,
+    )
     model_id: Optional[str] = Field(description="Name of the model", default=None)
     stream: Optional[bool] = Field(
         description="Whether responses should be streamed", default=None
@@ -74,8 +78,17 @@ class ApiEndpoint(BaseModel):
         if isinstance(values, dict):
             api_key = values.get("api_key")
             api_key_name = values.get("api_key_name")
+            api_key_value = values.get("api_key_value")
 
-            # If both are set, raise an error
+            # If both api_key_name and api_key_value are set, raise an error
+            if api_key_name is not None and api_key_value is not None:
+                raise ValueError(
+                    "Both 'api_key_name' and 'api_key_value' are set. "
+                    "Please use only one: 'api_key_name' for environment variable reference, "
+                    "or 'api_key_value' for a literal API key."
+                )
+
+            # If both api_key and api_key_name are set with different values, raise an error
             if (
                 api_key is not None
                 and api_key_name is not None
@@ -87,7 +100,7 @@ class ApiEndpoint(BaseModel):
                 )
 
             # If only api_key is set, copy to api_key_name and warn
-            if api_key is not None and api_key_name is None:
+            if api_key is not None and api_key_name is None and api_key_value is None:
                 warnings.warn(
                     "'api_key' is deprecated and will be removed in a future version. "
                     "Please use 'api_key_name' instead.",
@@ -106,6 +119,10 @@ class EndpointModelConfig(BaseModel):
     url: str = Field(description="Url of the model")
     api_key_name: Optional[str] = Field(
         description="Name of the env variable that stores API key", default=None
+    )
+    api_key_value: Optional[str] = Field(
+        description="Literal API key value for authentication. Cannot be used together with 'api_key_name'.",
+        default=None,
     )
     stream: Optional[bool] = Field(
         description="Whether responses should be streamed", default=None
@@ -127,6 +144,22 @@ class EndpointModelConfig(BaseModel):
     )
     # NOTE: we don't use extra yet but it will allow customization when needed
     extra: Optional[Dict[str, Any]] = Field(description="Extra", default=None)
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_api_key_fields(cls, values):
+        """Validate that api_key_name and api_key_value are mutually exclusive."""
+        if isinstance(values, dict):
+            api_key_name = values.get("api_key_name")
+            api_key_value = values.get("api_key_value")
+
+            if api_key_name is not None and api_key_value is not None:
+                raise ValueError(
+                    "Both 'api_key_name' and 'api_key_value' are set. "
+                    "Please use only one: 'api_key_name' for environment variable reference, "
+                    "or 'api_key_value' for a literal API key."
+                )
+        return values
 
 
 class EvaluationTarget(BaseModel):

--- a/packages/nemo-evaluator/tests/unit_tests/core/test_dataclasses.py
+++ b/packages/nemo-evaluator/tests/unit_tests/core/test_dataclasses.py
@@ -19,7 +19,7 @@ from datetime import datetime
 
 import pytest
 
-from nemo_evaluator.api.api_dataclasses import ApiEndpoint
+from nemo_evaluator.api.api_dataclasses import ApiEndpoint, EndpointModelConfig
 
 
 @pytest.mark.parametrize(
@@ -51,6 +51,63 @@ def test_api_key_deprecation(api_key, api_key_name):
             endpoint.api_key is None
         )
         assert (endpoint.api_key == api_key) or (endpoint.api_key is None)
+
+
+def test_api_key_value_field():
+    """Test that api_key_value field works correctly."""
+    # api_key_value can be set alone
+    endpoint = ApiEndpoint(api_key_value="sk-literal-key-123")
+    assert endpoint.api_key_value == "sk-literal-key-123"
+    assert endpoint.api_key_name is None
+
+    # api_key_name can be set alone
+    endpoint = ApiEndpoint(api_key_name="MY_API_KEY_ENV")
+    assert endpoint.api_key_name == "MY_API_KEY_ENV"
+    assert endpoint.api_key_value is None
+
+
+def test_api_key_value_and_api_key_name_mutually_exclusive():
+    """Test that api_key_value and api_key_name cannot be set together."""
+    with pytest.raises(
+        ValueError,
+        match="Both 'api_key_name' and 'api_key_value' are set",
+    ):
+        ApiEndpoint(api_key_name="MY_API_KEY_ENV", api_key_value="sk-literal-key")
+
+
+def test_endpoint_model_config_api_key_value():
+    """Test that api_key_value field works in EndpointModelConfig."""
+    # api_key_value can be set alone
+    config = EndpointModelConfig(
+        model_id="test-model",
+        url="http://localhost:8000",
+        api_key_value="sk-literal-key-123",
+    )
+    assert config.api_key_value == "sk-literal-key-123"
+    assert config.api_key_name is None
+
+    # api_key_name can be set alone
+    config = EndpointModelConfig(
+        model_id="test-model",
+        url="http://localhost:8000",
+        api_key_name="MY_API_KEY_ENV",
+    )
+    assert config.api_key_name == "MY_API_KEY_ENV"
+    assert config.api_key_value is None
+
+
+def test_endpoint_model_config_api_key_mutually_exclusive():
+    """Test that api_key_value and api_key_name cannot be set together in EndpointModelConfig."""
+    with pytest.raises(
+        ValueError,
+        match="Both 'api_key_name' and 'api_key_value' are set",
+    ):
+        EndpointModelConfig(
+            model_id="test-model",
+            url="http://localhost:8000",
+            api_key_name="MY_API_KEY_ENV",
+            api_key_value="sk-literal-key",
+        )
 
 
 def test_api_key_deprecation_removal_reminder():


### PR DESCRIPTION
The api_key/api_key_name fields were designed to hold environment variable names, not literal API keys. Users passing actual API keys directly would get 401 errors because the code tried to resolve them as env var names.

This adds api_key_value to ApiEndpoint and EndpointModelConfig that accepts a literal API key string directly. The two approaches are mutually exclusive with validation to prevent setting both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added option to provide API keys directly as literal values instead of only through environment variables.
  * Enhanced API key resolution with smart fallback: uses literal keys first, then environment variables, then defaults.
  * Added validation to prevent conflicting API key configurations.

* **Tests**
  * Expanded test coverage for API key configuration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->