### PR TITLE
feat: Add top-level task file uploads to MLflow and WandB exporters

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
@@ -422,6 +422,13 @@ class MLflowExporter(BaseExporter):
                         logged_names.append(f"logs/{rel}")
                         logger.debug(f"mlflow upload log: {rel}")
 
+            # Upload top-level task files (run.sub, etc.)
+            for p in base_dir.iterdir():
+                if p.is_file():
+                    mlflow.log_artifact(str(p), artifact_path=artifact_path)
+                    logged_names.append(p.name)
+                    logger.debug(f"mlflow upload top-level: {p.name}")
+
             logger.info(
                 f"MLflow upload summary: files={len(logged_names)}, only_required={mlflow_config.get('only_required', True)}, log_logs={mlflow_config.get('log_logs', False)}"
             )

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/wandb.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/wandb.py
@@ -291,6 +291,12 @@ class WandBExporter(BaseExporter):
                         artifact.add_file(str(p), name=f"{artifact_root}/logs/{rel}")
                         logged_names.append(f"logs/{rel}")
 
+            # Upload top-level task files (run.sub, etc.)
+            for p in base_dir.iterdir():
+                if p.is_file():
+                    artifact.add_file(str(p), name=f"{artifact_root}/{p.name}")
+                    logged_names.append(p.name)
+
             return logged_names
         except Exception as e:
             logger.error(f"Error logging artifacts: {e}")


### PR DESCRIPTION
- Implemented functionality to upload top-level task files (e.g., run.sub) in both MLflow and WandB exporters.
- Enhanced logging to include details of uploaded files for better traceability.