### PR TITLE
feat(slurm): add launcher_install_cmd option for custom auto-export installation

### DIFF
--- a/packages/nemo-evaluator-launcher/examples/local_auto_export.yaml
+++ b/packages/nemo-evaluator-launcher/examples/local_auto_export.yaml
@@ -37,6 +37,11 @@ execution:
   # Auto-export destinations
   auto_export:
     destinations: ["mlflow"]
+    # Optional: custom command to install nemo-evaluator-launcher in the export container.
+    # Useful for installing from a git branch or specific version. Supports multi-line.
+    # launcher_install_cmd: |
+    #   apt-get update -qq && apt-get install -qq -y git
+    #   pip install "nemo-evaluator-launcher[all] @ git+https://github.com/NVIDIA-NeMo/Evaluator.git@main#subdirectory=packages/nemo-evaluator-launcher"
 
 target:
   api_endpoint:


### PR DESCRIPTION
## Summary

Adds a new `launcher_install_cmd` option to the SLURM auto-export configuration, allowing full customization of how nemo-evaluator-launcher is installed in the export container.

## Motivation

The default `pip install nemo-evaluator-launcher[all]` may not work when:
- Testing unreleased features from a git branch
- The export container (python:slim) lacks git for `git+` URLs
- Custom dependencies or setup commands are needed

## Usage

```
auto_export:
  destinations: ["mlflow"]
  launcher_install_cmd: |
    apt-get update -qq && apt-get install -qq -y git
    pip install "nemo-evaluator-launcher[all] @ git+https://github.com/NVIDIA-NeMo/Evaluator.git@main#subdirectory=packages/nemo-evaluator-launcher"
```