### PR TITLE
fix(launcher): re-raise unrelated ModuleNotFoundError in container_metadata init

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/container_metadata/__init__.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/container_metadata/__init__.py
@@ -56,6 +56,10 @@ try:
             "parse_framework_to_irs",
         ]
     )
-except ModuleNotFoundError:
+except ModuleNotFoundError as exc:
     # Allow importing this package for IR-only workflows (docs autogen, etc.)
-    pass
+    # Only suppress when nemo_evaluator itself is missing; re-raise if a
+    # transitive dependency (pydantic, structlog, …) is absent — that is a
+    # broken installation, not an IR-only workflow.
+    if exc.name is None or not exc.name.startswith("nemo_evaluator"):
+        raise

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/container_metadata/loading.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/container_metadata/loading.py
@@ -25,7 +25,6 @@ import tempfile
 from typing import Optional
 
 import yaml
-from nemo_evaluator.core.input import get_framework_evaluations
 
 from nemo_evaluator_launcher.common.container_metadata.intermediate_repr import (
     HarnessIntermediateRepresentation,
@@ -943,6 +942,8 @@ def parse_framework_to_irs(
             temp_file_path = temp_file.name
 
         try:
+            from nemo_evaluator.core.input import get_framework_evaluations
+
             include_internal = (
                 importlib.util.find_spec("nemo_evaluator_internal") is not None
                 or importlib.util.find_spec("nemo_evaluator_launcher_internal")

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_loading.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_loading.py
@@ -208,9 +208,7 @@ class TestCreateTaskIrs:
 class TestParseFrameworkToIrs:
     """Test parsing framework.yml to IRs."""
 
-    @patch(
-        "nemo_evaluator_launcher.common.container_metadata.loading.get_framework_evaluations"
-    )
+    @patch("nemo_evaluator.core.input.get_framework_evaluations")
     def test_parse_framework_to_irs_success(self, mock_get_evaluations):
         """Test successful parsing of framework.yml."""
         framework_content = """
@@ -237,9 +235,7 @@ evaluations:
         assert harness_ir.name == "test-harness"  # Original name preserved
         assert len(task_irs) > 0
 
-    @patch(
-        "nemo_evaluator_launcher.common.container_metadata.loading.get_framework_evaluations"
-    )
+    @patch("nemo_evaluator.core.input.get_framework_evaluations")
     def test_parse_framework_to_irs_preserves_case(self, mock_get_evaluations):
         """Test that framework name case is preserved."""
         framework_content = """
@@ -274,9 +270,7 @@ evaluations: []
 """
         # This should not raise an error - no validation in loading.py
         # We'll mock get_framework_evaluations to avoid actual parsing
-        with patch(
-            "nemo_evaluator_launcher.common.container_metadata.loading.get_framework_evaluations"
-        ) as mock_get:
+        with patch("nemo_evaluator.core.input.get_framework_evaluations") as mock_get:
             mock_get.return_value = ("test-harness-123", {}, {})
             harness_ir, task_irs = parse_framework_to_irs(
                 framework_content, "test:latest", None


### PR DESCRIPTION
## Summary
- The bare `except ModuleNotFoundError: pass` in `container_metadata/__init__.py` silently swallowed errors from transitive dependencies (pydantic, structlog, etc.) when `nemo_evaluator` was on `PYTHONPATH` as source but its deps were not installed in the active venv.
- This caused `extract_framework_yml` (and other `loading` symbols) to silently disappear from the namespace with no error, breaking downstream scripts like docs autogen.
- Now only suppresses the error when `nemo_evaluator` itself is the missing module; any other missing dependency is re-raised.
