### PR TITLE
feat(caching): add seed_cache_dir for cross-run cache reuse

### DIFF
--- a/docs/libraries/nemo-evaluator/interceptors/caching.md
+++ b/docs/libraries/nemo-evaluator/interceptors/caching.md
@@ -86,3 +86,19 @@ Each cache uses a SHA256 hash of the request data as the lookup key. When a cach
 2. **Response received** from model API
 3. **Store response** in cache with generated key
 4. **Continue processing** with response interceptors
+
+## Seed Cache
+
+Use `seed_cache_dir` to reuse cached responses from a previous run — e.g., when resuming after a timeout or migrating between clusters.
+
+```yaml
+target:
+  api_endpoint:
+    adapter_config:
+      use_caching: true
+      seed_cache_dir: /path/to/previous/run/cache
+```
+
+On a primary cache miss, the interceptor falls back to the seed cache. Seed hits are **automatically promoted** into the primary cache, so the output cache is self-contained. The seed cache is never modified.
+
+Cache keys are SHA-256 hashes of the request JSON body — portable across clusters as long as the request data is identical.

--- a/docs/libraries/nemo-evaluator/interceptors/caching.md
+++ b/docs/libraries/nemo-evaluator/interceptors/caching.md
@@ -91,12 +91,32 @@ Each cache uses a SHA256 hash of the request data as the lookup key. When a cach
 
 Use `seed_cache_dir` to reuse cached responses from a previous run — e.g., when resuming after a timeout or migrating between clusters.
 
+Legacy (flat) configuration:
+
 ```yaml
 target:
   api_endpoint:
     adapter_config:
       use_caching: true
       seed_cache_dir: /path/to/previous/run/cache
+```
+
+Interceptor configuration:
+
+```yaml
+target:
+  api_endpoint:
+    adapter_config:
+      interceptors:
+        - name: "caching"
+          enabled: true
+          config:
+            cache_dir: "./evaluation_cache"
+            seed_cache_dir: /path/to/previous/run/cache
+            reuse_cached_responses: true
+        - name: "endpoint"
+          enabled: true
+          config: {}
 ```
 
 On a primary cache miss, the interceptor falls back to the seed cache. Seed hits are **automatically promoted** into the primary cache, so the output cache is self-contained. The seed cache is never modified.

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/adapter_config.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/adapter_config.py
@@ -114,6 +114,13 @@ class LegacyAdapterConfig(BaseModel):
     log_failed_requests: bool = Field(default=False, description="Log failed requests")
     endpoint_type: str = Field(default="chat", description="Endpoint type")
     caching_dir: str | None = Field(default=None, description="Caching directory")
