### PR TITLE
feat(results): enhance report generation pipeline and fix incomplete reports

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/analyze.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/analyze.py
@@ -1,0 +1,693 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Analyze evaluation artifacts and generate a rich HTML report."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from html import escape
+from pathlib import Path
+from typing import Any, Iterable
+
+from simple_parsing import field
+
+
+def _load_json(path: Path) -> Any:
+    if not path.exists():
+        return None
+    try:
+        import json
+
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        from omegaconf import OmegaConf
+
+        data = OmegaConf.load(path)
+        return OmegaConf.to_container(data, resolve=True) or {}
+    except Exception:
+        return {}
+
+
+def _get_nested(data: dict[str, Any], keys: Iterable[str]) -> Any:
+    current: Any = data
+    for key in keys:
+        if not isinstance(current, dict) or key not in current:
+            return None
+        current = current[key]
+    return current
+
+
+def _flatten_metrics(data: Any, prefix: str = "") -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if isinstance(data, dict):
+        if "value" in data and isinstance(data["value"], (int, float, str)):
+            rows.append(
+                {
+                    "path": prefix.rstrip("."),
+                    "value": data.get("value"),
+                    "stats": data.get("stats"),
+                }
+            )
+        for key, value in data.items():
+            next_prefix = f"{prefix}{key}."
+            rows.extend(_flatten_metrics(value, next_prefix))
+    elif isinstance(data, list):
+        for idx, value in enumerate(data):
+            next_prefix = f"{prefix}{idx}."
+            rows.extend(_flatten_metrics(value, next_prefix))
+    return rows
+
+
+def _flatten_numeric(data: Any, prefix: str = "") -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if isinstance(data, dict):
+        for key, value in data.items():
+            next_prefix = f"{prefix}{key}."
+            if isinstance(value, (int, float)):
+                rows.append({"path": next_prefix.rstrip("."), "value": value})
+            else:
+                rows.extend(_flatten_numeric(value, next_prefix))
+    elif isinstance(data, list):
+        for idx, value in enumerate(data):
+            next_prefix = f"{prefix}{idx}."
+            rows.extend(_flatten_numeric(value, next_prefix))
+    return rows
+
+
+def _format_value(value: Any) -> str:
+    if value is None:
+        return "-"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+def _format_bytes(size: int) -> str:
+    for unit in ["B", "KB", "MB", "GB"]:
+        if size < 1024:
+            return f"{size:.0f} {unit}"
+        size = size / 1024
+    return f"{size:.0f} TB"
+
+def _safe_json_dumps(data: Any) -> str:
+    try:
+        import json
+
+        return json.dumps(data, ensure_ascii=False)
+    except Exception:
+        return str(data)
+
+
+def _detect_request_type(request_content: Any) -> str:
+    if isinstance(request_content, dict):
+        if "messages" in request_content:
+            return "chat"
+        if "prompt" in request_content:
+            return "completion"
+    return "unknown"
+
+
+def _extract_finish_reasons(response_content: Any) -> list[str]:
+    reasons: list[str] = []
+    if isinstance(response_content, dict):
+        choices = response_content.get("choices") or []
+        for choice in choices:
+            if isinstance(choice, dict):
+                reason = choice.get("finish_reason")
+                if reason:
+                    reasons.append(str(reason))
+    return reasons
+
+
+def _extract_usage_from_entry(entry: dict[str, Any]) -> dict[str, Any]:
+    usage = entry.get("usage")
+    if isinstance(usage, dict):
+        return usage
+    response = entry.get("response")
+    if isinstance(response, dict):
+        usage = response.get("usage")
+        if isinstance(usage, dict):
+            return usage
+    return {}
+
+
+def _has_error(entry: dict[str, Any]) -> bool:
+    if entry.get("has_error"):
+        return True
+    response = entry.get("response")
+    if isinstance(response, dict):
+        return "error" in response or "errors" in response
+    return False
+
+
+def _has_tool_calls(entry: dict[str, Any]) -> bool:
+    if entry.get("has_tool_calls"):
+        return True
+    response = entry.get("response")
+    if not isinstance(response, dict):
+        return False
+    choices = response.get("choices") or []
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        if choice.get("tool_calls") or choice.get("function_call"):
+            return True
+        message = choice.get("message")
+        if isinstance(message, dict):
+            if message.get("tool_calls") or message.get("function_call"):
+                return True
+    return False
+
+
+def _render_table(headers: list[str], rows: list[list[str]]) -> str:
+    if not rows:
+        return "<div class=\"empty\">No data available.</div>"
+    header_html = "".join(f"<th>{escape(h)}</th>" for h in headers)
+    body_html = ""
+    for row in rows:
+        cells = "".join(f"<td>{escape(cell)}</td>" for cell in row)
+        body_html += f"<tr>{cells}</tr>"
+    return f"""
+    <table>
+        <thead><tr>{header_html}</tr></thead>
+        <tbody>{body_html}</tbody>
+    </table>
+    """
+
+
+def _render_key_value(items: list[tuple[str, str]]) -> str:
+    if not items:
+        return "<div class=\"empty\">No summary details available.</div>"
+    rows = "".join(
+        f"<div class=\"kv\"><span>{escape(k)}</span><strong>{escape(v)}</strong></div>"
+        for k, v in items
+    )
+    return f"<div class=\"kv-grid\">{rows}</div>"
+
+
+def _render_samples(samples: list[dict[str, Any]]) -> str:
+    if not samples:
+        return "<div class=\"empty\">No samples found in report.json.</div>"
+    def _pretty(value: Any) -> str:
+        try:
+            import json
+
+            if isinstance(value, (dict, list)):
+                return json.dumps(value, indent=2, ensure_ascii=False)
+        except Exception:
+            pass
+        return _format_value(value)
+
+    entries_html = ""
+    for idx, entry in enumerate(samples, start=1):
+        cache_key = escape(str(entry.get("cache_key", "-")))
+        request = escape(_pretty(entry.get("request_data")))
+        response = escape(_pretty(entry.get("response")))
+        entries_html += f"""
+        <div class="entry">
+            <div class="entry-head">
+                <span class="pill">Sample {idx}</span>
+                <span class="muted">Cache Key: <strong>{cache_key}</strong></span>
+            </div>
+            <div class="block">
+                <div class="block-title">Request</div>
+                <pre>{request}</pre>
+            </div>
+            <div class="block">
+                <div class="block-title">Response</div>
+                <pre>{response}</pre>
+            </div>
+        </div>
+        """
+    return entries_html
+
+
+def render_analysis_html(payload: dict[str, Any]) -> str:
+    summary_html = _render_key_value(payload.get("summary", []))
+    stats_html = _render_key_value(payload.get("stats", []))
+    metrics_table = _render_table(
+        ["Metric Path", "Value", "Stats"],
+        payload.get("metrics_rows", []),
+    )
+    perf_table = _render_table(
+        ["Metric Path", "Value"],
+        payload.get("perf_rows", []),
+    )
+    artifacts_table = _render_table(
+        ["Artifact", "Size"],
+        payload.get("artifact_rows", []),
+    )
+    finish_table = _render_table(
+        ["Finish Reason", "Count"],
+        payload.get("finish_rows", []),
+    )
+    samples_html = _render_samples(payload.get("samples", []))
+    raw_results = payload.get("raw_results", "")
+    raw_run_config = payload.get("raw_run_config", "")
+    raw_eval_metrics = payload.get("raw_eval_metrics", "")
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Evaluation Analysis</title>
+  <style>
+    :root {{
+      --bg: #0f1116;
+      --panel: #141824;
+      --panel-2: #10131b;
+      --text: #e8ecf1;
+      --muted: #9aa6b2;
+      --accent: #6f9bff;
+      --accent-2: #60d394;
+      --border: rgba(255, 255, 255, 0.08);
+      --shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+    }}
+    body {{
+      font-family: "Space Grotesk", "IBM Plex Sans", "Source Sans 3", sans-serif;
+      margin: 0;
+      padding: 30px;
+      color: var(--text);
+      background: radial-gradient(1200px 700px at 15% -20%, #1e2a3b 0%, rgba(15, 17, 22, 0) 65%),
+                  radial-gradient(900px 900px at 110% 10%, #1f2440 0%, rgba(15, 17, 22, 0) 60%),
+                  var(--bg);
+    }}
+    h1 {{
+      margin: 0 0 6px;
+      font-size: 2.2rem;
+    }}
+    .subtitle {{
+      color: var(--muted);
+      margin-bottom: 22px;
+    }}
+    .section {{
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 14px;
+      padding: 18px 20px;
+      margin-bottom: 18px;
+      box-shadow: var(--shadow);
+    }}
+    .section h2 {{
+      margin: 0 0 12px;
+      font-size: 1.2rem;
+    }}
+    .kv-grid {{
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 12px;
+    }}
+    .kv {{
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 12px 14px;
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }}
+    .kv span {{
+      color: var(--muted);
+      font-size: 0.82rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }}
+    .kv strong {{
+      font-size: 1rem;
+    }}
+    table {{
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.9rem;
+    }}
+    th, td {{
+      text-align: left;
+      padding: 10px 8px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+      word-break: break-word;
+    }}
+    th {{
+      color: var(--muted);
+      font-size: 0.78rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }}
+    .empty {{
+      color: var(--muted);
+      padding: 18px;
+      border: 1px dashed var(--border);
+      border-radius: 10px;
+      text-align: center;
+    }}
+    .entry {{
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 14px;
+      margin-bottom: 12px;
+    }}
+    .entry-head {{
+      display: flex;
+      gap: 10px;
+      align-items: center;
+      margin-bottom: 10px;
+      flex-wrap: wrap;
+    }}
+    .pill {{
+      background: rgba(111, 155, 255, 0.2);
+      color: var(--accent);
+      border: 1px solid rgba(111, 155, 255, 0.35);
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 0.78rem;
+    }}
+    .muted {{
+      color: var(--muted);
+      font-size: 0.86rem;
+    }}
+    .block {{
+      background: #0c0f16;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      padding: 10px 12px;
+      margin-bottom: 8px;
+    }}
+    details {{
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 10px 12px;
+      margin-top: 12px;
+      background: var(--panel-2);
+    }}
+    details summary {{
+      cursor: pointer;
+      color: var(--accent-2);
+      font-weight: 600;
+    }}
+    .block-title {{
+      color: var(--muted);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      margin-bottom: 6px;
+    }}
+    pre {{
+      white-space: pre-wrap;
+      word-break: break-word;
+      margin: 0;
+      font-family: "IBM Plex Mono", "SFMono-Regular", ui-monospace, monospace;
+      font-size: 0.82rem;
+      color: #d9e2ef;
+    }}
+    @media (max-width: 720px) {{
+      body {{
+        padding: 20px;
+      }}
+      h1 {{
+        font-size: 1.8rem;
+      }}
+    }}
+  </style>
+</head>
+<body>
+  <h1>Evaluation Analysis</h1>
+  <div class="subtitle">Post-run insights from evaluation artifacts.</div>
+
+  <div class="section">
+    <h2>Run Summary</h2>
+    {summary_html}
+  </div>
+
+  <div class="section">
+    <h2>Sample Stats</h2>
+    {stats_html}
+  </div>
+
+  <div class="section">
+    <h2>Score Metrics</h2>
+    {metrics_table}
+  </div>
+
+  <div class="section">
+    <h2>Performance Metrics</h2>
+    {perf_table}
+  </div>
+
+  <div class="section">
+    <h2>Artifacts</h2>
+    {artifacts_table}
+    {f'''<details><summary>Raw results.yml</summary><pre>{escape(raw_results)}</pre></details>''' if raw_results else ''}
+    {f'''<details><summary>Raw run_config.yml</summary><pre>{escape(raw_run_config)}</pre></details>''' if raw_run_config else ''}
+    {f'''<details><summary>Raw eval_factory_metrics.json</summary><pre>{escape(raw_eval_metrics)}</pre></details>''' if raw_eval_metrics else ''}
+  </div>
+
+  <div class="section">
+    <h2>Finish Reasons</h2>
+    {finish_table}
+  </div>
+
+  <div class="section">
+    <h2>Sample Interactions</h2>
+    {samples_html}
+  </div>
+</body>
+</html>
+"""
+
+
+@dataclass
+class Cmd:
+    """Generate an HTML analysis report from a task artifacts directory."""
+
+    artifacts_dir: str = field(
+        positional=True,
+        help="Path to a task artifacts directory (contains results.yml, report.json, eval_factory_metrics.json).",
+    )
+    output: str | None = field(
+        default=None,
+        alias=["--output", "-o"],
+        help="Output HTML path (default: <artifacts_dir>/analysis.html).",
+    )
+    sample_limit: int = field(
+        default=20,
+        alias=["--sample-limit"],
+        help="Maximum number of sample interactions to include (default: 20).",
+    )
+
+    def execute(self) -> None:
+        artifacts_dir = Path(self.artifacts_dir).expanduser()
+        if not artifacts_dir.exists():
+            print(f"Error: artifacts_dir not found: {artifacts_dir}")
+            return
+
+        output_path = (
+            Path(self.output).expanduser()
+            if self.output
+            else artifacts_dir / "analysis.html"
+        )
+
+        results_path = artifacts_dir / "results.yml"
+        run_config_path = artifacts_dir / "run_config.yml"
+        metrics_path = artifacts_dir / "eval_factory_metrics.json"
+        report_path = artifacts_dir / "report.json"
+
+        results = _load_yaml(results_path)
+        run_config = _load_yaml(run_config_path)
+        eval_metrics = _load_json(metrics_path) or {}
+        report_entries = _load_json(report_path) or []
+
+        raw_results = results_path.read_text(encoding="utf-8") if results_path.exists() else ""
+        raw_run_config = (
+            run_config_path.read_text(encoding="utf-8") if run_config_path.exists() else ""
+        )
+        raw_eval_metrics = ""
+        if metrics_path.exists():
+            try:
+                raw_eval_metrics = json.dumps(eval_metrics, indent=2, ensure_ascii=False)
+            except Exception:
+                raw_eval_metrics = metrics_path.read_text(encoding="utf-8")
+
+        if not isinstance(report_entries, list):
+            report_entries = []
+
+        sample_count = len(report_entries)
+        error_count = sum(1 for entry in report_entries if _has_error(entry))
+        tool_count = sum(1 for entry in report_entries if _has_tool_calls(entry))
+        model_set = sorted(
+            {entry.get("model") for entry in report_entries if entry.get("model")}
+        )
+        request_type_counts: dict[str, int] = {}
+        finish_reason_counts: dict[str, int] = {}
+        usage_totals = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+        request_char_sum = 0
+        response_char_sum = 0
+
+        for entry in report_entries:
+            request_type = entry.get("request_type") or _detect_request_type(
+                entry.get("request_data")
+            )
+            request_type_counts[request_type] = request_type_counts.get(request_type, 0) + 1
+            for reason in entry.get("finish_reasons") or _extract_finish_reasons(
+                entry.get("response")
+            ):
+                finish_reason_counts[reason] = finish_reason_counts.get(reason, 0) + 1
+
+            usage = _extract_usage_from_entry(entry)
+            for key in usage_totals:
+                value = usage.get(key)
+                if isinstance(value, (int, float)):
+                    usage_totals[key] += value
+
+            req_chars = entry.get("request_chars")
+            if not isinstance(req_chars, int):
+                req_chars = len(_safe_json_dumps(entry.get("request_data")))
+            request_char_sum += req_chars
+
+            resp_chars = entry.get("response_chars")
+            if not isinstance(resp_chars, int):
+                resp_chars = len(_safe_json_dumps(entry.get("response")))
+            response_char_sum += resp_chars
+
+        summary_items: list[tuple[str, str]] = []
+        summary_items.append(("Artifacts Dir", str(artifacts_dir)))
+        summary_items.append(("Results File", str(results_path) if results else "-"))
+        summary_items.append(("Report File", str(report_path) if report_entries else "-"))
+
+        command = _get_nested(results, ["command"])
+        if command:
+            summary_items.append(("Command", str(command)))
+
+        git_hash = _get_nested(results, ["git_hash"])
+        if git_hash:
+            summary_items.append(("Git Hash", str(git_hash)))
+
+        model_id = _get_nested(results, ["target", "api_endpoint", "model_id"])
+        if not model_id:
+            model_id = _get_nested(run_config, ["target", "api_endpoint", "model_id"])
+        if model_id:
+            summary_items.append(("Model ID", str(model_id)))
+
+        endpoint = _get_nested(results, ["target", "api_endpoint", "url"])
+        if not endpoint:
+            endpoint = _get_nested(run_config, ["target", "api_endpoint", "url"])
+        if endpoint:
+            summary_items.append(("Endpoint", str(endpoint)))
+
+        task_name = _get_nested(run_config, ["task", "name"])
+        if not task_name:
+            task_name = _get_nested(run_config, ["task", "task_name"])
+        if task_name:
+            summary_items.append(("Task", str(task_name)))
+        if model_set:
+            summary_items.append(("Models", ", ".join(model_set)))
+
+        metrics_rows = []
+        results_metrics = _get_nested(results, ["results"])
+        if isinstance(results_metrics, dict):
+            for row in _flatten_metrics(results_metrics):
+                metrics_rows.append(
+                    [
+                        row.get("path", "-"),
+                        _format_value(row.get("value")),
+                        _format_value(row.get("stats")),
+                    ]
+                )
+
+        perf_rows = []
+        if isinstance(eval_metrics, dict):
+            for row in _flatten_numeric(eval_metrics):
+                perf_rows.append([row.get("path", "-"), _format_value(row.get("value"))])
+
+        artifact_rows: list[list[str]] = []
+        for child in sorted(artifacts_dir.iterdir()):
+            if child.is_file():
+                size = child.stat().st_size
+                artifact_rows.append([child.name, _format_bytes(size)])
+            elif child.is_dir():
+                try:
+                    count = sum(1 for _ in child.iterdir())
+                except Exception:
+                    count = 0
+                artifact_rows.append([f"{child.name}/", f"{count} items"])
+
+        report_entries = report_entries[: self.sample_limit]
+
+        stats_items: list[tuple[str, str]] = []
+        stats_items.append(("Samples", str(sample_count)))
+        stats_items.append(
+            ("Errors", f"{error_count} ({(error_count / sample_count * 100):.1f}%)")
+            if sample_count
+            else ("Errors", "0")
+        )
+        stats_items.append(
+            ("Tool Calls", f"{tool_count} ({(tool_count / sample_count * 100):.1f}%)")
+            if sample_count
+            else ("Tool Calls", "0")
+        )
+        if sample_count:
+            stats_items.append(
+                ("Avg Request Chars", f"{request_char_sum / sample_count:.0f}")
+            )
+            stats_items.append(
+                ("Avg Response Chars", f"{response_char_sum / sample_count:.0f}")
+            )
+        if any(usage_totals.values()):
+            stats_items.append(
+                (
+                    "Tokens (prompt / completion / total)",
+                    f"{usage_totals['prompt_tokens']} / {usage_totals['completion_tokens']} / {usage_totals['total_tokens']}",
+                )
+            )
+        if request_type_counts:
+            request_type_summary = ", ".join(
+                f"{key}:{value}" for key, value in sorted(request_type_counts.items())
+            )
+            stats_items.append(("Request Types", request_type_summary))
+
+        finish_rows = [
+            [reason, str(count)]
+            for reason, count in sorted(
+                finish_reason_counts.items(), key=lambda x: (-x[1], x[0])
+            )
+        ]
+
+        payload = {
+            "summary": summary_items,
+            "stats": stats_items,
+            "metrics_rows": metrics_rows,
+            "perf_rows": perf_rows,
+            "artifact_rows": artifact_rows,
+            "samples": report_entries,
+            "finish_rows": finish_rows,
+            "raw_results": raw_results,
+            "raw_run_config": raw_run_config,
+            "raw_eval_metrics": raw_eval_metrics,
+        }
+
+        html_content = render_analysis_html(payload)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(html_content, encoding="utf-8")
+
+        print(f"Analysis report written to: {output_path}")

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/main.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/main.py
@@ -19,6 +19,7 @@ import os
 
 from simple_parsing import ArgumentParser
 
+import nemo_evaluator_launcher.cli.analyze as analyze
 import nemo_evaluator_launcher.cli.export as export
 import nemo_evaluator_launcher.cli.info as info
 import nemo_evaluator_launcher.cli.kill as kill
@@ -52,6 +53,7 @@ def is_verbose_enabled(args) -> bool:
         "runs",
         "task",
         "export",
+        "analyze",
     ]
     for subcmd in subcommands:
         if hasattr(args, subcmd) and hasattr(getattr(args, subcmd), "verbose"):
@@ -183,6 +185,14 @@ def create_parser() -> ArgumentParser:
     )
     export_parser.add_arguments(export.ExportCmd, dest="export")
 
+    # Analyze subcommand
+    analyze_parser = subparsers.add_parser(
+        "analyze",
+        help="Generate an HTML analysis report from artifacts",
+        description="Generate a post-evaluation analysis report from a task artifacts directory",
+    )
+    analyze_parser.add_arguments(analyze.Cmd, dest="analyze")
+
     # Info subcommand
     info_parser = subparsers.add_parser(
         "info",
@@ -245,6 +255,8 @@ def main() -> None:
             args.runs.execute()
     elif args.command == "export":
         args.export.execute()
+    elif args.command == "analyze":
+        args.analyze.execute()
     elif args.command == "info":
         args.info.execute()
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/main.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/main.py
@@ -20,6 +20,7 @@ import os
 from simple_parsing import ArgumentParser
 
 import nemo_evaluator_launcher.cli.analyze as analyze
+import nemo_evaluator_launcher.cli.view as view
 import nemo_evaluator_launcher.cli.export as export
 import nemo_evaluator_launcher.cli.info as info
 import nemo_evaluator_launcher.cli.kill as kill
@@ -54,6 +55,7 @@ def is_verbose_enabled(args) -> bool:
         "task",
         "export",
         "analyze",
+        "view",
     ]
     for subcmd in subcommands:
         if hasattr(args, subcmd) and hasattr(getattr(args, subcmd), "verbose"):
@@ -193,6 +195,14 @@ def create_parser() -> ArgumentParser:
     )
     analyze_parser.add_arguments(analyze.Cmd, dest="analyze")
 
+    # View subcommand
+    view_parser = subparsers.add_parser(
+        "view",
+        help="Start a local viewer for evaluation logs and reports",
+        description="Start a lightweight local web viewer for NeMo Evaluator runs",
+    )
+    view_parser.add_arguments(view.Cmd, dest="view")
+
     # Info subcommand
     info_parser = subparsers.add_parser(
         "info",
@@ -257,6 +267,8 @@ def main() -> None:
         args.export.execute()
     elif args.command == "analyze":
         args.analyze.execute()
+    elif args.command == "view":
+        args.view.execute()
     elif args.command == "info":
         args.info.execute()
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/view.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/view.py
@@ -1,0 +1,519 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Run a lightweight log viewer for NeMo Evaluator results."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import json
+import os
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+from simple_parsing import field
+
+
+HTML_PAGE = """<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NeMo Evaluator Viewer</title>
+  <style>
+    :root {
+      --bg: #0f1116;
+      --panel: #141824;
+      --panel-2: #10131b;
+      --text: #e8ecf1;
+      --muted: #9aa6b2;
+      --accent: #6f9bff;
+      --border: rgba(255, 255, 255, 0.08);
+      --shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+    }
+    body {
+      margin: 0;
+      font-family: "Space Grotesk", "IBM Plex Sans", "Source Sans 3", sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      height: 100vh;
+      display: grid;
+      grid-template-columns: 280px 1fr;
+    }
+    .sidebar {
+      background: var(--panel);
+      border-right: 1px solid var(--border);
+      padding: 16px;
+      overflow-y: auto;
+    }
+    .main {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+    h1 {
+      font-size: 1.2rem;
+      margin: 0 0 8px;
+    }
+    .list {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      margin-bottom: 16px;
+    }
+    .item {
+      padding: 8px 10px;
+      border-radius: 10px;
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      cursor: pointer;
+      font-size: 0.85rem;
+      color: var(--text);
+    }
+    .item.active {
+      background: var(--accent);
+      color: #0b0f14;
+      border-color: rgba(111, 155, 255, 0.6);
+    }
+    .toolbar {
+      display: flex;
+      gap: 8px;
+      padding: 10px 14px;
+      background: var(--panel);
+      border-bottom: 1px solid var(--border);
+      align-items: center;
+    }
+    .select {
+      background: var(--panel-2);
+      border: 1px solid var(--border);
+      color: var(--text);
+      padding: 6px 10px;
+      border-radius: 8px;
+      font-size: 0.85rem;
+    }
+    .tabs {
+      display: flex;
+      gap: 8px;
+      padding: 8px 14px;
+      background: var(--panel);
+      border-bottom: 1px solid var(--border);
+    }
+    .tab {
+      padding: 6px 12px;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--panel-2);
+      color: var(--text);
+      cursor: pointer;
+      font-size: 0.85rem;
+    }
+    .tab.active {
+      background: var(--accent);
+      color: #0b0f14;
+    }
+    .content {
+      flex: 1;
+      overflow: hidden;
+    }
+    .pane {
+      display: none;
+      height: 100%;
+    }
+    .pane.active {
+      display: block;
+    }
+    iframe {
+      border: 0;
+      width: 100%;
+      height: 100%;
+    }
+    pre {
+      margin: 0;
+      padding: 16px;
+      color: var(--text);
+      font-family: "IBM Plex Mono", ui-monospace, monospace;
+      font-size: 0.82rem;
+      white-space: pre-wrap;
+    }
+    .empty {
+      padding: 24px;
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <aside class="sidebar">
+    <h1>Runs</h1>
+    <div id="runList" class="list"></div>
+    <h1>Tasks</h1>
+    <div id="taskList" class="list"></div>
+  </aside>
+  <main class="main">
+    <div class="toolbar">
+      <select id="runSelect" class="select"></select>
+      <select id="taskSelect" class="select"></select>
+      <span id="status" style="color: var(--muted); font-size: 0.85rem;"></span>
+    </div>
+    <div class="tabs">
+      <button class="tab active" data-pane="reportPane">Report</button>
+      <button class="tab" data-pane="logsPane">Logs</button>
+      <button class="tab" data-pane="rawPane">Raw</button>
+    </div>
+    <div class="content">
+      <div id="reportPane" class="pane active">
+        <iframe id="reportFrame" src=""></iframe>
+      </div>
+      <div id="logsPane" class="pane">
+        <div class="toolbar">
+          <select id="logSelect" class="select"></select>
+        </div>
+        <pre id="logOutput" class="empty">Select a log file.</pre>
+      </div>
+      <div id="rawPane" class="pane">
+        <pre id="rawOutput" class="empty">Select a task to view raw files.</pre>
+      </div>
+    </div>
+  </main>
+  <script>
+    const runList = document.getElementById('runList');
+    const taskList = document.getElementById('taskList');
+    const runSelect = document.getElementById('runSelect');
+    const taskSelect = document.getElementById('taskSelect');
+    const status = document.getElementById('status');
+    const reportFrame = document.getElementById('reportFrame');
+    const logSelect = document.getElementById('logSelect');
+    const logOutput = document.getElementById('logOutput');
+    const rawOutput = document.getElementById('rawOutput');
+    const tabs = document.querySelectorAll('.tab');
+    const panes = document.querySelectorAll('.pane');
+
+    async function fetchJson(url) {
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(await res.text());
+      return await res.json();
+    }
+
+    function setActive(list, value) {
+      list.querySelectorAll('.item').forEach((el) => {
+        if (el.dataset.value === value) el.classList.add('active');
+        else el.classList.remove('active');
+      });
+    }
+
+    async function loadRuns() {
+      const data = await fetchJson('/api/runs');
+      runList.innerHTML = '';
+      runSelect.innerHTML = '';
+      data.runs.forEach((run) => {
+        const item = document.createElement('div');
+        item.className = 'item';
+        item.textContent = run;
+        item.dataset.value = run;
+        item.onclick = () => selectRun(run);
+        runList.appendChild(item);
+        const opt = document.createElement('option');
+        opt.value = run;
+        opt.textContent = run;
+        runSelect.appendChild(opt);
+      });
+      if (data.runs.length) {
+        selectRun(data.runs[0]);
+      }
+    }
+
+    async function selectRun(run) {
+      runSelect.value = run;
+      setActive(runList, run);
+      status.textContent = `Run: ${run}`;
+      const data = await fetchJson(`/api/run/${encodeURIComponent(run)}/tasks`);
+      taskList.innerHTML = '';
+      taskSelect.innerHTML = '';
+      data.tasks.forEach((task) => {
+        const item = document.createElement('div');
+        item.className = 'item';
+        item.textContent = task;
+        item.dataset.value = task;
+        item.onclick = () => selectTask(run, task);
+        taskList.appendChild(item);
+        const opt = document.createElement('option');
+        opt.value = task;
+        opt.textContent = task;
+        taskSelect.appendChild(opt);
+      });
+      if (data.tasks.length) {
+        selectTask(run, data.tasks[0]);
+      }
+    }
+
+    async function selectTask(run, task) {
+      taskSelect.value = task;
+      setActive(taskList, task);
+      status.textContent = `Run: ${run} • Task: ${task}`;
+
+      const report = await fetchJson(`/api/run/${encodeURIComponent(run)}/task/${encodeURIComponent(task)}/report`);
+      reportFrame.src = report.url || '';
+
+      const logs = await fetchJson(`/api/run/${encodeURIComponent(run)}/task/${encodeURIComponent(task)}/logs`);
+      logSelect.innerHTML = '';
+      logs.files.forEach((file) => {
+        const opt = document.createElement('option');
+        opt.value = file;
+        opt.textContent = file;
+        logSelect.appendChild(opt);
+      });
+      if (logs.files.length) {
+        logSelect.value = logs.files[0];
+        await loadLog();
+      } else {
+        logOutput.textContent = 'No logs found for this task.';
+      }
+
+      const raw = await fetchJson(`/api/run/${encodeURIComponent(run)}/task/${encodeURIComponent(task)}/raw`);
+      rawOutput.textContent = raw.text || 'No raw files found.';
+    }
+
+    async function loadLog() {
+      const run = runSelect.value;
+      const task = taskSelect.value;
+      const file = logSelect.value;
+      if (!file) return;
+      const data = await fetchJson(`/api/run/${encodeURIComponent(run)}/task/${encodeURIComponent(task)}/log?file=${encodeURIComponent(file)}`);
+      logOutput.textContent = data.text || '';
+    }
+
+    runSelect.addEventListener('change', () => selectRun(runSelect.value));
+    taskSelect.addEventListener('change', () => selectTask(runSelect.value, taskSelect.value));
+    logSelect.addEventListener('change', () => loadLog());
+
+    tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        tabs.forEach((btn) => btn.classList.remove('active'));
+        tab.classList.add('active');
+        const target = tab.dataset.pane;
+        panes.forEach((pane) => {
+          pane.classList.toggle('active', pane.id === target);
+        });
+      });
+    });
+
+    setInterval(() => {
+      if (document.getElementById('logsPane').classList.contains('active')) {
+        loadLog().catch(() => {});
+      }
+    }, 4000);
+
+    loadRuns().catch((err) => {
+      runList.innerHTML = `<div class=\"empty\">Failed to load runs: ${err}</div>`;
+    });
+  </script>
+</body>
+</html>
+"""
+
+
+def _safe_join(root: Path, *parts: str) -> Path:
+    joined = root.joinpath(*parts).resolve()
+    if not str(joined).startswith(str(root.resolve())):
+        raise ValueError("Invalid path")
+    return joined
+
+
+def _find_runs(log_dir: Path, recursive: bool) -> list[str]:
+    runs: list[str] = []
+    if not log_dir.exists():
+        return runs
+    if not recursive:
+        for child in sorted(log_dir.iterdir()):
+            if child.is_dir():
+                runs.append(child.name)
+        return runs
+
+    for child in sorted(log_dir.rglob("*")):
+        if child.is_dir():
+            # Detect a run by presence of at least one task dir with artifacts
+            if any((task / "artifacts").is_dir() for task in child.iterdir() if task.is_dir()):
+                rel = child.relative_to(log_dir).as_posix()
+                runs.append(rel)
+    return runs
+
+
+def _find_tasks(run_dir: Path) -> list[str]:
+    tasks: list[str] = []
+    if not run_dir.exists():
+        return tasks
+    for child in sorted(run_dir.iterdir()):
+        if child.is_dir() and (child / "artifacts").is_dir():
+            tasks.append(child.name)
+    return tasks
+
+
+def _find_logs(task_dir: Path) -> list[str]:
+    candidates: list[Path] = []
+    logs_dir = task_dir / "logs"
+    if logs_dir.is_dir():
+        candidates.extend([p for p in logs_dir.iterdir() if p.is_file()])
+    for child in task_dir.iterdir():
+        if child.is_file() and child.suffix in {".log", ".txt", ".out"}:
+            candidates.append(child)
+    return [p.name for p in sorted(set(candidates))]
+
+
+def _tail_file(path: Path, max_lines: int = 400) -> str:
+    if not path.exists():
+        return ""
+    lines: list[str] = []
+    with path.open("r", encoding="utf-8", errors="ignore") as f:
+        for line in f:
+            lines.append(line.rstrip("\n"))
+    return "\n".join(lines[-max_lines:])
+
+
+@dataclass
+class Cmd:
+    """Start a NeMo Evaluator log viewer in the browser."""
+
+    log_dir: str = field(
+        default="nel-results",
+        alias=["--log-dir"],
+        help="Directory containing evaluator run outputs.",
+    )
+    host: str = field(
+        default="127.0.0.1",
+        alias=["--host"],
+        help="Host interface to bind the viewer.",
+    )
+    port: int = field(
+        default=7575,
+        alias=["--port"],
+        help="Port to bind the viewer.",
+    )
+    recursive: bool = field(
+        default=True,
+        alias=["--recursive"],
+        help="Recursively scan log_dir for runs.",
+    )
+
+    def execute(self) -> None:
+        log_root = Path(self.log_dir).expanduser().resolve()
+
+        class Handler(BaseHTTPRequestHandler):
+            def _send_json(self, payload: dict[str, Any], status: int = 200) -> None:
+                body = json.dumps(payload).encode("utf-8")
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def _send_text(self, text: str, content_type: str = "text/plain") -> None:
+                body = text.encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def do_GET(self) -> None:  # noqa: N802
+                parsed = urlparse(self.path)
+                if parsed.path == "/":
+                    self._send_text(HTML_PAGE, "text/html")
+                    return
+                if parsed.path == "/api/runs":
+                    runs = _find_runs(log_root, self.server.recursive)
+                    self._send_json({"runs": runs})
+                    return
+                if parsed.path.startswith("/api/run/") and parsed.path.endswith("/tasks"):
+                    parts = parsed.path.split("/")
+                    run_rel = "/".join(parts[3:-1])
+                    run_dir = _safe_join(log_root, run_rel)
+                    tasks = _find_tasks(run_dir)
+                    self._send_json({"tasks": tasks})
+                    return
+                if parsed.path.startswith("/api/run/") and parsed.path.endswith("/report"):
+                    parts = parsed.path.split("/")
+                    run_rel = "/".join(parts[3:-2])
+                    task = parts[-2]
+                    report = _safe_join(log_root, run_rel, task, "artifacts", "report.html")
+                    url = f"/file?path={report.relative_to(log_root).as_posix()}" if report.exists() else ""
+                    self._send_json({"url": url})
+                    return
+                if parsed.path.startswith("/api/run/") and parsed.path.endswith("/logs"):
+                    parts = parsed.path.split("/")
+                    run_rel = "/".join(parts[3:-2])
+                    task = parts[-2]
+                    task_dir = _safe_join(log_root, run_rel, task)
+                    files = _find_logs(task_dir)
+                    self._send_json({"files": files})
+                    return
+                if parsed.path.startswith("/api/run/") and parsed.path.endswith("/raw"):
+                    parts = parsed.path.split("/")
+                    run_rel = "/".join(parts[3:-2])
+                    task = parts[-2]
+                    artifacts = _safe_join(log_root, run_rel, task, "artifacts")
+                    files = []
+                    for name in ("results.yml", "run_config.yml", "eval_factory_metrics.json"):
+                        path = artifacts / name
+                        if path.exists():
+                            files.append(f"{name}\\n{'-'*40}\\n{path.read_text(encoding='utf-8', errors='ignore')}")
+                    self._send_json({"text": \"\\n\\n\".join(files)})
+                    return
+                if parsed.path.startswith("/api/run/") and parsed.path.endswith("/log"):
+                    parts = parsed.path.split("/")
+                    run_rel = "/".join(parts[3:-2])
+                    task = parts[-2]
+                    qs = parse_qs(parsed.query)
+                    file_name = qs.get("file", [""])[0]
+                    task_dir = _safe_join(log_root, run_rel, task)
+                    logs_dir = task_dir / "logs"
+                    path = logs_dir / file_name if logs_dir.is_dir() else task_dir / file_name
+                    text = _tail_file(path)
+                    self._send_json({"text": text})
+                    return
+                if parsed.path == "/file":
+                    qs = parse_qs(parsed.query)
+                    rel = qs.get("path", [""])[0]
+                    try:
+                        path = _safe_join(log_root, rel)
+                    except Exception:
+                        self.send_error(400)
+                        return
+                    if not path.exists():
+                        self.send_error(404)
+                        return
+                    ext = path.suffix.lower()
+                    content_type = "text/plain"
+                    if ext == ".html":
+                        content_type = "text/html"
+                    elif ext == ".json":
+                        content_type = "application/json"
+                    elif ext in {".yml", ".yaml"}:
+                        content_type = "text/yaml"
+                    self._send_text(path.read_text(encoding="utf-8", errors="ignore"), content_type)
+                    return
+                self.send_error(404)
+
+        server = ThreadingHTTPServer((self.host, self.port), Handler)
+        server.recursive = self.recursive
+
+        print(f"NeMo Evaluator Viewer running at http://{self.host}:{self.port}")
+        print(f"Log directory: {log_root}")
+        print("Press Ctrl+C to stop.")
+        try:
+            server.serve_forever()
+        except KeyboardInterrupt:
+            print("Stopping viewer.")
+            server.server_close()

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/post_eval_report_hook.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/post_eval_report_hook.py
@@ -16,6 +16,7 @@
 """Post-evaluation report generation hook."""
 
 import json
+import re
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, List, Literal, Optional
@@ -85,6 +86,109 @@ class PostEvalReportHook(PostEvalHook):
         import html
 
         return html.escape(json.dumps(data, indent=2, ensure_ascii=False))
+
+    def _load_tasks_irs(self) -> dict[str, Any] | None:
+        """Load tasks-to-harness/container mapping if available."""
+        candidates: list[Path] = []
+        try:
+            repo_root = Path(__file__).resolve().parents[6]
+            candidates.append(
+                repo_root
+                / "packages"
+                / "nemo-evaluator-launcher"
+                / "src"
+                / "nemo_evaluator_launcher"
+                / "resources"
+                / "all_tasks_irs.yaml"
+            )
+        except Exception:
+            pass
+
+        for candidate in candidates:
+            if candidate.exists():
+                try:
+                    return yaml.safe_load(candidate.read_text(encoding="utf-8"))
+                except Exception:
+                    return None
+
+        try:
+            from importlib import resources as importlib_resources
+
+            with importlib_resources.as_file(
+                importlib_resources.files("nemo_evaluator_launcher.resources")
+                / "all_tasks_irs.yaml"
+            ) as resource_path:
+                if resource_path.exists():
+                    return yaml.safe_load(resource_path.read_text(encoding="utf-8"))
+        except Exception:
+            return None
+
+        return None
+
+    def _container_url_from_image(self, image: str) -> str | None:
+        """Map an NGC image to a catalog URL when possible."""
+        if not image:
+            return None
+        match = re.match(r"^nvcr\\.io/nvidia/([^/]+)/([^:]+)(?::.+)?$", image)
+        if not match:
+            return None
+        org_or_team, name = match.groups()
+        if org_or_team == "eval-factory":
+            return (
+                "https://catalog.ngc.nvidia.com/orgs/nvidia/teams/"
+                f"eval-factory/containers/{name}"
+            )
+        return f"https://catalog.ngc.nvidia.com/orgs/nvidia/containers/{name}"
+
+    def _resolve_container_info(self, task_name: str | None) -> dict[str, Any]:
+        """Resolve benchmark container info from the launcher task registry."""
+        if not task_name:
+            return {}
+        registry = self._load_tasks_irs()
+        if not registry:
+            return {}
+
+        raw_task = task_name
+        harness_hint = None
+        if "." in task_name:
+            harness_hint, raw_task = task_name.split(".", 1)
+
+        task_entry = None
+        for task in registry.get("tasks", []):
+            if task.get("name") == raw_task and (
+                not harness_hint or task.get("harness") == harness_hint
+            ):
+                task_entry = task
+                break
+
+        if not task_entry:
+            for task in registry.get("tasks", []):
+                if task.get("name") == raw_task:
+                    task_entry = task
+                    break
+
+        harness_name = task_entry.get("harness") if task_entry else None
+        harness_entry = None
+        for harness in registry.get("harnesses", []):
+            if harness.get("name") == harness_name:
+                harness_entry = harness
+                break
+
+        container = harness_entry.get("container") if harness_entry else None
+        container_digest = (
+            harness_entry.get("container_digest") if harness_entry else None
+        )
+        container_url = self._container_url_from_image(container) if container else None
+        harness_url = harness_entry.get("url") if harness_entry else None
+
+        return {
+            "benchmark_task": raw_task,
+            "benchmark_harness": harness_name,
+            "benchmark_container": container,
+            "benchmark_container_digest": container_digest,
+            "benchmark_container_url": container_url,
+            "benchmark_harness_url": harness_url,
+        }
 
     def _get_request_content(self, request_data: Any) -> Any:
         """Extract content from request data."""
@@ -299,6 +403,36 @@ class PostEvalReportHook(PostEvalHook):
             return path.split(".metrics.", 1)[1]
         return path
 
+    def _collect_scoped_metrics(
+        self, results: dict[str, Any], scope_key: str
+    ) -> list[dict[str, Any]]:
+        scoped = self._get_nested(results, ["results", scope_key])
+        rows: list[dict[str, Any]] = []
+        if not isinstance(scoped, dict):
+            return rows
+
+        for scope_name, scope_data in scoped.items():
+            if not isinstance(scope_data, dict):
+                continue
+            metrics = scope_data.get("metrics")
+            if not isinstance(metrics, dict):
+                continue
+            for row in self._flatten_metrics(metrics, prefix="metrics."):
+                path = row.get("path") or ""
+                path_display = path[len("metrics.") :] if path.startswith("metrics.") else path
+                rows.append(
+                    {
+                        "scope": scope_name,
+                        "path": path,
+                        "path_display": path_display,
+                        "value": row.get("value"),
+                        "value_display": self._format_value(row.get("value")),
+                        "stats": row.get("stats"),
+                        "stats_display": self._format_stats(row.get("stats")),
+                    }
+                )
+        return rows
+
     def _flatten_numeric(self, data: Any, prefix: str = "") -> list[dict[str, Any]]:
         rows: list[dict[str, Any]] = []
         if isinstance(data, dict):
@@ -445,6 +579,8 @@ class PostEvalReportHook(PostEvalHook):
                 value = record[key]
                 if isinstance(value, bool):
                     return value
+                if isinstance(value, (int, float)):
+                    return value > 0
                 if isinstance(value, list) and value:
                     return all(bool(v) for v in value)
         return None
@@ -538,17 +674,129 @@ class PostEvalReportHook(PostEvalHook):
         return ""
 
     def _extract_target(self, record: dict[str, Any]) -> str:
+        def parse_options_string(options_text: str) -> dict[str, str]:
+            mapping: dict[str, str] = {}
+            for line in options_text.splitlines():
+                line = line.strip()
+                if not line:
+                    continue
+                if len(line) >= 2 and line[1] in {")", "."}:
+                    label = line[0].upper()
+                    value = line[2:].strip()
+                    if label.isalpha() and value:
+                        mapping[label] = value
+            return mapping
+
+        def choice_label(idx: int) -> str:
+            if idx < 0:
+                return ""
+            return chr(ord("A") + idx)
+
         expected = record.get("expected_answer")
         if expected is not None:
-            return str(expected)
+            if isinstance(expected, str):
+                expected = expected.strip()
+            if expected != "":
+                # Try to render expected answer with choices/options when available.
+                doc = record.get("doc")
+                choices: list[Any] | None = None
+                options_map: dict[str, str] = {}
+                if isinstance(doc, dict):
+                    maybe_choices = doc.get("choices") or doc.get("options")
+                    if isinstance(maybe_choices, list):
+                        choices = maybe_choices
+                options = record.get("options")
+                if isinstance(options, str):
+                    options_map = parse_options_string(options)
+                if isinstance(expected, str) and len(expected) == 1 and expected.isalpha():
+                    letter = expected.upper()
+                    if letter in options_map:
+                        return f"{letter}) {options_map[letter]}"
+                if isinstance(expected, (int, float)) and choices:
+                    idx = int(expected)
+                    if 0 <= idx < len(choices):
+                        letter = choice_label(idx)
+                        return f"{letter}) {choices[idx]}"
+                if isinstance(expected, str) and choices and expected in choices:
+                    return expected
+                return str(expected)
+
         target = record.get("target")
+        doc = record.get("doc")
+        choices: list[Any] | None = None
+        options_map: dict[str, str] = {}
+        if isinstance(doc, dict):
+            maybe_choices = doc.get("choices") or doc.get("options")
+            if isinstance(maybe_choices, list):
+                choices = maybe_choices
+        options = record.get("options")
+        if isinstance(options, str):
+            options_map = parse_options_string(options)
+        expected_answer = record.get("expected_answer")
+        if isinstance(expected_answer, str):
+            expected_letter = expected_answer.strip().upper()
+            if expected_letter in options_map:
+                return f"{expected_letter}) {options_map[expected_letter]}"
+            if expected_answer.strip() and expected_answer.strip() in options_map:
+                letter = expected_answer.strip()
+                return f"{letter}) {options_map[letter]}"
+            if expected_answer.strip():
+                return expected_answer.strip()
+
+        # Direct string targets that are not numeric
         if isinstance(target, str) and target and not target.isdigit():
             return target
-        doc = record.get("doc")
+
+        # Map numeric targets to choices when available
+        target_idx: int | None = None
+        if isinstance(target, int):
+            target_idx = target
+        elif isinstance(target, str) and target.isdigit():
+            target_idx = int(target)
+
+        if target_idx is not None and choices and 0 <= target_idx < len(choices):
+            letter = choice_label(target_idx)
+            return f"{letter}) {choices[target_idx]}"
+
+        # Map doc-level answer/label when provided
         if isinstance(doc, dict):
+            doc_answer = doc.get("answer") or doc.get("label") or doc.get("gold")
+            if isinstance(doc_answer, int) and choices and 0 <= doc_answer < len(choices):
+                letter = choice_label(doc_answer)
+                return f"{letter}) {choices[doc_answer]}"
+            if isinstance(doc_answer, str):
+                stripped = doc_answer.strip()
+                if choices:
+                    if stripped.isdigit():
+                        idx = int(stripped)
+                        if 0 <= idx < len(choices):
+                            letter = choice_label(idx)
+                            return f"{letter}) {choices[idx]}"
+                    if len(stripped) == 1 and stripped.isalpha():
+                        idx = ord(stripped.upper()) - ord("A")
+                        if 0 <= idx < len(choices):
+                            letter = choice_label(idx)
+                            return f"{letter}) {choices[idx]}"
+                    if stripped in choices:
+                        return stripped
+                if stripped and len(stripped) == 1 and stripped.isalpha():
+                    letter = stripped.upper()
+                    if letter in options_map:
+                        return f"{letter}) {options_map[letter]}"
+                if stripped:
+                    return stripped
+
             doc_target = doc.get("target")
             if isinstance(doc_target, str) and doc_target:
                 return doc_target
+
+            # Instruction-following tasks may not have a single ground truth.
+            if "instruction_id_list" in doc:
+                return "N/A (instruction-following)"
+
+        # Fallback to numeric targets when nothing else is available
+        if target is not None:
+            return str(target)
         return ""
 
     def _collect_grading_records(self, output_dir: Path) -> list[dict[str, Any]]:
@@ -574,11 +822,19 @@ class PostEvalReportHook(PostEvalHook):
                             continue
                         graded_response = self._extract_graded_response(record)
                         correctness = self._derive_correctness(record)
+                        target_display = self._extract_target(record)
                         records.append(
                             {
                                 "variants": variants,
                                 "input": self._extract_primary_input(record),
-                                "target": self._extract_target(record),
+                                "problem": record.get("problem")
+                                if isinstance(record.get("problem"), str)
+                                else None,
+                                "options": record.get("options")
+                                if isinstance(record.get("options"), str)
+                                else None,
+                                "target": target_display,
+                                "target_display": target_display,
                                 "graded_response": graded_response,
                                 "correct": correctness,
                                 "expected": record.get("expected_answer"),
@@ -681,10 +937,16 @@ class PostEvalReportHook(PostEvalHook):
 
         grading_records = self._collect_grading_records(output_dir)
         grading_exact: dict[str, dict[str, Any]] = {}
+        grading_exact_norm: dict[str, dict[str, Any]] = {}
         for record in grading_records:
             for variant in record.get("variants", []):
-                if variant and variant not in grading_exact:
+                if not variant:
+                    continue
+                if variant not in grading_exact:
                     grading_exact[variant] = record
+                normalized_variant = self._normalize_ws(variant)
+                if normalized_variant and normalized_variant not in grading_exact_norm:
+                    grading_exact_norm[normalized_variant] = record
 
         def find_grading(prompt: str) -> Optional[dict[str, Any]]:
             if not prompt:
@@ -692,22 +954,50 @@ class PostEvalReportHook(PostEvalHook):
             if prompt in grading_exact:
                 return grading_exact[prompt]
             normalized_prompt = self._normalize_ws(prompt)
-            if normalized_prompt in grading_exact:
-                return grading_exact[normalized_prompt]
+            if normalized_prompt in grading_exact_norm:
+                return grading_exact_norm[normalized_prompt]
+
             best_match: Optional[dict[str, Any]] = None
+            best_score = 0
             best_len = 0
             for record in grading_records:
+                score = 0
+                record_len = 0
+                problem = record.get("problem") or record.get("input")
+                if isinstance(problem, str):
+                    normalized_problem = self._normalize_ws(problem)
+                    if normalized_problem and normalized_problem in normalized_prompt:
+                        score += 3
+                        record_len = max(record_len, len(normalized_problem))
+                options = record.get("options")
+                if isinstance(options, str):
+                    normalized_options = self._normalize_ws(options)
+                    if normalized_options and normalized_options in normalized_prompt:
+                        score += 3
+                        record_len = max(record_len, len(normalized_options))
+
                 for variant in record.get("variants", []):
                     if not variant:
                         continue
                     normalized_variant = self._normalize_ws(variant)
+                    if not normalized_variant:
+                        continue
                     if (
                         normalized_variant in normalized_prompt
                         or normalized_prompt in normalized_variant
                     ):
-                        if len(normalized_variant) > best_len:
-                            best_match = record
-                            best_len = len(normalized_variant)
+                        score += 1
+                        record_len = max(record_len, len(normalized_variant))
+
+                if score > best_score or (
+                    score == best_score and record_len > best_len
+                ):
+                    best_match = record
+                    best_score = score
+                    best_len = record_len
+
+            if best_score == 0:
+                return None
             return best_match
 
         for entry in entries:
@@ -715,6 +1005,8 @@ class PostEvalReportHook(PostEvalHook):
             entry.setdefault("graded_response", None)
             entry.setdefault("graded_input", None)
             entry.setdefault("graded_target", None)
+            entry.setdefault("target_display", None)
+            entry.setdefault("prompt_sections", [])
             entry.setdefault("graded_expected", None)
             entry.setdefault("graded_predicted", None)
             entry.setdefault("graded_score", None)
@@ -729,6 +1021,7 @@ class PostEvalReportHook(PostEvalHook):
                 entry["graded_correct"] = match.get("correct")
                 entry["graded_input"] = match.get("input")
                 entry["graded_target"] = match.get("target")
+                entry["target_display"] = match.get("target_display") or match.get("target")
                 entry["graded_score"] = match.get("score")
                 entry["graded_metrics"] = match.get("metrics")
                 entry["graded_source"] = match.get("source")
@@ -740,13 +1033,48 @@ class PostEvalReportHook(PostEvalHook):
                     f"{entry.get('search_blob', '')} {graded_blob} {graded_input} {graded_target}".lower()
                 )
 
+            prompt_sections: list[dict[str, str]] = []
+            seen_prompts: set[str] = set()
+            graded_input = entry.get("graded_input")
+            prompt_preview = entry.get("prompt_preview")
+
+            def add_prompt(label: str, text: str | None) -> None:
+                if not text:
+                    return
+                normalized = self._normalize_ws(text)
+                if not normalized or normalized in seen_prompts:
+                    return
+                seen_prompts.add(normalized)
+                prompt_sections.append({"label": label, "text": text})
+
+            add_prompt("Prompt", graded_input or prompt_preview)
+            entry["prompt_sections"] = prompt_sections
+
+        for entry in entries:
+            if entry.get("request_chars") is None:
+                entry["request_chars"] = len(
+                    self._safe_json_dumps(entry.get("request_data"))
+                )
+            if entry.get("response_chars") is None:
+                entry["response_chars"] = len(
+                    self._safe_json_dumps(entry.get("response"))
+                )
+
         error_count = sum(1 for entry in entries if entry.get("has_error"))
         tool_count = sum(1 for entry in entries if entry.get("has_tool_calls"))
-        correct_count = sum(1 for entry in entries if entry.get("graded_label") == "correct")
-        incorrect_count = sum(
-            1 for entry in entries if entry.get("graded_label") == "incorrect"
+        correct_count = sum(
+            1 for entry in entries if (entry.get("graded_label") or "unknown") == "correct"
         )
-        unknown_count = sum(1 for entry in entries if entry.get("graded_label") == "unknown")
+        incorrect_count = sum(
+            1
+            for entry in entries
+            if (entry.get("graded_label") or "unknown") == "incorrect"
+        )
+        unknown_count = sum(
+            1 for entry in entries if (entry.get("graded_label") or "unknown") == "unknown"
+        )
+        graded_count = correct_count + incorrect_count
+        report_count = len(entries)
         avg_request_chars = (
             sum(entry.get("request_chars", 0) for entry in entries) / len(entries)
         )
@@ -792,14 +1120,31 @@ class PostEvalReportHook(PostEvalHook):
         task_name = self._get_nested(run_config, ["task", "name"])
         if not task_name:
             task_name = self._get_nested(run_config, ["task", "task_name"])
+        if not task_name:
+            task_name = self._get_nested(results, ["config", "params", "task"])
+        if not task_name:
+            task_name = self._get_nested(results, ["config", "type"])
+        container_info = self._resolve_container_info(task_name)
+
         if task_name:
             summary_items.append({"label": "Task", "value": str(task_name)})
+        if container_info.get("benchmark_container"):
+            summary_items.append(
+                {"label": "Benchmark Container", "value": container_info["benchmark_container"]}
+            )
+        if container_info.get("benchmark_harness"):
+            summary_items.append(
+                {"label": "Harness", "value": container_info["benchmark_harness"]}
+            )
 
         command = self._get_nested(results, ["command"])
         if command:
             summary_items.append({"label": "Command", "value": str(command)})
         if model_set:
             summary_items.append({"label": "Models", "value": ", ".join(model_set)})
+
+        rollup_rows = self._collect_scoped_metrics(results, "groups")
+        task_rows = self._collect_scoped_metrics(results, "tasks")
 
         metrics_rows: list[dict[str, Any]] = []
         results_metrics = self._get_nested(results, ["results"])
@@ -849,7 +1194,15 @@ class PostEvalReportHook(PostEvalHook):
             "shown_entries": len(entries),
             "total_entries": total_available,
             "limited": total_available > len(entries),
+            "model_id": model_id,
+            "task_name": task_name,
+            "benchmark_container": container_info.get("benchmark_container"),
+            "benchmark_container_url": container_info.get("benchmark_container_url"),
+            "benchmark_harness": container_info.get("benchmark_harness"),
+            "benchmark_harness_url": container_info.get("benchmark_harness_url"),
             "summary_items": summary_items,
+            "rollup_rows": rollup_rows,
+            "task_rows": task_rows,
             "metrics_rows": metrics_rows,
             "perf_rows": perf_rows,
             "artifacts_rows": artifacts_rows,
@@ -862,6 +1215,8 @@ class PostEvalReportHook(PostEvalHook):
                 "correct_count": correct_count,
                 "incorrect_count": incorrect_count,
                 "unknown_count": unknown_count,
+                "graded_count": graded_count,
+                "report_count": report_count,
                 "accuracy": (
                     (correct_count / (correct_count + incorrect_count))
                     if (correct_count + incorrect_count)

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
@@ -22,7 +22,7 @@ and distributed with the rest of the code.
 """
 
 SIMPLE_TEMPLATE = """<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -192,26 +192,6 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
         .brand-link:hover {
             filter: brightness(1.1);
         }
-        .brand-meta {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px;
-            margin-top: 10px;
-        }
-        .meta-pill {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            padding: 6px 12px;
-            border-radius: 999px;
-            border: 1px solid var(--border);
-            background: rgba(255, 255, 255, 0.04);
-            font-size: 0.85rem;
-            color: var(--muted);
-        }
-        .meta-pill strong {
-            color: var(--text);
-        }
         .hero strong {
             color: var(--accent);
         }
@@ -238,6 +218,152 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             margin-top: 6px;
             word-break: break-word;
         }
+
+        /* ---- Hero Stats Banner ---- */
+        .hero-stats {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            margin-bottom: 20px;
+            padding: 20px 24px;
+            background: linear-gradient(135deg, rgba(96, 211, 148, 0.06), rgba(111, 155, 255, 0.06));
+            border: 1px solid var(--border);
+            border-radius: 14px;
+        }
+        .hero-stat {
+            flex: 1;
+            min-width: 140px;
+            text-align: center;
+            padding: 12px 16px;
+        }
+        .hero-stat .stat-value {
+            font-size: 2.2rem;
+            font-weight: 700;
+            line-height: 1.2;
+            color: var(--accent);
+        }
+        .hero-stat .stat-value.accent-blue { color: var(--accent-2); }
+        .hero-stat .stat-value.accent-warn { color: var(--warn); }
+        .hero-stat .stat-value.accent-muted { color: var(--muted); }
+        .hero-stat .stat-label {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            margin-top: 4px;
+        }
+        .hero-stat .accuracy-bar-lg {
+            width: 100%;
+            height: 8px;
+            background: rgba(255, 154, 154, 0.25);
+            border-radius: 4px;
+            margin-top: 10px;
+            overflow: hidden;
+        }
+        .hero-stat .accuracy-fill-lg {
+            height: 100%;
+            background: var(--accent);
+            border-radius: 4px;
+            transition: width 0.4s ease;
+        }
+
+        /* ---- Category Groups ---- */
+        .category-group { margin-bottom: 18px; }
+        .category-group:last-child { margin-bottom: 0; }
+        .category-title {
+            color: var(--muted);
+            font-size: 0.72rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+            margin-bottom: 10px;
+            padding-left: 4px;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .category-title::after {
+            content: '';
+            flex: 1;
+            height: 1px;
+            background: var(--border);
+        }
+
+        /* ---- Enhanced Summary Cards ---- */
+        .summary-grid-v2 {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 10px;
+        }
+        .summary-card-v2 {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            border-radius: 10px;
+            border-left: 3px solid var(--border);
+            transition: border-color 0.2s;
+        }
+        .summary-card-v2:hover { border-color: rgba(255,255,255,0.15); }
+        .summary-card-v2.cat-config { border-left-color: var(--accent-2); }
+        .summary-card-v2.cat-eval   { border-left-color: var(--accent); }
+        .summary-card-v2.cat-perf   { border-left-color: var(--warn); }
+        .summary-card-v2.cat-system { border-left-color: rgba(155,208,255,0.5); }
+        .summary-card-v2 .label {
+            color: var(--muted);
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .summary-card-v2 .value {
+            font-size: 1.05rem;
+            margin-top: 4px;
+            word-break: break-word;
+        }
+        .summary-card-v2 .value.large {
+            font-size: 1.3rem;
+            font-weight: 600;
+        }
+
+        /* ---- Eval Params Pills ---- */
+        .params-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 10px;
+        }
+        .param-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: rgba(111,155,255,0.08);
+            font-size: 0.78rem;
+        }
+        .param-pill .param-key {
+            color: var(--muted);
+            font-size: 0.68rem;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+        }
+        .param-pill .param-val {
+            color: var(--text);
+            font-weight: 500;
+        }
+
+        /* ---- Grade Distribution Bar ---- */
+        .grade-bar {
+            display: flex;
+            height: 6px;
+            border-radius: 3px;
+            overflow: hidden;
+            margin-top: 8px;
+            gap: 2px;
+        }
+        .grade-bar .bar-correct   { background: rgba(126,224,129,0.8); }
+        .grade-bar .bar-incorrect { background: rgba(255,154,154,0.8); }
+        .grade-bar .bar-unknown   { background: rgba(246,211,101,0.6); }
+
         .toolbar {
             display: flex;
             flex-wrap: wrap;
@@ -564,29 +690,6 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
         .entry.grade-unknown::before {
             background: rgba(246, 211, 101, 0.9);
         }
-        .entry[data-graded="correct"] {
-            border-color: rgba(126, 224, 129, 0.4);
-            box-shadow: 0 0 0 1px rgba(126, 224, 129, 0.08), var(--shadow);
-            background: linear-gradient(90deg, rgba(126, 224, 129, 0.06), rgba(20, 24, 36, 0) 45%), var(--panel);
-        }
-        .entry[data-graded="incorrect"] {
-            border-color: rgba(255, 154, 154, 0.4);
-            box-shadow: 0 0 0 1px rgba(255, 154, 154, 0.08), var(--shadow);
-            background: linear-gradient(90deg, rgba(255, 154, 154, 0.06), rgba(20, 24, 36, 0) 45%), var(--panel);
-        }
-        .entry[data-graded="unknown"] {
-            border-color: rgba(246, 211, 101, 0.35);
-            background: linear-gradient(90deg, rgba(246, 211, 101, 0.07), rgba(20, 24, 36, 0) 45%), var(--panel);
-        }
-        .entry[data-graded="correct"]::before {
-            background: rgba(126, 224, 129, 0.9);
-        }
-        .entry[data-graded="incorrect"]::before {
-            background: rgba(255, 154, 154, 0.9);
-        }
-        .entry[data-graded="unknown"]::before {
-            background: rgba(246, 211, 101, 0.9);
-        }
         .entry.highlight {
             outline: 2px solid rgba(111, 155, 255, 0.5);
             outline-offset: 2px;
@@ -796,6 +899,10 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                 font-size: 1.6rem;
             }
         }
+        button:focus-visible, input:focus-visible, select:focus-visible, a:focus-visible {
+            outline: 2px solid var(--accent-2);
+            outline-offset: 2px;
+        }
     </style>
 </head>
 <body>
@@ -898,92 +1005,217 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                     <button class="toggle active" data-target="graded">Graded</button>
                     <button class="toggle" data-target="curl">Curl</button>
                 </div>
+                <button class="button" id="exportCsv">Export CSV</button>
+                <button class="button" id="exportJson">Export JSON</button>
             </div>
 
-            {% if meta.summary_items %}
+            {% if meta.summary_items or meta.stats %}
                 <div class="section">
                     <h2>Run Summary</h2>
-                    <div class="summary-grid">
-                        {% for item in meta.summary_items %}
-                            <div class="summary-card">
-                                <div class="label">{{ item.label }}</div>
-                                <div class="value">{{ item.value }}</div>
-                            </div>
-                        {% endfor %}
-                    </div>
-                </div>
-            {% endif %}
 
-            {% if meta.stats %}
-                <div class="section">
-                    <h2>Sample Stats</h2>
-                    <div class="summary-grid">
-                        <div class="summary-card">
-                            <div class="label">Report Accuracy (Graded)</div>
-                            <div class="value">
+                    {# ---- Hero Stats Banner ---- #}
+                    {% if meta.stats %}
+                        <div class="hero-stats">
+                            <div class="hero-stat">
                                 {% if meta.stats.graded_count %}
-                                    {{ (meta.stats.accuracy * 100) | round(2) }}% ({{ meta.stats.correct_count }}/{{ meta.stats.graded_count }})
-                                    <div class="accuracy-bar"><div class="accuracy-fill" style="width: {{ (meta.stats.accuracy * 100) | round(1) }}%"></div></div>
+                                    <div class="stat-value">{{ (meta.stats.accuracy * 100) | round(1) }}%</div>
+                                    <div class="stat-label">Accuracy ({{ meta.stats.correct_count }}/{{ meta.stats.graded_count }})</div>
+                                    <div class="accuracy-bar-lg"><div class="accuracy-fill-lg" style="width: {{ (meta.stats.accuracy * 100) | round(1) }}%"></div></div>
                                 {% else %}
-                                    —
+                                    <div class="stat-value accent-muted">&mdash;</div>
+                                    <div class="stat-label">Accuracy</div>
                                 {% endif %}
                             </div>
+                            <div class="hero-stat">
+                                <div class="stat-value accent-blue">{{ meta.stats.report_count }}</div>
+                                <div class="stat-label">Total Samples</div>
+                            </div>
+                            <div class="hero-stat">
+                                <div class="stat-value">{{ meta.stats.correct_count }}</div>
+                                <div class="stat-label">Correct</div>
+                            </div>
+                            <div class="hero-stat">
+                                <div class="stat-value accent-warn">{{ (meta.stats.error_rate * 100) | round(1) }}%</div>
+                                <div class="stat-label">Error Rate ({{ meta.stats.error_count }})</div>
+                            </div>
                         </div>
-                        <div class="summary-card">
-                            <div class="label">Correct / Incorrect / Unknown</div>
-                            <div class="value">{{ meta.stats.correct_count }} / {{ meta.stats.incorrect_count }} / {{ meta.stats.unknown_count }}</div>
+                    {% endif %}
+
+                    {# ---- Configuration Group ---- #}
+                    <div class="category-group">
+                        <div class="category-title">Configuration</div>
+                        <div class="summary-grid-v2">
+                            <div class="summary-card-v2 cat-config">
+                                <div class="label">Endpoint</div>
+                                <div class="value">{{ meta.endpoint }}</div>
+                            </div>
+                            {% if meta.model_id %}
+                                <div class="summary-card-v2 cat-config">
+                                    <div class="label">Model</div>
+                                    <div class="value">{{ meta.model_id }}</div>
+                                </div>
+                            {% endif %}
+                            {% if meta.task_name %}
+                                <div class="summary-card-v2 cat-config">
+                                    <div class="label">Task</div>
+                                    <div class="value">{{ meta.task_name }}</div>
+                                </div>
+                            {% endif %}
+                            {% if meta.framework_name %}
+                                <div class="summary-card-v2 cat-config">
+                                    <div class="label">Framework</div>
+                                    <div class="value">{{ meta.framework_name }}</div>
+                                </div>
+                            {% endif %}
+                            {% if meta.benchmark_harness %}
+                                <div class="summary-card-v2 cat-config">
+                                    <div class="label">Harness</div>
+                                    <div class="value">{{ meta.benchmark_harness }}</div>
+                                </div>
+                            {% endif %}
+                            {% if meta.benchmark_container %}
+                                <div class="summary-card-v2 cat-config">
+                                    <div class="label">Container</div>
+                                    <div class="value">
+                                        {% if meta.benchmark_container_url %}
+                                            <a style="color: var(--accent-2); text-decoration: none;" href="{{ meta.benchmark_container_url }}" target="_blank" rel="noopener">{{ meta.benchmark_container }}</a>
+                                        {% else %}
+                                            {{ meta.benchmark_container }}
+                                        {% endif %}
+                                    </div>
+                                </div>
+                            {% endif %}
                         </div>
-                        <div class="summary-card">
-                            <div class="label">Report Samples</div>
-                            <div class="value">{{ meta.stats.report_count }} shown / {{ meta.total_entries }} cached</div>
-                        </div>
-                        <div class="summary-card">
-                            <div class="label">Error Rate</div>
-                            <div class="value">{{ (meta.stats.error_rate * 100) | round(2) }}% ({{ meta.stats.error_count }})</div>
-                        </div>
-                        <div class="summary-card">
-                            <div class="label">Tool Calls</div>
-                            <div class="value">{{ meta.stats.tool_count }}</div>
-                        </div>
-                        <div class="summary-card">
-                            <div class="label">Avg Request Chars</div>
-                            <div class="value">{{ meta.stats.avg_request_chars | round(0) }}</div>
-                        </div>
-                        <div class="summary-card">
-                            <div class="label">Avg Response Chars</div>
-                            <div class="value">{{ meta.stats.avg_response_chars | round(0) }}</div>
-                        </div>
-                        {% if meta.stats.usage_totals.prompt_tokens or meta.stats.usage_totals.completion_tokens or meta.stats.usage_totals.total_tokens %}
-                            <div class="summary-card">
-                                <div class="label">Tokens (Prompt / Completion / Total)</div>
-                                <div class="value">{{ meta.stats.usage_totals.prompt_tokens }} / {{ meta.stats.usage_totals.completion_tokens }} / {{ meta.stats.usage_totals.total_tokens }}</div>
+                        {% if meta.eval_params %}
+                            <div class="params-row">
+                                {% for key, val in meta.eval_params.items() %}
+                                    <span class="param-pill">
+                                        <span class="param-key">{{ key }}</span>
+                                        <span class="param-val">{{ val }}</span>
+                                    </span>
+                                {% endfor %}
                             </div>
                         {% endif %}
                     </div>
 
-                    {% if meta.stats.request_type_counts %}
-                        <div class="chips">
-                            {% for key, value in meta.stats.request_type_counts.items() %}
-                                {% if key != 'unknown' %}
-                                    <div class="chip">{{ key }}: {{ value }}</div>
+                    {# ---- Evaluation Results Group ---- #}
+                    {% if meta.stats %}
+                        <div class="category-group">
+                            <div class="category-title">Evaluation Results</div>
+                            <div class="summary-grid-v2">
+                                <div class="summary-card-v2 cat-eval">
+                                    <div class="label">Correct / Incorrect / Unknown</div>
+                                    <div class="value large">{{ meta.stats.correct_count }} / {{ meta.stats.incorrect_count }} / {{ meta.stats.unknown_count }}</div>
+                                    {% if meta.stats.graded_count %}
+                                        <div class="grade-bar">
+                                            <div class="bar-correct" style="width: {{ (meta.stats.correct_count / (meta.stats.correct_count + meta.stats.incorrect_count + meta.stats.unknown_count) * 100) | round(1) }}%"></div>
+                                            <div class="bar-incorrect" style="width: {{ (meta.stats.incorrect_count / (meta.stats.correct_count + meta.stats.incorrect_count + meta.stats.unknown_count) * 100) | round(1) }}%"></div>
+                                            <div class="bar-unknown" style="width: {{ (meta.stats.unknown_count / (meta.stats.correct_count + meta.stats.incorrect_count + meta.stats.unknown_count) * 100) | round(1) }}%"></div>
+                                        </div>
+                                    {% endif %}
+                                </div>
+                                <div class="summary-card-v2 cat-eval">
+                                    <div class="label">Report Samples</div>
+                                    <div class="value">{{ meta.stats.report_count }} shown / {{ meta.total_entries }} cached</div>
+                                </div>
+                                {% if meta.stats.tool_count %}
+                                    <div class="summary-card-v2 cat-eval">
+                                        <div class="label">Tool Calls</div>
+                                        <div class="value">{{ meta.stats.tool_count }}</div>
+                                    </div>
                                 {% endif %}
-                            {% endfor %}
+                            </div>
+                            {% if meta.stats.request_type_counts or meta.stats.finish_reason_counts %}
+                                <div class="params-row">
+                                    {% if meta.stats.request_type_counts %}
+                                        {% for key, value in meta.stats.request_type_counts.items() %}
+                                            {% if key != 'unknown' %}
+                                                <span class="param-pill">
+                                                    <span class="param-key">{{ key }}</span>
+                                                    <span class="param-val">{{ value }}</span>
+                                                </span>
+                                            {% endif %}
+                                        {% endfor %}
+                                    {% endif %}
+                                    {% if meta.stats.finish_reason_counts %}
+                                        {% for key, value in meta.stats.finish_reason_counts.items() %}
+                                            {% if key != 'unknown' %}
+                                                <span class="param-pill">
+                                                    <span class="param-key">{{ key }}</span>
+                                                    <span class="param-val">{{ value }}</span>
+                                                </span>
+                                            {% endif %}
+                                        {% endfor %}
+                                    {% endif %}
+                                </div>
+                            {% endif %}
+                            <div class="note">
+                                <strong>Note:</strong> Report accuracy uses graded log samples shown above.
+                                Results rollups below come from results.yml and may use task-specific definitions and the full eval set.
+                            </div>
                         </div>
                     {% endif %}
-                    {% if meta.stats.finish_reason_counts %}
-                        <div class="chips">
-                            {% for key, value in meta.stats.finish_reason_counts.items() %}
-                                {% if key != 'unknown' %}
-                                    <div class="chip">{{ key }}: {{ value }}</div>
+
+                    {# ---- Performance Group ---- #}
+                    {% if meta.stats %}
+                        <div class="category-group">
+                            <div class="category-title">Performance</div>
+                            <div class="summary-grid-v2">
+                                <div class="summary-card-v2 cat-perf">
+                                    <div class="label">Avg Request Chars</div>
+                                    <div class="value">{{ meta.stats.avg_request_chars | round(0) }}</div>
+                                </div>
+                                <div class="summary-card-v2 cat-perf">
+                                    <div class="label">Avg Response Chars</div>
+                                    <div class="value">{{ meta.stats.avg_response_chars | round(0) }}</div>
+                                </div>
+                                {% if meta.stats.usage_totals.prompt_tokens or meta.stats.usage_totals.completion_tokens or meta.stats.usage_totals.total_tokens %}
+                                    <div class="summary-card-v2 cat-perf">
+                                        <div class="label">Tokens (Prompt / Completion / Total)</div>
+                                        <div class="value">{{ meta.stats.usage_totals.prompt_tokens }} / {{ meta.stats.usage_totals.completion_tokens }} / {{ meta.stats.usage_totals.total_tokens }}</div>
+                                    </div>
                                 {% endif %}
-                            {% endfor %}
+                            </div>
                         </div>
                     {% endif %}
-                    <div class="note">
-                        <strong>Note:</strong> Report accuracy uses graded log samples shown above (correct / incorrect).
-                        Results rollups below come from results.yml and may use task-specific definitions (inst-level vs prompt-level)
-                        and the full eval set.
+
+                    {# ---- System Group ---- #}
+                    <div class="category-group">
+                        <div class="category-title">System</div>
+                        <div class="summary-grid-v2">
+                            <div class="summary-card-v2 cat-system">
+                                <div class="label">Generated At (UTC)</div>
+                                <div class="value">{{ meta.generated_at }}</div>
+                            </div>
+                            <div class="summary-card-v2 cat-system">
+                                <div class="label">Shown / Cached</div>
+                                <div class="value">{{ meta.shown_entries }} / {{ meta.total_entries }}</div>
+                            </div>
+                            <div class="summary-card-v2 cat-system">
+                                <div class="label">Output Dir</div>
+                                <div class="value" style="font-size: 0.85rem;">{{ meta.output_dir_path }}</div>
+                            </div>
+                            {% if meta.git_hash %}
+                                <div class="summary-card-v2 cat-system">
+                                    <div class="label">Git Hash</div>
+                                    <div class="value" style="font-size: 0.85rem; font-family: monospace;">{{ meta.git_hash }}</div>
+                                </div>
+                            {% endif %}
+                            {% if meta.evaluator_version %}
+                                <div class="summary-card-v2 cat-system">
+                                    <div class="label">Evaluator Version</div>
+                                    <div class="value">{{ meta.evaluator_version }}</div>
+                                </div>
+                            {% endif %}
+                            {% if meta.launcher_version %}
+                                <div class="summary-card-v2 cat-system">
+                                    <div class="label">Launcher Version</div>
+                                    <div class="value">{{ meta.launcher_version }}</div>
+                                </div>
+                            {% endif %}
+                        </div>
                     </div>
+
                 </div>
             {% endif %}
 
@@ -1022,7 +1254,7 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                         <td class="idx-col">
                                             <a class="details-link" data-detail-link="true" href="#sample-{{ entry.cache_key }}">{{ loop.index }}</a>
                                         </td>
-                                        <td class="input-col">{{ (entry.graded_input or entry.prompt_preview or '—') | truncate(160, True, '...') }}</td>
+                                        <td class="input-col">{{ (entry.graded_problem_only or entry.graded_input or entry.prompt_preview or '—') | truncate(160, True, '...') }}</td>
                                         <td class="target-col">{{ (entry.target_display or entry.graded_target or entry.graded_expected or '—') | truncate(80, True, '...') }}</td>
                                         <td class="answer-col">{% if entry.graded_predicted %}<span class="predicted-letter">{{ entry.graded_predicted }}</span> {% endif %}{{ (entry.graded_response or '—') | truncate(100, True, '...') }}</td>
                                         <td class="score-col">
@@ -1132,6 +1364,38 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                                 <div class="meta-value">{{ entry.graded_predicted }}</div>
                                             </div>
                                         {% endif %}
+                                        {% if entry.graded_metrics %}
+                                            <div class="meta-card span-2">
+                                                <div class="meta-label">Grading Metrics</div>
+                                                <div class="meta-value">
+                                                    {% for key, val in entry.graded_metrics.items() %}
+                                                        <span class="chip">{{ key }}: {{ val }}</span>
+                                                    {% endfor %}
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                        {% if entry.graded_instruction_ids %}
+                                            <div class="meta-card span-2">
+                                                <div class="meta-label">Instruction IDs</div>
+                                                <div class="meta-value">
+                                                    {% set inst_metrics = entry.graded_metrics or {} %}
+                                                    {% set strict_arr = inst_metrics.get('inst_level_strict_acc') %}
+                                                    {% for iid in entry.graded_instruction_ids %}
+                                                        {% if strict_arr is iterable and strict_arr is not string and loop.index0 < strict_arr|length %}
+                                                            <span class="badge {{ 'correct' if strict_arr[loop.index0] else 'incorrect' }}">{{ iid }}</span>
+                                                        {% else %}
+                                                            <span class="chip">{{ iid }}</span>
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                </div>
+                                            </div>
+                                        {% endif %}
+                                        {% if entry.graded_source %}
+                                            <div class="meta-card span-2">
+                                                <div class="meta-label">Grading Source</div>
+                                                <div class="meta-value" style="font-size: 0.82rem; color: var(--muted);">{{ entry.graded_source }}</div>
+                                            </div>
+                                        {% endif %}
                                     </div>
                                 </div>
                                 {% if entry.prompt_sections %}
@@ -1165,7 +1429,9 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                 <div id="curl-{{ entry.cache_key }}" class="block hidden" data-section="curl">
                                     <div class="block-title">Repro Curl</div>
                                     <pre># Save payload to file first:
-echo '{{ entry.request_data|tojson }}' > request.json
+cat &lt;&lt;'PAYLOAD_EOF' > request.json
+{{ entry.request_data|tojson_utf8|safe }}
+PAYLOAD_EOF
 
 curl "{{ entry.endpoint }}" \
   -H "Content-Type: application/json" \
@@ -1326,6 +1592,12 @@ curl "{{ entry.endpoint }}" \
                         <pre>{{ meta.raw_eval_metrics|e }}</pre>
                     </details>
                 {% endif %}
+                {% if meta.raw_metadata %}
+                    <details>
+                        <summary>Raw metadata.yaml</summary>
+                        <pre>{{ meta.raw_metadata|e }}</pre>
+                    </details>
+                {% endif %}
             </div>
 
 
@@ -1422,26 +1694,17 @@ curl "{{ entry.endpoint }}" \
             rows.forEach((row) => {
                 const visible = matchesFilters(row);
                 row.style.display = visible ? '' : 'none';
-                if (visible) visibleRows += 1;
+                if (visible) {
+                    visibleRows += 1;
+                    const idxCell = row.querySelector('.idx-col a');
+                    if (idxCell) idxCell.textContent = visibleRows;
+                }
             });
 
             if (visibleCount) {
                 const count = rows.length ? visibleRows : visibleEntries;
                 visibleCount.textContent = `Visible: ${count} / ${total}`;
             }
-        }
-
-        function normalizeGradeClasses() {
-            document.querySelectorAll('.entry').forEach((entry) => {
-                const grade = entry.getAttribute('data-graded') || 'unknown';
-                entry.classList.remove('grade-correct', 'grade-incorrect', 'grade-unknown');
-                entry.classList.add(`grade-${grade || 'unknown'}`);
-            });
-            document.querySelectorAll('.sample-row').forEach((row) => {
-                const grade = row.getAttribute('data-graded') || 'unknown';
-                row.classList.remove('grade-correct', 'grade-incorrect', 'grade-unknown');
-                row.classList.add(`grade-${grade || 'unknown'}`);
-            });
         }
 
         function syncEntryCounts() {
@@ -1517,7 +1780,14 @@ curl "{{ entry.endpoint }}" \
             }
         }
 
-        [searchBox, modelFilter, typeFilter, finishFilter, gradingFilter, errorOnly, toolOnly].forEach((el) => {
+        let searchTimeout = null;
+        if (searchBox) {
+            searchBox.addEventListener('input', () => {
+                clearTimeout(searchTimeout);
+                searchTimeout = setTimeout(applyFilters, 200);
+            });
+        }
+        [modelFilter, typeFilter, finishFilter, gradingFilter, errorOnly, toolOnly].forEach((el) => {
             if (!el) return;
             el.addEventListener('input', applyFilters);
             el.addEventListener('change', applyFilters);
@@ -1674,10 +1944,62 @@ curl "{{ entry.endpoint }}" \
                 if (toggle) toggle.textContent = 'Expand';
             }
         });
-        normalizeGradeClasses();
         syncEntryCounts();
         sortEntries();
         applyFilters();
+
+        function getVisibleTableData() {
+            const rows = Array.from(document.querySelectorAll('.sample-row'));
+            const headers = ['#', 'Input', 'Target', 'Answer', 'Score', 'Cache Key'];
+            const data = [];
+            rows.forEach((row) => {
+                if (row.style.display === 'none') return;
+                const cells = row.querySelectorAll('td');
+                if (cells.length < 5) return;
+                data.push({
+                    '#': (cells[0].textContent || '').trim(),
+                    'Input': (cells[1].textContent || '').trim(),
+                    'Target': (cells[2].textContent || '').trim(),
+                    'Answer': (cells[3].textContent || '').trim(),
+                    'Score': (cells[4].textContent || '').trim(),
+                    'Cache Key': row.getAttribute('data-cache') || '',
+                });
+            });
+            return { headers, data };
+        }
+
+        function downloadBlob(content, filename, mimeType) {
+            const blob = new Blob([content], { type: mimeType });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = filename;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+        }
+
+        const exportCsvBtn = document.getElementById('exportCsv');
+        if (exportCsvBtn) {
+            exportCsvBtn.addEventListener('click', () => {
+                const { headers, data } = getVisibleTableData();
+                const escape = (v) => '"' + String(v).replace(/"/g, '""') + '"';
+                const lines = [headers.map(escape).join(',')];
+                data.forEach((row) => {
+                    lines.push(headers.map((h) => escape(row[h] || '')).join(','));
+                });
+                downloadBlob(lines.join('\\n'), 'eval_report.csv', 'text/csv;charset=utf-8;');
+            });
+        }
+
+        const exportJsonBtn = document.getElementById('exportJson');
+        if (exportJsonBtn) {
+            exportJsonBtn.addEventListener('click', () => {
+                const { data } = getVisibleTableData();
+                downloadBlob(JSON.stringify(data, null, 2), 'eval_report.json', 'application/json;charset=utf-8;');
+            });
+        }
     </script>
 </body>
 </html>"""

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
@@ -26,210 +26,716 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{% if entries %}Example Request-Response Pairs{% else %}Example Request-Response Pair{% endif %}</title>
+    <title>Evaluation Report</title>
     <style>
