### PR TITLE
fix(ci): wrap uv install in retry block

### DIFF
--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -45,7 +45,11 @@ jobs:
 
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          for i in 1 2 3; do
+            curl -LsSf https://astral.sh/uv/install.sh | sh && break
+            echo "uv install attempt $i failed, retrying..."
+            sleep 10
+          done
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install nemo-evaluator
@@ -76,7 +80,11 @@ jobs:
 
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          for i in 1 2 3; do
+            curl -LsSf https://astral.sh/uv/install.sh | sh && break
+            echo "uv install attempt $i failed, retrying..."
+            sleep 10
+          done
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install nemo-evaluator-launcher
@@ -118,7 +126,11 @@ jobs:
 
       - name: Install uv
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
+          for i in 1 2 3; do
+            curl -LsSf https://astral.sh/uv/install.sh | sh && break
+            echo "uv install attempt $i failed, retrying..."
+            sleep 10
+          done
           echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Install package


### PR DESCRIPTION
## Summary

- Wraps the `uv` installer curl command in a retry loop (3 attempts, 10 s sleep between attempts) in all three jobs in `install-test.yml`.

## Motivation

The install occasionally fails due to transient network issues. Without a retry, the entire CI job fails hard on a flaky download.

## Example

```yaml
- name: Install uv
  run: |
    for i in 1 2 3; do
      curl -LsSf https://astral.sh/uv/install.sh | sh && break
      echo "uv install attempt $i failed, retrying..."
      sleep 10
    done
    echo "$HOME/.local/bin" >> $GITHUB_PATH
```
