### PR TITLE
fix(export): add large Gym artifacts to excluded files

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/utils.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/utils.py
@@ -48,7 +48,16 @@ OPTIONAL_ARTIFACTS = ["omni-info.json"]
 
 # Glob-style patterns to exclude when only_required=false (applied recursively)
 # Matches: cache/, response_stats_cache/, lm_cache_rank0.db/, *.lock, synthetic/, etc.
-EXCLUDED_PATTERNS = ["*cache*", "*.db", "*.lock", "synthetic", "debug.json"]
+EXCLUDED_PATTERNS = [
+    "*cache*",
+    "*.db",
+    "*.lock",
+    "synthetic",
+    "debug.json",
+    "preprocessed_datasets",
+    "evaluator_rollouts.jsonl",
+    "evaluator_rollouts_materialized_inputs.jsonl",
+]
 
 
 @dataclass


### PR DESCRIPTION
Otherwise we try to upload large (sometimes even mutli-GB) files to MLFlow and it times out. With this change we skip the worst offenders and the upload for LCB job takes ~30s