-        /* Container and general styles */
+        :root {
+            --bg: #0f1116;
+            --bg-accent: #1a1f2b;
+            --panel: #141824;
+            --panel-2: #10131b;
+            --text: #e8ecf1;
+            --muted: #9aa6b2;
+            --accent: #60d394;
+            --accent-2: #6f9bff;
+            --warn: #f5c451;
+            --border: rgba(255, 255, 255, 0.08);
+            --shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+        }
+
         body {
-            font-family: Arial, sans-serif;
-            line-height: 1.6;
+            font-family: "Space Grotesk", "IBM Plex Sans", "Source Sans 3", sans-serif;
+            line-height: 1.5;
             margin: 0;
-            padding: 20px;
-            color: #333;
+            color: var(--text);
+            background: radial-gradient(1200px 700px at 15% -20%, #1e2a3b 0%, rgba(15, 17, 22, 0) 65%),
+                        radial-gradient(900px 900px at 110% 10%, #1f2440 0%, rgba(15, 17, 22, 0) 60%),
+                        var(--bg);
+            padding: 32px;
         }
         .container {
             max-width: 1200px;
             margin: 0 auto;
         }
         h1 {
-            color: #2c3e50;
-            border-bottom: 2px solid #eee;
-            padding-bottom: 10px;
-            margin-bottom: 10px;
+            font-size: 2.4rem;
+            margin: 0 0 8px;
         }
         .subtitle {
-            color: #666;
-            font-style: italic;
-            margin-bottom: 20px;
-            font-size: 1.1em;
+            color: var(--muted);
+            margin: 0 0 24px;
+            font-size: 1.02rem;
+        }
+        .hero {
+            background: linear-gradient(135deg, rgba(96, 211, 148, 0.08), rgba(111, 155, 255, 0.08));
+            border: 1px solid var(--border);
+            padding: 22px 24px;
+            border-radius: 14px;
+            box-shadow: var(--shadow);
+            margin-bottom: 18px;
+        }
+        .hero strong {
+            color: var(--accent);
+        }
+        .summary-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 12px;
+            margin: 20px 0 26px;
+        }
+        .summary-card {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            padding: 14px 16px;
+            border-radius: 12px;
+        }
+        .summary-card .label {
+            color: var(--muted);
+            font-size: 0.82rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        .summary-card .value {
+            font-size: 1.15rem;
+            margin-top: 6px;
+            word-break: break-word;
+        }
+        .toolbar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 16px;
+        }
+        .search {
+            flex: 1;
+            min-width: 220px;
+            background: var(--panel-2);
+            border: 1px solid var(--border);
+            padding: 10px 14px;
+            border-radius: 999px;
+            color: var(--text);
+            font-size: 0.95rem;
+        }
+        .toggle-group {
+            display: flex;
+            gap: 8px;
+            flex-wrap: wrap;
+        }
+        .toggle {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            color: var(--text);
+            padding: 8px 12px;
+            border-radius: 999px;
+            cursor: pointer;
+            font-size: 0.85rem;
+        }
+        .toggle.active {
+            background: var(--accent);
+            color: #0b0f14;
+            border-color: rgba(96, 211, 148, 0.6);
+        }
+        .select {
+            background: var(--panel-2);
+            border: 1px solid var(--border);
+            color: var(--text);
+            padding: 8px 12px;
+            border-radius: 10px;
+            font-size: 0.85rem;
+        }
+        .check {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            color: var(--muted);
+            font-size: 0.85rem;
+        }
+        .visible-count {
+            color: var(--muted);
+            font-size: 0.85rem;
         }
         .note {
-            color: #546E7A;
-            font-weight: bold;
-            font-style: normal;
+            color: var(--muted);
+            font-size: 0.9rem;
+            margin: 8px 0 18px;
         }
-        .cache-info-header {
-            background-color: #E8F5E9;
-            color: #2E7D32;
-            padding: 12px 16px;
-            border-radius: 4px;
-            margin-bottom: 20px;
-            font-size: 0.95em;
-            border: 1px solid #C8E6C9;
+        .note strong {
+            color: var(--warn);
         }
-        .cache-info-header .note {
-            color: #546E7A;
-            font-weight: bold;
-            font-style: normal;
-            display: block;
-            margin-top: 8px;
+        .chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 10px;
+        }
+        .chip {
+            background: var(--panel-2);
+            border: 1px solid var(--border);
+            color: var(--muted);
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 0.78rem;
+        }
+        .section {
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 14px;
+            padding: 18px 20px;
+            margin-bottom: 18px;
+            box-shadow: var(--shadow);
+        }
+        .section h2 {
+            margin: 0 0 12px;
+            font-size: 1.15rem;
+        }
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 0.9rem;
+        }
+        th, td {
+            text-align: left;
+            padding: 10px 8px;
+            border-bottom: 1px solid var(--border);
+            vertical-align: top;
+            word-break: break-word;
+        }
+        th {
+            color: var(--muted);
+            font-size: 0.78rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+        }
+        details {
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 10px 12px;
+            margin-top: 12px;
+            background: var(--panel-2);
+        }
+        details summary {
+            cursor: pointer;
+            color: var(--accent-2);
+            font-weight: 600;
         }
 
-        /* Entry styles */
         .entry {
-            margin: 20px 0;
-            padding: 15px;
-            background: #f9f9f9;
-            border: 1px solid #ddd;
-            border-radius: 5px;
+            margin: 16px 0;
+            padding: 18px;
+            background: var(--panel);
+            border: 1px solid var(--border);
+            border-radius: 14px;
+            box-shadow: var(--shadow);
         }
-        .cache-info {
-            padding: 8px 16px;
+        .entry-header {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 12px;
+        }
+        .entry-meta {
+            font-size: 0.9rem;
+            color: var(--muted);
+        }
+        .entry-meta.secondary {
+            margin-top: 6px;
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            font-size: 0.85rem;
+        }
+        .entry-meta strong {
+            color: var(--text);
+        }
+        .badge {
+            padding: 2px 8px;
+            border-radius: 999px;
+            font-size: 0.72rem;
+            border: 1px solid var(--border);
+        }
+        .badge.error {
+            color: #ffb4a2;
+            border-color: rgba(255, 180, 162, 0.4);
+            background: rgba(255, 180, 162, 0.1);
+        }
+        .badge.info {
+            color: #9bd0ff;
+            border-color: rgba(155, 208, 255, 0.35);
+            background: rgba(155, 208, 255, 0.12);
+        }
+        .prompt-preview {
+            margin-top: 10px;
+            padding: 10px 12px;
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px dashed var(--border);
+            border-radius: 10px;
+            color: var(--text);
+            font-size: 0.88rem;
+        }
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            background: rgba(96, 211, 148, 0.12);
+            color: var(--accent);
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 0.78rem;
+            border: 1px solid rgba(96, 211, 148, 0.2);
+        }
+        .block {
+            background: #0c0f16;
+            border: 1px solid var(--border);
+            padding: 12px 14px;
+            border-radius: 10px;
+            margin-bottom: 10px;
+        }
+        .block-title {
+            font-size: 0.8rem;
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            color: var(--muted);
             margin-bottom: 8px;
-            border-radius: 4px;
-            font-family: monospace;
-            background-color: #E3F2FD;
-            color: #0D47A1;
-            font-size: 0.9em;
-        }
-        .cache-explanation {
-            font-size: 0.8em;
-            color: #666;
-            margin-top: 4px;
-            font-style: italic;
-        }
-        .request, .response, .curl-command {
-            padding: 8px 16px;
-            margin-bottom: 8px;
-            border-radius: 4px;
-            font-family: monospace;
-        }
-        .request {
-            background-color: #B2DFDB;
-            color: #00695C;
-        }
-        .response {
-            background-color: #B39DDB;
-            color: #4527A0;
-        }
-        .curl-command {
-            background-color: #EEEEEE;
-            color: #212121;
-            white-space: pre-wrap;
-            display: none;
         }
         pre {
             white-space: pre-wrap;
+            word-break: break-word;
             margin: 0;
-            background: #f5f5f5;
-            padding: 10px;
-            border-radius: 3px;
-            overflow-x: auto;
+            font-family: "IBM Plex Mono", "SFMono-Regular", ui-monospace, monospace;
+            font-size: 0.85rem;
+            color: #d9e2ef;
         }
         .buttons {
             display: flex;
-            gap: 10px;
+            flex-wrap: wrap;
+            gap: 8px;
             margin-bottom: 10px;
         }
         .button {
-            padding: 5px 10px;
-            border: none;
-            border-radius: 3px;
+            padding: 6px 12px;
+            border: 1px solid var(--border);
+            border-radius: 8px;
             cursor: pointer;
-            font-size: 12px;
-            background-color: #4CAF50;
-            color: white;
+            font-size: 0.8rem;
+            background-color: var(--panel-2);
+            color: var(--text);
+        }
+        .button.primary {
+            background-color: var(--accent-2);
+            color: #0b0f14;
+            border-color: rgba(111, 155, 255, 0.4);
         }
         .button:hover {
-            background-color: #45a049;
+            filter: brightness(1.1);
+        }
+        .hidden {
+            display: none !important;
+        }
+        .empty {
+            padding: 40px 20px;
+            text-align: center;
+            color: var(--muted);
+            border: 1px dashed var(--border);
+            border-radius: 12px;
+            margin-top: 20px;
+        }
+        @media (max-width: 720px) {
+            body {
+                padding: 20px;
+            }
+            h1 {
+                font-size: 1.9rem;
+            }
         }
     </style>
 </head>
 <body>
     <div class="container">
         {% if entries %}
-            <h1>Example Request-Response Pairs</h1>
-            <p class="subtitle">Final request (sent directly to the endpoint) and response pairs with curl commands for reproducibility. <span class="note">*Note: Responses may vary due to generation parameters, randomness, and other factors.</span></p>
-            <div class="cache-info-header">
-                <strong>About Cache Keys:</strong> Each request-response pair is identified by a unique cache key generated from the request payload hash. <span class="note">Note: Cache keys may differ across different models because the model field in the request payload will be different.</span>
+            <div class="hero">
+                <h1>Evaluation Report</h1>
+                <p class="subtitle">Curated request and response samples captured during evaluation. Built for quick review, sharing, and debugging.</p>
+                <div class="note"><strong>Note:</strong> Responses can vary due to generation parameters and randomness.</div>
             </div>
+
+            {% if meta.limited %}
+                <div class="note"><strong>Limited:</strong> Showing the first {{ meta.shown_entries }} entries of {{ meta.total_entries }} due to HTML report size settings.</div>
+            {% endif %}
+
+            <div class="toolbar">
+                <input class="search" id="searchBox" type="search" placeholder="Search cache keys, requests, responses..." />
+                <select id="modelFilter" class="select">
+                    <option value="">All models</option>
+                    {% for model in meta.filters.models %}
+                        <option value="{{ model }}">{{ model }}</option>
+                    {% endfor %}
+                </select>
+                <select id="typeFilter" class="select">
+                    <option value="">All request types</option>
+                    {% for req_type in meta.filters.request_types %}
+                        <option value="{{ req_type }}">{{ req_type }}</option>
+                    {% endfor %}
+                </select>
+                <select id="finishFilter" class="select">
+                    <option value="">All finish reasons</option>
+                    {% for reason in meta.filters.finish_reasons %}
+                        <option value="{{ reason }}">{{ reason }}</option>
+                    {% endfor %}
+                </select>
+                <label class="check"><input type="checkbox" id="errorOnly" /> Errors only</label>
+                <label class="check"><input type="checkbox" id="toolOnly" /> Tool calls</label>
+                <select id="sortSelect" class="select">
+                    <option value="cache">Sort: cache key</option>
+                    <option value="request">Sort: request length</option>
+                    <option value="response">Sort: response length</option>
+                </select>
+                <span class="visible-count" id="visibleCount"></span>
+                <div class="toggle-group">
+                    <button class="toggle active" data-target="request">Requests</button>
+                    <button class="toggle active" data-target="response">Responses</button>
+                    <button class="toggle" data-target="curl">Curl</button>
+                </div>
+            </div>
+
+            {% if meta.summary_items %}
+                <div class="section">
+                    <h2>Run Summary</h2>
+                    <div class="summary-grid">
+                        {% for item in meta.summary_items %}
+                            <div class="summary-card">
+                                <div class="label">{{ item.label }}</div>
+                                <div class="value">{{ item.value }}</div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            {% endif %}
+
+            {% if meta.stats %}
+                <div class="section">
+                    <h2>Sample Stats</h2>
+                    <div class="summary-grid">
+                        <div class="summary-card">
+                            <div class="label">Error Rate</div>
+                            <div class="value">{{ (meta.stats.error_rate * 100) | round(2) }}% ({{ meta.stats.error_count }})</div>
+                        </div>
+                        <div class="summary-card">
+                            <div class="label">Tool Calls</div>
+                            <div class="value">{{ meta.stats.tool_count }}</div>
+                        </div>
+                        <div class="summary-card">
+                            <div class="label">Avg Request Chars</div>
+                            <div class="value">{{ meta.stats.avg_request_chars | round(0) }}</div>
+                        </div>
+                        <div class="summary-card">
+                            <div class="label">Avg Response Chars</div>
+                            <div class="value">{{ meta.stats.avg_response_chars | round(0) }}</div>
+                        </div>
+                        {% if meta.stats.usage_totals.prompt_tokens or meta.stats.usage_totals.completion_tokens or meta.stats.usage_totals.total_tokens %}
+                            <div class="summary-card">
+                                <div class="label">Tokens (Prompt / Completion / Total)</div>
+                                <div class="value">{{ meta.stats.usage_totals.prompt_tokens }} / {{ meta.stats.usage_totals.completion_tokens }} / {{ meta.stats.usage_totals.total_tokens }}</div>
+                            </div>
+                        {% endif %}
+                    </div>
+
+                    {% if meta.stats.request_type_counts %}
+                        <div class="chips">
+                            {% for key, value in meta.stats.request_type_counts.items() %}
+                                <div class="chip">{{ key }}: {{ value }}</div>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                    {% if meta.stats.finish_reason_counts %}
+                        <div class="chips">
+                            {% for key, value in meta.stats.finish_reason_counts.items() %}
+                                <div class="chip">{{ key }}: {{ value }}</div>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+            {% endif %}
+
+            <div class="section">
+                <h2>Score Metrics</h2>
+                {% if meta.metrics_rows %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Metric Path</th>
+                                <th>Value</th>
+                                <th>Stats</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in meta.metrics_rows %}
+                                <tr>
+                                    <td>{{ row.path }}</td>
+                                    <td>{{ row.value }}</td>
+                                    <td>{{ row.stats }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <div class="note">No metrics were found in results.yml.</div>
+                {% endif %}
+            </div>
+
+            <div class="section">
+                <h2>Performance Metrics</h2>
+                {% if meta.perf_rows %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Metric Path</th>
+                                <th>Value</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in meta.perf_rows %}
+                                <tr>
+                                    <td>{{ row.path }}</td>
+                                    <td>{{ row.value }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <div class="note">No performance metrics were found.</div>
+                {% endif %}
+            </div>
+
+            <div class="section">
+                <h2>Artifacts</h2>
+                {% if meta.artifacts_rows %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Artifact</th>
+                                <th>Details</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in meta.artifacts_rows %}
+                                <tr>
+                                    <td>{{ row.name }}</td>
+                                    <td>{{ row.detail }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <div class="note">No artifact metadata found.</div>
+                {% endif %}
+
+                {% if meta.raw_results %}
+                    <details>
+                        <summary>Raw results.yml</summary>
+                        <pre>{{ meta.raw_results|e }}</pre>
+                    </details>
+                {% endif %}
+                {% if meta.raw_run_config %}
+                    <details>
+                        <summary>Raw run_config.yml</summary>
+                        <pre>{{ meta.raw_run_config|e }}</pre>
+                    </details>
+                {% endif %}
+                {% if meta.raw_eval_metrics %}
+                    <details>
+                        <summary>Raw eval_factory_metrics.json</summary>
+                        <pre>{{ meta.raw_eval_metrics|e }}</pre>
+                    </details>
+                {% endif %}
+            </div>
+
+            <div id="entriesContainer">
             {% for entry in entries %}
-                <div class="entry">
-                    <div class="cache-info">
-                        <strong>Cache Key:</strong> {{ entry.cache_key }}
+                <div class="entry"
+                     data-search="{{ entry.search_blob|e }}"
+                     data-cache="{{ entry.cache_key|e }}"
+                     data-model="{{ entry.model|e }}"
+                     data-request-type="{{ entry.request_type|e }}"
+                     data-has-error="{{ 'true' if entry.has_error else 'false' }}"
+                     data-has-tool="{{ 'true' if entry.has_tool_calls else 'false' }}"
+                     data-finish-reasons="{{ entry.finish_reasons | join(',') | e }}"
+                     data-request-chars="{{ entry.request_chars }}"
+                     data-response-chars="{{ entry.response_chars }}">
+                    <div class="entry-header">
+                        <div class="entry-meta">
+                            <span class="pill">Sample {{ loop.index }}</span>
+                            <span>Cache Key: <strong>{{ entry.cache_key }}</strong></span>
+                            <span>Model: <strong>{{ entry.model }}</strong></span>
+                            <span>Type: <strong>{{ entry.request_type }}</strong></span>
+                            {% if entry.finish_reasons %}
+                                <span>Finish: <strong>{{ entry.finish_reasons | join(', ') }}</strong></span>
+                            {% endif %}
+                        </div>
+                        <div class="buttons">
+                            <button class="button" onclick="copyBlock('req-{{ entry.cache_key }}')">Copy Request</button>
+                            <button class="button" onclick="copyBlock('res-{{ entry.cache_key }}')">Copy Response</button>
+                            <button class="button primary" onclick="toggleRaw('curl-{{ entry.cache_key }}')">Toggle Curl</button>
+                        </div>
                     </div>
-                    <div class="request">
-                        <strong>Request:</strong>
-                        <pre>{{ entry.display_request|tojson_utf8|safe }}</pre>
+                    <div class="entry-meta secondary">
+                        <span>Req chars: <strong>{{ entry.request_chars }}</strong></span>
+                        <span>Resp chars: <strong>{{ entry.response_chars }}</strong></span>
+                        {% if entry.usage %}
+                            <span>Tokens: <strong>{{ entry.usage.prompt_tokens }} / {{ entry.usage.completion_tokens }} / {{ entry.usage.total_tokens }}</strong></span>
+                        {% endif %}
+                        {% if entry.has_error %}
+                            <span class="badge error">Error</span>
+                        {% endif %}
+                        {% if entry.has_tool_calls %}
+                            <span class="badge info">Tool calls</span>
+                        {% endif %}
                     </div>
-
-                    <div class="response">
-                        <strong>Response:</strong>
-                        <pre>{{ entry.response|tojson_utf8|safe }}</pre>
+                    {% if entry.prompt_preview %}
+                        <div class="prompt-preview">{{ entry.prompt_preview }}</div>
+                    {% endif %}
+                    <div class="block request-block" data-section="request">
+                        <div class="block-title">Request</div>
+                        <pre id="req-{{ entry.cache_key }}">{{ entry.display_request|tojson_utf8|safe }}</pre>
                     </div>
-
-                    <div class="buttons">
-                        <button class="button" onclick="toggleRaw('curl-{{ entry.cache_key }}')">Show Curl Command</button>
+                    <div class="block response-block" data-section="response">
+                        <div class="block-title">Response</div>
+                        <pre id="res-{{ entry.cache_key }}">{{ entry.response|tojson_utf8|safe }}</pre>
                     </div>
+                    <div id="curl-{{ entry.cache_key }}" class="block hidden" data-section="curl">
+                        <div class="block-title">Repro Curl</div>
+                        <pre># Save payload to file first:
+echo '{{ entry.request_data|tojson }}' > request.json
 
-                    <div id="curl-{{ entry.cache_key }}" class="curl-command">
-                        # Save payload to file first:
-                        echo '{{ entry.request_data|tojson }}' > request.json
-
-                        curl "{{ entry.endpoint }}" \
-                        -H "Content-Type: application/json" \
-                        -H "Authorization: Bearer $API_KEY" \
-                        -H "Accept: application/json" \
-                        -d @request.json
+curl "{{ entry.endpoint }}" \\
+  -H "Content-Type: application/json" \\
+  -H "Authorization: Bearer $API_KEY" \\
+  -H "Accept: application/json" \\
+  -d @request.json</pre>
                     </div>
                 </div>
             {% endfor %}
+            </div>
         {% else %}
-            <h1>Example Request-Response Pair</h1>
-            <p class="subtitle">Final request (sent directly to the endpoint) and response with curl command for reproducibility. <span class="note">*Note: Responses may vary due to generation parameters, randomness, and other factors.</span></p>
-            <div class="cache-info-header">
-                <strong>About Cache Keys:</strong> Each request-response pair is identified by a unique cache key generated from the request payload hash. <span class="note">Note: Cache keys may differ across different models because the model field in the request payload will be different.</span>
-            </div>
-            <div class="entry">
-                <div class="cache-info">
-                    <strong>Cache Key:</strong> {{ cache_key }}
-                </div>
-                <div class="request">
-                    <strong>Request:</strong>
-                    <pre>{{ display_request|tojson_utf8|safe }}</pre>
-                </div>
-
-                <div class="response">
-                    <strong>Response:</strong>
-                    <pre>{{ response|tojson_utf8|safe }}</pre>
-                </div>
-
-                <div class="buttons">
-                    <button class="button" onclick="toggleRaw('curl-{{ cache_key }}')">Show Curl Command</button>
-                </div>
-
-                <div id="curl-{{ cache_key }}" class="curl-command">
-                        # Save payload to file first:
-                        echo '{{ request_data|tojson }}' > request.json
-
-                        curl "{{ endpoint }}" \
-                        -H "Content-Type: application/json" \
-                        -H "Authorization: Bearer $API_KEY" \
-                        -H "Accept: application/json" \
-                        -d @request.json
-                </div>
-            </div>
+            <div class="empty">No cached entries were found to render a report.</div>
         {% endif %}
     </div>
 
     <script>
         function toggleRaw(elementId) {
             const element = document.getElementById(elementId);
-            if (element.style.display === 'none' || element.style.display === '') {
-                element.style.display = 'block';
-            } else {
-                element.style.display = 'none';
+            if (!element) return;
+            element.classList.toggle('hidden');
+        }
+
+        function copyBlock(elementId) {
+            const element = document.getElementById(elementId);
+            if (!element) return;
+            const text = element.innerText || element.textContent || "";
+            navigator.clipboard.writeText(text);
+        }
+
+        const toggles = document.querySelectorAll('.toggle');
+        toggles.forEach((toggle) => {
+            toggle.addEventListener('click', () => {
+                toggle.classList.toggle('active');
+                const target = toggle.getAttribute('data-target');
+                const sections = document.querySelectorAll(`[data-section="${target}"]`);
+                sections.forEach((section) => {
+                    if (toggle.classList.contains('active')) {
+                        section.classList.remove('hidden');
+                    } else {
+                        section.classList.add('hidden');
+                    }
+                });
+            });
+        });
+
+        const searchBox = document.getElementById('searchBox');
+        const modelFilter = document.getElementById('modelFilter');
+        const typeFilter = document.getElementById('typeFilter');
+        const finishFilter = document.getElementById('finishFilter');
+        const errorOnly = document.getElementById('errorOnly');
+        const toolOnly = document.getElementById('toolOnly');
+        const sortSelect = document.getElementById('sortSelect');
+        const visibleCount = document.getElementById('visibleCount');
+        const entriesContainer = document.getElementById('entriesContainer');
+
+        function applyFilters() {
+            const query = (searchBox?.value || "").toLowerCase();
+            const model = modelFilter?.value || "";
+            const type = typeFilter?.value || "";
+            const finish = finishFilter?.value || "";
+            const errorsOnly = errorOnly?.checked || false;
+            const toolsOnly = toolOnly?.checked || false;
+
+            const entries = entriesContainer ? entriesContainer.querySelectorAll('.entry') : document.querySelectorAll('.entry');
+            let count = 0;
+            const total = entries.length;
+            entries.forEach((entry) => {
+                const haystack = entry.getAttribute('data-search') || "";
+                const entryModel = entry.getAttribute('data-model') || "";
+                const entryType = entry.getAttribute('data-request-type') || "";
+                const entryFinish = (entry.getAttribute('data-finish-reasons') || "").split(',').filter(Boolean);
+                const hasError = entry.getAttribute('data-has-error') === 'true';
+                const hasTool = entry.getAttribute('data-has-tool') === 'true';
+
+                const matchesSearch = !query || haystack.indexOf(query) !== -1;
+                const matchesModel = !model || entryModel === model;
+                const matchesType = !type || entryType === type;
+                const matchesFinish = !finish || entryFinish.includes(finish);
+                const matchesError = !errorsOnly || hasError;
+                const matchesTool = !toolsOnly || hasTool;
+
+                const visible = matchesSearch && matchesModel && matchesType && matchesFinish && matchesError && matchesTool;
+                entry.style.display = visible ? 'block' : 'none';
+                if (visible) count += 1;
+            });
+
+            if (visibleCount) {
+                visibleCount.textContent = `Visible: ${count} / ${total}`;
             }
         }
+
+        function sortEntries() {
+            if (!entriesContainer || !sortSelect) return;
+            const entries = Array.from(entriesContainer.querySelectorAll('.entry'));
+            const sortBy = sortSelect.value;
+            entries.sort((a, b) => {
+                if (sortBy === 'cache') {
+                    return (a.getAttribute('data-cache') || '').localeCompare(
+                        b.getAttribute('data-cache') || ''
+                    );
+                }
+                if (sortBy === 'request') {
+                    return (parseInt(a.getAttribute('data-request-chars') || '0', 10) -
+                        parseInt(b.getAttribute('data-request-chars') || '0', 10));
+                }
+                if (sortBy === 'response') {
+                    return (parseInt(a.getAttribute('data-response-chars') || '0', 10) -
+                        parseInt(b.getAttribute('data-response-chars') || '0', 10));
+                }
+                return 0;
+            });
+            entries.forEach((entry) => entriesContainer.appendChild(entry));
+        }
+
+        [searchBox, modelFilter, typeFilter, finishFilter, errorOnly, toolOnly].forEach((el) => {
+            if (!el) return;
+            el.addEventListener('input', applyFilters);
+            el.addEventListener('change', applyFilters);
+        });
+
+        if (sortSelect) {
+            sortSelect.addEventListener('change', () => {
+                sortEntries();
+                applyFilters();
+            });
+        }
+
+        sortEntries();
+        applyFilters();
     </script>
 </body>
 </html>"""

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
@@ -57,7 +57,7 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             margin: 0 auto;
         }
         h1 {
-            font-size: 2.4rem;
+            font-size: 1.9rem;
             margin: 0 0 8px;
         }
         .subtitle {
@@ -72,6 +72,145 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             border-radius: 14px;
             box-shadow: var(--shadow);
             margin-bottom: 18px;
+        }
+        .brand-bar {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 16px;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 16px;
+        }
+        .brand-left {
+            display: flex;
+            flex-direction: column;
+            gap: 4px;
+        }
+        .brand-header {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 10px;
+        }
+        .brand-logo {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .nvidia-logo {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+        }
+        .nvidia-eye {
+            width: 38px;
+            height: 26px;
+            flex: 0 0 auto;
+        }
+        .nvidia-word {
+            font-weight: 800;
+            letter-spacing: 0.16em;
+            font-size: 0.9rem;
+            color: #76b900;
+            text-transform: uppercase;
+        }
+        .brand-title {
+            font-size: 1.1rem;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+        }
+        .brand-sub {
+            color: var(--muted);
+            font-size: 0.85rem;
+            margin-top: 2px;
+        }
+        .hero-pills {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin: 10px 0 6px;
+        }
+        .pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: rgba(118, 185, 0, 0.12);
+            box-shadow: inset 0 0 0 1px rgba(118, 185, 0, 0.12);
+            font-size: 0.82rem;
+        }
+        .pill-label {
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 0.62rem;
+            color: var(--muted);
+        }
+        .pill-value {
+            color: var(--text);
+            font-weight: 600;
+        }
+        .pill-link {
+            color: var(--text);
+            font-weight: 600;
+            text-decoration: none;
+        }
+        .pill-link:hover {
+            text-decoration: underline;
+        }
+        .pill-model {
+            background: rgba(111, 155, 255, 0.14);
+            border-color: rgba(111, 155, 255, 0.35);
+            box-shadow: inset 0 0 0 1px rgba(111, 155, 255, 0.16);
+        }
+        .pill-model .pill-label {
+            color: rgba(208, 223, 255, 0.9);
+        }
+        .pill-benchmark {
+            background: rgba(118, 185, 0, 0.14);
+            border-color: rgba(118, 185, 0, 0.38);
+            box-shadow: inset 0 0 0 1px rgba(118, 185, 0, 0.14);
+        }
+        .pill-benchmark .pill-label {
+            color: rgba(204, 232, 190, 0.92);
+        }
+        .pill-container {
+            background: rgba(255, 255, 255, 0.06);
+            border-color: rgba(255, 255, 255, 0.15);
+            box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+        }
+        .brand-link {
+            color: var(--accent-2);
+            text-decoration: none;
+            font-size: 0.85rem;
+            border: 1px solid rgba(111, 155, 255, 0.35);
+            padding: 6px 12px;
+            border-radius: 999px;
+            background: rgba(111, 155, 255, 0.08);
+        }
+        .brand-link:hover {
+            filter: brightness(1.1);
+        }
+        .brand-meta {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 10px;
+        }
+        .meta-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 999px;
+            border: 1px solid var(--border);
+            background: rgba(255, 255, 255, 0.04);
+            font-size: 0.85rem;
+            color: var(--muted);
+        }
+        .meta-pill strong {
+            color: var(--text);
         }
         .hero strong {
             color: var(--accent);
@@ -146,8 +285,9 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             text-align: left;
         }
         .sample-table .idx-col { width: 56px; }
-        .sample-table .target-col { width: 140px; min-width: 140px; }
+        .sample-table .target-col { width: 180px; min-width: 180px; }
         .sample-table .score-col { width: 120px; min-width: 120px; text-align: center; }
+        .sample-table .details-col { width: 90px; min-width: 90px; text-align: center; }
         .sample-table .answer-col { width: 35%; }
         .sample-table .input-col { width: auto; }
         .score-badge {
@@ -171,12 +311,36 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             border-color: rgba(255, 154, 154, 0.35);
         }
         .score-badge.unknown {
-            background: rgba(199, 199, 199, 0.12);
-            color: #c7c7c7;
-            border-color: rgba(199, 199, 199, 0.3);
+            background: rgba(246, 211, 101, 0.18);
+            color: #f6d365;
+            border-color: rgba(246, 211, 101, 0.45);
         }
         .sample-row:hover {
             background: rgba(111, 155, 255, 0.08);
+        }
+        .sample-row.grade-correct {
+            background: rgba(126, 224, 129, 0.06);
+        }
+        .sample-row.grade-incorrect {
+            background: rgba(255, 154, 154, 0.06);
+        }
+        .sample-row.grade-unknown {
+            background: rgba(246, 211, 101, 0.08);
+        }
+        .sample-table td {
+            border-right: 1px solid rgba(255, 255, 255, 0.04);
+        }
+        .sample-table td:last-child,
+        .sample-table th:last-child {
+            border-right: none;
+        }
+        .details-link {
+            color: var(--accent-2);
+            text-decoration: none;
+            font-size: 0.78rem;
+        }
+        .details-link:hover {
+            text-decoration: underline;
         }
         .metric-path {
             max-width: 420px;
@@ -193,10 +357,16 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
         }
         .sample-table td.score-col,
         .sample-table th.score-col,
-        .sample-table td.target-col,
-        .sample-table th.target-col {
+        .sample-table td.details-col,
+        .sample-table th.details-col {
             white-space: nowrap;
             word-break: normal;
+        }
+        .sample-table td.target-col,
+        .sample-table th.target-col {
+            white-space: normal;
+            word-break: break-word;
+            overflow-wrap: anywhere;
         }
         .sample-row.grade-correct td:first-child {
             border-left: 3px solid rgba(126, 224, 129, 0.7);
@@ -285,13 +455,40 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             background: var(--panel);
             border: 1px solid var(--border);
             border-radius: 14px;
-            padding: 18px 20px;
+            padding: 0;
             margin-bottom: 18px;
             box-shadow: var(--shadow);
+            overflow: hidden;
         }
         .section h2 {
-            margin: 0 0 12px;
+            margin: 0;
             font-size: 1.15rem;
+        }
+        .section-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 16px 20px;
+            cursor: pointer;
+        }
+        .section-toggle {
+            border: 1px solid var(--border);
+            background: rgba(255, 255, 255, 0.04);
+            color: var(--muted);
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 0.72rem;
+            cursor: pointer;
+        }
+        .section-toggle:hover {
+            color: var(--text);
+        }
+        .section-body {
+            padding: 0 20px 18px;
+        }
+        .section.collapsed .section-body {
+            display: none;
         }
         table {
             width: 100%;
@@ -331,28 +528,114 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             border: 1px solid var(--border);
             border-radius: 14px;
             box-shadow: var(--shadow);
+            scroll-margin-top: 24px;
+            position: relative;
+            overflow: hidden;
+        }
+        .entry::before {
+            content: "";
+            position: absolute;
+            left: 0;
+            top: 0;
+            height: 100%;
+            width: 4px;
+            background: rgba(199, 199, 199, 0.4);
+        }
+        .entry.grade-correct {
+            border-color: rgba(126, 224, 129, 0.4);
+            box-shadow: 0 0 0 1px rgba(126, 224, 129, 0.08), var(--shadow);
+            background: linear-gradient(90deg, rgba(126, 224, 129, 0.06), rgba(20, 24, 36, 0) 45%), var(--panel);
+        }
+        .entry.grade-incorrect {
+            border-color: rgba(255, 154, 154, 0.4);
+            box-shadow: 0 0 0 1px rgba(255, 154, 154, 0.08), var(--shadow);
+            background: linear-gradient(90deg, rgba(255, 154, 154, 0.06), rgba(20, 24, 36, 0) 45%), var(--panel);
+        }
+        .entry.grade-unknown {
+            border-color: rgba(246, 211, 101, 0.35);
+            background: linear-gradient(90deg, rgba(246, 211, 101, 0.07), rgba(20, 24, 36, 0) 45%), var(--panel);
+        }
+        .entry.grade-correct::before {
+            background: rgba(126, 224, 129, 0.9);
+        }
+        .entry.grade-incorrect::before {
+            background: rgba(255, 154, 154, 0.9);
+        }
+        .entry.grade-unknown::before {
+            background: rgba(246, 211, 101, 0.9);
+        }
+        .entry[data-graded="correct"] {
+            border-color: rgba(126, 224, 129, 0.4);
+            box-shadow: 0 0 0 1px rgba(126, 224, 129, 0.08), var(--shadow);
+            background: linear-gradient(90deg, rgba(126, 224, 129, 0.06), rgba(20, 24, 36, 0) 45%), var(--panel);
+        }
+        .entry[data-graded="incorrect"] {
+            border-color: rgba(255, 154, 154, 0.4);
+            box-shadow: 0 0 0 1px rgba(255, 154, 154, 0.08), var(--shadow);
+            background: linear-gradient(90deg, rgba(255, 154, 154, 0.06), rgba(20, 24, 36, 0) 45%), var(--panel);
+        }
+        .entry[data-graded="unknown"] {
+            border-color: rgba(246, 211, 101, 0.35);
+            background: linear-gradient(90deg, rgba(246, 211, 101, 0.07), rgba(20, 24, 36, 0) 45%), var(--panel);
+        }
+        .entry[data-graded="correct"]::before {
+            background: rgba(126, 224, 129, 0.9);
+        }
+        .entry[data-graded="incorrect"]::before {
+            background: rgba(255, 154, 154, 0.9);
+        }
+        .entry[data-graded="unknown"]::before {
+            background: rgba(246, 211, 101, 0.9);
+        }
+        .entry.highlight {
+            outline: 2px solid rgba(111, 155, 255, 0.5);
+            outline-offset: 2px;
         }
         .entry-header {
             display: flex;
-            flex-wrap: wrap;
+            flex-direction: column;
             gap: 10px;
-            justify-content: space-between;
-            align-items: center;
             margin-bottom: 12px;
         }
-        .entry-meta {
-            font-size: 0.9rem;
-            color: var(--muted);
-        }
-        .entry-meta.secondary {
-            margin-top: 6px;
+        .entry-top {
             display: flex;
             flex-wrap: wrap;
-            gap: 12px;
-            font-size: 0.85rem;
+            gap: 10px;
+            align-items: center;
+            justify-content: space-between;
         }
-        .entry-meta strong {
+        .meta-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            align-items: center;
+        }
+        .meta-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 10px 12px;
+        }
+        .meta-card {
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 8px 12px;
+            min-width: 0;
+        }
+        .meta-card.span-2 {
+            grid-column: 1 / -1;
+        }
+        .meta-label {
+            text-transform: uppercase;
+            letter-spacing: 0.08em;
+            font-size: 0.68rem;
+            color: var(--muted);
+        }
+        .meta-value {
+            margin-top: 4px;
             color: var(--text);
+            word-break: break-word;
+            overflow-wrap: anywhere;
         }
         .badge {
             padding: 2px 8px;
@@ -381,9 +664,34 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             background: rgba(255, 154, 154, 0.12);
         }
         .badge.unknown {
-            color: #c7c7c7;
-            border-color: rgba(199, 199, 199, 0.3);
-            background: rgba(199, 199, 199, 0.08);
+            color: #f6d365;
+            border-color: rgba(246, 211, 101, 0.45);
+            background: rgba(246, 211, 101, 0.16);
+        }
+        .status-pill {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 0.78rem;
+            border: 1px solid var(--border);
+            background: var(--panel-2);
+        }
+        .status-pill.correct {
+            color: #7ee081;
+            border-color: rgba(126, 224, 129, 0.4);
+            background: rgba(126, 224, 129, 0.12);
+        }
+        .status-pill.incorrect {
+            color: #ff9a9a;
+            border-color: rgba(255, 154, 154, 0.4);
+            background: rgba(255, 154, 154, 0.12);
+        }
+        .status-pill.unknown {
+            color: #f6d365;
+            border-color: rgba(246, 211, 101, 0.45);
+            background: rgba(246, 211, 101, 0.16);
         }
         .prompt-preview {
             margin-top: 10px;
@@ -394,16 +702,16 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             color: var(--text);
             font-size: 0.88rem;
         }
-        .pill {
+        .sample-pill {
             display: inline-flex;
             align-items: center;
             gap: 6px;
-            background: rgba(96, 211, 148, 0.12);
-            color: var(--accent);
+            background: rgba(111, 155, 255, 0.14);
+            color: #bcd2ff;
             padding: 4px 10px;
             border-radius: 999px;
             font-size: 0.78rem;
-            border: 1px solid rgba(96, 211, 148, 0.2);
+            border: 1px solid rgba(111, 155, 255, 0.35);
         }
         .block {
             background: #0c0f16;
@@ -466,7 +774,7 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                 padding: 20px;
             }
             h1 {
-                font-size: 1.9rem;
+                font-size: 1.6rem;
             }
         }
     </style>
@@ -474,10 +782,55 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
 <body>
     <div class="container">
         {% if entries %}
+            <div class="brand-bar">
+                <div class="brand-left">
+                    <div class="brand-logo">
+                        <span class="nvidia-logo">
+                            <svg class="nvidia-eye" viewBox="0 0 64 40" role="img" aria-label="NVIDIA logo">
+                                <defs>
+                                    <linearGradient id="nvidiaGreen" x1="0" x2="1" y1="0" y2="1">
+                                        <stop offset="0%" stop-color="#76b900"/>
+                                        <stop offset="100%" stop-color="#8cd63f"/>
+                                    </linearGradient>
+                                </defs>
+                                <rect x="1" y="1" width="62" height="38" rx="9" fill="url(#nvidiaGreen)" />
+                                <path d="M10 20c8-8 16-12 22-12 6 0 14 4 22 12-8 8-16 12-22 12-6 0-14-4-22-12z" fill="rgba(8, 18, 8, 0.2)" />
+                                <circle cx="32" cy="20" r="7" fill="#0b1a0d" />
+                                <circle cx="32" cy="20" r="3.2" fill="#76b900" />
+                            </svg>
+                            <span class="nvidia-word">NVIDIA</span>
+                        </span>
+                    </div>
+                    <div class="brand-header">
+                        <div class="brand-title">NeMo Evaluator</div>
+                        <a class="brand-link" href="https://github.com/NVIDIA-NeMo/Evaluator" target="_blank" rel="noopener">GitHub Repo</a>
+                    </div>
+                    <div class="brand-sub">Evaluation Report</div>
+                </div>
+            </div>
             <div class="hero">
                 <h1>Evaluation Report</h1>
+                {% if meta.model_id or meta.task_name or meta.benchmark_container %}
+                    <div class="hero-pills">
+                        {% if meta.task_name %}
+                            <span class="pill pill-benchmark"><span class="pill-label">Benchmark</span><span class="pill-value">{{ meta.task_name }}</span></span>
+                        {% endif %}
+                        {% if meta.model_id %}
+                            <span class="pill pill-model"><span class="pill-label">Model</span><span class="pill-value">{{ meta.model_id }}</span></span>
+                        {% endif %}
+                        {% if meta.benchmark_container %}
+                            <span class="pill pill-container">
+                                <span class="pill-label">Container</span>
+                                {% if meta.benchmark_container_url %}
+                                    <a class="pill-link" href="{{ meta.benchmark_container_url }}" target="_blank" rel="noopener">{{ meta.benchmark_container }}</a>
+                                {% else %}
+                                    <span class="pill-value">{{ meta.benchmark_container }}</span>
+                                {% endif %}
+                            </span>
+                        {% endif %}
+                    </div>
+                {% endif %}
                 <p class="subtitle">Curated request and response samples captured during evaluation. Built for quick review, sharing, and debugging.</p>
-                <div class="note"><strong>Note:</strong> Responses can vary due to generation parameters and randomness.</div>
             </div>
 
             {% if meta.limited %}
@@ -485,7 +838,7 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             {% endif %}
 
             <div class="toolbar">
-                <input class="search" id="searchBox" type="search" placeholder="Search cache keys, requests, responses..." />
+                
                 <select id="modelFilter" class="select">
                     <option value="">All models</option>
                     {% for model in meta.filters.models %}
@@ -545,12 +898,22 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                     <h2>Sample Stats</h2>
                     <div class="summary-grid">
                         <div class="summary-card">
-                            <div class="label">Accuracy</div>
-                            <div class="value">{{ (meta.stats.accuracy * 100) | round(2) }}%</div>
+                            <div class="label">Report Accuracy (Graded)</div>
+                            <div class="value">
+                                {% if meta.stats.graded_count %}
+                                    {{ (meta.stats.accuracy * 100) | round(2) }}% ({{ meta.stats.correct_count }}/{{ meta.stats.graded_count }})
+                                {% else %}
+                                    —
+                                {% endif %}
+                            </div>
                         </div>
                         <div class="summary-card">
                             <div class="label">Correct / Incorrect / Unknown</div>
                             <div class="value">{{ meta.stats.correct_count }} / {{ meta.stats.incorrect_count }} / {{ meta.stats.unknown_count }}</div>
+                        </div>
+                        <div class="summary-card">
+                            <div class="label">Report Samples</div>
+                            <div class="value">{{ meta.stats.report_count }} shown / {{ meta.total_entries }} cached</div>
                         </div>
                         <div class="summary-card">
                             <div class="label">Error Rate</div>
@@ -579,17 +942,26 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                     {% if meta.stats.request_type_counts %}
                         <div class="chips">
                             {% for key, value in meta.stats.request_type_counts.items() %}
-                                <div class="chip">{{ key }}: {{ value }}</div>
+                                {% if key != 'unknown' %}
+                                    <div class="chip">{{ key }}: {{ value }}</div>
+                                {% endif %}
                             {% endfor %}
                         </div>
                     {% endif %}
                     {% if meta.stats.finish_reason_counts %}
                         <div class="chips">
                             {% for key, value in meta.stats.finish_reason_counts.items() %}
-                                <div class="chip">{{ key }}: {{ value }}</div>
+                                {% if key != 'unknown' %}
+                                    <div class="chip">{{ key }}: {{ value }}</div>
+                                {% endif %}
                             {% endfor %}
                         </div>
                     {% endif %}
+                    <div class="note">
+                        <strong>Note:</strong> Report accuracy uses graded log samples shown above (correct / incorrect).
+                        Results rollups below come from results.yml and may use task-specific definitions (inst-level vs prompt-level)
+                        and the full eval set.
+                    </div>
                 </div>
             {% endif %}
 
@@ -609,6 +981,7 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                     <th class="target-col">Target</th>
                                     <th class="answer-col">Answer</th>
                                     <th class="score-col">Score</th>
+                                    <th class="details-col">Details</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -624,9 +997,11 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                         data-graded="{{ entry.graded_label | e }}"
                                         data-request-chars="{{ entry.request_chars }}"
                                         data-response-chars="{{ entry.response_chars }}">
-                                        <td class="idx-col"><a href="#sample-{{ entry.cache_key }}">{{ loop.index }}</a></td>
+                                        <td class="idx-col">
+                                            <a class="details-link" data-detail-link="true" href="#sample-{{ entry.cache_key }}">{{ loop.index }}</a>
+                                        </td>
                                         <td class="input-col">{{ (entry.graded_input or entry.prompt_preview or '—') | truncate(160, True, '...') }}</td>
-                                        <td class="target-col">{{ (entry.graded_target or entry.graded_expected or '—') | truncate(80, True, '...') }}</td>
+                                        <td class="target-col">{{ (entry.target_display or entry.graded_target or entry.graded_expected or '—') | truncate(80, True, '...') }}</td>
                                         <td class="answer-col">{{ (entry.graded_response or entry.graded_predicted or '—') | truncate(120, True, '...') }}</td>
                                         <td class="score-col">
                                             {% if entry.graded_label == 'correct' %}
@@ -636,6 +1011,9 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                             {% else %}
                                                 <span class="score-badge unknown">Ungraded</span>
                                             {% endif %}
+                                        </td>
+                                        <td class="details-col">
+                                            <a class="details-link" data-detail-link="true" href="#sample-{{ entry.cache_key }}">View</a>
                                         </td>
                                     </tr>
                                 {% endfor %}
@@ -659,52 +1037,88 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                  data-request-chars="{{ entry.request_chars }}"
                                  data-response-chars="{{ entry.response_chars }}">
                                 <div class="entry-header">
-                                    <div class="entry-meta">
-                                        <span class="pill">Sample {{ loop.index }}</span>
-                                        <span>Cache Key: <strong>{{ entry.cache_key }}</strong></span>
-                                        <span>Model: <strong>{{ entry.model }}</strong></span>
-                                        <span>Type: <strong>{{ entry.request_type }}</strong></span>
+                                    <div class="entry-top">
+                                        <div class="meta-row">
+                                            <span class="sample-pill">Sample {{ loop.index }}</span>
+                                            {% if entry.graded_label == 'correct' %}
+                                                <span class="status-pill correct">Correct</span>
+                                            {% elif entry.graded_label == 'incorrect' %}
+                                                <span class="status-pill incorrect">Incorrect</span>
+                                            {% else %}
+                                                <span class="status-pill unknown">Ungraded</span>
+                                            {% endif %}
+                                            {% if entry.has_error %}
+                                                <span class="badge error">Error</span>
+                                            {% endif %}
+                                            {% if entry.has_tool_calls %}
+                                                <span class="badge info">Tool calls</span>
+                                            {% endif %}
+                                        </div>
+                                        <div class="buttons">
+                                            <button class="button" onclick="copyBlock('req-{{ entry.cache_key }}')">Copy Request</button>
+                                            <button class="button" onclick="copyBlock('res-{{ entry.cache_key }}')">Copy Response</button>
+                                            <button class="button primary" onclick="toggleRaw('curl-{{ entry.cache_key }}')">Toggle Curl</button>
+                                        </div>
+                                    </div>
+                                    <div class="meta-grid">
+                                        <div class="meta-card span-2">
+                                            <div class="meta-label">Cache Key</div>
+                                            <div class="meta-value">{{ entry.cache_key }}</div>
+                                        </div>
+                                        <div class="meta-card">
+                                            <div class="meta-label">Model</div>
+                                            <div class="meta-value">{{ entry.model }}</div>
+                                        </div>
+                                        <div class="meta-card">
+                                            <div class="meta-label">Type</div>
+                                            <div class="meta-value">{{ entry.request_type }}</div>
+                                        </div>
                                         {% if entry.finish_reasons %}
-                                            <span>Finish: <strong>{{ entry.finish_reasons | join(', ') }}</strong></span>
+                                            <div class="meta-card">
+                                                <div class="meta-label">Finish</div>
+                                                <div class="meta-value">{{ entry.finish_reasons | join(', ') }}</div>
+                                            </div>
+                                        {% endif %}
+                                        <div class="meta-card">
+                                            <div class="meta-label">Req chars</div>
+                                            <div class="meta-value">{{ entry.request_chars }}</div>
+                                        </div>
+                                        <div class="meta-card">
+                                            <div class="meta-label">Resp chars</div>
+                                            <div class="meta-value">{{ entry.response_chars }}</div>
+                                        </div>
+                                        {% if entry.usage %}
+                                            <div class="meta-card">
+                                                <div class="meta-label">Tokens</div>
+                                                <div class="meta-value">{{ entry.usage.prompt_tokens }} / {{ entry.usage.completion_tokens }} / {{ entry.usage.total_tokens }}</div>
+                                            </div>
+                                        {% endif %}
+                                        {% if entry.target_display %}
+                                            <div class="meta-card span-2">
+                                                <div class="meta-label">Target</div>
+                                                <div class="meta-value">{{ entry.target_display }}</div>
+                                            </div>
+                                        {% elif entry.graded_expected %}
+                                            <div class="meta-card span-2">
+                                                <div class="meta-label">Expected</div>
+                                                <div class="meta-value">{{ entry.graded_expected }}</div>
+                                            </div>
+                                        {% endif %}
+                                        {% if entry.graded_predicted %}
+                                            <div class="meta-card span-2">
+                                                <div class="meta-label">Predicted</div>
+                                                <div class="meta-value">{{ entry.graded_predicted }}</div>
+                                            </div>
                                         {% endif %}
                                     </div>
-                                    <div class="buttons">
-                                        <button class="button" onclick="copyBlock('req-{{ entry.cache_key }}')">Copy Request</button>
-                                        <button class="button" onclick="copyBlock('res-{{ entry.cache_key }}')">Copy Response</button>
-                                        <button class="button primary" onclick="toggleRaw('curl-{{ entry.cache_key }}')">Toggle Curl</button>
-                                    </div>
                                 </div>
-                                <div class="entry-meta secondary">
-                                    <span>Req chars: <strong>{{ entry.request_chars }}</strong></span>
-                                    <span>Resp chars: <strong>{{ entry.response_chars }}</strong></span>
-                                    {% if entry.usage %}
-                                        <span>Tokens: <strong>{{ entry.usage.prompt_tokens }} / {{ entry.usage.completion_tokens }} / {{ entry.usage.total_tokens }}</strong></span>
-                                    {% endif %}
-                                    {% if entry.has_error %}
-                                        <span class="badge error">Error</span>
-                                    {% endif %}
-                                    {% if entry.has_tool_calls %}
-                                        <span class="badge info">Tool calls</span>
-                                    {% endif %}
-                                    {% if entry.graded_label == 'correct' %}
-                                        <span class="badge correct">Correct</span>
-                                    {% elif entry.graded_label == 'incorrect' %}
-                                        <span class="badge incorrect">Incorrect</span>
-                                    {% elif entry.graded_label == 'unknown' %}
-                                        <span class="badge unknown">Ungraded</span>
-                                    {% endif %}
-                                    {% if entry.graded_expected %}
-                                        <span>Expected: <strong>{{ entry.graded_expected }}</strong></span>
-                                    {% endif %}
-                                    {% if entry.graded_predicted %}
-                                        <span>Predicted: <strong>{{ entry.graded_predicted }}</strong></span>
-                                    {% endif %}
-                                </div>
-                                {% if entry.prompt_preview %}
-                                    <div class="prompt-preview">{{ entry.prompt_preview }}</div>
-                                {% endif %}
-                                {% if entry.graded_input and entry.graded_input != entry.prompt_preview %}
-                                    <div class="prompt-preview">{{ entry.graded_input }}</div>
+                                {% if entry.prompt_sections %}
+                                    {% for section in entry.prompt_sections %}
+                                        <div class="prompt-preview">
+                                            <div class="block-title">{{ section.label }}</div>
+                                            <div>{{ section.text }}</div>
+                                        </div>
+                                    {% endfor %}
                                 {% endif %}
                                 <div class="block request-block" data-section="request">
                                     <div class="block-title">Request</div>
@@ -718,6 +1132,12 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                     <div class="block graded-block" data-section="graded">
                                         <div class="block-title">Graded Response</div>
                                         <pre id="graded-{{ entry.cache_key }}">{{ entry.graded_response | e }}</pre>
+                                    </div>
+                                {% endif %}
+                                {% if entry.target_display %}
+                                    <div class="block graded-block" data-section="graded">
+                                        <div class="block-title">Target (Ground Truth)</div>
+                                        <pre>{{ entry.target_display | e }}</pre>
                                     </div>
                                 {% endif %}
                                 <div id="curl-{{ entry.cache_key }}" class="block hidden" data-section="curl">
@@ -738,7 +1158,63 @@ curl "{{ entry.endpoint }}" \
             </div>
 
             <div class="section">
-                <h2>Score Metrics</h2>
+                <h2>Results Rollup (Groups)</h2>
+                {% if meta.rollup_rows %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Group</th>
+                                <th>Metric</th>
+                                <th>Value</th>
+                                <th>Stats</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in meta.rollup_rows %}
+                                <tr>
+                                    <td>{{ row.scope }}</td>
+                                    <td class="metric-path" title="{{ row.path }}">{{ row.path_display }}</td>
+                                    <td class="metric-value">{{ row.value_display or '—' }}</td>
+                                    <td>{{ row.stats_display or '—' }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <div class="note">No rollup metrics were found in results.yml.</div>
+                {% endif %}
+            </div>
+
+            <div class="section">
+                <h2>Results (Tasks)</h2>
+                {% if meta.task_rows %}
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>Task</th>
+                                <th>Metric</th>
+                                <th>Value</th>
+                                <th>Stats</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for row in meta.task_rows %}
+                                <tr>
+                                    <td>{{ row.scope }}</td>
+                                    <td class="metric-path" title="{{ row.path }}">{{ row.path_display }}</td>
+                                    <td class="metric-value">{{ row.value_display or '—' }}</td>
+                                    <td>{{ row.stats_display or '—' }}</td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <div class="note">No task metrics were found in results.yml.</div>
+                {% endif %}
+            </div>
+
+            <div class="section">
+                <h2>All Metrics (Flattened)</h2>
                 {% if meta.metrics_rows %}
                     <table>
                         <thead>
@@ -866,7 +1342,7 @@ curl "{{ entry.endpoint }}" \
             });
         });
 
-        const searchBox = document.getElementById('searchBox');
+        const searchBox = null;
         const modelFilter = document.getElementById('modelFilter');
         const typeFilter = document.getElementById('typeFilter');
         const finishFilter = document.getElementById('finishFilter');
@@ -881,7 +1357,7 @@ curl "{{ entry.endpoint }}" \
         const tabContents = document.querySelectorAll('.tab-content');
 
         function matchesFilters(element) {
-            const query = (searchBox?.value || "").toLowerCase();
+            const query = "";
             const model = modelFilter?.value || "";
             const type = typeFilter?.value || "";
             const finish = finishFilter?.value || "";
@@ -911,23 +1387,52 @@ curl "{{ entry.endpoint }}" \
         function applyFilters() {
             const entries = entriesContainer ? entriesContainer.querySelectorAll('.entry') : document.querySelectorAll('.entry');
             const rows = document.querySelectorAll('.sample-row');
-            let count = 0;
-            const total = entries.length;
+            let visibleEntries = 0;
+            let visibleRows = 0;
+            const total = rows.length || entries.length;
 
             entries.forEach((entry) => {
                 const visible = matchesFilters(entry);
                 entry.style.display = visible ? 'block' : 'none';
-                if (visible) count += 1;
+                if (visible) visibleEntries += 1;
             });
 
             rows.forEach((row) => {
                 const visible = matchesFilters(row);
                 row.style.display = visible ? '' : 'none';
+                if (visible) visibleRows += 1;
             });
 
             if (visibleCount) {
+                const count = rows.length ? visibleRows : visibleEntries;
                 visibleCount.textContent = `Visible: ${count} / ${total}`;
             }
+        }
+
+        function normalizeGradeClasses() {
+            document.querySelectorAll('.entry').forEach((entry) => {
+                const grade = entry.getAttribute('data-graded') || 'unknown';
+                entry.classList.remove('grade-correct', 'grade-incorrect', 'grade-unknown');
+                entry.classList.add(`grade-${grade || 'unknown'}`);
+            });
+            document.querySelectorAll('.sample-row').forEach((row) => {
+                const grade = row.getAttribute('data-graded') || 'unknown';
+                row.classList.remove('grade-correct', 'grade-incorrect', 'grade-unknown');
+                row.classList.add(`grade-${grade || 'unknown'}`);
+            });
+        }
+
+        function syncEntryCounts() {
+            if (!entriesContainer || !tableBody) return;
+            const rows = Array.from(tableBody.querySelectorAll('.sample-row'));
+            const entries = Array.from(entriesContainer.querySelectorAll('.entry'));
+            if (!rows.length || !entries.length) return;
+            if (entries.length <= rows.length) return;
+            entries.forEach((entry, idx) => {
+                if (idx >= rows.length) {
+                    entry.style.display = 'none';
+                }
+            });
         }
 
         function sortEntries() {
@@ -974,7 +1479,7 @@ curl "{{ entry.endpoint }}" \
             }
         }
 
-        [searchBox, modelFilter, typeFilter, finishFilter, gradingFilter, errorOnly, toolOnly].forEach((el) => {
+        [modelFilter, typeFilter, finishFilter, gradingFilter, errorOnly, toolOnly].forEach((el) => {
             if (!el) return;
             el.addEventListener('input', applyFilters);
             el.addEventListener('change', applyFilters);
@@ -1002,6 +1507,127 @@ curl "{{ entry.endpoint }}" \
             });
         });
 
+        function openDetailById(targetId) {
+            if (!targetId) return;
+            const targetTab = document.querySelector('.tab[data-tab="detailView"]');
+            if (targetTab) targetTab.click();
+            const el = document.getElementById(targetId);
+            if (!el) return;
+            el.classList.add('highlight');
+            el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            setTimeout(() => el.classList.remove('highlight'), 1600);
+        }
+
+        document.querySelectorAll('a[data-detail-link="true"]').forEach((link) => {
+            link.addEventListener('click', (event) => {
+                event.preventDefault();
+                const href = link.getAttribute('href') || '';
+                const targetId = href.startsWith('#') ? href.slice(1) : href;
+                openDetailById(targetId);
+                history.replaceState(null, '', `#${targetId}`);
+            });
+        });
+
+        if (window.location.hash) {
+            const targetId = window.location.hash.slice(1);
+            if (targetId.startsWith('sample-')) {
+                openDetailById(targetId);
+            }
+        }
+
+        document.querySelectorAll('.entry').forEach((entry) => {
+            const previews = Array.from(entry.querySelectorAll('.prompt-preview'));
+            const texts = previews.map((preview) =>
+                (preview.textContent || '').replace(/\s+/g, ' ').trim()
+            );
+
+            previews.forEach((preview, idx) => {
+                const text = texts[idx];
+                if (!text) {
+                    preview.remove();
+                }
+            });
+
+            for (let i = 0; i < previews.length; i += 1) {
+                if (!previews[i] || !texts[i]) continue;
+                for (let j = 0; j < previews.length; j += 1) {
+                    if (i === j || !previews[j] || !texts[j]) continue;
+                    if (texts[j].includes(texts[i])) {
+                        previews[i].remove();
+                        texts[i] = '';
+                        previews[i] = null;
+                        break;
+                    }
+                }
+            }
+
+            const seen = new Set();
+            previews.forEach((preview, idx) => {
+                if (!preview) return;
+                const text = texts[idx];
+                if (!text) return;
+                if (seen.has(text)) {
+                    preview.remove();
+                } else {
+                    seen.add(text);
+                }
+            });
+        });
+
+        function setupCollapsibles() {
+            document.querySelectorAll('.section').forEach((section) => {
+                const header = section.querySelector('h2');
+                if (!header) return;
+                if (!header.classList.contains('section-header')) {
+                    header.classList.add('section-header');
+                }
+
+                let body = section.querySelector('.section-body');
+                if (!body) {
+                    body = document.createElement('div');
+                    body.className = 'section-body';
+                    const siblings = [];
+                    let node = header.nextSibling;
+                    while (node) {
+                        const next = node.nextSibling;
+                        siblings.push(node);
+                        node = next;
+                    }
+                    siblings.forEach((node) => body.appendChild(node));
+                    section.appendChild(body);
+                }
+
+                if (!header.querySelector('.section-toggle')) {
+                    const toggle = document.createElement('button');
+                    toggle.type = 'button';
+                    toggle.className = 'section-toggle';
+                    toggle.textContent = 'Collapse';
+                    toggle.addEventListener('click', (event) => {
+                        event.stopPropagation();
+                        section.classList.toggle('collapsed');
+                        toggle.textContent = section.classList.contains('collapsed')
+                            ? 'Expand'
+                            : 'Collapse';
+                    });
+                    header.appendChild(toggle);
+                }
+
+                header.addEventListener('click', (event) => {
+                    if (event.target && event.target.closest('.section-toggle')) return;
+                    const toggle = header.querySelector('.section-toggle');
+                    section.classList.toggle('collapsed');
+                    if (toggle) {
+                        toggle.textContent = section.classList.contains('collapsed')
+                            ? 'Expand'
+                            : 'Collapse';
+                    }
+                });
+            });
+        }
+
+        setupCollapsibles();
+        normalizeGradeClasses();
+        syncEntryCounts();
         sortEntries();
         applyFilters();
     </script>

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
@@ -1334,17 +1334,25 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                                             </div>
                                         {% endif %}
                                         <div class="meta-card">
-                                            <div class="meta-label">Req chars</div>
+                                            <div class="meta-label">Request Chars</div>
                                             <div class="meta-value">{{ entry.request_chars }}</div>
                                         </div>
                                         <div class="meta-card">
-                                            <div class="meta-label">Resp chars</div>
+                                            <div class="meta-label">Response Chars</div>
                                             <div class="meta-value">{{ entry.response_chars }}</div>
                                         </div>
                                         {% if entry.usage %}
                                             <div class="meta-card">
-                                                <div class="meta-label">Tokens</div>
-                                                <div class="meta-value">{{ entry.usage.prompt_tokens }} / {{ entry.usage.completion_tokens }} / {{ entry.usage.total_tokens }}</div>
+                                                <div class="meta-label">Prompt Tokens</div>
+                                                <div class="meta-value">{{ entry.usage.prompt_tokens }}</div>
+                                            </div>
+                                            <div class="meta-card">
+                                                <div class="meta-label">Completion Tokens</div>
+                                                <div class="meta-value">{{ entry.usage.completion_tokens }}</div>
+                                            </div>
+                                            <div class="meta-card">
+                                                <div class="meta-label">Total Tokens</div>
+                                                <div class="meta-value">{{ entry.usage.total_tokens }}</div>
                                             </div>
                                         {% endif %}
                                         {% if entry.target_display %}

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/reports/templates/simple_template.py
@@ -106,6 +106,111 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             align-items: center;
             margin-bottom: 16px;
         }
+        .tabs {
+            display: inline-flex;
+            gap: 8px;
+            margin: 10px 0 16px;
+            flex-wrap: wrap;
+        }
+        .tab {
+            background: var(--panel-2);
+            border: 1px solid var(--border);
+            color: var(--text);
+            padding: 8px 14px;
+            border-radius: 999px;
+            cursor: pointer;
+            font-size: 0.85rem;
+        }
+        .tab.active {
+            background: var(--accent-2);
+            color: #0b0f14;
+            border-color: rgba(111, 155, 255, 0.5);
+        }
+        .tab-content {
+            display: none;
+        }
+        .tab-content.active {
+            display: block;
+        }
+        .table-wrap {
+            overflow-x: auto;
+        }
+        .sample-table {
+            width: 100%;
+            min-width: 760px;
+            table-layout: fixed;
+        }
+        .sample-table th {
+            white-space: nowrap;
+            word-break: normal;
+            text-align: left;
+        }
+        .sample-table .idx-col { width: 56px; }
+        .sample-table .target-col { width: 140px; min-width: 140px; }
+        .sample-table .score-col { width: 120px; min-width: 120px; text-align: center; }
+        .sample-table .answer-col { width: 35%; }
+        .sample-table .input-col { width: auto; }
+        .score-badge {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 0.75rem;
+            border: 1px solid var(--border);
+            white-space: nowrap;
+        }
+        .score-badge.correct {
+            background: rgba(126, 224, 129, 0.16);
+            color: #7ee081;
+            border-color: rgba(126, 224, 129, 0.35);
+        }
+        .score-badge.incorrect {
+            background: rgba(255, 154, 154, 0.16);
+            color: #ff9a9a;
+            border-color: rgba(255, 154, 154, 0.35);
+        }
+        .score-badge.unknown {
+            background: rgba(199, 199, 199, 0.12);
+            color: #c7c7c7;
+            border-color: rgba(199, 199, 199, 0.3);
+        }
+        .sample-row:hover {
+            background: rgba(111, 155, 255, 0.08);
+        }
+        .metric-path {
+            max-width: 420px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .metric-value {
+            white-space: nowrap;
+        }
+        .sample-table td, .sample-table th {
+            vertical-align: top;
+            line-height: 1.35;
+        }
+        .sample-table td.score-col,
+        .sample-table th.score-col,
+        .sample-table td.target-col,
+        .sample-table th.target-col {
+            white-space: nowrap;
+            word-break: normal;
+        }
+        .sample-row.grade-correct td:first-child {
+            border-left: 3px solid rgba(126, 224, 129, 0.7);
+        }
+        .sample-row.grade-incorrect td:first-child {
+            border-left: 3px solid rgba(255, 154, 154, 0.7);
+        }
+        .sample-row.grade-unknown td:first-child {
+            border-left: 3px solid rgba(199, 199, 199, 0.4);
+        }
+        .sample-table .muted {
+            color: var(--muted);
+            font-size: 0.78rem;
+        }
         .search {
             flex: 1;
             min-width: 220px;
@@ -265,6 +370,21 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             border-color: rgba(155, 208, 255, 0.35);
             background: rgba(155, 208, 255, 0.12);
         }
+        .badge.correct {
+            color: #7ee081;
+            border-color: rgba(126, 224, 129, 0.4);
+            background: rgba(126, 224, 129, 0.12);
+        }
+        .badge.incorrect {
+            color: #ff9a9a;
+            border-color: rgba(255, 154, 154, 0.4);
+            background: rgba(255, 154, 154, 0.12);
+        }
+        .badge.unknown {
+            color: #c7c7c7;
+            border-color: rgba(199, 199, 199, 0.3);
+            background: rgba(199, 199, 199, 0.08);
+        }
         .prompt-preview {
             margin-top: 10px;
             padding: 10px 12px;
@@ -384,6 +504,12 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                         <option value="{{ reason }}">{{ reason }}</option>
                     {% endfor %}
                 </select>
+                <select id="gradingFilter" class="select">
+                    <option value="">All grading</option>
+                    {% for grade in meta.filters.grading %}
+                        <option value="{{ grade }}">{{ grade }}</option>
+                    {% endfor %}
+                </select>
                 <label class="check"><input type="checkbox" id="errorOnly" /> Errors only</label>
                 <label class="check"><input type="checkbox" id="toolOnly" /> Tool calls</label>
                 <select id="sortSelect" class="select">
@@ -395,6 +521,7 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                 <div class="toggle-group">
                     <button class="toggle active" data-target="request">Requests</button>
                     <button class="toggle active" data-target="response">Responses</button>
+                    <button class="toggle" data-target="graded">Graded</button>
                     <button class="toggle" data-target="curl">Curl</button>
                 </div>
             </div>
@@ -417,6 +544,14 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                 <div class="section">
                     <h2>Sample Stats</h2>
                     <div class="summary-grid">
+                        <div class="summary-card">
+                            <div class="label">Accuracy</div>
+                            <div class="value">{{ (meta.stats.accuracy * 100) | round(2) }}%</div>
+                        </div>
+                        <div class="summary-card">
+                            <div class="label">Correct / Incorrect / Unknown</div>
+                            <div class="value">{{ meta.stats.correct_count }} / {{ meta.stats.incorrect_count }} / {{ meta.stats.unknown_count }}</div>
+                        </div>
                         <div class="summary-card">
                             <div class="label">Error Rate</div>
                             <div class="value">{{ (meta.stats.error_rate * 100) | round(2) }}% ({{ meta.stats.error_count }})</div>
@@ -459,6 +594,150 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
             {% endif %}
 
             <div class="section">
+                <h2>Samples</h2>
+                <div class="tabs">
+                    <button class="tab active" data-tab="tableView">Table</button>
+                    <button class="tab" data-tab="detailView">Details</button>
+                </div>
+                <div id="tableView" class="tab-content active">
+                    <div class="table-wrap">
+                        <table class="sample-table">
+                            <thead>
+                                <tr>
+                                    <th class="idx-col">#</th>
+                                    <th class="input-col">Input</th>
+                                    <th class="target-col">Target</th>
+                                    <th class="answer-col">Answer</th>
+                                    <th class="score-col">Score</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for entry in entries %}
+                                    <tr class="sample-row grade-{{ entry.graded_label or 'unknown' }}"
+                                        data-search="{{ entry.search_blob|e }}"
+                                        data-cache="{{ entry.cache_key|e }}"
+                                        data-model="{{ entry.model|e }}"
+                                        data-request-type="{{ entry.request_type|e }}"
+                                        data-has-error="{{ 'true' if entry.has_error else 'false' }}"
+                                        data-has-tool="{{ 'true' if entry.has_tool_calls else 'false' }}"
+                                        data-finish-reasons="{{ entry.finish_reasons | join(',') | e }}"
+                                        data-graded="{{ entry.graded_label | e }}"
+                                        data-request-chars="{{ entry.request_chars }}"
+                                        data-response-chars="{{ entry.response_chars }}">
+                                        <td class="idx-col"><a href="#sample-{{ entry.cache_key }}">{{ loop.index }}</a></td>
+                                        <td class="input-col">{{ (entry.graded_input or entry.prompt_preview or '—') | truncate(160, True, '...') }}</td>
+                                        <td class="target-col">{{ (entry.graded_target or entry.graded_expected or '—') | truncate(80, True, '...') }}</td>
+                                        <td class="answer-col">{{ (entry.graded_response or entry.graded_predicted or '—') | truncate(120, True, '...') }}</td>
+                                        <td class="score-col">
+                                            {% if entry.graded_label == 'correct' %}
+                                                <span class="score-badge correct">Correct</span>
+                                            {% elif entry.graded_label == 'incorrect' %}
+                                                <span class="score-badge incorrect">Incorrect</span>
+                                            {% else %}
+                                                <span class="score-badge unknown">Ungraded</span>
+                                            {% endif %}
+                                        </td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div id="detailView" class="tab-content">
+                    <div id="entriesContainer">
+                        {% for entry in entries %}
+                                    <div class="entry grade-{{ entry.graded_label or 'unknown' }}"
+                                         id="sample-{{ entry.cache_key }}"
+                                         data-search="{{ entry.search_blob|e }}"
+                                         data-cache="{{ entry.cache_key|e }}"
+                                         data-model="{{ entry.model|e }}"
+                                 data-request-type="{{ entry.request_type|e }}"
+                                 data-has-error="{{ 'true' if entry.has_error else 'false' }}"
+                                 data-has-tool="{{ 'true' if entry.has_tool_calls else 'false' }}"
+                                 data-finish-reasons="{{ entry.finish_reasons | join(',') | e }}"
+                                 data-graded="{{ entry.graded_label | e }}"
+                                 data-request-chars="{{ entry.request_chars }}"
+                                 data-response-chars="{{ entry.response_chars }}">
+                                <div class="entry-header">
+                                    <div class="entry-meta">
+                                        <span class="pill">Sample {{ loop.index }}</span>
+                                        <span>Cache Key: <strong>{{ entry.cache_key }}</strong></span>
+                                        <span>Model: <strong>{{ entry.model }}</strong></span>
+                                        <span>Type: <strong>{{ entry.request_type }}</strong></span>
+                                        {% if entry.finish_reasons %}
+                                            <span>Finish: <strong>{{ entry.finish_reasons | join(', ') }}</strong></span>
+                                        {% endif %}
+                                    </div>
+                                    <div class="buttons">
+                                        <button class="button" onclick="copyBlock('req-{{ entry.cache_key }}')">Copy Request</button>
+                                        <button class="button" onclick="copyBlock('res-{{ entry.cache_key }}')">Copy Response</button>
+                                        <button class="button primary" onclick="toggleRaw('curl-{{ entry.cache_key }}')">Toggle Curl</button>
+                                    </div>
+                                </div>
+                                <div class="entry-meta secondary">
+                                    <span>Req chars: <strong>{{ entry.request_chars }}</strong></span>
+                                    <span>Resp chars: <strong>{{ entry.response_chars }}</strong></span>
+                                    {% if entry.usage %}
+                                        <span>Tokens: <strong>{{ entry.usage.prompt_tokens }} / {{ entry.usage.completion_tokens }} / {{ entry.usage.total_tokens }}</strong></span>
+                                    {% endif %}
+                                    {% if entry.has_error %}
+                                        <span class="badge error">Error</span>
+                                    {% endif %}
+                                    {% if entry.has_tool_calls %}
+                                        <span class="badge info">Tool calls</span>
+                                    {% endif %}
+                                    {% if entry.graded_label == 'correct' %}
+                                        <span class="badge correct">Correct</span>
+                                    {% elif entry.graded_label == 'incorrect' %}
+                                        <span class="badge incorrect">Incorrect</span>
+                                    {% elif entry.graded_label == 'unknown' %}
+                                        <span class="badge unknown">Ungraded</span>
+                                    {% endif %}
+                                    {% if entry.graded_expected %}
+                                        <span>Expected: <strong>{{ entry.graded_expected }}</strong></span>
+                                    {% endif %}
+                                    {% if entry.graded_predicted %}
+                                        <span>Predicted: <strong>{{ entry.graded_predicted }}</strong></span>
+                                    {% endif %}
+                                </div>
+                                {% if entry.prompt_preview %}
+                                    <div class="prompt-preview">{{ entry.prompt_preview }}</div>
+                                {% endif %}
+                                {% if entry.graded_input and entry.graded_input != entry.prompt_preview %}
+                                    <div class="prompt-preview">{{ entry.graded_input }}</div>
+                                {% endif %}
+                                <div class="block request-block" data-section="request">
+                                    <div class="block-title">Request</div>
+                                    <pre id="req-{{ entry.cache_key }}">{{ entry.display_request|tojson_utf8|safe }}</pre>
+                                </div>
+                                <div class="block response-block" data-section="response">
+                                    <div class="block-title">Response</div>
+                                    <pre id="res-{{ entry.cache_key }}">{{ entry.response|tojson_utf8|safe }}</pre>
+                                </div>
+                                {% if entry.graded_response %}
+                                    <div class="block graded-block" data-section="graded">
+                                        <div class="block-title">Graded Response</div>
+                                        <pre id="graded-{{ entry.cache_key }}">{{ entry.graded_response | e }}</pre>
+                                    </div>
+                                {% endif %}
+                                <div id="curl-{{ entry.cache_key }}" class="block hidden" data-section="curl">
+                                    <div class="block-title">Repro Curl</div>
+                                    <pre># Save payload to file first:
+echo '{{ entry.request_data|tojson }}' > request.json
+
+curl "{{ entry.endpoint }}" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $API_KEY" \
+  -H "Accept: application/json" \
+  -d @request.json</pre>
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </div>
+            </div>
+
+            <div class="section">
                 <h2>Score Metrics</h2>
                 {% if meta.metrics_rows %}
                     <table>
@@ -472,9 +751,9 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                         <tbody>
                             {% for row in meta.metrics_rows %}
                                 <tr>
-                                    <td>{{ row.path }}</td>
-                                    <td>{{ row.value }}</td>
-                                    <td>{{ row.stats }}</td>
+                                    <td class="metric-path" title="{{ row.path }}">{{ row.path_display }}</td>
+                                    <td class="metric-value">{{ row.value_display or '—' }}</td>
+                                    <td>{{ row.stats_display or '—' }}</td>
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -497,8 +776,8 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                         <tbody>
                             {% for row in meta.perf_rows %}
                                 <tr>
-                                    <td>{{ row.path }}</td>
-                                    <td>{{ row.value }}</td>
+                                    <td class="metric-path" title="{{ row.path }}">{{ row.path_display }}</td>
+                                    <td class="metric-value">{{ row.value_display or '—' }}</td>
                                 </tr>
                             {% endfor %}
                         </tbody>
@@ -551,72 +830,7 @@ SIMPLE_TEMPLATE = """<!DOCTYPE html>
                 {% endif %}
             </div>
 
-            <div id="entriesContainer">
-            {% for entry in entries %}
-                <div class="entry"
-                     data-search="{{ entry.search_blob|e }}"
-                     data-cache="{{ entry.cache_key|e }}"
-                     data-model="{{ entry.model|e }}"
-                     data-request-type="{{ entry.request_type|e }}"
-                     data-has-error="{{ 'true' if entry.has_error else 'false' }}"
-                     data-has-tool="{{ 'true' if entry.has_tool_calls else 'false' }}"
-                     data-finish-reasons="{{ entry.finish_reasons | join(',') | e }}"
-                     data-request-chars="{{ entry.request_chars }}"
-                     data-response-chars="{{ entry.response_chars }}">
-                    <div class="entry-header">
-                        <div class="entry-meta">
-                            <span class="pill">Sample {{ loop.index }}</span>
-                            <span>Cache Key: <strong>{{ entry.cache_key }}</strong></span>
-                            <span>Model: <strong>{{ entry.model }}</strong></span>
-                            <span>Type: <strong>{{ entry.request_type }}</strong></span>
-                            {% if entry.finish_reasons %}
-                                <span>Finish: <strong>{{ entry.finish_reasons | join(', ') }}</strong></span>
-                            {% endif %}
-                        </div>
-                        <div class="buttons">
-                            <button class="button" onclick="copyBlock('req-{{ entry.cache_key }}')">Copy Request</button>
-                            <button class="button" onclick="copyBlock('res-{{ entry.cache_key }}')">Copy Response</button>
-                            <button class="button primary" onclick="toggleRaw('curl-{{ entry.cache_key }}')">Toggle Curl</button>
-                        </div>
-                    </div>
-                    <div class="entry-meta secondary">
-                        <span>Req chars: <strong>{{ entry.request_chars }}</strong></span>
-                        <span>Resp chars: <strong>{{ entry.response_chars }}</strong></span>
-                        {% if entry.usage %}
-                            <span>Tokens: <strong>{{ entry.usage.prompt_tokens }} / {{ entry.usage.completion_tokens }} / {{ entry.usage.total_tokens }}</strong></span>
-                        {% endif %}
-                        {% if entry.has_error %}
-                            <span class="badge error">Error</span>
-                        {% endif %}
-                        {% if entry.has_tool_calls %}
-                            <span class="badge info">Tool calls</span>
-                        {% endif %}
-                    </div>
-                    {% if entry.prompt_preview %}
-                        <div class="prompt-preview">{{ entry.prompt_preview }}</div>
-                    {% endif %}
-                    <div class="block request-block" data-section="request">
-                        <div class="block-title">Request</div>
-                        <pre id="req-{{ entry.cache_key }}">{{ entry.display_request|tojson_utf8|safe }}</pre>
-                    </div>
-                    <div class="block response-block" data-section="response">
-                        <div class="block-title">Response</div>
-                        <pre id="res-{{ entry.cache_key }}">{{ entry.response|tojson_utf8|safe }}</pre>
-                    </div>
-                    <div id="curl-{{ entry.cache_key }}" class="block hidden" data-section="curl">
-                        <div class="block-title">Repro Curl</div>
-                        <pre># Save payload to file first:
-echo '{{ entry.request_data|tojson }}' > request.json
 
-curl "{{ entry.endpoint }}" \\
-  -H "Content-Type: application/json" \\
-  -H "Authorization: Bearer $API_KEY" \\
-  -H "Accept: application/json" \\
-  -d @request.json</pre>
-                    </div>
-                </div>
-            {% endfor %}
-            </div>
         {% else %}
             <div class="empty">No cached entries were found to render a report.</div>
         {% endif %}
@@ -656,41 +870,59 @@ curl "{{ entry.endpoint }}" \\
         const modelFilter = document.getElementById('modelFilter');
         const typeFilter = document.getElementById('typeFilter');
         const finishFilter = document.getElementById('finishFilter');
+        const gradingFilter = document.getElementById('gradingFilter');
         const errorOnly = document.getElementById('errorOnly');
         const toolOnly = document.getElementById('toolOnly');
         const sortSelect = document.getElementById('sortSelect');
         const visibleCount = document.getElementById('visibleCount');
         const entriesContainer = document.getElementById('entriesContainer');
+        const tableBody = document.querySelector('.sample-table tbody');
+        const tabs = document.querySelectorAll('.tab');
+        const tabContents = document.querySelectorAll('.tab-content');
 
-        function applyFilters() {
+        function matchesFilters(element) {
             const query = (searchBox?.value || "").toLowerCase();
             const model = modelFilter?.value || "";
             const type = typeFilter?.value || "";
             const finish = finishFilter?.value || "";
             const errorsOnly = errorOnly?.checked || false;
             const toolsOnly = toolOnly?.checked || false;
+            const grading = gradingFilter?.value || "";
 
+            const haystack = element.getAttribute('data-search') || "";
+            const entryModel = element.getAttribute('data-model') || "";
+            const entryType = element.getAttribute('data-request-type') || "";
+            const entryFinish = (element.getAttribute('data-finish-reasons') || "").split(',').filter(Boolean);
+            const hasError = element.getAttribute('data-has-error') === 'true';
+            const hasTool = element.getAttribute('data-has-tool') === 'true';
+            const grade = element.getAttribute('data-graded') || "";
+
+            const matchesSearch = !query || haystack.indexOf(query) !== -1;
+            const matchesModel = !model || entryModel === model;
+            const matchesType = !type || entryType === type;
+            const matchesFinish = !finish || entryFinish.includes(finish);
+            const matchesError = !errorsOnly || hasError;
+            const matchesTool = !toolsOnly || hasTool;
+            const matchesGrading = !grading || grade === grading;
+
+            return matchesSearch && matchesModel && matchesType && matchesFinish && matchesError && matchesTool && matchesGrading;
+        }
+
+        function applyFilters() {
             const entries = entriesContainer ? entriesContainer.querySelectorAll('.entry') : document.querySelectorAll('.entry');
+            const rows = document.querySelectorAll('.sample-row');
             let count = 0;
             const total = entries.length;
+
             entries.forEach((entry) => {
-                const haystack = entry.getAttribute('data-search') || "";
-                const entryModel = entry.getAttribute('data-model') || "";
-                const entryType = entry.getAttribute('data-request-type') || "";
-                const entryFinish = (entry.getAttribute('data-finish-reasons') || "").split(',').filter(Boolean);
-                const hasError = entry.getAttribute('data-has-error') === 'true';
-                const hasTool = entry.getAttribute('data-has-tool') === 'true';
-
-                const matchesSearch = !query || haystack.indexOf(query) !== -1;
-                const matchesModel = !model || entryModel === model;
-                const matchesType = !type || entryType === type;
-                const matchesFinish = !finish || entryFinish.includes(finish);
-                const matchesError = !errorsOnly || hasError;
-                const matchesTool = !toolsOnly || hasTool;
-
-                const visible = matchesSearch && matchesModel && matchesType && matchesFinish && matchesError && matchesTool;
+                const visible = matchesFilters(entry);
                 entry.style.display = visible ? 'block' : 'none';
                 if (visible) count += 1;
+            });
+
+            rows.forEach((row) => {
+                const visible = matchesFilters(row);
+                row.style.display = visible ? '' : 'none';
             });
 
             if (visibleCount) {
@@ -719,9 +951,30 @@ curl "{{ entry.endpoint }}" \\
                 return 0;
             });
             entries.forEach((entry) => entriesContainer.appendChild(entry));
+
+            if (tableBody) {
+                const rows = Array.from(tableBody.querySelectorAll('.sample-row'));
+                rows.sort((a, b) => {
+                    if (sortBy === 'cache') {
+                        return (a.getAttribute('data-cache') || '').localeCompare(
+                            b.getAttribute('data-cache') || ''
+                        );
+                    }
+                    if (sortBy === 'request') {
+                        return (parseInt(a.getAttribute('data-request-chars') || '0', 10) -
+                            parseInt(b.getAttribute('data-request-chars') || '0', 10));
+                    }
+                    if (sortBy === 'response') {
+                        return (parseInt(a.getAttribute('data-response-chars') || '0', 10) -
+                            parseInt(b.getAttribute('data-response-chars') || '0', 10));
+                    }
+                    return 0;
+                });
+                rows.forEach((row) => tableBody.appendChild(row));
+            }
         }
 
-        [searchBox, modelFilter, typeFilter, finishFilter, errorOnly, toolOnly].forEach((el) => {
+        [searchBox, modelFilter, typeFilter, finishFilter, gradingFilter, errorOnly, toolOnly].forEach((el) => {
             if (!el) return;
             el.addEventListener('input', applyFilters);
             el.addEventListener('change', applyFilters);
@@ -733,6 +986,21 @@ curl "{{ entry.endpoint }}" \\
                 applyFilters();
             });
         }
+
+        tabs.forEach((tab) => {
+            tab.addEventListener('click', () => {
+                tabs.forEach((btn) => btn.classList.remove('active'));
+                tab.classList.add('active');
+                const target = tab.getAttribute('data-tab');
+                tabContents.forEach((content) => {
+                    if (content.id === target) {
+                        content.classList.add('active');
+                    } else {
+                        content.classList.remove('active');
+                    }
+                });
+            });
+        });
 
         sortEntries();
         applyFilters();

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/test_post_eval_report_hook.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/test_post_eval_report_hook.py
@@ -526,7 +526,7 @@ def test_git_hash_fallback_from_metadata(tmpdir):
 
     metadata = {
         "versioning": {
-            "git-hash": "abc123def456",  # pragma: allowlist secret
+            "git-hash": "testhash42",
             "nemo_evaluator": "1.2.3",
             "nemo_evaluator_launcher": "4.5.6",
         }
@@ -541,7 +541,7 @@ def test_git_hash_fallback_from_metadata(tmpdir):
     hook.post_eval_hook(context)
 
     html = (tmpdir / "report.html").read()
-    assert "abc123def456" in html  # git hash from metadata.yaml
+    assert "testhash42" in html  # git hash from metadata.yaml
     assert "1.2.3" in html  # evaluator version
     assert "4.5.6" in html  # launcher version
 

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/test_post_eval_report_hook.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/test_post_eval_report_hook.py
@@ -526,7 +526,7 @@ def test_git_hash_fallback_from_metadata(tmpdir):
 
     metadata = {
         "versioning": {
-            "git-hash": "abc123def456",
+            "git-hash": "abc123def456",  # pragma: allowlist secret
             "nemo_evaluator": "1.2.3",
             "nemo_evaluator_launcher": "4.5.6",
         }


### PR DESCRIPTION
 ## Evaluation Report Enhancements

  This PR overhauls the post-evaluation reporting system — the HTML reports generated after each evaluation run. It fixes data completeness issues, redesigns the visual layout, adds new CLI tooling,
   and significantly expands test coverage.

  ---

  ### CLI

  - Added `nel analyze <artifacts_dir>` — generates standalone HTML analysis report from evaluation artifacts (results.yml, report.json, eval_factory_metrics.json)
  - Added `nel view --log-dir <path>` — local HTTP viewer for browsing evaluation runs, tasks, logs, and reports with auto-refreshing logs
  - Registered both commands in the launcher CLI entry point

  ### Report Data Fixes

  - Fixed incomplete MMLU Pro and IFEval reports missing Benchmark, Container, and Git Hash pills when `results.yml` is absent — added fallback resolution through `run_config.yml` (`config.type`,
  `config.params.task`) and `metadata.yaml` (`versioning.git-hash`)
  - Fixed container resolution failing for ambiguous task names — uses `framework_name` from `run_config.yml` to construct qualified lookups (e.g. `lm-evaluation-harness.ifeval` vs `codec.ifeval`)
  - Fixed ARC expected/predicted values always null — lm-eval-harness uses `target` + `filtered_resps`, not `expected_answer` + `predicted_answer`
  - Fixed `graded_metrics` (inst_level_strict_acc, symbolic_correct) collected but never rendered — now displayed in detail view
  - Fixed `graded_source` (originating JSONL file path) collected but never rendered
  - Fixed IFEval `instruction_id_list` labels lost during grading — now preserved and rendered as badges
  - Fixed grading records not discovered from `output.jsonl-async` files
  - Fixed Jinja2 autoescape ineffective against XSS — `select_autoescape(["html", "xml"])` does not apply to `from_string()` templates, changed to `autoescape=True`
  - Fixed curl command heredoc breaking on single quotes in payloads — replaced `echo '...'` with `cat <<'PAYLOAD_EOF'` heredoc
  - Fixed table row numbers not updating after filtering
  - Removed redundant character count recomputation loop (already computed earlier in pipeline)
  - Removed dead `normalizeGradeClasses()` JS function and call
  - Removed duplicate `[data-graded="correct/incorrect/unknown"]` CSS selectors (`.grade-*` classes already handle this)
  - Removed unused `.brand-meta` and `.meta-pill` CSS blocks

  ### Report Visual Improvements

  - Merged flat "Run Summary" and "Sample Stats" sections into unified layout with hero stats banner (Accuracy %, Total Samples, Correct, Error Rate)
  - Added category-grouped cards with color-coded left borders — Configuration (blue), Evaluation Results (green), Performance (yellow), System (light blue)
  - Added eval parameter pills (temperature, top_p, max_new_tokens, parallelism, etc.) extracted from `run_config.yml`
  - Added grade distribution bar (tri-color correct/incorrect/unknown)
  - Added versioning info from `metadata.yaml` (evaluator version, launcher version)
  - Added framework name display in Configuration group
  - Added `metadata.yaml` to raw artifacts section
  - Added CSV/JSON export buttons
  - Added `lang="en"` to `<html>` tag
  - Added keyboard focus styles (`:focus-visible`)
  - Added debounced search input (200ms)
  - Split confusing per-sample "Tokens: 711 / 3 / 714" into separate labeled cards (Prompt Tokens, Completion Tokens, Total Tokens)
  - Renamed abbreviated labels "Req chars" / "Resp chars" to "Request Chars" / "Response Chars"
  - Changed table Input column to show problem text only (without repeated options blob)

  ### Architecture

  - Decomposed 333-line `post_eval_hook` into `_load_auxiliary_data`, `_build_grading_index`, `_match_entries_to_grades`, `_compute_report_stats`, `_build_report_meta`
  - Pre-normalized fuzzy match data to eliminate redundant `_normalize_ws()` calls in O(n*m) loop
  - Added diagnostic logging — DEBUG on match failure with prompt preview, INFO summary of matched vs unmatched counts

  ### Tests 

  | Test | Coverage |
  |------|----------|
  | `test_report_counts_and_target_for_ifeval` | IFEval grading + instruction metrics |
  | `test_report_counts_and_target_for_ns_mmlu_pro` | MMLU Pro grading + expected answer |
  | `test_report_grading_from_jsonl_async` | Grading from `output.jsonl-async` files |
  | `test_grading_match_failure` | Unmatched entries render as ungraded |
  | `test_lm_eval_harness_arc_format` | ARC `target` + `filtered_resps` format |
  | `test_whitespace_fuzzy_matching` | Normalized whitespace matching |
  | `test_container_url_from_image` | NGC image → catalog URL mapping |
  | `test_flatten_numeric` | Nested metric flattening |
  | `test_task_name_fallback_from_run_config_type` | Task name from `run_config.config.type` |
  | `test_git_hash_fallback_from_metadata` | Git hash + versions from `metadata.yaml` |
  | `test_eval_params_rendered` | Eval param pills in HTML output |

  ### Example Report
Example new report HTML:
[arc_challenge_report.html](https://github.com/user-attachments/files/25186766/arc_challenge_report.html)
