### PR TITLE
ci: Update release-docs workflow to use FW-CI-templates v0.72.0

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -20,19 +20,20 @@ on:
         required: true
         type: boolean
         default: true
-      version-number:
-        description: Version number to release this as (use `latest` for main branch)
-        required: true
-        type: string
-      notify-emails:
-        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
-        required: true
-        type: string
-      aws-region:
-        description: AWS region
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: true
+      docs-version-override:
+        description: Docs version if commit is not tagged
         required: false
         type: string
-        default: us-east-1
+        default: ""
+      notify-emails:
+        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
+        required: false
+        type: string
 
 jobs:
   build-docs:
@@ -47,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.67.2
+          ref: v0.72.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs
@@ -60,11 +61,12 @@ jobs:
           dry-run: ${{ inputs.dry-run }}
           artifacts-name: docs-html
           artifacts-path: _build/html
-          emails-csv: ${{ inputs.notify-emails }}
-          overwrite-latest-on-tag: false
+          emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
+          overwrite-latest-on-tag: ${{ inputs.publish-as-latest }}
+          docs-version-override: ${{ inputs.docs-version-override }}
           run-on-version-tag-only: ${{ github.ref_name != 'main' }}
           request-name: megatron-bridge-publish-docs-${{ github.run_id }}
-          aws-region: ${{ inputs.aws-region }}
+          aws-region: ${{ vars.DOCS_AWS_REGION }}
           aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
ci: Update release-docs workflow to use FW-CI-templates v0.72.0

The latest tag in some repos was whatever was published from main branch. However, we will now designate "latest" as the latest stable version. A follow-up change will include publshing docs as part of the release repo workflow. And we will also begin to publish "nightly" docs from the main branch.

Will need to sync with Evaluator team on what their plans are for their docs especially given the automated releases.  