### PR TITLE
fix(evaluator): distinguish interrupted and failed sigterm exits

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/lepton/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/lepton/executor.py
@@ -889,6 +889,11 @@ exit_code=$?
 # Set proper permissions
 chmod 777 -R {output_dir} 2>/dev/null || true
 
+if [ "$exit_code" -eq 0 ] && [ -f "{output_dir}/.nemo_evaluator_interrupted" ]; then
+    echo "Evaluation exited cleanly after SIGTERM; marking job as interrupted" >&2
+    exit_code=143
+fi
+
 # Record completion status
 echo "exit_code: $exit_code" > {output_dir}/logs/stage.exit
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
@@ -69,6 +69,9 @@ from nemo_evaluator_launcher.executors.base import (
 )
 from nemo_evaluator_launcher.executors.registry import register_executor
 
+# Keep in sync with nemo_evaluator.core.evaluate.INTERRUPTED_MARKER_FILENAME
+INTERRUPTED_MARKER_FILENAME = ".nemo_evaluator_interrupted"
+
 
 @register_executor("local")
 class LocalExecutor(BaseExecutor):
@@ -526,6 +529,8 @@ class LocalExecutor(BaseExecutor):
                 )
             ]
 
+        interrupted_marker = artifacts_dir / INTERRUPTED_MARKER_FILENAME
+
         # Check if job was killed
         if job_data.data.get("killed", False):
             return [
@@ -546,7 +551,19 @@ class LocalExecutor(BaseExecutor):
                 if " " in content:
                     timestamp, exit_code_str = content.rsplit(" ", 1)
                     exit_code = int(exit_code_str)
-                    if exit_code == 0:
+                    if interrupted_marker.exists():
+                        if exit_code != 0:
+                            logger.warning(
+                                f"Job {id} was interrupted but exited with code {exit_code}"
+                            )
+                        return [
+                            ExecutionStatus(
+                                id=id,
+                                state=ExecutionState.KILLED,
+                                progress=dict(progress=progress),
+                            )
+                        ]
+                    elif exit_code == 0:
                         return [
                             ExecutionStatus(
                                 id=id,

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/run.template.sh
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/run.template.sh
@@ -44,6 +44,7 @@ chmod 666 "$logs_dir/client_stdout.log"
 task_dir="{{ task.output_dir }}"
 artifacts_dir="$task_dir/artifacts"
 logs_dir="$task_dir/logs"
+interrupted_marker="$artifacts_dir/.nemo_evaluator_interrupted"
 
 mkdir -m 777 -p "$task_dir"
 mkdir -m 777 -p "$artifacts_dir"
@@ -134,6 +135,11 @@ else
     # Stop the server
     docker stop $SERVER_CONTAINER_NAME 2>/dev/null || true
     {% endif %}
+
+    if [ "$exit_code" = "0" ] && [ -f "$interrupted_marker" ]; then
+        echo "Evaluation exited cleanly after SIGTERM; marking job as interrupted." >&2
+        exit_code=143
+    fi
 
     echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $exit_code" > "$logs_dir/stage.exit"
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -1064,6 +1064,16 @@ def _create_slurm_sbatch_script(
             remote_task_subdir=remote_task_subdir,
         )
 
+    # Keep in sync with nemo_evaluator.core.evaluate.INTERRUPTED_MARKER_FILENAME
+    interrupted_marker = (
+        remote_task_subdir / "artifacts" / ".nemo_evaluator_interrupted"
+    )
+    s += "\n# Propagate interrupted status so SLURM marks the job as FAILED\n"
+    s += f'if [ -f "{interrupted_marker}" ]; then\n'
+    s += '    echo "Evaluation was interrupted (SIGTERM). Exiting with code 143."\n'
+    s += "    exit 143\n"
+    s += "fi\n"
+
     debug_str = "\n".join(["# " + line for line in s.splitlines()])
 
     # Combine unsafe flags from deployment, auxiliary deployments, and evaluation
@@ -1095,8 +1105,18 @@ def _generate_auto_export_section(
     if not destinations:
         return ""
 
+    # Keep in sync with nemo_evaluator.core.evaluate.INTERRUPTED_MARKER_FILENAME
+    interrupted_marker = (
+        remote_task_subdir / "artifacts" / ".nemo_evaluator_interrupted"
+    )
+
     s = "\n# Auto-export on success\n"
     s += "EVAL_EXIT_CODE=$?\n"
+    s += f'EVAL_INTERRUPTED_MARKER="{interrupted_marker}"\n'
+    s += 'if [ $EVAL_EXIT_CODE -eq 0 ] && [ -f "$EVAL_INTERRUPTED_MARKER" ]; then\n'
+    s += "    echo 'Evaluation exited 0 after SIGTERM. Skipping auto-export.'\n"
+    s += "    EVAL_EXIT_CODE=143\n"
+    s += "fi\n"
     s += "if [ $EVAL_EXIT_CODE -eq 0 ]; then\n"
     s += "    echo 'Evaluation completed successfully. Starting auto-export...'\n"
     s += f'    cd "{remote_task_subdir}/artifacts"\n'

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_lepton_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_lepton_executor.py
@@ -23,11 +23,32 @@ from omegaconf import OmegaConf
 
 from nemo_evaluator_launcher.common.execdb import ExecutionDB, JobData
 from nemo_evaluator_launcher.executors.base import ExecutionState, ExecutionStatus
-from nemo_evaluator_launcher.executors.lepton.executor import LeptonExecutor
+from nemo_evaluator_launcher.executors.lepton.executor import (
+    LeptonExecutor,
+    _create_evaluation_launch_script,
+)
 
 
 class TestLeptonExecutor:
     """Test Lepton executor functionality."""
+
+    def test_launch_script_marks_interrupted_runs_nonzero(self):
+        cfg = OmegaConf.create({"execution": {"output_dir": "/tmp/out"}})
+        task = OmegaConf.create({"name": "test_task"})
+
+        script = _create_evaluation_launch_script(
+            cfg=cfg,
+            task=task,
+            task_definition={},
+            endpoint_url="https://example.lepton.run/v1/chat/completions",
+            task_name="test_task",
+            invocation_id="abc12345",
+            eval_command="nemo-evaluator run_eval --output_dir /results",
+            eval_command_debug_comment="# debug",
+        )
+
+        assert ".nemo_evaluator_interrupted" in script
+        assert "exit_code=143" in script
 
     def test_lepton_executor_import(self):
         """Test that Lepton executor can be imported conditionally."""

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_local_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_local_executor.py
@@ -26,7 +26,10 @@ from omegaconf import OmegaConf
 
 from nemo_evaluator_launcher.common.execdb import ExecutionDB, JobData
 from nemo_evaluator_launcher.executors.base import ExecutionState
-from nemo_evaluator_launcher.executors.local.executor import LocalExecutor
+from nemo_evaluator_launcher.executors.local.executor import (
+    INTERRUPTED_MARKER_FILENAME,
+    LocalExecutor,
+)
 
 
 class TestLocalExecutorDryRun:
@@ -451,6 +454,24 @@ class TestLocalExecutorGetStatus:
         assert len(statuses) == 1
         assert statuses[0].state == ExecutionState.SUCCESS
         assert statuses[0].progress["progress"] == 100
+
+    def test_get_status_interrupted_marker_overrides_exit_code_0(
+        self, mock_execdb, sample_job_data, setup_job_filesystem
+    ):
+        """Test get_status treats exit_code 0 plus interruption marker as killed."""
+        _, artifacts_dir, _ = setup_job_filesystem(
+            stage_files={"exit": "2025-01-01T12:00:00Z 0"},
+            progress_value=85,
+        )
+        (artifacts_dir / INTERRUPTED_MARKER_FILENAME).write_text("{}")
+
+        db = ExecutionDB()
+        db.write_job(sample_job_data)
+
+        statuses = LocalExecutor.get_status("abc12345.0")
+        assert len(statuses) == 1
+        assert statuses[0].state == ExecutionState.KILLED
+        assert statuses[0].progress["progress"] == 85
 
     def test_get_status_failed_with_nonzero_exit_code(
         self, mock_execdb, sample_job_data, setup_job_filesystem

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -24,12 +24,14 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from omegaconf import OmegaConf
 
+from nemo_evaluator_launcher.common.env_vars import SecretsEnvResult
 from nemo_evaluator_launcher.common.execdb import ExecutionDB, JobData
 from nemo_evaluator_launcher.executors.base import ExecutionState, ExecutionStatus
 from nemo_evaluator_launcher.executors.slurm.executor import (
     SlurmExecutor,
     _create_slurm_sbatch_script,
     _generate_autoresume_handler,
+    _generate_auto_export_section,
 )
 
 
@@ -1347,6 +1349,82 @@ class TestSlurmExecutorDryRun:
 
         finally:
             # Clean up environment
+            for env_var in ["TEST_API_KEY", "GLOBAL_VALUE", "TASK_VALUE"]:
+                if env_var in os.environ:
+                    del os.environ[env_var]
+
+    def test_generate_auto_export_section_skips_marker_interrupted_runs(self):
+        cfg = OmegaConf.create(
+            {
+                "execution": {
+                    "output_dir": "/tmp/out",
+                    "auto_export": {"destinations": ["wandb"]},
+                },
+                "export": {},
+            }
+        )
+
+        section = _generate_auto_export_section(
+            cfg=cfg,
+            job_id="abc12345.0",
+            destinations=["wandb"],
+            env_var_names=[],
+            secrets=SecretsEnvResult(secrets_content=""),
+            remote_task_subdir=Path("/tmp/out/test_task"),
+        )
+
+        assert "EVAL_INTERRUPTED_MARKER=" in section
+        assert ".nemo_evaluator_interrupted" in section
+        assert "Skipping auto-export" in section
+        assert "EVAL_EXIT_CODE=143" in section
+
+    def test_sbatch_script_exits_nonzero_on_interrupted_marker(
+        self, sample_config, mock_tasks_mapping, tmpdir
+    ):
+        """Sbatch script must exit 143 when the interrupted marker exists."""
+        os.environ["TEST_API_KEY"] = "test-key"
+        os.environ["GLOBAL_VALUE"] = "global_env_value"
+        os.environ["TASK_VALUE"] = "task_env_value"
+        try:
+            with (
+                patch(
+                    "nemo_evaluator_launcher.executors.slurm.executor.load_tasks_mapping"
+                ) as mock_load_tasks,
+                patch(
+                    "nemo_evaluator_launcher.executors.slurm.executor.get_task_definition_for_job"
+                ) as mock_get_task_def,
+                patch(
+                    "nemo_evaluator_launcher.common.helpers.get_eval_factory_command"
+                ) as mock_get_eval_command,
+                patch(
+                    "nemo_evaluator_launcher.common.helpers.get_served_model_name"
+                ) as mock_get_model_name,
+            ):
+                mock_load_tasks.return_value = mock_tasks_mapping
+                mock_get_task_def.return_value = {
+                    "container": "nvcr.io/nvidia/nemo:24.01",
+                    "endpoint_type": "openai",
+                    "task": "mmlu_pro",
+                }
+                from nemo_evaluator_launcher.common.helpers import CmdAndReadableComment
+
+                mock_get_eval_command.return_value = CmdAndReadableComment(
+                    cmd="nemo-evaluator run_eval --test", debug="# Test command"
+                )
+                mock_get_model_name.return_value = "test-model"
+
+                result = _create_slurm_sbatch_script(
+                    cfg=sample_config,
+                    task=OmegaConf.create({"name": "mmlu_pro"}),
+                    eval_image="nvcr.io/nvidia/nemo:24.01",
+                    remote_task_subdir=Path("/test/remote"),
+                    invocation_id="test123",
+                    job_id="test123.0",
+                )
+
+            assert ".nemo_evaluator_interrupted" in result.cmd
+            assert "exit 143" in result.cmd
+        finally:
             for env_var in ["TEST_API_KEY", "GLOBAL_VALUE", "TASK_VALUE"]:
                 if env_var in os.environ:
                     del os.environ[env_var]

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -30,8 +30,8 @@ from nemo_evaluator_launcher.executors.base import ExecutionState, ExecutionStat
 from nemo_evaluator_launcher.executors.slurm.executor import (
     SlurmExecutor,
     _create_slurm_sbatch_script,
-    _generate_autoresume_handler,
     _generate_auto_export_section,
+    _generate_autoresume_handler,
 )
 
 
@@ -1420,6 +1420,7 @@ class TestSlurmExecutorDryRun:
                     remote_task_subdir=Path("/test/remote"),
                     invocation_id="test123",
                     job_id="test123.0",
+                    task_idx=0,
                 )
 
             assert ".nemo_evaluator_interrupted" in result.cmd

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/server.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/server.py
@@ -379,6 +379,18 @@ class AdapterServer:
                 current_request if "current_request" in locals() else None,
             )
 
+            # Write server error marker so the parent's SIGTERM handler knows
+            # this is a server-initiated shutdown (not an operator interruption).
+            # Keep in sync with nemo_evaluator.core.evaluate.SERVER_ERROR_MARKER_FILENAME
+            try:
+                error_marker = os.path.join(
+                    self.output_dir, ".nemo_evaluator_server_error"
+                )
+                with open(error_marker, "w") as f:
+                    f.write(str(e))
+            except OSError:
+                pass
+
             # Send SIGTERM to parent process - the signal handler will run post-eval hooks
             logger.info("Sending SIGTERM to parent process")
             try:

--- a/packages/nemo-evaluator/src/nemo_evaluator/core/evaluate.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/core/evaluate.py
@@ -269,7 +269,9 @@ def _run_evaluation(
             exit_code = (
                 1
                 if server_error_shutdown
-                else 0 if cleanup_succeeded and not alive else 1
+                else 0
+                if cleanup_succeeded and not alive
+                else 1
             )
         sys.exit(exit_code)
 

--- a/packages/nemo-evaluator/src/nemo_evaluator/core/evaluate.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/core/evaluate.py
@@ -16,6 +16,7 @@
 import copy
 import importlib
 import json
+import math
 import os
 import signal
 import sys
@@ -48,7 +49,75 @@ from nemo_evaluator.package_info import __version__
 
 logger = get_logger(__name__)
 
-__all__ = ["evaluate"]
+__all__ = ["evaluate", "INTERRUPTED_MARKER_FILENAME"]
+
+SHUTDOWN_TIMEOUT_ENV_VAR = "NEMO_EVALUATOR_SHUTDOWN_TIMEOUT_SECONDS"
+DEFAULT_SHUTDOWN_TIMEOUT_SECONDS = 30.0
+INTERRUPTED_MARKER_FILENAME = ".nemo_evaluator_interrupted"
+SERVER_ERROR_MARKER_FILENAME = ".nemo_evaluator_server_error"
+
+
+def _get_interrupted_marker_path(output_dir: str) -> str:
+    return os.path.join(output_dir, INTERRUPTED_MARKER_FILENAME)
+
+
+def _clear_marker(output_dir: str, filename: str) -> None:
+    marker_path = os.path.join(output_dir, filename)
+    try:
+        os.remove(marker_path)
+    except FileNotFoundError:
+        return
+    except OSError as e:
+        logger.warning(f"Failed to remove marker {marker_path}: {e}")
+
+
+def _clear_interrupted_marker(output_dir: str) -> None:
+    _clear_marker(output_dir, INTERRUPTED_MARKER_FILENAME)
+
+
+def _write_interrupted_marker(output_dir: str, signum: Optional[int] = None) -> None:
+    marker_path = _get_interrupted_marker_path(output_dir)
+    signal_name = None
+    if signum is not None:
+        try:
+            signal_name = signal.Signals(signum).name
+        except ValueError:
+            signal_name = str(signum)
+
+    payload = {
+        "signal": signal_name,
+        "timestamp": time.time(),
+    }
+    try:
+        with open(marker_path, "w") as f:
+            json.dump(payload, f)
+    except OSError as e:
+        logger.warning(f"Failed to write interruption marker {marker_path}: {e}")
+
+
+def _get_shutdown_timeout_seconds() -> float:
+    """Return the graceful shutdown timeout for child processes."""
+    raw_timeout = os.getenv(SHUTDOWN_TIMEOUT_ENV_VAR)
+    if raw_timeout is None:
+        return DEFAULT_SHUTDOWN_TIMEOUT_SECONDS
+
+    try:
+        timeout = float(raw_timeout)
+    except ValueError:
+        logger.warning(
+            f"Invalid {SHUTDOWN_TIMEOUT_ENV_VAR}={raw_timeout!r}; "
+            f"falling back to {DEFAULT_SHUTDOWN_TIMEOUT_SECONDS} seconds"
+        )
+        return DEFAULT_SHUTDOWN_TIMEOUT_SECONDS
+
+    if not math.isfinite(timeout) or timeout <= 0:
+        logger.warning(
+            f"{SHUTDOWN_TIMEOUT_ENV_VAR}={raw_timeout!r} is not a positive finite number; "
+            f"falling back to {DEFAULT_SHUTDOWN_TIMEOUT_SECONDS} seconds"
+        )
+        return DEFAULT_SHUTDOWN_TIMEOUT_SECONDS
+
+    return timeout
 
 
 def parse_output(evaluation: Evaluation) -> EvaluationResult:
@@ -117,41 +186,64 @@ def _run_evaluation(
         and target_cfg.api_endpoint.adapter_config.mode == "client"
     )
 
+    # Import eagerly so it is available inside the signal handler without
+    # risking a deadlock on the import lock.
+    from nemo_evaluator.adapters.pipeline import AdapterPipeline
+
+    # Cache timeout so the signal handler avoids redundant env-var parsing.
+    shutdown_timeout = _get_shutdown_timeout_seconds()
+
     # Track if graceful cleanup has been performed
-    cleanup_performed = False
+    cleanup_status: Optional[bool] = None
 
-    def run_client_mode_cleanup():
+    def run_client_mode_cleanup() -> bool:
         """Run post-eval hooks for client mode during graceful shutdown."""
-        nonlocal cleanup_performed
-        if cleanup_performed:
-            return
+        nonlocal cleanup_status
+        if cleanup_status is not None:
+            return cleanup_status
 
-        cleanup_performed = True
-        if (
+        cleanup_status = True
+        if not (
             use_client_mode
             and target_cfg.api_endpoint
             and target_cfg.api_endpoint.adapter_config
         ):
-            try:
-                from nemo_evaluator.adapters.pipeline import AdapterPipeline
+            return cleanup_status
 
-                pipeline = AdapterPipeline(
-                    target_cfg.api_endpoint.adapter_config,
-                    evaluation.config.output_dir,
-                    target_cfg.api_endpoint.model_id,
-                )
-                pipeline.run_post_eval_hooks(url=target_cfg.api_endpoint.url or "")
-                logger.info("Post-eval hooks executed during shutdown")
-            except Exception as e:
-                logger.error(f"Failed to run post-eval hooks during shutdown: {e}")
+        try:
+            pipeline = AdapterPipeline(
+                target_cfg.api_endpoint.adapter_config,
+                evaluation.config.output_dir,
+                target_cfg.api_endpoint.model_id,
+            )
+            pipeline.run_post_eval_hooks(url=target_cfg.api_endpoint.url or "")
+            logger.info("Post-eval hooks executed during shutdown")
+        except Exception as e:
+            cleanup_status = False
+            logger.error(f"Failed to run post-eval hooks during shutdown: {e}")
+
+        return cleanup_status
 
     def kill_all(signum=None, frame=None):
         """Kill all processes and exit."""
-        logger.critical("FATAL: Terminating all processes...")
+        # If another SIGINT/SIGTERM arrives during shutdown, use default handling
+        # instead of re-entering kill_all and repeating cleanup/termination logic.
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
 
-        # For SIGTERM (graceful shutdown), run client mode cleanup first
+        logger.info("Terminating all processes...")
+
+        server_error_shutdown = False
+        cleanup_succeeded = True
         if signum == signal.SIGTERM:
-            run_client_mode_cleanup()
+            server_error_path = os.path.join(
+                evaluation.config.output_dir, SERVER_ERROR_MARKER_FILENAME
+            )
+            server_error_shutdown = os.path.exists(server_error_path)
+            if not server_error_shutdown:
+                _write_interrupted_marker(evaluation.config.output_dir, signum)
+        if signum != signal.SIGINT:
+            cleanup_succeeded = run_client_mode_cleanup()
 
         parent = psutil.Process(os.getpid())  # current process
         children = parent.children(recursive=True)
@@ -163,14 +255,23 @@ def _run_evaluation(
                 # Send SIGTERM to children for graceful termination (run post-eval hooks)
                 child.terminate()
 
-        # Use faster timeout for keyboard interrupt (SIGINT)
-        timeout = 1 if signum == signal.SIGINT else 5
-        gone, alive = psutil.wait_procs(children, timeout=timeout)
+        timeout = 1 if signum == signal.SIGINT else shutdown_timeout
+        _, alive = psutil.wait_procs(children, timeout=timeout)
         for child in alive:
-            logger.warning(f"Force killing child process {child.pid}")
+            logger.warning(
+                f"Force killing child process {child.pid} after waiting {timeout} seconds"
+            )
             child.kill()
 
-        sys.exit(1)
+        if signum == signal.SIGINT:
+            exit_code = 128 + signal.SIGINT
+        else:
+            exit_code = (
+                1
+                if server_error_shutdown
+                else 0 if cleanup_succeeded and not alive else 1
+            )
+        sys.exit(exit_code)
 
     # Set up signal handlers
     signal.signal(signal.SIGTERM, kill_all)
@@ -188,8 +289,8 @@ def _run_evaluation(
             # In client mode, explicitly run post-eval hooks after command completes
             # This ensures hooks run reliably from the parent process rather than
             # depending on finalizers in the subprocess during interpreter shutdown
-            # Note: cleanup_performed flag prevents double execution if SIGTERM was received
-            if not cleanup_performed:
+            # Note: cleanup_status prevents double execution if a signal was received
+            if cleanup_status is None:
                 run_client_mode_cleanup()
 
             return evaluation_result
@@ -361,6 +462,8 @@ def evaluate(
     verify_capabilities(evaluation)
 
     prepare_output_directory(evaluation)
+    _clear_interrupted_marker(evaluation.config.output_dir)
+    _clear_marker(evaluation.config.output_dir, SERVER_ERROR_MARKER_FILENAME)
 
     model_name = (
         target_cfg.api_endpoint.model_id

--- a/packages/nemo-evaluator/tests/unit_tests/core/test_evaluate.py
+++ b/packages/nemo-evaluator/tests/unit_tests/core/test_evaluate.py
@@ -14,19 +14,28 @@
 # limitations under the License.
 
 import os
+import signal
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+import pytest
 import yaml
 
+from nemo_evaluator.adapters.adapter_config import AdapterConfig
 from nemo_evaluator.api.api_dataclasses import (
+    ApiEndpoint,
     ConfigParams,
     Evaluation,
     EvaluationConfig,
     EvaluationTarget,
 )
 from nemo_evaluator.config import TelemetryLevel
-from nemo_evaluator.core.evaluate import evaluate
+from nemo_evaluator.core.evaluate import (
+    INTERRUPTED_MARKER_FILENAME,
+    SERVER_ERROR_MARKER_FILENAME,
+    _run_evaluation,
+    evaluate,
+)
 
 
 def test_evaluate_result_config_matches_run_config(tmp_path: Path):
@@ -144,3 +153,252 @@ def test_evaluate_telemetry_uses_framework_name(tmp_path: Path):
     assert completion_event.task == "test_task"
     assert completion_event.model == "unknown"
     assert completion_event.status == "success"
+
+
+def _build_evaluation(tmp_path: Path, *, client_mode: bool = False):
+    target_cfg = EvaluationTarget()
+    if client_mode:
+        target_cfg = EvaluationTarget(
+            api_endpoint=ApiEndpoint(
+                model_id="test-model",
+                url="http://example.com",
+                adapter_config=AdapterConfig(mode="client"),
+            )
+        )
+
+    evaluation = Evaluation(
+        command="command",
+        framework_name="framework_name",
+        pkg_name="pkg_name",
+        config=EvaluationConfig(
+            output_dir=str(tmp_path),
+            params=ConfigParams(),
+        ),
+        target=target_cfg,
+    )
+    return evaluation, target_cfg
+
+
+def _invoke_shutdown_handler(
+    tmp_path: Path,
+    signum: int,
+    *,
+    client_mode: bool = False,
+    env: dict[str, str] | None = None,
+    cleanup_side_effect: Exception | None = None,
+    alive_children: list[MagicMock] | None = None,
+):
+    evaluation, target_cfg = _build_evaluation(tmp_path, client_mode=client_mode)
+    handlers = {}
+    child = MagicMock(pid=1234)
+    parent = MagicMock()
+    parent.children.return_value = [child]
+    alive_children = alive_children or []
+
+    def register_handler(sig, handler):
+        handlers[sig] = handler
+
+    def trigger_signal(*args, **kwargs):
+        handlers[signum](signum, None)
+
+    with (
+        patch(
+            "nemo_evaluator.core.evaluate.signal.signal",
+            side_effect=register_handler,
+        ),
+        patch("nemo_evaluator.core.evaluate.psutil.Process", return_value=parent),
+        patch(
+            "nemo_evaluator.core.evaluate.psutil.wait_procs",
+            return_value=([], alive_children),
+        ) as wait_procs,
+        patch(
+            "nemo_evaluator.core.evaluate.monitor_memory_usage",
+            side_effect=trigger_signal,
+        ),
+        patch.dict(os.environ, env or {}, clear=False),
+    ):
+        if client_mode:
+            with patch(
+                "nemo_evaluator.adapters.pipeline.AdapterPipeline"
+            ) as pipeline_cls:
+                if cleanup_side_effect is not None:
+                    pipeline_cls.return_value.run_post_eval_hooks.side_effect = (
+                        cleanup_side_effect
+                    )
+                with pytest.raises(SystemExit) as exc_info:
+                    _run_evaluation(evaluation, target_cfg, None)
+                return exc_info.value.code, child, wait_procs, pipeline_cls
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_evaluation(evaluation, target_cfg, None)
+        return exc_info.value.code, child, wait_procs, None
+
+
+def test_shutdown_handler_exits_zero_for_sigterm_after_graceful_cleanup(tmp_path: Path):
+    exit_code, child, wait_procs, pipeline_cls = _invoke_shutdown_handler(
+        tmp_path,
+        signal.SIGTERM,
+        client_mode=True,
+    )
+
+    assert exit_code == 0
+    child.terminate.assert_called_once()
+    child.send_signal.assert_not_called()
+    wait_procs.assert_called_once_with([child], timeout=30.0)
+    pipeline_cls.return_value.run_post_eval_hooks.assert_called_once_with(
+        url="http://example.com"
+    )
+    marker_path = tmp_path / INTERRUPTED_MARKER_FILENAME
+    assert marker_path.exists()
+    marker = yaml.safe_load(marker_path.read_text())
+    assert marker["signal"] == "SIGTERM"
+
+
+def test_shutdown_handler_skips_interrupted_marker_on_server_error(tmp_path: Path):
+    """When the server error marker exists, SIGTERM should not write the interrupted marker."""
+    (tmp_path / SERVER_ERROR_MARKER_FILENAME).write_text("FatalErrorException")
+
+    exit_code, child, wait_procs, pipeline_cls = _invoke_shutdown_handler(
+        tmp_path,
+        signal.SIGTERM,
+        client_mode=True,
+    )
+
+    assert exit_code == 1
+    child.terminate.assert_called_once()
+    wait_procs.assert_called_once_with([child], timeout=30.0)
+    pipeline_cls.return_value.run_post_eval_hooks.assert_called_once_with(
+        url="http://example.com"
+    )
+    assert not (tmp_path / INTERRUPTED_MARKER_FILENAME).exists()
+    assert (tmp_path / SERVER_ERROR_MARKER_FILENAME).exists()
+
+
+def test_shutdown_handler_exits_130_for_sigint(tmp_path: Path):
+    exit_code, child, wait_procs, pipeline_cls = _invoke_shutdown_handler(
+        tmp_path,
+        signal.SIGINT,
+        client_mode=True,
+    )
+
+    assert exit_code == 130
+    child.terminate.assert_not_called()
+    child.send_signal.assert_called_once_with(signal.SIGINT)
+    wait_procs.assert_called_once_with([child], timeout=1)
+    pipeline_cls.assert_not_called()
+
+
+def test_shutdown_handler_uses_env_override_timeout(tmp_path: Path):
+    exit_code, child, wait_procs, _ = _invoke_shutdown_handler(
+        tmp_path,
+        signal.SIGTERM,
+        env={"NEMO_EVALUATOR_SHUTDOWN_TIMEOUT_SECONDS": "45"},
+    )
+
+    assert exit_code == 0
+    child.terminate.assert_called_once()
+    wait_procs.assert_called_once_with([child], timeout=45.0)
+
+
+def test_shutdown_handler_warns_and_falls_back_on_invalid_timeout(tmp_path: Path):
+    with patch("nemo_evaluator.core.evaluate.logger.warning") as warning_logger:
+        exit_code, child, wait_procs, _ = _invoke_shutdown_handler(
+            tmp_path,
+            signal.SIGTERM,
+            env={"NEMO_EVALUATOR_SHUTDOWN_TIMEOUT_SECONDS": "invalid"},
+        )
+
+    assert exit_code == 0
+    child.terminate.assert_called_once()
+    wait_procs.assert_called_once_with([child], timeout=30.0)
+    warning_logger.assert_called_once()
+    assert "NEMO_EVALUATOR_SHUTDOWN_TIMEOUT_SECONDS" in warning_logger.call_args.args[0]
+
+
+@pytest.mark.parametrize("raw_timeout", ["nan", "inf"])
+def test_shutdown_handler_warns_and_falls_back_on_non_finite_timeout(
+    tmp_path: Path, raw_timeout: str
+):
+    with patch("nemo_evaluator.core.evaluate.logger.warning") as warning_logger:
+        exit_code, child, wait_procs, _ = _invoke_shutdown_handler(
+            tmp_path,
+            signal.SIGTERM,
+            env={"NEMO_EVALUATOR_SHUTDOWN_TIMEOUT_SECONDS": raw_timeout},
+        )
+
+    assert exit_code == 0
+    child.terminate.assert_called_once()
+    wait_procs.assert_called_once_with([child], timeout=30.0)
+    warning_logger.assert_called_once()
+    assert "NEMO_EVALUATOR_SHUTDOWN_TIMEOUT_SECONDS" in warning_logger.call_args.args[0]
+
+
+def test_shutdown_handler_force_kills_children_and_exits_one(tmp_path: Path):
+    stuck_child = MagicMock(pid=5678)
+    exit_code, child, wait_procs, _ = _invoke_shutdown_handler(
+        tmp_path,
+        signal.SIGTERM,
+        alive_children=[stuck_child],
+    )
+
+    assert exit_code == 1
+    child.terminate.assert_called_once()
+    wait_procs.assert_called_once_with([child], timeout=30.0)
+    stuck_child.kill.assert_called_once()
+
+
+def test_shutdown_handler_exits_one_when_cleanup_fails(tmp_path: Path):
+    exit_code, child, wait_procs, pipeline_cls = _invoke_shutdown_handler(
+        tmp_path,
+        signal.SIGTERM,
+        client_mode=True,
+        cleanup_side_effect=RuntimeError("cleanup failed"),
+    )
+
+    assert exit_code == 1
+    child.terminate.assert_called_once()
+    wait_procs.assert_called_once_with([child], timeout=30.0)
+    pipeline_cls.return_value.run_post_eval_hooks.assert_called_once_with(
+        url="http://example.com"
+    )
+
+
+def test_evaluate_clears_stale_markers(tmp_path: Path):
+    marker_path = tmp_path / INTERRUPTED_MARKER_FILENAME
+    marker_path.write_text("stale")
+    server_error_path = tmp_path / SERVER_ERROR_MARKER_FILENAME
+    server_error_path.write_text("stale")
+
+    with (
+        patch(
+            "nemo_evaluator.telemetry.get_telemetry_level",
+            return_value=TelemetryLevel.OFF,
+        ),
+        patch(
+            "nemo_evaluator.core.evaluate.validate_configuration",
+            return_value=Evaluation(
+                command="command",
+                framework_name="framework_name",
+                pkg_name="pkg_name",
+                config=EvaluationConfig(
+                    output_dir=str(tmp_path),
+                    params=ConfigParams(),
+                ),
+                target=EvaluationTarget(),
+            ),
+        ),
+        patch(
+            "nemo_evaluator.core.evaluate.monitor_memory_usage",
+            return_value=(MagicMock(model_dump=lambda **k: {"test": "result"}), {}),
+        ),
+    ):
+        evaluate(
+            eval_cfg=EvaluationConfig(
+                output_dir=str(tmp_path),
+                params=ConfigParams(),
+            ),
+            target_cfg=EvaluationTarget(),
+        )
+
+    assert not marker_path.exists()
+    assert not server_error_path.exists()


### PR DESCRIPTION
## Summary
- add graceful SIGTERM interruption markers and configurable shutdown timeout handling in `nemo-evaluator`
- distinguish adapter server fatal shutdowns from external interruptions so server-triggered SIGTERM exits nonzero instead of looking successful
- update local, SLURM, and Lepton launcher flows to treat interrupted runs as non-success and skip auto-export
- add unit coverage for shutdown handling and launcher classification paths