+    seed_cache_dir: str | None = Field(
+        default=None,
+        description="Optional seed cache directory for cross-run cache reuse. "
+        "On cache miss in the primary cache, the interceptor falls back to this directory. "
+        "Useful for reusing cached responses from a previous evaluation run "
+        "(e.g., when migrating between clusters).",
+    )
 
     # Optional string/dict configuration parameters
     custom_system_prompt: str | None = Field(
@@ -515,6 +522,9 @@ class AdapterConfig(BaseModel):
                 config["max_saved_requests"] = max_saved_requests
             if max_saved_responses is not None:
                 config["max_saved_responses"] = max_saved_responses
+
+            if legacy_config["seed_cache_dir"] is not None:
+                config["seed_cache_dir"] = legacy_config["seed_cache_dir"]
 
             interceptors.append(
                 InterceptorConfig(

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/caching_interceptor.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/caching_interceptor.py
@@ -90,6 +90,9 @@ class CachingInterceptor(RequestToResponseInterceptor, ResponseInterceptor):
             params: Configuration parameters
         """
 
+        # Get logger for this interceptor with interceptor context
+        self.logger = get_logger(self.__class__.__name__)
+
         # Initialize caches immediately
         self.responses_cache = Cache(directory=f"{params.cache_dir}/responses")
         self.requests_cache = Cache(directory=f"{params.cache_dir}/requests")
@@ -104,6 +107,11 @@ class CachingInterceptor(RequestToResponseInterceptor, ResponseInterceptor):
                 self.seed_responses_cache = Cache(directory=seed_responses_dir)
                 self.seed_headers_cache = Cache(directory=seed_headers_dir)
             else:
+                self.logger.warning(
+                    "seed_cache_dir is configured but required subdirectories "
+                    "(responses/, headers/) were not found; seed cache disabled",
+                    seed_cache_dir=params.seed_cache_dir,
+                )
                 self.seed_responses_cache = None
                 self.seed_headers_cache = None
         else:
@@ -129,9 +137,6 @@ class CachingInterceptor(RequestToResponseInterceptor, ResponseInterceptor):
 
         # Thread safety
         self._count_lock = threading.Lock()
-
-        # Get logger for this interceptor with interceptor context
-        self.logger = get_logger(self.__class__.__name__)
 
         self.logger.info(
             "Caching interceptor initialized",
@@ -254,8 +259,11 @@ class CachingInterceptor(RequestToResponseInterceptor, ResponseInterceptor):
                 cached_content = self.seed_responses_cache[cache_key]
                 cached_headers = self.seed_headers_cache[cache_key]
                 self.logger.debug("Cache hit (seed)", cache_key=cache_key[:8] + "...")
-                # Promote seed entry into primary cache so the output cache is self-contained
-                self._save_to_cache(cache_key, cached_content, cached_headers)
+                # Promote seed entry into primary cache so the output cache is self-contained.
+                # Write directly instead of calling _save_to_cache to avoid
+                # incrementing _cached_responses_count for promoted entries.
+                self.responses_cache[cache_key] = cached_content
+                self.headers_cache[cache_key] = cached_headers
                 return cached_content, cached_headers
             except KeyError:
                 pass

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/caching/test_seed_cache.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/caching/test_seed_cache.py
@@ -1,0 +1,264 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for seed_cache_dir functionality in CachingInterceptor."""
+
+import pytest
+
+from nemo_evaluator.adapters.caching.diskcaching import Cache
+from nemo_evaluator.adapters.interceptors.caching_interceptor import CachingInterceptor
+
+
+def _make_cache_key(data: dict) -> str:
+    """Generate cache key the same way the interceptor does."""
+    return CachingInterceptor._generate_cache_key(data)
+
+
+def _populate_seed_cache(seed_dir: str, entries: dict[str, tuple[bytes, dict]]) -> None:
+    """Populate a seed cache directory with test entries.
+
+    Args:
+        seed_dir: Root seed cache directory.
+        entries: Mapping of cache_key -> (response_content, headers_dict).
+    """
+    responses_cache = Cache(directory=f"{seed_dir}/responses")
+    headers_cache = Cache(directory=f"{seed_dir}/headers")
+    for key, (content, headers) in entries.items():
+        responses_cache[key] = content
+        headers_cache[key] = headers
+    responses_cache.close()
+    headers_cache.close()
+
+
+class TestSeedCacheFallback:
+    """Test that seed cache is used as a read-only fallback."""
+
+    def test_seed_cache_hit_on_primary_miss(self, tmp_path):
+        """Primary cache miss + seed cache hit → returns seed data."""
+        primary_dir = str(tmp_path / "primary")
+        seed_dir = str(tmp_path / "seed")
+
+        request_data = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        cache_key = _make_cache_key(request_data)
+        seed_content = b'{"choices": [{"message": {"content": "from seed"}}]}'
+        seed_headers = {"content-type": "application/json"}
+
+        _populate_seed_cache(seed_dir, {cache_key: (seed_content, seed_headers)})
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=seed_dir,
+                reuse_cached_responses=True,
+            )
+        )
+
+        result = interceptor._get_from_cache(cache_key)
+        assert result is not None
+        content, headers = result
+        assert content == seed_content
+        assert headers == seed_headers
+
+    def test_primary_cache_takes_precedence(self, tmp_path):
+        """Primary cache hit → returns primary data, seed not used."""
+        primary_dir = str(tmp_path / "primary")
+        seed_dir = str(tmp_path / "seed")
+
+        request_data = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        cache_key = _make_cache_key(request_data)
+
+        primary_content = b'{"choices": [{"message": {"content": "from primary"}}]}'
+        primary_headers = {"content-type": "application/json", "x-source": "primary"}
+        seed_content = b'{"choices": [{"message": {"content": "from seed"}}]}'
+        seed_headers = {"content-type": "application/json", "x-source": "seed"}
+
+        _populate_seed_cache(seed_dir, {cache_key: (seed_content, seed_headers)})
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=seed_dir,
+                reuse_cached_responses=True,
+            )
+        )
+
+        # Populate primary cache directly
+        interceptor.responses_cache[cache_key] = primary_content
+        interceptor.headers_cache[cache_key] = primary_headers
+
+        result = interceptor._get_from_cache(cache_key)
+        assert result is not None
+        content, headers = result
+        assert content == primary_content
+        assert headers == primary_headers
+
+    def test_both_caches_miss(self, tmp_path):
+        """Both primary and seed miss → returns None."""
+        primary_dir = str(tmp_path / "primary")
+        seed_dir = str(tmp_path / "seed")
+
+        # Create empty seed cache directories
+        _populate_seed_cache(seed_dir, {})
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=seed_dir,
+                reuse_cached_responses=True,
+            )
+        )
+
+        cache_key = _make_cache_key({"model": "test", "messages": []})
+        result = interceptor._get_from_cache(cache_key)
+        assert result is None
+
+    def test_no_seed_cache_configured(self, tmp_path):
+        """seed_cache_dir=None → only primary cache checked."""
+        primary_dir = str(tmp_path / "primary")
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=None,
+                reuse_cached_responses=True,
+            )
+        )
+
+        assert interceptor.seed_responses_cache is None
+        assert interceptor.seed_headers_cache is None
+
+        cache_key = _make_cache_key({"model": "test", "messages": []})
+        result = interceptor._get_from_cache(cache_key)
+        assert result is None
+
+    def test_seed_cache_nonexistent_dir(self, tmp_path):
+        """seed_cache_dir points to nonexistent dir → no crash, seed ignored."""
+        primary_dir = str(tmp_path / "primary")
+        seed_dir = str(tmp_path / "nonexistent_seed")
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=seed_dir,
+                reuse_cached_responses=True,
+            )
+        )
+
+        assert interceptor.seed_responses_cache is None
+        assert interceptor.seed_headers_cache is None
+
+    def test_new_responses_saved_to_primary_only(self, tmp_path):
+        """New cache entries go to primary cache, not seed."""
+        primary_dir = str(tmp_path / "primary")
+        seed_dir = str(tmp_path / "seed")
+
+        _populate_seed_cache(seed_dir, {})
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=seed_dir,
+                reuse_cached_responses=True,
+                save_responses=True,
+            )
+        )
+
+        cache_key = _make_cache_key(
+            {"model": "test", "messages": [{"role": "user", "content": "new"}]}
+        )
+        new_content = b'{"choices": [{"message": {"content": "new response"}}]}'
+        new_headers = {"content-type": "application/json"}
+
+        interceptor._save_to_cache(cache_key, new_content, new_headers)
+
+        # Verify it's in primary
+        assert interceptor.responses_cache[cache_key] == new_content
+        assert interceptor.headers_cache[cache_key] == new_headers
+
+        # Verify it's NOT in seed
+        with pytest.raises(KeyError):
+            _ = interceptor.seed_responses_cache[cache_key]
+        with pytest.raises(KeyError):
+            _ = interceptor.seed_headers_cache[cache_key]
+
+    def test_seed_cache_not_modified(self, tmp_path):
+        """Verify seed cache is never written to during normal operation."""
+        primary_dir = str(tmp_path / "primary")
+        seed_dir = str(tmp_path / "seed")
+
+        original_data = {
+            "model": "test",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+        cache_key = _make_cache_key(original_data)
+        seed_content = b'{"choices": [{"message": {"content": "original seed"}}]}'
+        seed_headers = {"content-type": "application/json"}
+
+        _populate_seed_cache(seed_dir, {cache_key: (seed_content, seed_headers)})
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=seed_dir,
+                reuse_cached_responses=True,
+                save_responses=True,
+            )
+        )
+
+        # Read from seed (populates nothing in seed)
+        result = interceptor._get_from_cache(cache_key)
+        assert result is not None
+
+        # Save a different entry
+        other_key = _make_cache_key(
+            {"model": "test", "messages": [{"role": "user", "content": "other"}]}
+        )
+        interceptor._save_to_cache(other_key, b"other", {"x": "y"})
+
+        # Verify seed still has exactly the original entry and nothing else
+        assert interceptor.seed_responses_cache[cache_key] == seed_content
+        with pytest.raises(KeyError):
+            _ = interceptor.seed_responses_cache[other_key]
+
+
+class TestSeedCacheLegacyConfig:
+    """Test that seed_cache_dir is passed through legacy config conversion."""
+
+    def test_seed_cache_dir_in_legacy_config(self):
+        """seed_cache_dir flows from legacy config to interceptor config."""
+        from nemo_evaluator.adapters.adapter_config import AdapterConfig
+
+        legacy = {"seed_cache_dir": "/path/to/seed/cache"}
+        config = AdapterConfig.from_legacy_config(legacy)
+
+        caching_configs = [ic for ic in config.interceptors if ic.name == "caching"]
+        assert len(caching_configs) == 1
+        assert caching_configs[0].config["seed_cache_dir"] == "/path/to/seed/cache"
+
+    def test_no_seed_cache_dir_in_legacy_config(self):
+        """When seed_cache_dir is not set, it's absent from interceptor config."""
+        from nemo_evaluator.adapters.adapter_config import AdapterConfig
+
+        config = AdapterConfig.from_legacy_config({})
+
+        caching_configs = [ic for ic in config.interceptors if ic.name == "caching"]
+        assert len(caching_configs) == 1
+        assert "seed_cache_dir" not in caching_configs[0].config

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/caching/test_seed_cache.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/caching/test_seed_cache.py
@@ -206,6 +206,25 @@ class TestSeedCacheFallback:
         assert interceptor.seed_responses_cache is None
         assert interceptor.seed_headers_cache is None
 
