### PR TITLE
feat(launcher): add judge deployment support for on-cluster judge model serving

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/env_vars.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/env_vars.py
@@ -409,3 +409,29 @@ def collect_deployment_env_vars(cfg: DictConfig) -> dict[str, EnvVarValue]:
             parsed[target_name] = parse_env_var_value(str(raw_value))
 
     return parsed
+
+
+def collect_judge_deployment_env_vars(cfg: DictConfig) -> dict[str, EnvVarValue]:
+    """Collect and parse judge deployment env vars from config.
+
+    Merges (last wins):
+        cfg.env_vars → cfg.judge_deployment.env_vars
+
+    Args:
+        cfg: Full run config.
+
+    Returns:
+        dict mapping target_name → EnvVarValue.
+    """
+    # 1. Top-level env_vars (new unified config) — uses host default
+    top_level_vars = _collect_top_level_env_vars(cfg)
+    parsed: dict[str, EnvVarValue] = {}
+    for target_name, raw_value in top_level_vars.items():
+        parsed[target_name] = parse_env_var_value(str(raw_value))
+
+    # 2. cfg.judge_deployment.env_vars to override the top ones
+    if cfg.judge_deployment.get("env_vars"):
+        for target_name, raw_value in cfg.judge_deployment["env_vars"].items():
+            parsed[target_name] = parse_env_var_value(str(raw_value))
+
+    return parsed

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
@@ -350,6 +350,33 @@ def get_endpoint_url(
         return endpoint_url
 
 
+def get_judge_endpoint_url(cfg: DictConfig) -> str | None:
+    """Get the judge deployment endpoint URL.
+
+    Returns None if judge_deployment.type is "none" or judge_deployment is not configured.
+    When a judge is deployed, returns the URL pointing to the judge server.
+    """
+    if not cfg.get("judge_deployment") or cfg.judge_deployment.type == "none":
+        return None
+
+    endpoint_uri = cfg.judge_deployment.endpoints.get("chat", "/v1/chat/completions")
+    port = cfg.judge_deployment.port
+    # Judge always runs on JUDGE_PRIMARY_NODE which is resolved at runtime
+    # in the sbatch script. At config generation time we use a placeholder.
+    endpoint_url = f"http://${{JUDGE_PRIMARY_NODE}}:{port}{endpoint_uri}"
+    return endpoint_url
+
+
+def get_judge_served_model_name(cfg: DictConfig) -> str | None:
+    """Get the judge deployment served model name.
+
+    Returns None if judge_deployment is not configured or type is "none".
+    """
+    if not cfg.get("judge_deployment") or cfg.judge_deployment.type == "none":
+        return None
+    return str(cfg.judge_deployment.served_model_name)
+
+
 def get_health_url(cfg: DictConfig, endpoint_url: str) -> str:
     if cfg.deployment.type == "none":
         logger.warning("Using endpoint URL as health URL", will_be_used=endpoint_url)

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/slurm/default.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/slurm/default.yaml
@@ -32,8 +32,13 @@ sbatch_comment: null # Optional comment for SLURM job (translates to #SBATCH --c
 deployment:
   n_tasks: 1 # Number of tasks for deployment srun (default: 1, for multi-instance set to num_nodes)
 
+# Judge deployment-specific SLURM configuration
+judge_deployment:
+  n_tasks: 1 # Number of tasks for judge deployment srun
+
 mounts:
   deployment: {}
+  judge_deployment: {}
   evaluation: {}
   mount_home: true
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/judge_deployment/none.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/judge_deployment/none.yaml
@@ -13,22 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-defaults:
-  - execution: local
-  - deployment: none
-  - judge_deployment: none
-  - _self_
-
-# Top-level env vars applied to all jobs (deployment + evaluation).
-# Values use explicit prefixes: "host:VAR_NAME", "lit:value", "runtime:VAR_NAME".
-# Section-level and task-level env_vars override these.
-env_vars: {}
-
-# NOTE(dfridman): If deployment is used, `target` parameters will be automatically populated.
-target:
-  api_endpoint:
-    url: ???
-    model_id: ???
-    api_key_name: "<YOUR_API_KEY_NAME>" # NOTE: the name of the env var
-
-evaluation: []
+type: none

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/judge_deployment/sglang.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/judge_deployment/sglang.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+type: sglang
+image: lmsysorg/sglang:latest
+checkpoint_path: ???
+served_model_name: ???
+port: 8001
+tensor_parallel_size: 8
+pipeline_parallel_size: 1
+data_parallel_size: 1
+extra_args: ""
+env_vars: {} # {name: value} dict
+num_nodes: 1
+
+endpoints:
+  chat: /v1/chat/completions
+  completions: /v1/completions
+  health: /health
+
+command: python3 -m sglang.launch_server
+  --model-path ${oc.select:judge_deployment.hf_model_handle,/checkpoint}
+  --host 0.0.0.0
+  --port ${judge_deployment.port}
+  --served-model-name ${judge_deployment.served_model_name}
+  --tp-size ${judge_deployment.tensor_parallel_size}
+  --dp-size ${judge_deployment.data_parallel_size}
+  --pp-size ${judge_deployment.pipeline_parallel_size}
+  ${judge_deployment.extra_args}

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/judge_deployment/vllm.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/judge_deployment/vllm.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+type: vllm
+image: vllm/vllm-openai:latest
+checkpoint_path: ???
+served_model_name: ???
+port: 8001
+tensor_parallel_size: 8
+pipeline_parallel_size: 1
+data_parallel_size: 1
+gpu_memory_utilization: 0.95
+extra_args: ""
+env_vars: {} # {name: value} dict
+num_nodes: 1
+
+endpoints:
+  chat: /v1/chat/completions
+  completions: /v1/completions
+  health: /health
+
+command: vllm serve ${oc.select:judge_deployment.hf_model_handle,/checkpoint}
+  --tensor-parallel-size=${judge_deployment.tensor_parallel_size}
+  --pipeline-parallel-size=${judge_deployment.pipeline_parallel_size}
+  --data-parallel-size=${judge_deployment.data_parallel_size}
+  --port ${judge_deployment.port}
+  --trust-remote-code
+  --served-model-name ${judge_deployment.served_model_name}
+  --gpu-memory-utilization ${judge_deployment.gpu_memory_utilization}
+  ${judge_deployment.extra_args}

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -35,6 +35,7 @@ from nemo_evaluator_launcher.common.env_vars import (
     build_reexport_commands,
     collect_deployment_env_vars,
     collect_eval_env_vars,
+    collect_judge_deployment_env_vars,
     generate_secrets_env,
     redact_secrets_env_content,
 )
@@ -651,13 +652,21 @@ def _create_slurm_sbatch_script(
     )
 
     # TODO(public release): convert to template
+    # Determine if judge deployment is active
+    has_judge_deployment = (
+        cfg.get("judge_deployment") is not None
+        and cfg.judge_deployment.get("type", "none") != "none"
+    )
+    judge_num_nodes = cfg.judge_deployment.get("num_nodes", 1) if has_judge_deployment else 0
+    total_num_nodes = cfg.execution.num_nodes + judge_num_nodes
+
     s = "#!/bin/bash\n"
 
     # SBATCH headers
     s += "#SBATCH --time {}\n".format(cfg.execution.walltime)
     s += "#SBATCH --account {}\n".format(cfg.execution.account)
     s += "#SBATCH --partition {}\n".format(cfg.execution.partition)
-    s += "#SBATCH --nodes {}\n".format(cfg.execution.num_nodes)
+    s += "#SBATCH --nodes {}\n".format(total_num_nodes)
     s += "#SBATCH --ntasks-per-node {}\n".format(cfg.execution.ntasks_per_node)
     if cfg.execution.get("gpus_per_node", None) is not None:
         s += "#SBATCH --gpus-per-node {}\n".format(cfg.execution.gpus_per_node)
@@ -682,6 +691,7 @@ def _create_slurm_sbatch_script(
     api_key_name = get_api_key_name(cfg)
     eval_env_vars = collect_eval_env_vars(cfg, task, api_key_name)
     deployment_env_vars = collect_deployment_env_vars(cfg)
+    judge_deployment_env_vars = collect_judge_deployment_env_vars(cfg) if has_judge_deployment else {}
 
     # Merge all into groups for secrets file generation
     env_groups = {}
@@ -691,6 +701,9 @@ def _create_slurm_sbatch_script(
     # Deployment vars (merged: top-level → exec deployment → deployment.env_vars)
     if deployment_env_vars:
         env_groups["deployment"] = deployment_env_vars
+    # Judge deployment vars (merged: top-level → judge_deployment.env_vars)
+    if judge_deployment_env_vars:
+        env_groups["judge_deployment"] = judge_deployment_env_vars
 
     secrets_result = None
     eval_reexport_cmd = ""
@@ -707,6 +720,7 @@ def _create_slurm_sbatch_script(
 
         eval_reexport_cmd = build_reexport_commands(task.name, secrets_result)
         deploy_reexport_cmd = build_reexport_commands("deployment", secrets_result)
+        judge_deploy_reexport_cmd = build_reexport_commands("judge_deployment", secrets_result) if has_judge_deployment else ""
 
     # auto resume after timeout (with optional max_walltime enforcement)
     max_walltime = cfg.execution.get("max_walltime", "120:00:00")
@@ -725,23 +739,52 @@ def _create_slurm_sbatch_script(
     s += "set -x  # print commands and their arguments as they are executed\n"
     s += "\n"
 
-    # Resolve a primary node for single-node sruns (client/proxy/export).
-    # This must be safe under `set -u` and work for deployment.type == "none".
-    # Prefer SLURM_JOB_NODELIST but fall back to SLURM_NODELIST; if neither exists,
-    # fall back to the local hostname.
-    s += "# Resolve PRIMARY_NODE for single-node sruns\n"
-    s += 'NODELIST="${SLURM_JOB_NODELIST:-${SLURM_NODELIST:-}}"\n'
-    s += 'if command -v scontrol >/dev/null 2>&1 && [[ -n "${NODELIST}" ]]; then\n'
-    s += '  nodes=( $(scontrol show hostnames "${NODELIST}") )\n'
-    s += "else\n"
-    s += '  nodes=( "$(hostname)" )\n'
-    s += "fi\n"
-    s += 'nodes_array=("${nodes[@]}")\n'
-    s += "if [[ ${#nodes_array[@]} -eq 0 ]]; then\n"
-    s += '  nodes_array=( "$(hostname)" )\n'
-    s += "fi\n"
-    s += 'export PRIMARY_NODE="${nodes_array[0]}"\n'
-    s += 'echo "PRIMARY_NODE: ${PRIMARY_NODE}"\n'
+    if has_judge_deployment:
+        # Resolve all allocated nodes and split between model and judge deployments
+        s += "# Resolve all allocated nodes\n"
+        s += 'NODELIST="${SLURM_JOB_NODELIST:-${SLURM_NODELIST:-}}"\n'
+        s += 'if command -v scontrol >/dev/null 2>&1 && [[ -n "${NODELIST}" ]]; then\n'
+        s += '  ALL_NODES=( $(scontrol show hostnames "${NODELIST}") )\n'
+        s += "else\n"
+        s += '  ALL_NODES=( "$(hostname)" )\n'
+        s += "fi\n"
+        s += 'if [[ ${#ALL_NODES[@]} -eq 0 ]]; then\n'
+        s += '  ALL_NODES=( "$(hostname)" )\n'
+        s += "fi\n"
+        s += 'echo "ALL_NODES (${#ALL_NODES[@]}): ${ALL_NODES[*]}"\n'
+        s += "\n"
+        # Split nodes: first num_nodes for model deployment, remaining for judge
+        s += "# Split nodes between model deployment and judge deployment\n"
+        s += f"MODEL_NUM_NODES={cfg.execution.num_nodes}\n"
+        s += f"JUDGE_NUM_NODES={judge_num_nodes}\n"
+        s += 'MODEL_NODES=("${ALL_NODES[@]:0:$MODEL_NUM_NODES}")\n'
+        s += 'JUDGE_NODES=("${ALL_NODES[@]:$MODEL_NUM_NODES:$JUDGE_NUM_NODES}")\n'
+        s += 'MODEL_NODELIST=$(IFS=,; echo "${MODEL_NODES[*]}")\n'
+        s += 'JUDGE_NODELIST=$(IFS=,; echo "${JUDGE_NODES[*]}")\n'
+        s += 'export PRIMARY_NODE="${MODEL_NODES[0]}"\n'
+        s += 'export JUDGE_PRIMARY_NODE="${JUDGE_NODES[0]}"\n'
+        s += 'echo "MODEL_NODES ($MODEL_NUM_NODES): ${MODEL_NODES[*]}"\n'
+        s += 'echo "JUDGE_NODES ($JUDGE_NUM_NODES): ${JUDGE_NODES[*]}"\n'
+        s += 'echo "PRIMARY_NODE: ${PRIMARY_NODE}"\n'
+        s += 'echo "JUDGE_PRIMARY_NODE: ${JUDGE_PRIMARY_NODE}"\n'
+    else:
+        # Resolve a primary node for single-node sruns (client/proxy/export).
+        # This must be safe under `set -u` and work for deployment.type == "none".
+        # Prefer SLURM_JOB_NODELIST but fall back to SLURM_NODELIST; if neither exists,
+        # fall back to the local hostname.
+        s += "# Resolve PRIMARY_NODE for single-node sruns\n"
+        s += 'NODELIST="${SLURM_JOB_NODELIST:-${SLURM_NODELIST:-}}"\n'
+        s += 'if command -v scontrol >/dev/null 2>&1 && [[ -n "${NODELIST}" ]]; then\n'
+        s += '  nodes=( $(scontrol show hostnames "${NODELIST}") )\n'
+        s += "else\n"
+        s += '  nodes=( "$(hostname)" )\n'
+        s += "fi\n"
+        s += 'nodes_array=("${nodes[@]}")\n'
+        s += "if [[ ${#nodes_array[@]} -eq 0 ]]; then\n"
+        s += '  nodes_array=( "$(hostname)" )\n'
+        s += "fi\n"
+        s += 'export PRIMARY_NODE="${nodes_array[0]}"\n'
+        s += 'echo "PRIMARY_NODE: ${PRIMARY_NODE}"\n'
     s += "\n"
 
     # prepare deployment mounts
@@ -768,6 +811,7 @@ def _create_slurm_sbatch_script(
                 deployment_mounts_list,
                 remote_task_subdir,
                 deployment_env_var_names=list(deployment_env_vars.keys()),
+                nodelist_var="MODEL_NODES" if has_judge_deployment else None,
             )
         )
         s += deployment_srun_cmd
@@ -791,6 +835,46 @@ def _create_slurm_sbatch_script(
         # add proxy load balancer for multi-instance deployments
         if cfg.deployment.get("multiple_instances", False):
             s += _get_proxy_server_srun_command(cfg, remote_task_subdir)
+
+    # --- Judge deployment (if configured) ---
+    judge_deployment_is_unsafe = False
+    if has_judge_deployment:
+        judge_deployment_mounts_list = []
+        if judge_checkpoint_path := cfg.judge_deployment.get("checkpoint_path"):
+            judge_deployment_mounts_list.append(f"{judge_checkpoint_path}:/checkpoint:ro")
+        if judge_cache_path := cfg.judge_deployment.get("cache_path"):
+            judge_deployment_mounts_list.append(f"{judge_cache_path}:/cache")
+        for source_mnt, target_mnt in (
+            cfg.execution.get("mounts", {}).get("judge_deployment", {}).items()
+        ):
+            judge_deployment_mounts_list.append(f"{source_mnt}:{target_mnt}")
+
+        # Re-export judge deployment vars right before judge deployment srun
+        if judge_deploy_reexport_cmd:
+            s += f"{judge_deploy_reexport_cmd}\n"
+
+        # Add judge deployment srun command
+        judge_srun_cmd, judge_deployment_is_unsafe, judge_debug = (
+            _generate_judge_deployment_srun_command(
+                cfg,
+                judge_deployment_mounts_list,
+                remote_task_subdir,
+                judge_deployment_env_var_names=list(judge_deployment_env_vars.keys()),
+            )
+        )
+        s += judge_srun_cmd
+
+        # Wait for judge server to initialize
+        judge_health_path = cfg.judge_deployment.endpoints.get("health", "/health")
+        s += _get_wait_for_server_handler(
+            '"${JUDGE_PRIMARY_NODE}"',
+            cfg.judge_deployment.port,
+            judge_health_path,
+            "judge server",
+            check_pid=True,
+            pid_var="JUDGE_SERVER_PID",
+        )
+        s += "\n\n"
 
     # prepare evaluation mounts
     evaluation_mounts_list = [
@@ -834,12 +918,26 @@ def _create_slurm_sbatch_script(
     if eval_reexport_cmd:
         s += f"{eval_reexport_cmd}\n"
 
+    # Export judge endpoint information for evaluation containers
+    judge_extra_env_names = []
+    if has_judge_deployment:
+        judge_chat_endpoint = cfg.judge_deployment.endpoints.get("chat", "/v1/chat/completions")
+        s += "# Judge endpoint for evaluation tasks\n"
+        s += f'export JUDGE_ENDPOINT_URL="http://${{JUDGE_PRIMARY_NODE}}:{cfg.judge_deployment.port}{judge_chat_endpoint}"\n'
+        s += f'export JUDGE_MODEL_ID="{cfg.judge_deployment.served_model_name}"\n'
+        s += 'echo "JUDGE_ENDPOINT_URL: ${JUDGE_ENDPOINT_URL}"\n'
+        s += 'echo "JUDGE_MODEL_ID: ${JUDGE_MODEL_ID}"\n'
+        s += "\n"
+        judge_extra_env_names = ["JUDGE_ENDPOINT_URL", "JUDGE_MODEL_ID"]
+
     s += "# evaluation client\n"
     s += "srun --mpi pmix --overlap "
     s += '--nodelist "${PRIMARY_NODE}" --nodes 1 --ntasks 1 '
     s += "--container-image {} ".format(eval_image)
-    if eval_env_vars:
-        s += "--container-env {} ".format(",".join(sorted(eval_env_vars.keys())))
+    # Combine eval env vars with judge endpoint env vars
+    all_eval_env_names = sorted(set(list(eval_env_vars.keys()) + judge_extra_env_names))
+    if all_eval_env_names:
+        s += "--container-env {} ".format(",".join(all_eval_env_names))
     if not cfg.execution.get("mounts", {}).get("mount_home", True):
         s += "--no-container-mount-home "
 
@@ -854,6 +952,11 @@ def _create_slurm_sbatch_script(
         s += "kill $SERVER_PID  # terminate the server to finish gracefully\n"
         if cfg.deployment.get("multiple_instances", False):
             s += "kill $PROXY_PID  # terminate proxy to finish gracefully\n"
+        s += "\n"
+
+    # terminate the judge server if deployed
+    if has_judge_deployment:
+        s += "kill $JUDGE_SERVER_PID  # terminate the judge server to finish gracefully\n"
         s += "\n"
 
     # auto-export
@@ -872,9 +975,11 @@ def _create_slurm_sbatch_script(
 
     debug_str = "\n".join(["# " + line for line in s.splitlines()])
 
-    # Combine unsafe flags from both deployment and evaluation
+    # Combine unsafe flags from deployment, judge deployment, and evaluation
     is_potentially_unsafe = (
-        eval_factory_command_struct.is_potentially_unsafe or deployment_is_unsafe
+        eval_factory_command_struct.is_potentially_unsafe
+        or deployment_is_unsafe
+        or judge_deployment_is_unsafe
     )
 
     return CmdAndReadableComment(
@@ -1670,8 +1775,20 @@ def _generate_deployment_srun_command(
     remote_task_subdir,
     deployment_env_var_names: list[str] | None = None,
     instance_id: int = 0,
+    nodelist_var: str | None = None,
 ):
     """Generate the deployment srun command with proper node/ntask configuration.
+
+    Args:
+        cfg: The configuration object.
+        deployment_mounts_list: List of mount strings for the deployment container.
+        remote_task_subdir: Remote directory for this task.
+        deployment_env_var_names: Names of env vars to pass to the container.
+        instance_id: Instance ID for multi-instance deployments.
+        nodelist_var: Shell variable name containing the comma-separated nodelist
+            to use for this deployment. When set, the srun uses --nodelist to
+            restrict to specific nodes (e.g. when judge deployment occupies other
+            nodes in the same allocation). If None, uses all allocated nodes.
 
     Returns:
         tuple: (script_string, is_potentially_unsafe, debug_comment)
@@ -1691,16 +1808,23 @@ def _generate_deployment_srun_command(
         )
         debug_comment += create_pre_script_cmd.debug + "\n\n"
 
-    s += "# Get node IPs\n"
-    s += 'NODELIST="${SLURM_JOB_NODELIST:-${SLURM_NODELIST:-}}"\n'
-    s += 'if command -v scontrol >/dev/null 2>&1 && [[ -n "${NODELIST}" ]]; then\n'
-    s += '  nodes=( $(scontrol show hostnames "${NODELIST}") )\n'
-    s += "else\n"
-    s += '  nodes=( "$(hostname)" )\n'
-    s += "fi\n"
-    s += 'nodes_array=("${nodes[@]}")  # Ensure nodes are stored properly\n'
-    s += 'if [[ ${#nodes_array[@]} -eq 0 ]]; then nodes_array=( "$(hostname)" ); fi\n'
-    s += 'export NODES_IPS_ARRAY=($(for node in "${nodes_array[@]}"; do srun --nodelist="$node" --ntasks=1 --nodes=1 hostname --ip-address; done))\n'
+    # Get node IPs — use explicit node list if provided (when judge deployment
+    # occupies other nodes in the same SLURM allocation).
+    if nodelist_var:
+        s += "# Get model deployment node IPs (restricted to model nodes)\n"
+        s += f'DEPLOY_NODES_ARRAY=("${{{nodelist_var}[@]}}")\n'
+    else:
+        s += "# Get node IPs\n"
+        s += 'NODELIST="${SLURM_JOB_NODELIST:-${SLURM_NODELIST:-}}"\n'
+        s += 'if command -v scontrol >/dev/null 2>&1 && [[ -n "${NODELIST}" ]]; then\n'
+        s += '  nodes=( $(scontrol show hostnames "${NODELIST}") )\n'
+        s += "else\n"
+        s += '  nodes=( "$(hostname)" )\n'
+        s += "fi\n"
+        s += 'DEPLOY_NODES_ARRAY=("${nodes[@]}")\n'
+        s += 'if [[ ${#DEPLOY_NODES_ARRAY[@]} -eq 0 ]]; then DEPLOY_NODES_ARRAY=( "$(hostname)" ); fi\n'
+
+    s += 'export NODES_IPS_ARRAY=($(for node in "${DEPLOY_NODES_ARRAY[@]}"; do srun --nodelist="$node" --ntasks=1 --nodes=1 hostname --ip-address; done))\n'
     s += 'echo "Node IPs: ${NODES_IPS_ARRAY[@]}"\n'
     s += "# Export MASTER_IP as the first node IP\n"
     s += "export MASTER_IP=${NODES_IPS_ARRAY[0]}\n"
@@ -1713,6 +1837,8 @@ def _generate_deployment_srun_command(
         s += "\n"
 
     s += "srun --mpi pmix --overlap "
+    if nodelist_var:
+        s += f'--nodelist "${{MODEL_NODELIST}}" '
     s += f"--nodes {cfg.execution.num_nodes} --ntasks {cfg.execution.get('deployment', {}).get('n_tasks', 1)} "
     s += "--container-image {} ".format(cfg.deployment.image)
     if deployment_mounts_list:
@@ -1756,17 +1882,103 @@ def _generate_deployment_srun_command(
     return s, is_potentially_unsafe, debug_comment
 
 
+def _generate_judge_deployment_srun_command(
+    cfg,
+    judge_deployment_mounts_list,
+    remote_task_subdir,
+    judge_deployment_env_var_names: list[str] | None = None,
+):
+    """Generate the judge deployment srun command.
+
+    The judge runs on dedicated nodes (JUDGE_NODES / JUDGE_NODELIST) which are
+    separate from the model deployment nodes in the same SLURM allocation.
+
+    Returns:
+        tuple: (script_string, is_potentially_unsafe, debug_comment)
+    """
+    s = ""
+    debug_comment = ""
+    is_potentially_unsafe = False
+
+    judge_num_nodes = cfg.judge_deployment.get("num_nodes", 1)
+
+    s += "# judge deployment server\n"
+
+    # Extract pre_cmd for later use inside container
+    pre_cmd: str = cfg.judge_deployment.get("pre_cmd") or ""
+    if pre_cmd:
+        is_potentially_unsafe = True
+        create_pre_script_cmd = _str_to_echo_command(
+            pre_cmd, filename="judge_deployment_pre_cmd.sh"
+        )
+        debug_comment += create_pre_script_cmd.debug + "\n\n"
+
+    # Resolve judge node IPs
+    s += "# Get judge deployment node IPs\n"
+    s += 'export JUDGE_NODES_IPS_ARRAY=($(for node in "${JUDGE_NODES[@]}"; do srun --nodelist="$node" --ntasks=1 --nodes=1 hostname --ip-address; done))\n'
+    s += 'echo "Judge Node IPs: ${JUDGE_NODES_IPS_ARRAY[@]}"\n'
+    s += "export JUDGE_MASTER_IP=${JUDGE_NODES_IPS_ARRAY[0]}\n"
+    s += 'echo "JUDGE_MASTER_IP: $JUDGE_MASTER_IP"\n'
+
+    # Add debug comment for judge deployment pre_cmd before srun command
+    if debug_comment:
+        s += "# Debug contents of judge deployment pre_cmd\n"
+        s += debug_comment
+        s += "\n"
+
+    n_tasks = cfg.execution.get("judge_deployment", {}).get("n_tasks", 1)
+    s += "srun --mpi pmix --overlap "
+    s += f'--nodelist "${{JUDGE_NODELIST}}" '
+    s += f"--nodes {judge_num_nodes} --ntasks {n_tasks} "
+    s += "--container-image {} ".format(cfg.judge_deployment.image)
+    if judge_deployment_mounts_list:
+        s += "--container-mounts {} ".format(",".join(judge_deployment_mounts_list))
+    if not cfg.execution.get("mounts", {}).get("mount_home", True):
+        s += "--no-container-mount-home "
+    s += "--output {} ".format(remote_task_subdir / "logs" / "judge-server-%A-%t.log")
+
+    if judge_deployment_env_var_names is None:
+        judge_deployment_env_var_names = []
+
+    # Always add JUDGE_MASTER_IP to the environment variables
+    if "JUDGE_MASTER_IP" not in judge_deployment_env_var_names:
+        judge_deployment_env_var_names.append("JUDGE_MASTER_IP")
+
+    if judge_deployment_env_var_names:
+        s += f"--container-env {','.join(sorted(judge_deployment_env_var_names))} "
+
+    # Wrap judge deployment command to execute pre_cmd inside container if needed
+    if pre_cmd:
+        create_pre_script_cmd = _str_to_echo_command(
+            pre_cmd, filename="judge_deployment_pre_cmd.sh"
+        )
+        escaped_cmd = cfg.judge_deployment.command.replace("'", "'\"'\"'")
+        wrapped_command = (
+            f"bash -c '{create_pre_script_cmd.cmd} && "
+            f"source judge_deployment_pre_cmd.sh && "
+            f"{escaped_cmd}'"
+        )
+        s += "{} &\n\n".format(wrapped_command)
+    else:
+        s += "{} &\n\n".format(cfg.judge_deployment.command)
+
+    s += "JUDGE_SERVER_PID=$!  # capture the PID of the judge server background srun process\n\n"
+
+    return s, is_potentially_unsafe, debug_comment
+
+
 def _get_wait_for_server_handler(
     ip_list: str,
     port: int,
     health_check_path: str,
     service_name: str = "server",
     check_pid: bool = False,
+    pid_var: str = "SERVER_PID",
 ):
     """Generate wait for server handler that takes a list of IPs."""
     pid_check = ""
     if check_pid:
-        pid_check = 'kill -0 "$SERVER_PID" 2>/dev/null || { echo "Server process $SERVER_PID died"; exit 1; }'
+        pid_check = 'kill -0 "$' + pid_var + '" 2>/dev/null || { echo "' + service_name + ' process $' + pid_var + ' died"; exit 1; }'
 
     handler = f"""date
 # wait for the {service_name} to initialize
@@ -1848,6 +2060,15 @@ def _collect_mount_paths(cfg: DictConfig) -> List[str]:
         if cache_path := cfg.deployment.get("cache_path"):
             mount_paths.append(cache_path)
         for source_mnt in cfg.execution.get("mounts", {}).get("deployment", {}).keys():
+            mount_paths.append(source_mnt)
+
+    # Judge deployment mounts
+    if cfg.get("judge_deployment") and cfg.judge_deployment.get("type", "none") != "none":
+        if checkpoint_path := cfg.judge_deployment.get("checkpoint_path"):
+            mount_paths.append(checkpoint_path)
+        if cache_path := cfg.judge_deployment.get("cache_path"):
+            mount_paths.append(cache_path)
+        for source_mnt in cfg.execution.get("mounts", {}).get("judge_deployment", {}).keys():
             mount_paths.append(source_mnt)
 
     # Evaluation mounts

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -2628,3 +2628,351 @@ class TestSlurmExecutorKillJob:
 
         with pytest.raises(RuntimeError, match="Could not find or kill job"):
             SlurmExecutor.kill_job("fail123.0")
+
+
+class TestJudgeDeploymentFeature:
+    """Test judge deployment support in SLURM executor."""
+
+    @pytest.fixture
+    def base_config_with_judge(self):
+        """Configuration with judge deployment enabled."""
+        return {
+            "deployment": {
+                "type": "vllm",
+                "image": "vllm/vllm-openai:v0.16.0",
+                "command": "vllm serve /checkpoint --port 8000",
+                "served_model_name": "model-under-test",
+                "port": 8000,
+                "endpoints": {
+                    "health": "/health",
+                    "chat": "/v1/chat/completions",
+                },
+            },
+            "judge_deployment": {
+                "type": "vllm",
+                "image": "vllm/vllm-openai:v0.16.0",
+                "command": "vllm serve /checkpoint --port 8001",
+                "served_model_name": "judge-model",
+                "port": 8001,
+                "num_nodes": 1,
+                "endpoints": {
+                    "health": "/health",
+                    "chat": "/v1/chat/completions",
+                },
+                "env_vars": {
+                    "HF_TOKEN": "lit:judge-hf-token",
+                },
+            },
+            "execution": {
+                "type": "slurm",
+                "output_dir": "/test/output",
+                "walltime": "04:00:00",
+                "account": "test-account",
+                "partition": "batch",
+                "num_nodes": 2,
+                "ntasks_per_node": 1,
+                "subproject": "test-subproject",
+                "judge_deployment": {
+                    "n_tasks": 1,
+                },
+                "mounts": {
+                    "deployment": {},
+                    "judge_deployment": {
+                        "/cache/huggingface": "/root/.cache/huggingface",
+                    },
+                    "evaluation": {},
+                    "mount_home": False,
+                },
+            },
+            "evaluation": {"env_vars": {}},
+            "target": {"api_endpoint": {"url": "http://localhost:8000/v1"}},
+        }
+
+    @pytest.fixture
+    def base_config_no_judge(self):
+        """Configuration without judge deployment (type: none)."""
+        return {
+            "deployment": {
+                "type": "vllm",
+                "image": "vllm/vllm-openai:v0.16.0",
+                "command": "vllm serve /checkpoint --port 8000",
+                "served_model_name": "model-under-test",
+                "port": 8000,
+                "endpoints": {
+                    "health": "/health",
+                    "chat": "/v1/chat/completions",
+                },
+            },
+            "judge_deployment": {
+                "type": "none",
+            },
+            "execution": {
+                "type": "slurm",
+                "output_dir": "/test/output",
+                "walltime": "01:00:00",
+                "account": "test-account",
+                "partition": "batch",
+                "num_nodes": 1,
+                "ntasks_per_node": 1,
+                "subproject": "test-subproject",
+            },
+            "evaluation": {"env_vars": {}},
+            "target": {"api_endpoint": {"url": "http://localhost:8000/v1"}},
+        }
+
+    @pytest.fixture
+    def mock_task(self):
+        return OmegaConf.create({"name": "test_task"})
+
+    @pytest.fixture
+    def mock_dependencies(self):
+        with (
+            patch(
+                "nemo_evaluator_launcher.executors.slurm.executor.load_tasks_mapping"
+            ) as mock_load_tasks,
+            patch(
+                "nemo_evaluator_launcher.executors.slurm.executor.get_task_definition_for_job"
+            ) as mock_get_task_def,
+            patch(
+                "nemo_evaluator_launcher.common.helpers.get_eval_factory_command"
+            ) as mock_get_eval_command,
+            patch(
+                "nemo_evaluator_launcher.common.helpers.get_served_model_name"
+            ) as mock_get_model_name,
+        ):
+            mock_load_tasks.return_value = {}
+            mock_get_task_def.return_value = {
+                "container": "test-eval-container:latest",
+                "endpoint_type": "openai",
+                "task": "test_task",
+            }
+            from nemo_evaluator_launcher.common.helpers import CmdAndReadableComment
+
+            mock_get_eval_command.return_value = CmdAndReadableComment(
+                cmd="nemo-evaluator run_eval --test", debug="# Test command"
+            )
+            mock_get_model_name.return_value = "model-under-test"
+            yield
+
+    def test_judge_deployment_total_node_count(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Total SBATCH node count = model nodes + judge nodes."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        # 2 model nodes + 1 judge node = 3 total
+        assert "#SBATCH --nodes 3" in script
+
+    def test_judge_deployment_node_splitting(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Nodes are split between model and judge deployment."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        assert "MODEL_NUM_NODES=2" in script
+        assert "JUDGE_NUM_NODES=1" in script
+        assert "MODEL_NODES" in script
+        assert "JUDGE_NODES" in script
+        assert "MODEL_NODELIST" in script
+        assert "JUDGE_NODELIST" in script
+        assert "JUDGE_PRIMARY_NODE" in script
+
+    def test_judge_deployment_srun_command(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Judge deployment srun is generated with correct image and nodelist."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        assert "# judge deployment server" in script
+        assert "JUDGE_SERVER_PID" in script
+        assert '--nodelist "${JUDGE_NODELIST}"' in script
+        # Judge deployment uses the judge image
+        assert "vllm serve /checkpoint --port 8001" in script
+
+    def test_judge_deployment_health_check(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Judge server health check waits for judge endpoint."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        assert "Waiting for judge server" in script
+        assert "8001/health" in script
+        assert "JUDGE_SERVER_PID" in script
+
+    def test_judge_deployment_env_vars(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Judge deployment env vars are collected and passed to judge container."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        result = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        )
+
+        # Judge env vars should be in secrets
+        assert result.secrets_env_result is not None
+        assert "judge-hf-token" in result.secrets_env_result.secrets_content
+
+    def test_judge_endpoint_exported_to_eval(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """JUDGE_ENDPOINT_URL and JUDGE_MODEL_ID are exported for eval containers."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        assert 'export JUDGE_ENDPOINT_URL="http://${JUDGE_PRIMARY_NODE}:8001/v1/chat/completions"' in script
+        assert 'export JUDGE_MODEL_ID="judge-model"' in script
+        # Both should be passed to eval container
+        assert "JUDGE_ENDPOINT_URL" in script
+        assert "JUDGE_MODEL_ID" in script
+
+    def test_judge_server_killed_after_eval(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Judge server is killed after evaluation completes."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        assert "kill $JUDGE_SERVER_PID" in script
+
+    def test_judge_deployment_mounts(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Judge deployment mounts are passed to judge container srun."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        assert "/cache/huggingface:/root/.cache/huggingface" in script
+
+    def test_model_deployment_uses_model_nodelist_with_judge(
+        self, base_config_with_judge, mock_task, mock_dependencies
+    ):
+        """Model deployment srun uses --nodelist to restrict to model nodes."""
+        cfg = OmegaConf.create(base_config_with_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        # Model deployment should use MODEL_NODELIST
+        assert '--nodelist "${MODEL_NODELIST}"' in script
+
+    def test_no_judge_deployment_type_none(
+        self, base_config_no_judge, mock_task, mock_dependencies
+    ):
+        """When judge_deployment.type is none, no judge infrastructure is generated."""
+        cfg = OmegaConf.create(base_config_no_judge)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        # Should not contain judge-specific elements
+        assert "JUDGE_SERVER_PID" not in script
+        assert "JUDGE_PRIMARY_NODE" not in script
+        assert "JUDGE_ENDPOINT_URL" not in script
+        assert "judge deployment server" not in script
+        # Node count should be just the model nodes
+        assert "#SBATCH --nodes 1" in script
+
+    def test_no_judge_deployment_absent(self, mock_task, mock_dependencies):
+        """When judge_deployment is completely absent from config, no judge infra."""
+        config = {
+            "deployment": {
+                "type": "vllm",
+                "image": "test-image:latest",
+                "command": "test-command",
+                "served_model_name": "test-model",
+                "port": 8000,
+                "endpoints": {"health": "/health"},
+            },
+            "execution": {
+                "type": "slurm",
+                "output_dir": "/test/output",
+                "walltime": "01:00:00",
+                "account": "test-account",
+                "partition": "batch",
+                "num_nodes": 1,
+                "ntasks_per_node": 1,
+                "subproject": "test-subproject",
+            },
+            "evaluation": {"env_vars": {}},
+            "target": {"api_endpoint": {"url": "http://localhost:8000/v1"}},
+        }
+        cfg = OmegaConf.create(config)
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+        ).cmd
+
+        assert "JUDGE_SERVER_PID" not in script
+        assert "#SBATCH --nodes 1" in script


### PR DESCRIPTION
## Summary

Add a `judge_deployment` config section to the launcher that deploys a judge model on dedicated SLURM nodes within the same allocation as the model under test. This eliminates the dependency on external judge APIs (e.g. NVCF) for judge-dependent evaluations.

## Motivation

The Ultra posttraining team needs to run 20+ checkpoints × 3-4 judge-dependent evals (ArenaHard, LCR, Tau2, HLE, IFBench). At this scale, NVCF judge capacity becomes a bottleneck — especially for heavy judges like DeepSeek-3.2 and Qwen-235B. On-cluster deployment removes that dependency entirely.

Feedback collected during the Ultra evaluation meeting (2026-03-04).

## What changed

### New config section: `judge_deployment`

```yaml
judge_deployment:
  type: vllm          # vllm | sglang | none (default: none)
  image: vllm/vllm-openai:v0.16.0
  checkpoint_path: /path/to/model
  hf_model_handle: Qwen/Qwen2.5-1.5B-Instruct
  served_model_name: Qwen/Qwen2.5-1.5B-Instruct
  tensor_parallel_size: 1
  data_parallel_size: 8
  num_nodes: 1
  port: 8001
  env_vars:
    HF_TOKEN: host:HF_TOKEN
```

### How it works

1. Total SLURM allocation = `num_nodes` (model) + `judge_deployment.num_nodes`
2. Nodes are split: first N for model deployment, remaining M for judge
3. Model deployment uses `--nodelist` to stay on assigned nodes
4. Judge server starts on its dedicated nodes, health-checks pass
5. `JUDGE_ENDPOINT_URL` and `JUDGE_MODEL_ID` env vars are auto-exported to evaluation containers
6. Evaluation tasks can reference these via `pre_cmd` to patch their configs at runtime
7. Judge server is terminated after evaluation completes

### Files changed (11 files, +888/-33)

- `configs/judge_deployment/none.yaml` — no-op default
- `configs/judge_deployment/vllm.yaml` — vLLM judge config
- `configs/judge_deployment/sglang.yaml` — SGLang judge config
- `configs/default.yaml` — added judge_deployment default
- `configs/execution/slurm/default.yaml` — judge_deployment mounts + n_tasks
- `executors/slurm/executor.py` — core implementation (node splitting, srun commands, health checks, env var export)
- `common/env_vars.py` — judge deployment env var handling
- `common/helpers.py` — helper utilities
- `tests/unit_tests/test_slurm_executor.py` — 348 lines of new tests

## E2E test results

### CW-DFW — MT-Bench with on-cluster judge ✅ (2026-03-05)

**Invocation** `1255ed21432f2ab4` | **Slurm job** `9814265` | **Cluster** CW-DFW | **2 nodes** (1 model + 1 judge)

| Phase | Status | Details |
|-------|--------|---------|
| Model deployment | ✅ | Llama-3.1-8B-Instruct on node 1, port 8000, DP=8 |
| Judge deployment | ✅ | Llama-3.1-8B-Instruct on node 2, port 8001, vLLM v0.16.0, health check passed |
| `JUDGE_ENDPOINT_URL` export | ✅ | `http://pool0-01461:8001/v1/chat/completions` |
| `JUDGE_MODEL_ID` export | ✅ | `meta-llama/Llama-3.1-8B-Instruct` |
| `pre_cmd` config patching | ✅ | `__JUDGE_BASE_URL__` and `__JUDGE_MODEL_ID__` replaced in `config_ef.yaml` |
| Generation (20 samples × 2 turns) | ✅ | 40/40 requests, all HTTP 200, ~9 min inference time |
| Judging (20 questions × 2 turns) | ✅ | 40/40 judgements scored, ~67s judging time |
| Artifacts | ✅ | `report.html`, `report.json`, judgements JSONL, response stats all written |

**Stats**: avg 656 tokens/response, 40 successful responses, 0 failures. Scores ranged 2–9 across both single-turn and multi-turn judgements.

> **Note**: The Slurm job exited with code 1 due to a **pre-existing mtbench container bug** — the output parser looks for `result.json` at root level but the mtbench container writes it to `mtbench/<model>/first_20/<model>-result.json`. This is unrelated to judge deployment — all generation, judging, and artifact output completed successfully.

### Earlier CW-DFW validation runs

| Run | Invocation | What was validated |
|-----|------------|--------------------|
| Attempt 3 | `33bf1b53927ad35d` | Judge deploys ✅, health check ✅, env vars ✅, pre_cmd ✅, generation completes ✅. Failed: walltime too short (30min) |
| Attempt 4 | `c6ce965c44d14482` | Killed manually to move testing to CW-PDX |

### Unit tests

348 lines of new tests covering:
- Node splitting logic (model vs judge nodes)
- Judge deployment srun command construction
- Environment variable generation and export
- Health check configuration with separate PID tracking

## Example usage

```yaml
# MT-Bench with on-cluster judge
defaults:
  - execution: slurm
  - deployment: vllm
  - judge_deployment: vllm
  - _self_

execution:
  num_nodes: 1          # for model under test
  walltime: 01:00:00

deployment:
  hf_model_handle: meta-llama/Llama-3.1-8B-Instruct
  tensor_parallel_size: 1
  data_parallel_size: 8

judge_deployment:
  hf_model_handle: Qwen/Qwen2.5-72B-Instruct
  tensor_parallel_size: 4
  data_parallel_size: 2
  num_nodes: 1

evaluation:
  tasks:
    - name: mtbench.mtbench
      pre_cmd: >-
        sed -i "s|__JUDGE_BASE_URL__|${JUDGE_ENDPOINT_URL%/chat/completions}|g" config_ef.yaml &&
        sed -i "s|__JUDGE_MODEL_ID__|${JUDGE_MODEL_ID}|g" config_ef.yaml
```

## TODO before merge

- [x] Full E2E completion on CW-DFW (generation + judging ✅)
- [ ] Multi-node judge deployment test (TP>1 across nodes)
- [ ] Documentation update
