### PR TITLE
fix(slurm): request zero GPUs when export falls back to GPU partition

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -1181,6 +1181,8 @@ def _generate_auto_export_section(
     export_sbatch += "#SBATCH --time=00:30:00\n"
     export_sbatch += f"#SBATCH --account {cfg.execution.account}\n"
     export_sbatch += f"#SBATCH --partition {export_partition}\n"
+    if not cpu_partition:
+        export_sbatch += "#SBATCH --gpus-per-node=0\n"
     export_sbatch += "#SBATCH --no-requeue\n"
     export_sbatch += (
         f"#SBATCH --output {remote_task_subdir / 'logs' / 'export-%A.log'}\n"


### PR DESCRIPTION
PR #901 introduced `export_partition = cpu_partition or cfg.execution.partition`. When cpu_partition is null (existing configs), export falls back to execution.partition — typically a GPU partition like 'batch' — with no --gpus-per-node in the sbatch header, and schedulers that enforce GPU specification on non-CPU partitions reject the submission:

  sbatch: error: Cannot find GPU specification, you may not submit a job
  not requesting GPUs in a non-CPU partition, partition: batch

The existing `--gpus 0` on the inner srun only applies to the step, not to the allocation. Declare `--gpus-per-node=0` at the sbatch level when falling back so the scheduler accepts an allocation with no GPUs.