### PR TITLE
feat: add local no-docker mode for nemo-evaluator-launcher

### DIFF
--- a/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
+++ b/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
@@ -2,13 +2,13 @@
 
 # Local Executor
 
-The Local executor runs evaluations on your machine using Docker. It provides a fast way to iterate if you have Docker installed, evaluating existing endpoints.
+The Local executor runs evaluations on your machine. By default it uses Docker containers, and it can also run evaluations directly on the host process (`execution.use_docker: false`).
 
 See common concepts and commands in {ref}`executors-overview`.
 
 ## Prerequisites
 
-- Docker
+- Docker (required only when `execution.use_docker: true`, which is the default)
 - Python environment with the NeMo Evaluator Launcher CLI available (install the launcher by following {ref}`gs-install`)
 
 ## Quick Start
@@ -28,6 +28,22 @@ Here's a quick overview for the Local executor:
 # Run evaluation
 nemo-evaluator-launcher run --config packages/nemo-evaluator-launcher/examples/local_basic.yaml \
   -o target.api_endpoint.api_key_name=NGC_API_KEY
+```
+
+### Run without Docker containers
+
+```bash
+nemo-evaluator-launcher run --config packages/nemo-evaluator-launcher/examples/local_basic.yaml \
+  --no-docker \
+  -o target.api_endpoint.api_key_name=NGC_API_KEY
+```
+
+Equivalent YAML:
+
+```yaml
+execution:
+  type: local
+  use_docker: false
 ```
 
 ## Environment Variables and Secrets
@@ -58,6 +74,7 @@ The Local executor uses Docker volume mounts for data persistence:
 You can customize your local executor by specifying `extra_docker_args`.
 This parameter allows you to pass any flag to the `docker run` command that is executed by the NeMo Evaluator Launcher.
 You can use it to mount additional volumes, set environment variables or customize your network settings.
+`extra_docker_args` is ignored when `execution.use_docker: false`.
 
 For example, if you would like your job to use a specific docker network, you can specify:
 

--- a/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
+++ b/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
@@ -46,6 +46,8 @@ execution:
   use_docker: false
 ```
 
+When using `use_docker: false`, the requested benchmark task must be available from locally installed NeMo Evaluator packages (harness wheels). The launcher now validates this before execution and fails early if the harness/task is not installed.
+
 ## Environment Variables and Secrets
 
 Environment variables use the unified prefix syntax (`$host:`, `$lit:`, `$runtime:`) described in {ref}`env-vars-configuration`. Declare them at the top-level `env_vars:` section, at `evaluation.env_vars`, or per-task. Secret values are stored in a `.secrets.env` file alongside the generated `run.sh` and sourced at runtime — they never appear in the script itself.

--- a/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
+++ b/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
@@ -48,41 +48,6 @@ execution:
 
 When using `use_docker: false`, the requested benchmark task must be available from locally installed NeMo Evaluator packages (harness wheels). The launcher now validates this before execution and fails early if the harness/task is not installed.
 
-### No-Docker Dependency Management
-
-`--no-docker` does not install benchmark harnesses automatically. Install and pin the harness packages in your runtime environment (for example, in your pod image build).
-
-`requirements.txt` example:
-
-```text
-nemo-evaluator-launcher
-nvidia-simple-evals
-nvidia-lm-eval
-nvidia-livecodebench
-# nemo-skills: install from your internal wheel/source if available in your environment
-```
-
-`pyproject.toml` example:
-
-```toml
-[project]
-dependencies = [
-  "nemo-evaluator-launcher",
-  "nvidia-simple-evals",
-  "nvidia-lm-eval",
-  "nvidia-livecodebench",
-  # nemo-skills harness dependency (if available in your environment)
-]
-```
-
-Quick preflight validation:
-
-```bash
-nemo-evaluator ls
-```
-
-If a task (for example from `nemo-skills`) is not installed locally, launcher will fail early in no-docker mode with an installation hint.
-
 ## Environment Variables and Secrets
 
 Environment variables use the unified prefix syntax (`$host:`, `$lit:`, `$runtime:`) described in {ref}`env-vars-configuration`. Declare them at the top-level `env_vars:` section, at `evaluation.env_vars`, or per-task. Secret values are stored in a `.secrets.env` file alongside the generated `run.sh` and sourced at runtime — they never appear in the script itself.

