### PR TITLE
feat: save original user-provided config in experiment's artifacts

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/api/types.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/api/types.py
@@ -81,6 +81,7 @@ class RunConfig(DictConfig):
                 version_base=None,
             )
         else:
+            config_path = None
             hydra.initialize_config_module(
                 config_module="nemo_evaluator_launcher.configs",
                 version_base=None,
@@ -93,6 +94,11 @@ class RunConfig(DictConfig):
         # Merge dict_overrides if provided
         if dict_overrides:
             cfg = OmegaConf.merge(cfg, dict_overrides)
+        if config_path:
+            is_struct = OmegaConf.is_struct(cfg)
+            OmegaConf.set_struct(cfg, False)
+            cfg.user_config_path = str(config_path)
+            OmegaConf.set_struct(cfg, is_struct)
 
         logger.debug(
             "Loaded run config from hydra",


### PR DESCRIPTION
The user-provided config is now stored with no overrides applied and pushed to MLFlow:
<img width="1484" height="974" alt="image" src="https://github.com/user-attachments/assets/26b58a10-fea3-414f-9a5a-75a5b5ce993d" />


Additionally this PR introduces:
  * Refactored command building to use list-based construction instead of string concatenation for better maintainability
  * Introduced constant for container results directory path to reduce hard-coded values
  * Enhanced debug output to include unresolved configuration details