### PR TITLE
fix: use deep copy in response stats interceptor to prevent live stat…

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/response_stats_interceptor.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/response_stats_interceptor.py
@@ -15,6 +15,7 @@
 
 """Response stats interceptor that collects aggregated statistics from API responses."""
 
+import copy
 import datetime
 import json
 import threading
@@ -66,7 +67,7 @@ class ResponseStatsInterceptor(ResponseInterceptor, PostEvalHook):
             default=True, description="Whether to collect tool call statistics"
         )
         stats_file_saving_interval: Optional[int] = Field(
-            default=None,
+            default=100,
             description="How often (every how many responses) to save stats to a file. If None, stats are only saved via post_eval_hook.",
         )
         save_individuals: bool = Field(
@@ -471,9 +472,8 @@ class ResponseStatsInterceptor(ResponseInterceptor, PostEvalHook):
         """Save current stats to the same file as post-eval hook."""
         # Get stats in a thread-safe manner
         with self._lock:
-            stats = self._stats.copy()
+            stats = copy.deepcopy(self._stats)
 
-        # Don't create file if no stats collected
         if stats["count"] == 0:
             self.logger.debug("No response statistics collected, skipping file write")
             return

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_response_stats_interceptor.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_response_stats_interceptor.py
@@ -62,7 +62,7 @@ class TestResponseStatsInterceptor:
                     "collect_token_stats": True,
                     "collect_finish_reasons": True,
                     "collect_tool_calls": True,
-                    "stats_file_saving_interval": None,
+                    "stats_file_saving_interval": 100,
                     "save_individuals": True,
                     "has_cache": True,
                 },
@@ -919,3 +919,114 @@ class TestResponseStatsInterceptorCache:
             assert actual_run_ids == expected_run_ids, (
                 f"Expected run_ids {expected_run_ids}, got {actual_run_ids}"
             )
+
+
+class TestStatsFileSavingInterval:
+    """Test that stats_file_saving_interval does not corrupt live stats."""
+
+    @staticmethod
+    def _make_response(request_id="req_1", latency_ms=100.0):
+        mock_resp = Mock(spec=requests.Response)
+        mock_resp.status_code = 200
+        mock_resp.headers = {"date": "2026-03-04T00:00:00Z"}
+        mock_resp.json.return_value = {
+            "usage": {
+                "prompt_tokens": 25,
+                "total_tokens": 35,
+                "completion_tokens": 10,
+            },
+            "choices": [{"finish_reason": "stop", "message": {}}],
+        }
+        return AdapterResponse(
+            r=mock_resp,
+            rctx=AdapterRequestContext(request_id=request_id),
+            latency_ms=latency_ms,
+        )
+
+    def test_interval_save_does_not_mutate_live_stats(self, tmp_path):
+        """Verify _save_stats_to_file uses a deep copy so inference_run_times
+        timestamps remain floats in the live self._stats after an interval save."""
+        cache_dir = tmp_path / "cache"
+        interceptor = ResponseStatsInterceptor(
+            ResponseStatsInterceptor.Params(
+                cache_dir=str(cache_dir),
+                save_individuals=False,
+                stats_file_saving_interval=2,
+            )
+        )
+        context = AdapterGlobalContext(
+            output_dir=str(tmp_path),
+            url="http://test.api.com/v1/chat/completions",
+        )
+
+        interceptor.intercept_response(self._make_response("req_1"), context)
+        interceptor.intercept_response(self._make_response("req_2"), context)
+
+        run_id = interceptor._stats["run_id"]
+        run_data = interceptor._stats["inference_run_times"][run_id]
+        assert isinstance(run_data["first_request_time"], float)
+        assert isinstance(run_data["last_request_time"], float)
+        assert isinstance(run_data["run_start"], float)
+
+    def test_responses_after_interval_save_succeed(self, tmp_path):
+        """Verify that processing responses after an interval-triggered save
+        works without errors (no TypeError from string arithmetic)."""
+        cache_dir = tmp_path / "cache"
+        interceptor = ResponseStatsInterceptor(
+            ResponseStatsInterceptor.Params(
+                cache_dir=str(cache_dir),
+                save_individuals=False,
+                stats_file_saving_interval=2,
+            )
+        )
+        context = AdapterGlobalContext(
+            output_dir=str(tmp_path),
+            url="http://test.api.com/v1/chat/completions",
+        )
+
+        for i in range(5):
+            interceptor.intercept_response(self._make_response(f"req_{i}"), context)
+
+        assert interceptor._stats["count"] == 5
+        assert interceptor._stats["successful_count"] == 5
+
+        run_id = interceptor._stats["run_id"]
+        assert isinstance(
+            interceptor._stats["inference_run_times"][run_id]["first_request_time"],
+            float,
+        )
+
+    def test_multiple_interval_saves_produce_valid_files(self, tmp_path):
+        """Verify that each interval-triggered save writes valid JSON with
+        ISO-formatted timestamps while keeping live stats as floats."""
+        cache_dir = tmp_path / "cache"
+        interceptor = ResponseStatsInterceptor(
+            ResponseStatsInterceptor.Params(
+                cache_dir=str(cache_dir),
+                save_individuals=False,
+                stats_file_saving_interval=3,
+            )
+        )
+        context = AdapterGlobalContext(
+            output_dir=str(tmp_path),
+            url="http://test.api.com/v1/chat/completions",
+        )
+
+        for i in range(9):
+            interceptor.intercept_response(self._make_response(f"req_{i}"), context)
+
+        metrics_path = tmp_path / "eval_factory_metrics.json"
+        assert metrics_path.exists()
+
+        with open(metrics_path, "r") as f:
+            metrics = json.load(f)
+
+        saved_run_times = metrics["response_stats"]["inference_run_times"]
+        for _run_id, run_data in saved_run_times.items():
+            assert isinstance(run_data["first_request_time"], str)
+            assert isinstance(run_data["run_start"], str)
+
+        run_id = interceptor._stats["run_id"]
+        live_run_data = interceptor._stats["inference_run_times"][run_id]
+        assert isinstance(live_run_data["first_request_time"], float)
+        assert isinstance(live_run_data["run_start"], float)


### PR DESCRIPTION
_save_stats_to_file used a shallow copy of self._stats, so converting timestamps to ISO strings for JSON output mutated the live stats via shared nested dict references. This caused a TypeError on the next response when _update_basic_stats tried float arithmetic on a string.

The pipeline silently caught the exception, so the visible symptom was the stats file only being written once and never updated again.

Also changes the default stats_file_saving_interval from None to 100 so stats files are written periodically out of the box.