### PR TITLE
fix(ci): replace invalid secrets: inherit with explicit secret declarations

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -64,7 +64,23 @@ on:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
-    secrets: inherit
+    secrets:
+      AWS_ASSUME_ROLE_ARN:
+        required: false
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      AKAMAI_HOST:
+        required: false
+      AKAMAI_CLIENT_TOKEN:
+        required: false
+      AKAMAI_CLIENT_SECRET:
+        required: false
+      AKAMAI_ACCESS_TOKEN:
+        required: false
+      S3_BUCKET_NAME:
+        required: false
 
 jobs:
   build-docs:


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Summary

- `secrets: inherit` is valid only at the **job level** when calling a reusable workflow (`jobs.<job>.secrets: inherit`), not under `on.workflow_call.secrets`
- GitHub's parser rejects the scalar value `inherit` at the workflow trigger definition level, producing the error: `Unexpected value 'inherit'`
- Replaced with explicit secret declarations matching the secrets consumed by the `publish-docs` job

## Test plan

- [ ] Verify the workflow file is accepted as valid by GitHub Actions (no parse error on the Actions tab)
- [ ] Trigger a dry-run dispatch to confirm secrets flow correctly into the `publish-docs` job

</details>
