### PR TITLE
ci: Fix integration test by avoid writing to read-only test directory

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -75,137 +75,137 @@ jobs:
           pre-commit install
           pre-commit run --all-files --show-diff-on-failure --color=always
 
-  # validate-container-digests:
-  #   runs-on: ubuntu-latest
-  #   needs: [pre-flight, linting]
-  #   if: |
-  #     (
-  #       needs.pre-flight.outputs.is_deployment_workflow == 'false'
-  #         && needs.pre-flight.outputs.is_ci_workload == 'true'
-  #     ) || (
-  #       needs.pre-flight.outputs.is_deployment_workflow == 'false'
-  #         && needs.pre-flight.outputs.is_ci_workload == 'false'
-  #         && needs.pre-flight.outputs.docs_only == 'false'
-  #     )
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: Setup Python
-  #       uses: actions/setup-python@v5
-  #       with:
-  #         python-version: "3.10"
-  #     - name: Install package dependencies
-  #       run: |
-  #         cd packages/nemo-evaluator-launcher
-  #         pip install -e .
-  #     - name: Validate container digests
-  #       run: |
-  #         make container-metadata-verify
+  validate-container-digests:
+    runs-on: ubuntu-latest
+    needs: [pre-flight, linting]
+    if: |
+      (
+        needs.pre-flight.outputs.is_deployment_workflow == 'false'
+          && needs.pre-flight.outputs.is_ci_workload == 'true'
+      ) || (
+        needs.pre-flight.outputs.is_deployment_workflow == 'false'
+          && needs.pre-flight.outputs.is_ci_workload == 'false'
+          && needs.pre-flight.outputs.docs_only == 'false'
+      )
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Install package dependencies
+        run: |
+          cd packages/nemo-evaluator-launcher
+          pip install -e .
+      - name: Validate container digests
+        run: |
+          make container-metadata-verify
 
-  # cicd-wait-in-queue:
-  #   runs-on: ubuntu-latest
-  #   needs: [pre-flight, linting, validate-container-digests]
-  #   environment: test
-  #   if: |
-  #     !(needs.pre-flight.outputs.is_ci_workload == 'true'
-  #     || needs.pre-flight.outputs.is_deployment_workflow == 'true'
-  #     || needs.pre-flight.outputs.docs_only == 'true')
-  #   steps:
-  #     - name: Running CI tests
-  #       run: |
-  #         echo "Running CI tests"
+  cicd-wait-in-queue:
+    runs-on: ubuntu-latest
+    needs: [pre-flight, linting, validate-container-digests]
+    environment: test
+    if: |
+      !(needs.pre-flight.outputs.is_ci_workload == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+      || needs.pre-flight.outputs.docs_only == 'true')
+    steps:
+      - name: Running CI tests
+        run: |
+          echo "Running CI tests"
 
-  # cicd-unit-tests-nemo-evaluator:
-  #   needs: [pre-flight, cicd-wait-in-queue, validate-container-digests]
-  #   runs-on: ubuntu-latest
-  #   name: unit-tests
-  #   environment: nemo-ci
-  #   if: |
-  #     (
-  #       success()
-  #       || needs.pre-flight.outputs.is_ci_workload == 'true'
-  #       || needs.pre-flight.outputs.force_run_all == 'true'
-  #     )
-  #     && !cancelled()
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: main
-  #       uses: ./.github/actions/test-template
-  #       with:
-  #         script: Launch_Unit_Tests
-  #         timeout: 10
-  #         type_of_test: "unit_tests"
-  #         cpu-only: true
-  #         package: nemo-evaluator
+  cicd-unit-tests-nemo-evaluator:
+    needs: [pre-flight, cicd-wait-in-queue, validate-container-digests]
+    runs-on: ubuntu-latest
+    name: unit-tests
+    environment: nemo-ci
+    if: |
+      (
+        success()
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || needs.pre-flight.outputs.force_run_all == 'true'
+      )
+      && !cancelled()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: main
+        uses: ./.github/actions/test-template
+        with:
+          script: Launch_Unit_Tests
+          timeout: 10
+          type_of_test: "unit_tests"
+          cpu-only: true
+          package: nemo-evaluator
 