--- a/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
+++ b/docs/libraries/nemo-evaluator-launcher/configuration/executors/local.md
@@ -48,6 +48,41 @@ execution:
 
 When using `use_docker: false`, the requested benchmark task must be available from locally installed NeMo Evaluator packages (harness wheels). The launcher now validates this before execution and fails early if the harness/task is not installed.
 
+### No-Docker Dependency Management
+
+`--no-docker` does not install benchmark harnesses automatically. Install and pin the harness packages in your runtime environment (for example, in your pod image build).
+
+`requirements.txt` example:
+
+```text
+nemo-evaluator-launcher
+nvidia-simple-evals
+nvidia-lm-eval
+nvidia-livecodebench
+# nemo-skills: install from your internal wheel/source if available in your environment
+```
+
+`pyproject.toml` example:
+
+```toml
+[project]
+dependencies = [
+  "nemo-evaluator-launcher",
+  "nvidia-simple-evals",
+  "nvidia-lm-eval",
+  "nvidia-livecodebench",
+  # nemo-skills harness dependency (if available in your environment)
+]
+```
+
+Quick preflight validation:
+
+```bash
+nemo-evaluator ls
+```
+
+If a task (for example from `nemo-skills`) is not installed locally, launcher will fail early in no-docker mode with an installation hint.
+
 ## Environment Variables and Secrets
 
 Environment variables use the unified prefix syntax (`$host:`, `$lit:`, `$runtime:`) described in {ref}`env-vars-configuration`. Declare them at the top-level `env_vars:` section, at `evaluation.env_vars`, or per-task. Secret values are stored in a `.secrets.env` file alongside the generated `run.sh` and sourced at runtime — they never appear in the script itself.

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
@@ -16,6 +16,7 @@
 import base64
 import datetime
 import os
+import shlex
 from dataclasses import dataclass
 from typing import Optional
 
@@ -61,8 +62,9 @@ def _str_to_echo_command(str_to_save: str, filename: str) -> CmdAndReadableComme
     debug_str = "\n".join(
         [f"# Contents of {filename}"] + ["# " + s for s in str_to_save.splitlines()]
     )
+    quoted_filename = shlex.quote(filename)
     return CmdAndReadableComment(
-        cmd=f'echo "{str_to_save_b64}" | base64 -d > {filename}', debug=debug_str
+        cmd=f'echo "{str_to_save_b64}" | base64 -d > {quoted_filename}', debug=debug_str
     )
 
 