+    def test_seed_cache_partial_dir(self, tmp_path):
+        """seed_cache_dir exists with responses/ but no headers/ → seed disabled, no crash."""
+        primary_dir = str(tmp_path / "primary")
+        seed_dir = str(tmp_path / "seed")
+
+        # Create only responses subdir, not headers
+        (tmp_path / "seed" / "responses").mkdir(parents=True)
+
+        interceptor = CachingInterceptor(
+            CachingInterceptor.Params(
+                cache_dir=primary_dir,
+                seed_cache_dir=seed_dir,
+                reuse_cached_responses=True,
+            )
+        )
+
+        assert interceptor.seed_responses_cache is None
+        assert interceptor.seed_headers_cache is None
+
     def test_new_responses_saved_to_primary_only(self, tmp_path):
         """New cache entries go to primary cache, not seed."""
         primary_dir = str(tmp_path / "primary")


### PR DESCRIPTION
## Problem

When the same evaluation is run on different clusters (e.g., CW-PDX → CW-DFW), each gets a separate `output_dir` and therefore a separate `cache_dir`. The cache keys are identical (SHA-256 of the request JSON body), but the caches are physically isolated on separate Lustre filesystems. If a run times out on one cluster and is restarted on another, all cached results are lost — even though the exact same requests would produce the exact same cache keys.

