### PR TITLE
feat: add export_mounts and export_image to auto-export config

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -1157,8 +1157,13 @@ def _generate_auto_export_section(
     #
     auto_export_cfg = cfg.execution.get("auto_export", {}) or {}
     launcher_install_cmd = None
+    export_mounts = {}
     if isinstance(auto_export_cfg, dict) or OmegaConf.is_config(auto_export_cfg):
         launcher_install_cmd = auto_export_cfg.get("launcher_install_cmd")
+        export_mounts = auto_export_cfg.get("export_mounts") or {}
+        configured_image = auto_export_cfg.get("export_image")
+        if configured_image:
+            export_image = configured_image
 
     if not launcher_install_cmd:
         launcher_install_cmd = "pip install nemo-evaluator-launcher[all]"
@@ -1173,7 +1178,13 @@ def _generate_auto_export_section(
     # and there's no use-case for mounting it
     s += "--no-container-mount-home "
 
-    s += f"--container-mounts {remote_task_subdir}/artifacts:{remote_task_subdir}/artifacts,{remote_task_subdir}/logs:{remote_task_subdir}/logs "
+    mounts = [
+        f"{remote_task_subdir}/artifacts:{remote_task_subdir}/artifacts",
+        f"{remote_task_subdir}/logs:{remote_task_subdir}/logs",
+    ]
+    for host_path, container_path in export_mounts.items():
+        mounts.append(f"{host_path}:{container_path}")
+    s += "--container-mounts {} ".format(",".join(mounts))
     s += "--output {} ".format(remote_task_subdir / "logs" / "export-%A.log")
     s += "    bash -c '\n"
     s += f"        {launcher_install_cmd}\n"

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -29,6 +29,7 @@ from nemo_evaluator_launcher.common.execdb import ExecutionDB, JobData
 from nemo_evaluator_launcher.executors.base import ExecutionState, ExecutionStatus
 from nemo_evaluator_launcher.executors.slurm.executor import (
     SlurmExecutor,
+    _collect_mount_paths,
     _create_slurm_sbatch_script,
     _generate_auto_export_section,
     _generate_autoresume_handler,
@@ -1377,6 +1378,63 @@ class TestSlurmExecutorDryRun:
         assert ".nemo_evaluator_interrupted" in section
         assert "Skipping auto-export" in section
         assert "EVAL_EXIT_CODE=143" in section
+
+    def test_generate_auto_export_section_with_export_mounts(self):
+        cfg = OmegaConf.create(
+            {
+                "execution": {
+                    "output_dir": "/tmp/out",
+                    "auto_export": {
+                        "destinations": ["mlflow"],
+                        "export_mounts": {
+                            "/lustre/cache/uv": "/cache/uv",
+                            "/lustre/data": "/data",
+                        },
+                    },
+                },
+                "export": {},
+            }
+        )
+
+        section = _generate_auto_export_section(
+            cfg=cfg,
+            job_id="abc12345.0",
+            destinations=["mlflow"],
+            env_var_names=[],
+            secrets=SecretsEnvResult(secrets_content=""),
+            remote_task_subdir=Path("/tmp/out/test_task"),
+        )
+
+        assert "/tmp/out/test_task/artifacts:/tmp/out/test_task/artifacts" in section
+        assert "/tmp/out/test_task/logs:/tmp/out/test_task/logs" in section
+        assert "/lustre/cache/uv:/cache/uv" in section
+        assert "/lustre/data:/data" in section
+
+    def test_generate_auto_export_section_with_custom_image(self):
+        cfg = OmegaConf.create(
+            {
+                "execution": {
+                    "output_dir": "/tmp/out",
+                    "auto_export": {
+                        "destinations": ["mlflow"],
+                        "export_image": "my-registry.com/uv-git:latest",
+                    },
+                },
+                "export": {},
+            }
+        )
+
+        section = _generate_auto_export_section(
+            cfg=cfg,
+            job_id="abc12345.0",
+            destinations=["mlflow"],
+            env_var_names=[],
+            secrets=SecretsEnvResult(secrets_content=""),
+            remote_task_subdir=Path("/tmp/out/test_task"),
+        )
+
+        assert "my-registry.com/uv-git:latest" in section
+        assert "python:3.12.7-slim" not in section
 
     def test_sbatch_script_exits_nonzero_on_interrupted_marker(
         self, sample_config, mock_tasks_mapping, tmpdir
@@ -4039,3 +4097,22 @@ class TestSbatchExtraFlags:
         switches_pos = script.index("#SBATCH --switches 1")
         job_name_pos = script.index("#SBATCH --job-name")
         assert comment_pos < switches_pos < job_name_pos
+
+
+class TestCollectMountPaths:
+    def test_export_mounts_not_in_collect(self):
+        """Export mounts should NOT be validated — they only exist on compute nodes."""
+        cfg = OmegaConf.create(
+            {
+                "deployment": {"type": "none"},
+                "execution": {
+                    "auto_export": {
+                        "export_mounts": {
+                            "/lustre/cache/uv": "/cache/uv",
+                        },
+                    },
+                },
+            }
+        )
+        paths = _collect_mount_paths(cfg)
+        assert "/lustre/cache/uv" not in paths


### PR DESCRIPTION
This tries to address the issue of fast startup of export execution as requested by Gym folks

Approx speedups are here:

| Setup | apt-get+git | install | Total |
|-------|-------------|---------|-------|
| Before (pip, python:3.12-slim) | ~1-2 min | ~2-3 min | **3-5 min** |
| After, cold uv cache | 0s | ~42s | **~42s** |
| After, warm uv cache | 0s | ~6s | **~6s** |


What was done 

- Add `export_mounts` config key: mount arbitrary host paths (e.g. a pre-heated uv cache) into the export srun container
- Add `export_image` config key: override the default `python:3.12.7-slim` export image with a custom one (e.g. one with uv+git pre-installed)

Together these eliminate the ~3-5 min `apt-get + pip install` overhead in the auto-export step, bringing it down to **~6s** with a warm uv cache.

To use this, now use this config (with new launcher installed)

```yaml
execution:
  auto_export:
    destinations: [mlflow]
    export_image: /path/to/uv-git-python3.12.sqsh  # or a registry image
    export_mounts:
      /lustre/.../users/me/.cache/uv: /cache/uv
    launcher_install_cmd: |
      export UV_CACHE_DIR=/cache/uv
      uv pip install --system "nemo-evaluator-launcher[all] @ git+https://github.com/NVIDIA-NeMo/Evaluator.git@main#subdirectory=packages/nemo-evaluator-launcher"
```