@@ -167,6 +169,7 @@ def get_eval_factory_command(
     cfg: DictConfig,
     user_task_config: DictConfig,
     task_definition: dict,
+    output_dir: str = CONTAINER_RESULTS_DIR,
 ) -> CmdAndReadableComment:
     # This gets the eval_factory_config merged from both top-level and task-level.
     merged_nemo_evaluator_config = get_eval_factory_config(
@@ -214,7 +217,7 @@ def get_eval_factory_command(
     _set_nested_optionally_overriding(
         merged_nemo_evaluator_config,
         ["config", "output_dir"],
-        CONTAINER_RESULTS_DIR,
+        output_dir,
     )
     api_key_name = get_api_key_name(cfg)
     if api_key_name:
@@ -275,7 +278,7 @@ def get_eval_factory_command(
     if config_path:
         create_unresolved_config_cmd = _str_to_echo_command(
             open(config_path, "r").read(),
-            filename=f"{CONTAINER_RESULTS_DIR}/launcher_unresolved_config.yaml",
+            filename=f"{output_dir}/launcher_unresolved_config.yaml",
         )
         commands.append(create_unresolved_config_cmd.cmd)
         debug.append(create_unresolved_config_cmd.debug)

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/local.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/local.yaml
@@ -15,5 +15,6 @@
 #
 type: local
 output_dir: ???
+use_docker: true
 extra_docker_args: ""
 mode: sequential

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
@@ -68,6 +68,61 @@ from nemo_evaluator_launcher.executors.base import (
 from nemo_evaluator_launcher.executors.registry import register_executor
 
 
+def _get_local_available_tasks() -> dict[str, set[str]]:
+    """Return locally installed NeMo Evaluator tasks grouped by harness."""
+    try:
+        from nemo_evaluator.api import get_available_evaluations
+    except ImportError as e:
+        raise RuntimeError(
+            "execution.use_docker=false requires `nemo-evaluator` to be installed locally. "
+            "Install nemo-evaluator (with the harness/task wheels you need), or enable Docker execution."
+        ) from e
+
+    framework_task_mapping, _, _ = get_available_evaluations()
+    return {
+        framework: set(tasks.keys())
+        for framework, tasks in framework_task_mapping.items()
+    }
+
+
+def _validate_task_available_locally(
+    *,
+    task_query: str,
+    task_definition: dict,
+    available_tasks_by_harness: dict[str, set[str]],
+) -> None:
+    """Validate that a task exists in locally installed NeMo Evaluator packages."""
+    harness_name = str(task_definition.get("harness") or "")
+    task_name = str(task_definition.get("task") or "")
+
+    if harness_name:
+        harness_tasks = available_tasks_by_harness.get(harness_name)
+        if harness_tasks is None:
+            available_harnesses = sorted(available_tasks_by_harness.keys())
+            raise ValueError(
+                f"Task '{task_query}' requires harness '{harness_name}', but this harness is not installed locally. "
+                f"Installed harnesses: {available_harnesses or ['<none>']}. "
+                "Install the corresponding NeMo Evaluator wheel, or run with Docker."
+            )
+        if task_name not in harness_tasks:
+            available_tasks = sorted(harness_tasks)
+            raise ValueError(
+                f"Task '{task_query}' is not available in installed harness '{harness_name}'. "
+                f"Available tasks in this harness: {available_tasks or ['<none>']}. "
+                "Install a wheel that contains this task, or run with Docker."
+            )
+        return
+
+    matching_harnesses = [
+        harness for harness, tasks in available_tasks_by_harness.items() if task_name in tasks
+    ]
+    if not matching_harnesses:
+        raise ValueError(
+            f"Task '{task_query}' is not available in locally installed NeMo Evaluator packages. "
+            "Install a wheel that contains this task, or run with Docker."
+        )
+
+
 @register_executor("local")
 class LocalExecutor(BaseExecutor):
     @classmethod
@@ -96,6 +151,9 @@ class LocalExecutor(BaseExecutor):
             raise ValueError(
                 "execution.use_docker=false is only supported with deployment.type=none."
             )
+        local_available_tasks: dict[str, set[str]] | None = None
+        if not use_docker:
+            local_available_tasks = _get_local_available_tasks()
 
         # Generate invocation ID for this evaluation run
         invocation_id = generate_invocation_id()
@@ -143,6 +201,12 @@ class LocalExecutor(BaseExecutor):
                 container=task.get("container"),
                 endpoint_type=task.get("endpoint_type"),
             )
+            if not use_docker:
+                _validate_task_available_locally(
+                    task_query=task.name,
+                    task_definition=task_definition,
+                    available_tasks_by_harness=local_available_tasks or {},
+                )
 
             # Track unlisted tasks for safeguard check
             if task_definition.get("is_unlisted", False):

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/resources/config_templates/execution/local.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/resources/config_templates/execution/local.yaml
@@ -3,3 +3,4 @@ defaults:
 
 execution:
   output_dir: nel-results
+  use_docker: true

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_get_eval_factory_command.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_get_eval_factory_command.py
@@ -93,3 +93,34 @@ def test_get_eval_factory_command_basic(monkeypatch):
 
     # The command to run eval is present
     assert "&& $cmd run_eval --run_config config_ef.yaml" in result.cmd
+
+
+def test_get_eval_factory_command_custom_output_dir():
+    cfg = OmegaConf.create(
+        {
+            "evaluation": {"nemo_evaluator_config": {"config": {}}},
+            "deployment": {"type": "none"},
+            "target": {
+                "api_endpoint": {
+                    "url": "https://example.test/api",
+                    "model_id": "model-123",
+                    "api_key_name": "MY_API_KEY",
+                }
+            },
+        }
+    )
+    user_task_config = OmegaConf.create({"nemo_evaluator_config": {"config": {}}})
+    task_definition = {"endpoint_type": "chat", "task": "my_task"}
+
+    result = get_eval_factory_command(
+        cfg,
+        user_task_config,
+        task_definition,
+        output_dir="/tmp/nel/results",
+    )
+
+    b64 = _extract_b64_from_echo_cmd(result.cmd)
+    decoded_yaml = base64.b64decode(b64.encode("utf-8")).decode("utf-8")
+    merged = yaml.safe_load(decoded_yaml)
+
+    assert merged["config"]["output_dir"] == "/tmp/nel/results"

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_local_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_local_executor.py
@@ -276,6 +276,9 @@ class TestLocalExecutorDryRun:
                     "nemo_evaluator_launcher.executors.local.executor.load_tasks_mapping"
                 ) as mock_load_mapping,
                 patch(
+                    "nemo_evaluator_launcher.executors.local.executor._get_local_available_tasks"
+                ) as mock_get_local_tasks,
+                patch(
                     "nemo_evaluator_launcher.executors.local.executor.get_task_definition_for_job"
                 ) as mock_get_task_def,
                 patch(
@@ -284,6 +287,10 @@ class TestLocalExecutorDryRun:
                 patch("builtins.print"),
             ):
                 mock_load_mapping.return_value = mock_tasks_mapping
+                mock_get_local_tasks.return_value = {
+                    "lm-eval": {"test_task_1"},
+                    "helm": {"test_task_2"},
+                }
 
                 def mock_get_task_def_side_effect(*_args, **kwargs):
                     task_name = kwargs.get("task_query")
@@ -336,6 +343,51 @@ class TestLocalExecutorDryRun:
             match="execution.use_docker=false is only supported with deployment.type=none",
         ):
             LocalExecutor.execute_eval(sample_config, dry_run=True)
+
+    def test_execute_eval_no_docker_missing_local_task_raises(
+        self, sample_config, mock_tasks_mapping
+    ):
+        sample_config.execution.use_docker = False
+        os.environ["TEST_API_KEY"] = "test_key_value"
+        os.environ["GLOBAL_VALUE"] = "global_env_value"
+        os.environ["TASK_VALUE"] = "task_env_value"
+
+        try:
+            with (
+                patch(
+                    "nemo_evaluator_launcher.executors.local.executor.load_tasks_mapping"
+                ) as mock_load_mapping,
+                patch(
+                    "nemo_evaluator_launcher.executors.local.executor._get_local_available_tasks"
+                ) as mock_get_local_tasks,
+                patch(
+                    "nemo_evaluator_launcher.executors.local.executor.get_task_definition_for_job"
+                ) as mock_get_task_def,
+            ):
+                mock_load_mapping.return_value = mock_tasks_mapping
+                mock_get_local_tasks.return_value = {
+                    "lm-eval": {"some_other_task"},
+                    "helm": {"test_task_2"},
+                }
+
+                def mock_get_task_def_side_effect(*_args, **kwargs):
+                    task_name = kwargs.get("task_query")
+                    mapping = kwargs.get("base_mapping", {})
+                    for (_harness, name), definition in mapping.items():
+                        if name == task_name:
+                            return definition
+                    raise KeyError(f"Task {task_name} not found")
+
+                mock_get_task_def.side_effect = mock_get_task_def_side_effect
+
+                with pytest.raises(
+                    ValueError, match="not available in installed harness"
+                ):
+                    LocalExecutor.execute_eval(sample_config, dry_run=True)
+        finally:
+            for env_var in ["TEST_API_KEY", "GLOBAL_VALUE", "TASK_VALUE"]:
+                if env_var in os.environ:
+                    del os.environ[env_var]
 
 
 class TestLocalExecutorGetStatus:


### PR DESCRIPTION
## Summary
- add `--no-docker` flag to `nemo-evaluator-launcher run`
- add `execution.use_docker` (default: `true`) for local executor config
- support host-process execution path (no `docker run`) in local executor scripts
- keep Docker as default behavior for backward compatibility
- add tests and docs for no-docker mode

## Rationale
This change enables running `nemo-evaluator-launcher` in environments where users do not have root access and cannot run Docker at all. A concrete example is workloads running on GKE Autopilot pods, where Docker-in-containerd patterns are prohibited.

This is especially useful for R&D workflows where teams want to run evaluations inside managed, restricted compute environments while still using the launcher orchestration and task config experience.

## Notes
- no-docker mode is restricted to `execution.type=local` with `deployment.type=none`
- existing Docker-based local flows remain unchanged by default

## Validation
- `uv run pytest tests/unit_tests/test_get_eval_factory_command.py tests/unit_tests/test_local_executor.py tests/unit_tests/test_cli_integration.py -q`
- `uv run ruff check ...` on modified files