## Solution

Add a `seed_cache_dir` parameter to `CachingInterceptor` that acts as a **read-only fallback cache**. On a cache miss in the primary cache, the interceptor checks the seed cache. **Seed cache hits are automatically promoted into the primary cache**, so the output cache is always self-contained after a run. The seed cache itself is never modified.

### Usage

**Legacy config:**
```yaml
adapter_config:
  seed_cache_dir: /path/to/previous/run/cache
```

**Interceptor config:**
```yaml
interceptors:
  - name: caching
    config:
      seed_cache_dir: /path/to/previous/run/cache
```

### Workflow

1. Run eval on Cluster A → cache populated at `{output_dir}/cache/`
2. Copy cache directory to Cluster B: `rsync -a clusterA:/path/cache/ clusterB:/path/seed-cache/`
3. Run eval on Cluster B with `seed_cache_dir: /path/seed-cache`
4. Cluster B gets instant cache hits for all previously completed items
5. **Output cache on Cluster B is self-contained** — includes both promoted seed entries and newly generated responses

## Changes

- **`caching_interceptor.py`**: Added `seed_cache_dir` param to `Params`, seed `Cache` initialization with directory existence validation (warns when subdirs are missing), fallback logic in `_get_from_cache`, automatic promotion of seed hits into primary cache via direct cache writes (bypasses response counter to avoid inflating `_cached_responses_count`)
- **`adapter_config.py`**: Added `seed_cache_dir` to `LegacyAdapterConfig`, wired through to caching interceptor in `from_legacy_config()`
- **`test_seed_cache.py`**: 11 tests covering fallback, **promotion to primary**, primary precedence, both-miss, no-seed, nonexistent dir, partial seed dir, write isolation, seed immutability, and legacy config passthrough
- **`docs/libraries/nemo-evaluator/interceptors/caching.md`**: Added "Seed Cache" section documenting both legacy and interceptor configuration formats, promotion behavior, and cross-cluster usage guide

## Testing

### Unit tests
- 11 tests, all passing
- Existing tests pass with zero regressions

### Real cluster validation

**1. End-to-end test (AA_math_test_500, CW-PDX → CW-DFW):**
- Copied cache (2,500 entries, 56MB) from CW-PDX to CW-DFW
- Ran eval with `pre_cmd` installing this branch
- **2,500 / 2,500 LLM responses served from seed cache — 100% hit rate**
- Zero GPU inference on DFW — all responses from cache

**2. Production use (HLE benchmark, CW-DFW → CW-PDX):**
- DFW multi-node run timed out at 63.5% (1,677/2,158 items)
- Copied 151MB cache from DFW to PDX
- Ran HLE eval on PDX with `seed_cache_dir` pointing to copied cache
- **1,677 cached items served in ~11 seconds**, then generated remaining 481 items in ~2h
- GPT-4o judging completed in ~30 min
- **Result: 23.17% judge_correct** — complete end-to-end evaluation with cross-cluster cache reuse
- Primary cache on PDX ended up self-contained (all 2,158 entries) thanks to seed promotion

### Test details
- **Invocations:** `84774da8d9154adc` (AA_math test), `d8f3b1db276dd6e2` (HLE production)
- **Clusters:** CW-DFW, CW-PDX
- **Model:** Qwen3.5-122B-A10B (vLLM, 8×GPU per node, 8 nodes)
- **Branch install:** `pip install nemo-evaluator @ git+...@feature/cache-seed-dir` via `pre_cmd`