-  # cicd-unit-tests-nemo-evaluator-launcher:
-  #   needs: [pre-flight, cicd-wait-in-queue, validate-container-digests]
-  #   runs-on: ubuntu-latest
-  #   name: unit-tests-launcher
-  #   environment: nemo-ci
-  #   if: |
-  #     (
-  #       success()
-  #       || needs.pre-flight.outputs.is_ci_workload == 'true'
-  #       || needs.pre-flight.outputs.force_run_all == 'true'
-  #     )
-  #     && !cancelled()
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: main
-  #       uses: ./.github/actions/test-template
-  #       with:
-  #         script: Launch_Unit_Tests
-  #         timeout: 10
-  #         type_of_test: "unit_tests"
-  #         cpu-only: true
-  #         package: nemo-evaluator-launcher
+  cicd-unit-tests-nemo-evaluator-launcher:
+    needs: [pre-flight, cicd-wait-in-queue, validate-container-digests]
+    runs-on: ubuntu-latest
+    name: unit-tests-launcher
+    environment: nemo-ci
+    if: |
+      (
+        success()
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || needs.pre-flight.outputs.force_run_all == 'true'
+      )
+      && !cancelled()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: main
+        uses: ./.github/actions/test-template
+        with:
+          script: Launch_Unit_Tests
+          timeout: 10
+          type_of_test: "unit_tests"
+          cpu-only: true
+          package: nemo-evaluator-launcher
 
-  # cicd-e2e-tests-nemo-evaluator:
-  #   needs:
-  #     [pre-flight, cicd-unit-tests-nemo-evaluator, validate-container-digests]
-  #   runs-on: ubuntu-latest
-  #   name: functional-tests
-  #   environment: nemo-ci
-  #   if: |
-  #     (
-  #       success()
-  #       || needs.pre-flight.outputs.is_ci_workload == 'true'
-  #       || needs.pre-flight.outputs.force_run_all == 'true'
-  #     )
-  #     && !cancelled()
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #     - name: main
-  #       uses: ./.github/actions/test-template
-  #       with:
-  #         script: Launch_Functional_Tests
-  #         timeout: ${{ matrix.timeout || 10 }}
-  #         type_of_test: "functional_tests"
-  #         cpu-only: true
-  #         package: nemo-evaluator
-  #         has-azure-credentials: true
-  #         azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-  #         azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-  #         azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  #         runner: ubuntu-latest
-  #         test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
+  cicd-e2e-tests-nemo-evaluator:
+    needs:
+      [pre-flight, cicd-unit-tests-nemo-evaluator, validate-container-digests]
+    runs-on: ubuntu-latest
+    name: functional-tests
+    environment: nemo-ci
+    if: |
+      (
+        success()
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || needs.pre-flight.outputs.force_run_all == 'true'
+      )
+      && !cancelled()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: main
+        uses: ./.github/actions/test-template
+        with:
+          script: Launch_Functional_Tests
+          timeout: ${{ matrix.timeout || 10 }}
+          type_of_test: "functional_tests"
+          cpu-only: true
+          package: nemo-evaluator
+          has-azure-credentials: true
+          azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          runner: ubuntu-latest
+          test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
 
   cicd-integration-tests:
     needs:
       - pre-flight
-      # - cicd-unit-tests-nemo-evaluator
+      - cicd-unit-tests-nemo-evaluator
     runs-on: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
-    # if: |
-    #   (
-    #     github.event_name == 'schedule'
-    #     || github.event_name == 'workflow_dispatch'
-    #     || (github.event_name == 'push' && github.ref == 'refs/heads/main')
-    #   )
-    #   && !cancelled()
+    if: |
+      (
+        github.event_name == 'schedule'
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      )
+      && !cancelled()
     name: integration-tests
     steps:
       - name: Checkout
