### PR TITLE
fix: raise error when execution.env_vars is used in config

### DIFF
--- a/packages/nemo-evaluator-launcher/examples/slurm_vllm_multinode_multiinstance_ray_tp_pp.yaml
+++ b/packages/nemo-evaluator-launcher/examples/slurm_vllm_multinode_multiinstance_ray_tp_pp.yaml
@@ -93,7 +93,7 @@ deployment:
   port: 8000
   extra_args: "--disable-custom-all-reduce --enforce-eager"
   env_vars:
-      HF_TOKEN: ${oc.env:HF_TOKEN}
+      HF_TOKEN: host:HF_TOKEN
 
 evaluation:
   nemo_evaluator_config:

--- a/packages/nemo-evaluator-launcher/examples/slurm_vllm_multinode_multiinstance_ray_tp_pp.yaml
+++ b/packages/nemo-evaluator-launcher/examples/slurm_vllm_multinode_multiinstance_ray_tp_pp.yaml
@@ -79,9 +79,6 @@ execution:
     deployment:
       /path/to/hf_home: /root/.cache/huggingface
     mount_home: false
-  env_vars:
-    deployment:
-      HF_TOKEN: ${oc.env:HF_TOKEN}
 
 # Ray cluster setup is handled by the vllm_ray deployment config (no pre_cmd needed)
 deployment:
@@ -95,6 +92,8 @@ deployment:
   gpu_memory_utilization: 0.90
   port: 8000
   extra_args: "--disable-custom-all-reduce --enforce-eager"
+  env_vars:
+      HF_TOKEN: ${oc.env:HF_TOKEN}
 
 evaluation:
   nemo_evaluator_config:

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/api/functional.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/api/functional.py
@@ -80,6 +80,19 @@ def _validate_config_sections(cfg: RunConfig) -> None:
     Raises:
         ValueError: If an unknown or removed key is present in a validated section.
     """
+    # Check for removed execution.env_vars — must use env_vars / deployment.env_vars / evaluation.env_vars
+    if (
+        cfg.execution is not None
+        and getattr(cfg.execution, "env_vars", None) is not None
+    ):
+        raise ValueError(
+            "'execution.env_vars' is not supported. "
+            "Use top-level 'env_vars' for variables that should apply to all jobs. "
+            "For variables that should be applied only to deployment or evaluation jobs, "
+            "use 'deployment.env_vars' or 'evaluation.env_vars' respectively.\n"
+            "Run 'nel migrate-config <config.yaml>' to migrate your config automatically."
+        )
+
     if cfg.evaluation is not None:
         eval_dict = OmegaConf.to_container(cfg.evaluation, resolve=False)
         try:

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_config_validation.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_config_validation.py
@@ -227,6 +227,42 @@ INVALID_STRUCTURAL_CONFIGS = [
         "Invalid 'execution.mounts' config",
         id="mounts_evaluation_invalid_value",
     ),
+    pytest.param(
+        """\
+        evaluation:
+          tasks:
+            - name: lm-evaluation-harness.ifeval
+        execution:
+          env_vars:
+            deployment:
+              HF_TOKEN: host:HF_TOKEN
+        """,
+        "execution.env_vars.*is not supported",
+        id="execution_env_vars_deployment",
+    ),
+    pytest.param(
+        """\
+        evaluation:
+          tasks:
+            - name: lm-evaluation-harness.ifeval
+        execution:
+          env_vars:
+            HF_TOKEN: host:HF_TOKEN
+        """,
+        "execution.env_vars.*is not supported",
+        id="execution_env_vars_flat",
+    ),
+    pytest.param(
+        """\
+        evaluation:
+          tasks:
+            - name: lm-evaluation-harness.ifeval
+        execution:
+          env_vars: {}
+        """,
+        "execution.env_vars.*is not supported",
+        id="execution_env_vars_empty",
+    ),
 ]
 
 


### PR DESCRIPTION
This PR adds a descriptive error and fixes broken example config