### PR TITLE
ci: Add secret detector

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -1,0 +1,207 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "pyproject\\.toml|\\.github/workflows/config/\\.secrets\\.baseline"
+      ]
+    }
+  ],
+  "results": {
+    "docs/_extensions/ai_assistant/core/AIClient.js": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/_extensions/ai_assistant/core/AIClient.js",
+        "hashed_secret": "54f034f9ba6c3f65758ffe3bb1264c5a836ce826",
+        "is_verified": false,
+        "line_number": 10
+      }
+    ],
+    "docs/_extensions/ai_assistant/core/main.js": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "docs/_extensions/ai_assistant/core/main.js",
+        "hashed_secret": "54f034f9ba6c3f65758ffe3bb1264c5a836ce826",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "packages/nemo-evaluator-launcher/examples/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/nemo-evaluator-launcher/examples/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml",
+        "hashed_secret": "a85b13313b8625a71cbee03550444030399f38a7",
+        "is_verified": false,
+        "line_number": 105
+      }
+    ],
+    "packages/nemo-evaluator-launcher/examples/nemotron/slurm_nvidia_nemotron_3_nano_30b_a3b_nvfp4.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/nemo-evaluator-launcher/examples/nemotron/slurm_nvidia_nemotron_3_nano_30b_a3b_nvfp4.yaml",
+        "hashed_secret": "a85b13313b8625a71cbee03550444030399f38a7",
+        "is_verified": false,
+        "line_number": 90
+      }
+    ],
+    "packages/nemo-evaluator-launcher/tests/unit_tests/conftest.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "packages/nemo-evaluator-launcher/tests/unit_tests/conftest.py",
+        "hashed_secret": "6740d1ecb48c5c9ca3b2a3cb1ca2f4b4d4487473",
+        "is_verified": false,
+        "line_number": 509
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "packages/nemo-evaluator-launcher/tests/unit_tests/conftest.py",
+        "hashed_secret": "59ea3d29c84b5c2b23f5d6eccf3f3e0d1cb07ccd",
+        "is_verified": false,
+        "line_number": 530
+      }
+    ],
+    "packages/nemo-evaluator-launcher/tests/unit_tests/test_logging_utils.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "packages/nemo-evaluator-launcher/tests/unit_tests/test_logging_utils.py",
+        "hashed_secret": "6740d1ecb48c5c9ca3b2a3cb1ca2f4b4d4487473",
+        "is_verified": false,
+        "line_number": 179
+      }
+    ],
+    "packages/nemo-evaluator/examples/notebooks/contamination_detection_demo.ipynb": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/nemo-evaluator/examples/notebooks/contamination_detection_demo.ipynb",
+        "hashed_secret": "60c84cb0ed4b2ee9015794ddc9535404c2b7d6f7",
+        "is_verified": false,
+        "line_number": 745
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "packages/nemo-evaluator/examples/notebooks/contamination_detection_demo.ipynb",
+        "hashed_secret": "8fb2066cd49291e88e2c4790d2ff8b387444655e",
+        "is_verified": false,
+        "line_number": 1134
+      }
+    ]
+  },
+  "generated_at": "2026-01-30T23:13:55Z"
+}

--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Secrets detector
+
+on:
+  pull_request:
+
+jobs:
+  # To rebuild the baseline, run:
+  # detect-secrets scan \
+  #   --exclude-files 'pyproject\.toml|\.github/workflows/config/\.secrets\.baseline' \
+  #   --disable-plugin KeywordDetector > .github/workflows/config/.secrets.baseline
+  #
+  # The KeywordDetector in this repo yields too many false positives.
+  secrets-detector:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_secrets-detector.yml@v0.70.0


### PR DESCRIPTION
ci: Add secret detector

This uses https://github.com/Yelp/detect-secrets to identify potential secrets.  On failure, a message will be shown to help recreate the secrets baseline if there is a false positive.