@@ -223,125 +223,125 @@ jobs:
           test-data-path: ${{ needs.pre-flight.outputs.test_data_path }}
           runner: ${{ needs.pre-flight.outputs.runner_prefix }}-gpu-x2
 
-  # Nemo_CICD_Test:
-  #   needs:
-  #     - pre-flight
-  #     - cicd-unit-tests-nemo-evaluator
-  #     - cicd-unit-tests-nemo-evaluator-launcher
-  #     - cicd-e2e-tests-nemo-evaluator
-  #   if: |
-  #     (
-  #       needs.pre-flight.outputs.docs_only == 'true'
-  #       || needs.pre-flight.outputs.is_deployment_workflow == 'true'
-  #       || needs.pre-flight.outputs.is_ci_workload == 'true'
-  #       || always()
-  #     )
-  #     && !cancelled()
-  #   runs-on: ubuntu-latest
-  #   permissions: write-all
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
+  Nemo_CICD_Test:
+    needs:
+      - pre-flight
+      - cicd-unit-tests-nemo-evaluator
+      - cicd-unit-tests-nemo-evaluator-launcher
+      - cicd-e2e-tests-nemo-evaluator
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || always()
+      )
+      && !cancelled()
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  #     - name: Get workflow result
-  #       id: result
-  #       shell: bash -x -e -u -o pipefail {0}
-  #       env:
-  #         GH_TOKEN: ${{ github.token }}
-  #         RUN_ID: ${{ github.run_id }}
-  #         IS_CI_WORKLOAD: ${{ needs.pre-flight.outputs.is_ci_workload == 'true' }}
-  #         SKIPPING_IS_ALLOWED: ${{ needs.pre-flight.outputs.docs_only == 'true' || needs.pre-flight.outputs.is_deployment_workflow == 'true' || needs.pre-flight.outputs.is_ci_workload == 'true' }}
-  #       run: |
-  #         if [ "$IS_CI_WORKLOAD" == "true" ]; then
-  #           FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
-  #         else
-  #           FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success" and .name != "integration-tests")] | length') || echo 0
-  #         fi
-  #         if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
-  #             echo "✅ All previous jobs completed successfully"
-  #             exit 0
-  #         else
-  #             echo "❌ Found $FAILED_JOBS failed job(s)"
-  #             # Show which jobs failed
-  #             gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
-  #             exit 1
-  #         fi
+      - name: Get workflow result
+        id: result
+        shell: bash -x -e -u -o pipefail {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          IS_CI_WORKLOAD: ${{ needs.pre-flight.outputs.is_ci_workload == 'true' }}
+          SKIPPING_IS_ALLOWED: ${{ needs.pre-flight.outputs.docs_only == 'true' || needs.pre-flight.outputs.is_deployment_workflow == 'true' || needs.pre-flight.outputs.is_ci_workload == 'true' }}
+        run: |
+          if [ "$IS_CI_WORKLOAD" == "true" ]; then
+            FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
+          else
+            FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success" and .name != "integration-tests")] | length') || echo 0
+          fi
+          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
+              echo "✅ All previous jobs completed successfully"
+              exit 0
+          else
+              echo "❌ Found $FAILED_JOBS failed job(s)"
+              # Show which jobs failed
+              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              exit 1
+          fi
 
-  # Coverage_Fake:
-  #   runs-on: ubuntu-latest
-  #   needs: [Nemo_CICD_Test, pre-flight]
-  #   if: |
-  #     (
-  #       needs.pre-flight.outputs.docs_only == 'true'
-  #       || needs.pre-flight.outputs.is_deployment_workflow == 'true'
-  #     )
-  #     && needs.pre-flight.outputs.is_ci_workload == 'false'
-  #     && !cancelled()
-  #   environment: nemo-ci
-  #   steps:
-  #     - name: Generate fake coverage report
-  #       uses: actions/github-script@v6
-  #       with:
-  #         github-token: ${{ secrets.PAT }}
-  #         script: |
-  #           await github.rest.repos.createCommitStatus({
-  #             owner: context.repo.owner,
-  #             repo: context.repo.repo,
-  #             sha: context.sha,
-  #             state: 'success',
-  #             description: 'No code changes - coverage check skipped',
-  #             context: 'codecov/patch'
-  #           });
+  Coverage_Fake:
+    runs-on: ubuntu-latest
+    needs: [Nemo_CICD_Test, pre-flight]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+      )
+      && needs.pre-flight.outputs.is_ci_workload == 'false'
+      && !cancelled()
+    environment: nemo-ci
+    steps:
+      - name: Generate fake coverage report
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.PAT }}
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: context.sha,
+              state: 'success',
+              description: 'No code changes - coverage check skipped',
+              context: 'codecov/patch'
+            });
 
