### PR TITLE
ci: Add `release-docs` workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -73,4 +73,4 @@ jobs:
           akamai-client-secret: ${{ secrets.AKAMAI_CLIENT_SECRET }}
           akamai-access-token: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
           s3-target-root: ${{ secrets.S3_BUCKET_NAME }}
-          s3-target-path: nemo/megatron-bridge
+          s3-target-path: nemo/evaluator


### PR DESCRIPTION
This workflow will be launched manually via the `Actions` tab - it is called `Release docs`.

When launching it, we can select the branch of the docs we want to deploy via the dropdown menu. When deploying `main`, we will upload the docs to the `latest` directory of the webserver. If it's a versioned tag, it will strip off the version prefix `v` and upload it into the version folder of the webserver (e.g. `0.2.0`).   