### PR TITLE
feat: improve launching-evals and nel-assistant skills

### DIFF
--- a/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/SKILL.md
+++ b/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/SKILL.md
@@ -47,7 +47,7 @@ The complete evaluation workflow is divided into the following steps you should 
 
 1. Create or modify a config using the `nel-assistant` skill. If the user provides a past run, use its `config.yml` artifact as a starting point.
 2. Run the evaluation. See `references/run-evaluation.md` when executing this step.
-3. Check progress (while RUNNING). See `references/check-progress.md` when executing this step.
+3. **Monitor progress (MANDATORY after every `nel run`)**: use `/loop` to poll until SUCCESS/FAILED. See `references/check-progress.md`.
 4. Post-run actions (when terminal state reached):
    1. When the evaluation status is `SUCCESS`, analyze the results. See `references/analyze-results.md` when executing this step.
    2. When the evaluation status is `FAILED`, debug the failed run. See `references/debug-failed-runs.md` when executing this step.

--- a/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/SKILL.md
+++ b/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/SKILL.md
@@ -50,7 +50,7 @@ The complete evaluation workflow is divided into the following steps you should 
 
 1. Create or modify a config using the `nel-assistant` skill. If the user provides a past run, use its `config.yml` artifact as a starting point.
 2. Run the evaluation. See `references/run-evaluation.md` when executing this step.
-3. **Monitor progress (MANDATORY after every `nel run`)**: use `/loop` to poll until SUCCESS/FAILED. See `references/check-progress.md`.
+3. **Monitor progress (MANDATORY after every `nel run`)**: poll status repeatedly until SUCCESS/FAILED. See `references/check-progress.md`.
 4. Post-run actions (when terminal state reached):
    1. When the evaluation status is `SUCCESS`, analyze the results. See `references/analyze-results.md` when executing this step.
    2. When the evaluation status is `FAILED`, debug the failed run. See `references/debug-failed-runs.md` when executing this step.

--- a/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/SKILL.md
+++ b/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/SKILL.md
@@ -33,6 +33,9 @@ uv run nemo-evaluator-launcher info <invocation_id> --copy-logs ./evaluation-res
 # ssh <user>@<hostname> "ls <artifacts_path>/"
 # rsync -avzP <user>@<hostname>:<artifacts_path>/{results.yml,eval_factory_metrics.json,config.yml} ./evaluation-results/<invocation_id>.<job_index>/artifacts/
 
+# Resume a failed/interrupted run (re-sbatches existing run.sub in the original run directory)
+uv run nemo-evaluator-launcher resume <invocation_id>
+
 # List past runs
 uv run nemo-evaluator-launcher ls runs --since 1d   
 

--- a/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/references/check-progress.md
+++ b/packages/nemo-evaluator-launcher/.claude/skills/launching-evals/references/check-progress.md
@@ -8,7 +8,7 @@ Follow the three phases and track your progress in the output.
 
 ## 1. INPUT
 
-- **Invocation ID**: The evaluation to monitor.
+- **Invocation ID**: The evaluation to monitor. After a `nel run` submission, this is printed in the output as `Invocation ID: <id>`.
 
 ## 2. EXPLORE
 

--- a/packages/nemo-evaluator-launcher/.claude/skills/nel-assistant/SKILL.md
+++ b/packages/nemo-evaluator-launcher/.claude/skills/nel-assistant/SKILL.md
@@ -198,6 +198,15 @@ deployment:
     pipeline_parallel_size: 2
 ```
 
+**Multi-node performance tips**
+
+- For multi-node deployments, add `switches: 1` to `execution.sbatch_extra_flags` to instruct SLURM to allocate all nodes on the same network switch, reducing inter-node communication latency:
+  ```yaml
+  execution:
+    sbatch_extra_flags:
+      switches: 1
+  ```
+
 **Common Confusions**
 
 - **`num_instances`** controls independent deployment instances with HAProxy. **`data_parallel_size`** controls DP replicas *within* a single instance.
@@ -236,6 +245,15 @@ export NEMO_EVALUATOR_TRUST_PRE_CMD=1
    ```
    nel run --config <config_path> -o ++evaluation.nemo_evaluator_config.config.params.limit_samples=10
    ```
+   For multi-instance deployments, also scale down to a single instance to validate the deployment faster:
+   ```
+   nel run --config <config_path> \
+     -o execution.num_nodes=1 \
+     -o execution.num_instances=1 \
+     -o evaluation.nemo_evaluator_config.config.params.parallelism=5 \
+     -o ++evaluation.nemo_evaluator_config.config.params.limit_samples=10
+   ```
+   Adjust `num_nodes` to match the number of nodes a single model instance needs (e.g., 2 for a model requiring 2-node Ray TP).
 
 3. **Re-run a single task** (useful for debugging or re-testing after config changes):
    ```


### PR DESCRIPTION
## Summary
- Makes post-run monitoring a mandatory step after every `nel run` by updating the skill workflow to poll until terminal state
- Clarifies where to find the invocation ID in `nel run` output
- Adds `resume` command documentation to launching-evals skill
- Adds multi-node `switches: 1` performance tip to nel-assistant skill
- Adds multi-instance scale-down example for quick validation runs to nel-assistant skill
- Uses tool-agnostic polling instruction (not Claude Code-specific `/loop`)

## Test plan
- [ ] Verify skill triggers monitoring after `nel run`
- [ ] Verify `resume` command appears in launching-evals skill reference
- [ ] Verify multi-node and scale-down tips render correctly in nel-assistant skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)