### PR TITLE
fix(docs): add nightly record and fix version-switcher path

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,10 +30,41 @@ on:
         required: false
         type: string
         default: ""
+      update-version-picker:
+        description: Update version picker.
+        required: false
+        type: boolean
+        default: true
       notify-emails:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
+  workflow_call:
+    inputs:
+      dry-run:
+        description: Whether to run the workflow in dry-run mode
+        required: true
+        type: boolean
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: true
+      docs-version-override:
+        description: Docs version if commit is not tagged
+        required: false
+        type: string
+        default: ""
+      update-version-picker:
+        description: Update version picker.
+        required: false
+        type: boolean
+        default: true
+      notify-emails:
+        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
+        required: false
+        type: string
+    secrets: inherit
 
 jobs:
   build-docs:
@@ -64,8 +95,9 @@ jobs:
           emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
           overwrite-latest-on-tag: ${{ inputs.publish-as-latest }}
           docs-version-override: ${{ inputs.docs-version-override }}
+          update-version-picker: ${{ inputs.update-version-picker }}
           run-on-version-tag-only: ${{ github.ref_name != 'main' }}
-          request-name: megatron-bridge-publish-docs-${{ github.run_id }}
+          request-name: nemo-evaluator-publish-docs-${{ github.run_id }}
           aws-region: ${{ vars.DOCS_AWS_REGION }}
           aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/release-nightly-docs.yml
+++ b/.github/workflows/release-nightly-docs.yml
@@ -1,0 +1,29 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Release Nightly Docs
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+
+jobs:
+  call-release-docs:
+    uses: ./.github/workflows/release-docs.yml
+    with:
+      dry-run: false
+      publish-as-latest: false
+      docs-version-override: "nightly"
+      update-version-picker: false
+    secrets: inherit

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,7 +197,7 @@ html_theme = "nvidia_sphinx_theme"
 
 html_theme_options = {
     "switcher": {
-        "json_url": "./versions1.json",
+        "json_url": "../versions1.json",
         "version_match": release,
     },
     # Configure PyData theme search

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,12 +26,10 @@ import sys
 # Add custom extensions directory to Python path
 sys.path.insert(0, os.path.abspath("_extensions"))
 
-from nemo_evaluator_launcher.package_info import __version__
-
 project = "NeMo Evaluator SDK"
-copyright = "2025, NVIDIA Corporation"
+copyright = "2026, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = __version__
+release = "nightly"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemo-evaluator", "version": "0.1.0"}
+{"name": "nemo-evaluator", "version": "nightly"}

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,5 +1,10 @@
 [
     {
+        "name": "nightly",
+        "version": "nightly",
+        "url": "../nightly"
+    },
+    {
         "name": "0.2.5 (latest)",
         "preferred": true,
         "version": "0.2.5",


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary

- Fixes `json_url` in `docs/conf.py` for the version switcher: `./versions1.json` → `../versions1.json`
- Adds nightly record to `docs/versions1.json`, `docs/project.json`, and sets `release = "nightly"` in `docs/conf.py` (mirroring NVIDIA/Megatron-LM)
- Adds `release-nightly-docs.yml` workflow (daily cron at 10:00 UTC) that publishes docs to the `nightly` directory without updating the version picker
- Adds `workflow_call` trigger and `update-version-picker` input to `release-docs.yml` so it can be called programmatically; also fixes the stale `request-name` (`megatron-bridge` → `nemo-evaluator`)

## Test plan

- [ ] Verify the version switcher shows "nightly" as the first entry in the built docs
- [ ] Verify nightly docs publish correctly to the `nightly` directory (dry-run first)

</details>