-  # Coverage:
-  #   runs-on: ubuntu-latest
-  #   needs: [Nemo_CICD_Test, pre-flight]
-  #   if: |
-  #     (
-  #       (needs.pre-flight.outputs.is_ci_workload == 'true' && !failure())
-  #       || success()
-  #     )
-  #     && !cancelled()
-  #   strategy:
-  #     matrix:
-  #       flag: [unit-test, e2e]
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
+  Coverage:
+    runs-on: ubuntu-latest
+    needs: [Nemo_CICD_Test, pre-flight]
+    if: |
+      (
+        (needs.pre-flight.outputs.is_ci_workload == 'true' && !failure())
+        || success()
+      )
+      && !cancelled()
+    strategy:
+      matrix:
+        flag: [unit-test, e2e]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  #     - name: Download coverage reports of current branch
-  #       uses: actions/download-artifact@v4
-  #       with:
-  #         pattern: coverage-${{ matrix.flag }}-*
-  #         merge-multiple: true
+      - name: Download coverage reports of current branch
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-${{ matrix.flag }}-*
+          merge-multiple: true
 
-  #     - name: List coverage files
-  #       run: find . -type f -name "*.xml" -o -name "*.lcov"
+      - name: List coverage files
+        run: find . -type f -name "*.xml" -o -name "*.lcov"
 
-  #     - name: Get total coverage of current branch
-  #       shell: bash -x -e -u -o pipefail {0}
-  #       if: always()
-  #       run: |
-  #         pip install coverage
+      - name: Get total coverage of current branch
+        shell: bash -x -e -u -o pipefail {0}
+        if: always()
+        run: |
+          pip install coverage
 
-  #         ls -al .
-  #         coverage combine --rcfile .github/config/.coveragerc
-  #         coverage report -i --rcfile .github/config/.coveragerc
-  #         coverage xml --rcfile .github/config/.coveragerc
-  #         rm -rf coverage-*
-  #         ls -al
+          ls -al .
+          coverage combine --rcfile .github/config/.coveragerc
+          coverage report -i --rcfile .github/config/.coveragerc
+          coverage xml --rcfile .github/config/.coveragerc
+          rm -rf coverage-*
+          ls -al
 
-  #     - name: Upload coverage reports to Codecov
-  #       uses: codecov/codecov-action@v5
-  #       with:
-  #         token: ${{ secrets.CODECOV_TOKEN }}
-  #         verbose: true
-  #         flags: ${{ matrix.flag }}
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          flags: ${{ matrix.flag }}
 
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: coverage-${{ matrix.flag }}-aggregated
-  #         path: |
-  #           .coverage
-  #         include-hidden-files: true
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.flag }}-aggregated
+          path: |
+            .coverage
+          include-hidden-files: true


### PR DESCRIPTION
ci: Fix integration test by copying test dataset to writable directory

In the AWS infra, our test directory is not writable. HF datasets unfortunately will always attempt to write a lock file even if the test data exists in the directory. This avoids that by copying the test datasets to a writable temp directory on the container. 

In other repos, sometimes mock the datasets.builder.FileLock object to also fix this problem. But it seems that the eval integration tests are called in a different process. So, it's not feasible to mock that object during the test. Fortunately, the test dataset is easy to copy over.

Successful run:
https://github.com/NVIDIA-NeMo/Evaluator/actions/runs/21506727996/job/61964385541