### PR TITLE
fix(slurm): node_array undefined

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/container_metadata/registries.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/container_metadata/registries.py
@@ -27,6 +27,7 @@ import requests
 
 from nemo_evaluator_launcher.common.logging_utils import logger
 
+
 def _get_docker_config_path() -> pathlib.Path:
     """Return the effective Docker `config.json` path.
 
@@ -45,6 +46,7 @@ def _first_env_set(*names: str) -> tuple[Optional[str], Optional[str]]:
         if v:
             return v, n
     return None, None
+
 
 # Docker Registry API v2 manifest Accept header.
 # IMPORTANT: include *manifest list* / *OCI index* types so multi-arch tags return

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -436,6 +436,11 @@ class TestSlurmExecutorFeatures:
         assert "evaluation client" in script
         assert "--container-env EVAL_VAR" in script
 
+        # PRIMARY_NODE should be resolved even without deployment
+        assert "Resolve PRIMARY_NODE for single-node sruns" in script
+        assert 'export PRIMARY_NODE="${nodes_array[0]}"' in script
+        assert '--nodelist "${PRIMARY_NODE}" --nodes 1 --ntasks 1 ' in script
+
     def test_complex_configuration_integration(
         self, base_config, mock_task, mock_dependencies
     ):


### PR DESCRIPTION
## Summary

When running the launcher on Slurm with `deployment.type: none`, the generated sbatch script could fail at runtime with:

- `line N: nodes_array[0]: unbound variable`

This was triggered by `set -u` (nounset) and an unconditional `--nodelist ${nodes_array[0]}` in the evaluation client `srun`.

## Impact

- **Configs affected**: any Slurm run with `deployment.type=none` (e.g., “target-only” evaluation).
- **Failure mode**: sbatch script exits before launching the evaluation client.
- **Where observed**: Slurm job log (`slurm_script` / `slurm-%A.log`).



## Direct cause

- The sbatch script enables:
  - `set -u` (treat unset variables as an error)
- The evaluation client `srun` was emitted as:
  - `srun ... --nodelist ${nodes_array[0]} ...`
- `nodes_array` was only defined inside the deployment block (`if cfg.deployment.type != "none": ...`).
- Therefore, for `deployment.type=none`, `nodes_array` was undefined and `${nodes_array[0]}` crashed under nounset.

## Secondary risks (also addressed)

Even when deployment is enabled, `${nodes_array[0]}` can still fail if:

- `$SLURM_JOB_NODELIST` is unset/empty (non-standard environment) or only `$SLURM_NODELIST` is present.
- `scontrol` is unavailable on the node or not in `PATH`.
- `scontrol show hostnames ...` returns an empty list.

Any of these can result in an empty/unset array index under `set -u`.

## Solution

### Approach

Introduce a **single, always-defined** “node pinning” variable for single-node sruns:

- `PRIMARY_NODE`

This is resolved at runtime in the sbatch script with safe fallbacks:

1. Prefer `SLURM_JOB_NODELIST`
2. Fallback to `SLURM_NODELIST`
3. Fallback to local `hostname`

