### PR TITLE
fix: support dotted task names in launcher

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/mapping.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/mapping.py
@@ -183,10 +183,8 @@ def get_task_from_mapping(query: str, mapping: dict[Any, Any]) -> dict[Any, Any]
         dict: Task data.
 
     """
-    num_dots = query.count(".")
-
     # if there are no dots in query, treat it like a task name
-    if num_dots == 0:
+    if "." not in query:
         matching_keys = [key for key in mapping.keys() if key[1] == query]
         # if exactly one task matching the query has been found:
         if len(matching_keys) == 1:
@@ -206,9 +204,10 @@ def get_task_from_mapping(query: str, mapping: dict[Any, Any]) -> dict[Any, Any]
         else:
             raise ValueError(f"task {repr(query)} does not exist in the mapping")
 
-    # if there is one dot in query, treat it like "{harness_name}.{task_name}"
-    elif num_dots == 1:
-        harness_name, task_name = query.split(".")
+    # query contains dot(s): split on FIRST dot only -> "{harness_name}.{task_name}"
+    # This allows task names to contain dots (e.g. "mteb.Touche2020Retrieval.v3").
+    else:
+        harness_name, task_name = query.split(".", 1)
         matching_keys = [
             key for key in mapping.keys() if key == (harness_name, task_name)
         ]
@@ -227,13 +226,6 @@ def get_task_from_mapping(query: str, mapping: dict[Any, Any]) -> dict[Any, Any]
             raise ValueError(
                 f"harness.task {repr(query)} does not exist in the mapping"
             )
-
-    # invalid query
-    else:
-        raise ValueError(
-            f"invalid query={repr(query)} for task mapping,"
-            " it must contain exactly zero or one occurrence of '.' character"
-        )
 
 
 def _minimal_task_definition(
@@ -257,17 +249,10 @@ def _minimal_task_definition(
         - 'container': Container image
         - 'is_unlisted': True (task not in FDF)
     """
-    num_dots = task_query.count(".")
-    if num_dots == 1:
-        harness, task = task_query.split(".")
-    elif num_dots == 0:
-        harness, task = "", task_query
+    if "." in task_query:
+        harness, task = task_query.split(".", 1)
     else:
