### PR TITLE
fix: use poll() and disable IPv6 in waitress adapter server

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/server.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/server.py
@@ -275,6 +275,8 @@ class AdapterServer:
             threads=threads,
             connection_limit=connection_limit,
             channel_timeout=300,
+            asyncore_use_poll=True,  # select.poll() has no fd limit; select.select() breaks above fd 1023
+            ipv6=False,  # avoid EADDRNOTAVAIL when IPv6 is disabled in container
         )
 
     # The headers we don't want to let out


### PR DESCRIPTION
Fixes two issues from #896:

- **`filedescriptor out of range in select()`**: `select.select()` can't handle fds > 1023. After raising RLIMIT_NOFILE to 65536, this is easily hit. `asyncore_use_poll=True` switches to `select.poll()` which has no fd limit.
- **`EADDRNOTAVAIL` in containers**: `localhost` resolves to `::1` in IPv6-disabled environments. `ipv6=False` forces IPv4-only binding.

Reproduced the select() issue in a core-evals container (`terminal-bench:2026-02-09T10-38-9216d4e3-amd64`): default soft=1024, hard=524288; after raising and opening 1100 sockets, `select.select()` fails exactly as reported.

## Test plan
- [x] 21/21 adapter server unit tests pass