### PR TITLE
chore: test FW-CI-templates ko3n1g/fix/linkcheck-retry-backoff

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [pre-flight]
     if: |
       !(needs.pre-flight.outputs.is_deployment_workflow == 'true')
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@ko3n1g/fix/linkcheck-retry-backoff
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.80.2
     with:
       requirements-file: .github/config/requirements.txt
 


### PR DESCRIPTION
## Summary
- Bumps \`NVIDIA-NeMo/FW-CI-templates\` reference in docs workflow from previous version to \`ko3n1g/fix/linkcheck-retry-backoff\`
- This branch includes retry with exponential backoff for Sphinx linkcheck to handle transient failures

## Test plan
- [ ] Verify the \`build-docs\` workflow triggers and passes after this bump