-        raise ValueError(
-            f"invalid query={repr(task_query)} for task mapping,"
-            " it must contain exactly zero or one occurrence of '.' character."
-            " Use 'task_name' or 'harness_name.task_name' format."
-        )
+        harness, task = "", task_query
 
     return {
         "task": task,
@@ -296,8 +281,8 @@ def get_task_definition_for_job(
     - 'task_query': Original query for use in EF command (when unlisted)
     """
     # Parse harness.task format
-    if task_query.count(".") == 1:
-        harness_name, _ = task_query.split(".")
+    if "." in task_query:
+        harness_name, _ = task_query.split(".", 1)
     else:
         harness_name = ""
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/lepton/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/lepton/executor.py
@@ -213,9 +213,9 @@ class LeptonExecutor(BaseExecutor):
 
                 for idx, task in enumerate(cfg.evaluation.tasks):
                     # Create shorter endpoint names: e.g., "nim-gpqa-0-abc123"
-                    sanitized_task_name = task.name.replace("_", "-").lower()
-                    if sanitized_task_name.count(".") > 0:
-                        sanitized_task_name = sanitized_task_name.split(".")[-1]
+                    sanitized_task_name = (
+                        task.name.replace("_", "-").replace(".", "-").lower()
+                    )
                     # Take only first 6 chars of task name to keep it short (leaving room for index)
                     short_task_name = sanitized_task_name[:6]
                     short_invocation = invocation_id[:6]
@@ -416,9 +416,9 @@ class LeptonExecutor(BaseExecutor):
                 # Create job ID and Lepton job name (max 36 chars)
                 job_id = generate_job_id(invocation_id, idx)
                 # Sanitized task name for RFC 1123 compliance (no underscores, lowercase)
-                sanitized_task_name = task.name.replace("_", "-").lower()
-                if sanitized_task_name.count(".") > 0:
-                    sanitized_task_name = sanitized_task_name.split(".")[-1]
+                sanitized_task_name = (
+                    task.name.replace("_", "-").replace(".", "-").lower()
+                )
                 base_job_name = f"eval-{invocation_id[:6]}-{sanitized_task_name}"
                 suffix = str(idx)
 

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_lepton_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_lepton_executor.py
@@ -1306,7 +1306,7 @@ class TestLeptonExecutorKillJob:
                 task_name = kwargs.get("task_query")
                 mapping = kwargs.get("base_mapping", {})
                 if "." in task_name:
-                    task_name = task_name.split(".")[-1]
+                    _, task_name = task_name.split(".", 1)
                 for (harness, name), definition in mapping.items():
                     if name == task_name:
                         return definition
@@ -1335,10 +1335,10 @@ class TestLeptonExecutorKillJob:
                 call.args[1] for call in mock_create_endpoint.call_args_list
             ]
 
-            # Check sanitization: underscores -> hyphens, dots removed, lowercase
+            # Check sanitization: underscores -> hyphens, dots -> hyphens, lowercase
             assert any("mmlu" in ep for ep in endpoint_names)
             assert any("gsm8k" in ep for ep in endpoint_names)
-            assert any("arc" in ep or "challenge" in ep for ep in endpoint_names)
+            assert any("lm-eva" in ep for ep in endpoint_names)
 
             # Verify all are within 36 character limit
             for ep_name in endpoint_names:

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_mapping.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_mapping.py
@@ -297,6 +297,97 @@ def test_get_task_definition_for_job_default_container_from_harness(monkeypatch)
     assert td["endpoint_type"] == "completions"
 
 
+def test_get_task_from_mapping_dotted_task_name():
+    """Test that task names with multiple dots are handled correctly.
+
+    The first dot separates harness from task name; additional dots are
+    part of the task name (e.g. mteb.Touche2020Retrieval.v3).
+    """
+    tasks_mapping = {
+        ("mteb", "Touche2020Retrieval.v3"): {
+            "task": "Touche2020Retrieval.v3",
+            "harness": "mteb",
+            "container": "test-container:latest",
+            "endpoint_type": "embedding",
+        },
+        ("mteb", "MIRACLRetrievalHardNegatives.en"): {
+            "task": "MIRACLRetrievalHardNegatives.en",
+            "harness": "mteb",
+            "container": "test-container:latest",
+            "endpoint_type": "embedding",
+        },
+        ("mteb", "ArguAna"): {
+            "task": "ArguAna",
+            "harness": "mteb",
+            "container": "test-container:latest",
+            "endpoint_type": "embedding",
+        },
+    }
+
+    # Multi-dot query: harness.task.version
+    result = get_task_from_mapping("mteb.Touche2020Retrieval.v3", tasks_mapping)
+    assert result["task"] == "Touche2020Retrieval.v3"
+    assert result["harness"] == "mteb"
+
+    # Multi-dot query: harness.task.language
+    result = get_task_from_mapping(
+        "mteb.MIRACLRetrievalHardNegatives.en", tasks_mapping
+    )
+    assert result["task"] == "MIRACLRetrievalHardNegatives.en"
+    assert result["harness"] == "mteb"
+
+    # Single-dot query still works
+    result = get_task_from_mapping("mteb.ArguAna", tasks_mapping)
+    assert result["task"] == "ArguAna"
+    assert result["harness"] == "mteb"
+
+    # No-dot query still works
+    result = get_task_from_mapping("ArguAna", tasks_mapping)
+    assert result["task"] == "ArguAna"
+
+    # Non-existent multi-dot task raises
+    with pytest.raises(ValueError, match="does not exist in the mapping"):
+        get_task_from_mapping("mteb.NonExistent.v1", tasks_mapping)
+
+
+def test_minimal_task_definition_dotted_task_name(monkeypatch):
+    """Test that _minimal_task_definition handles multi-dot task names."""
+    from nemo_evaluator_launcher.common.mapping import _minimal_task_definition
+
+    td = _minimal_task_definition(
+        "mteb.Touche2020Retrieval.v3",
+        container="test:latest",
+        endpoint_type="embedding",
+    )
+    assert td["harness"] == "mteb"
+    assert td["task"] == "Touche2020Retrieval.v3"
+    assert td["endpoint_type"] == "embedding"
+    assert td["is_unlisted"] is True
+
+
+def test_get_task_definition_for_job_dotted_task_name(monkeypatch):
+    """Test that get_task_definition_for_job handles multi-dot task names."""
+    container = "example.com/my-image:latest"
+    base_mapping = {}
+
+    monkeypatch.setattr(
+        "nemo_evaluator_launcher.common.mapping.load_tasks_mapping",
+        lambda *args, **kwargs: {},
+    )
+
+    td = get_task_definition_for_job(
+        task_query="mteb.Touche2020Retrieval.v3",
+        base_mapping=base_mapping,
+        container=container,
+        endpoint_type="embedding",
+    )
+
+    assert td["harness"] == "mteb"
+    assert td["task"] == "Touche2020Retrieval.v3"
+    assert td["is_unlisted"] is True
+    assert td["endpoint_type"] == "embedding"
+
+
 def test_get_task_definition_for_job_unknown_harness_raises(monkeypatch):
     """When harness not found in supported harnesses, raise error."""
 


### PR DESCRIPTION
Split task query strings on the first dot only (split(".", 1)) so that task names containing dots (e.g. mteb.Touche2020Retrieval.v3) are handled correctly instead of raising an error.

Replace dots with hyphens in Lepton endpoint/job names for RFC 1123 compliance, instead of dropping everything before the last dot.

Remove the restriction that rejected queries with more than one dot character.