### PR TITLE
docs: add version 0.2.5 to docs version switcher

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,6 +1,11 @@
 [
     {
+        "name": "0.2.5 (latest)",
         "preferred": true,
+        "version": "0.2.5",
+        "url": "../0.2.5"
+    },
+    {
         "version": "0.1.0",
         "url": "../0.1.0"
     }


### PR DESCRIPTION
# What does this PR do ?

Add version 0.2.5 to the docs "Choose version" dropdown so readers can navigate between published releases.

# Changelog

- Add 0.2.5 entry to `docs/versions1.json` as the preferred latest version.
- Move `preferred` flag from the 0.1.0 entry to the new 0.2.5 entry.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?

# Additional Information

The `versions1.json` file only listed the original GA release (0.1.0), leaving the "Choose version" switcher out of date for the current 0.2.5 docs deployment.

Made with [Cursor](https://cursor.com)