### PR TITLE
fix(migration-script): fix corener case issue for config migration

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/migrate_config.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/cli/migrate_config.py
@@ -563,7 +563,7 @@ def main():
             f.write(new_text)
         print(f"\nWritten to {args.output}", file=sys.stderr)
     else:
-        print(new_text)
+        sys.stdout.write(new_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Issue with cornercase where `execution.env_vars: {}` was explicitly passed