### PR TITLE
feat(byob): let @benchmark accept TemplateMetric classes + instances

### DIFF
--- a/src/nemo_evaluator/environments/custom.py
+++ b/src/nemo_evaluator/environments/custom.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
 from nemo_evaluator.environments.base import EvalEnvironment, SeedResult, VerifyResult
 from nemo_evaluator.sandbox.base import ImageBuildRequest, SandboxSpec
 from nemo_evaluator.environments.registry import register
+from nemo_evaluator.scoring.contracts import Metric, metric_as_scorer
 from nemo_evaluator.scoring.types import ScorerInput
 
 logger = logging.getLogger(__name__)
@@ -265,9 +266,35 @@ def benchmark(
     requirements: list[str] | None = None,
     prepare_row: Callable | None = None,
     seed_fn: Callable | None = None,
+    metric: Metric | None = None,
     **kwargs,
 ):
-    """Register a benchmark. Decorate a scorer function."""
+    """Register a benchmark. Decorate a scorer function or a :class:`Metric` class.
+
+    The decoration target may be:
+
+    - a **function** ``(ScorerInput) -> dict`` (classic NEL BYOB)
+    - a **class** that satisfies :class:`Metric` (e.g. a :class:`TemplateMetric`
+      subclass with a no-arg constructor)
+    - a **function**, with an **instance** passed via ``metric=`` kwarg
+
+    Examples::
+
+        # classic — function scorer
+        @benchmark(name="my-bench", dataset="hf://...", prompt="{q}", target_field="a")
+        @scorer
+        def score(s): return {"correct": s.response == s.target}
+
+        # object-style — TemplateMetric class
+        @benchmark(name="my-bench", dataset="hf://...", prompt="{q}", target_field="a")
+        class MyMetric(TemplateMetric):
+            type: Literal["my-metric"] = "my-metric"
+            def _score(self, input): return 1.0 if input.response == input.target else 0.0
+
+        # object-style — pre-configured instance
+        @benchmark(name="my-bench", ..., metric=BLEU(references="{{ reference }}"))
+        def _placeholder(): ...
+    """
     defn = BenchmarkDefinition(
         name=name,
         dataset=dataset,
@@ -282,10 +309,48 @@ def benchmark(
         seed_fn=seed_fn,
     )
 
-    def decorator(fn):
-        defn.scorer_fn = fn
-        if hasattr(fn, "_image_builder_fn"):
-            defn.image_builder_fn = fn._image_builder_fn
+    def decorator(target):
+        # Resolve the scorer_fn from whichever form we got
+        scorer_fn: Callable[[ScorerInput], dict] | None = None
+
+        if metric is not None:
+            # explicit instance via kwarg
+            scorer_fn = metric_as_scorer(metric)
+            image_src = target
+        elif isinstance(target, type):
+            # A class: must satisfy the Metric surface, else reject.
+            if not _class_satisfies_metric(target):
+                raise TypeError(
+                    f"@benchmark target is a class ({target.__name__}) but does "
+                    f"not satisfy the Metric contract (needs 'type', "
+                    f"'compute_scores', 'score_names'). Provide a TemplateMetric "
+                    f"subclass, a function scorer, or pass metric= kwarg."
+                )
+            # a Metric class — instantiate with no args, wrap
+            try:
+                instance = target()
+            except Exception as e:  # ValidationError, TypeError, etc.
+                raise TypeError(
+                    f"@benchmark can only auto-instantiate Metric classes with "
+                    f"a no-arg constructor. {target.__name__} requires "
+                    f"arguments; pass a pre-configured instance via "
+                    f"@benchmark(..., metric=MyMetric(...))"
+                ) from e
+            scorer_fn = metric_as_scorer(instance)
+            image_src = target
+        elif callable(target):
+            # function-style scorer
+            scorer_fn = target
+            image_src = target
+        else:
+            raise TypeError(
+                f"@benchmark target must be a callable scorer function, a "
+                f"Metric class, or called with metric= kwarg. Got {type(target).__name__}."
+            )
+
+        defn.scorer_fn = scorer_fn
+        if hasattr(image_src, "_image_builder_fn"):
+            defn.image_builder_fn = image_src._image_builder_fn
         _BYOB_REGISTRY[name] = defn
 
         @register(name)
@@ -295,9 +360,26 @@ def benchmark(
 
         _Env.__name__ = f"Bench_{name}"
         _Env.__qualname__ = f"Bench_{name}"
-        return fn
+        return target
 
     return decorator
+
+
+def _class_satisfies_metric(cls: type) -> bool:
+    """Return True if a class has the method-name surface of :class:`Metric`.
+
+    Avoids ``isinstance()`` which requires an instance. Handles Pydantic
+    BaseModel subclasses where ``type`` is a field (not a class attr): in
+    that case we check ``model_fields`` instead of ``hasattr``. Runtime
+    Protocol checks happen post-instantiation inside the decorator.
+    """
+    if not (hasattr(cls, "compute_scores") and hasattr(cls, "score_names")):
+        return False
+    # Pydantic v2 fields live in model_fields, not as class-level attrs
+    model_fields = getattr(cls, "model_fields", None)
+    if model_fields and "type" in model_fields:
+        return True
+    return hasattr(cls, "type")
 
 
 def scorer(fn: Callable[[ScorerInput], dict]) -> Callable[[ScorerInput], dict]:

--- a/src/nemo_evaluator/scoring/contracts.py
+++ b/src/nemo_evaluator/scoring/contracts.py
@@ -494,11 +494,18 @@ def metric_as_scorer(metric: Metric) -> Scorer:
 
     def _scorer(input: MetricInput) -> dict:
         result = _run_sync(lambda: metric.compute_scores(input))
-        out: dict[str, Any] = {"metric_type": metric.type}
+        # Put numeric values first so ByobEnvironment's fallback picker
+        # (next(iter(scores.values()))) lands on a number, not the metric_type
+        # string. Also expose 'reward' / 'score' aliases for the single-score
+        # case so the ByobEnvironment.verify() contract is satisfied.
+        out: dict[str, Any] = {}
         for score in result.scores:
             out[score.name] = score.value
         if len(result.scores) == 1:
-            out["score"] = float(result.scores[0].value)
+            value = float(result.scores[0].value)
+            out["score"] = value
+            out["reward"] = value
+        out["metric_type"] = metric.type
         return out
 
     return _scorer

--- a/tests/test_scoring/test_contracts.py
+++ b/tests/test_scoring/test_contracts.py
@@ -285,6 +285,7 @@ def test_metric_as_scorer_single_score():
     assert result["metric_type"] == "exact-match"
     assert result["exact-match"] == 1.0
     assert result["score"] == 1.0  # convenience for single-score case
+    assert result["reward"] == 1.0  # ByobEnvironment.verify() contract
 
 
 def test_metric_as_scorer_negative():

--- a/tests/test_scoring/test_contracts_byob.py
+++ b/tests/test_scoring/test_contracts_byob.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests: @benchmark accepts TemplateMetric classes + instances.
+
+Proves the 20-30 LOC user promise end-to-end.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+from nemo_evaluator.environments.custom import _BYOB_REGISTRY, benchmark, scorer
+from nemo_evaluator.scoring import MetricInput, TemplateMetric
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Isolate registry state across tests."""
+    snapshot = dict(_BYOB_REGISTRY)
+    yield
+    for key in list(_BYOB_REGISTRY):
+        if key not in snapshot:
+            del _BYOB_REGISTRY[key]
+
+
+# ---------------------------------------------------------------------------
+# @benchmark accepts function scorer (existing behavior — regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_accepts_function_scorer_classic_path():
+    @benchmark(name="classic-fn-bench", dataset=lambda: [{"q": "1", "answer": "2"}], prompt="{q}", target_field="answer")
+    @scorer
+    def score(sample):
+        return {"correct": sample.response == sample.target}
+
+    defn = _BYOB_REGISTRY["classic-fn-bench"]
+    assert defn.scorer_fn is score
+
+
+# ---------------------------------------------------------------------------
+# @benchmark accepts a TemplateMetric class (new behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_accepts_template_metric_class():
+    @benchmark(
+        name="class-metric-bench",
+        dataset=lambda: [{"q": "1", "answer": "1"}],
+        prompt="{q}",
+        target_field="answer",
+    )
+    class MyMetric(TemplateMetric):
+        type: Literal["my-metric"] = "my-metric"
+
+        def _score(self, input: MetricInput) -> float:
+            return 1.0 if input.response == input.target else 0.0
+
+    defn = _BYOB_REGISTRY["class-metric-bench"]
+    assert defn.scorer_fn is not None
+
+    # Invoke the wrapped scorer to confirm wiring
+    result = defn.scorer_fn(MetricInput(response="42", target="42"))
+    assert result["score"] == 1.0
+    assert result["metric_type"] == "my-metric"
+
+
+def test_benchmark_rejects_metric_class_needing_args():
+    """If the Metric class needs constructor args, the user must pass an instance."""
+    with pytest.raises(TypeError, match="no-arg constructor"):
+        @benchmark(name="needs-args", dataset=lambda: [], prompt="", target_field="a")
+        class RequiresArg(TemplateMetric):
+            type: Literal["requires-arg"] = "requires-arg"
+            # Required field with no default -> no-arg construction fails
+            required_field: str
+
+            def _score(self, input):
+                return 0.0
+
+
+# ---------------------------------------------------------------------------
+# @benchmark accepts a pre-configured Metric instance via metric= kwarg
+# ---------------------------------------------------------------------------
+
+
+def test_benchmark_accepts_metric_instance_via_kwarg():
+    class ConfiguredMetric(TemplateMetric):
+        type: Literal["configured"] = "configured"
+        threshold: float = 0.5
+
+        def _score(self, input: MetricInput) -> float:
+            return 1.0 if len(input.response) > self.threshold else 0.0
+
+    configured = ConfiguredMetric(threshold=3.0)
+
+    @benchmark(
+        name="configured-bench",
+        dataset=lambda: [{"q": "1", "answer": "1"}],
+        prompt="{q}",
+        target_field="answer",
+        metric=configured,
+    )
+    def _placeholder():  # body unused when metric= is provided
+        pass
+
+    defn = _BYOB_REGISTRY["configured-bench"]
+    assert defn.scorer_fn is not None
+
+    result_long = defn.scorer_fn(MetricInput(response="long-enough", target="_"))
+    assert result_long["score"] == 1.0
+    result_short = defn.scorer_fn(MetricInput(response="x", target="_"))
+    assert result_short["score"] == 0.0
+
+
+def test_benchmark_rejects_class_that_does_not_satisfy_metric():
+    with pytest.raises(TypeError, match="does not satisfy the Metric contract"):
+        @benchmark(name="bogus", dataset=lambda: [], prompt="", target_field="a")
+        class NotAMetric:  # missing required Metric methods
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Real "exact-match" metric in <25 LOC — proof of the 20-30 LOC promise
+# ---------------------------------------------------------------------------
+
+
+# Below this line is user code (counted against the 20-30 LOC target).
+# Everything needed for a working benchmark + metric.
+# vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
+
+@benchmark(
+    name="tiny-exact-match",
+    dataset=lambda: [{"q": "2+2=?", "answer": "4"}, {"q": "3+3=?", "answer": "6"}],
+    prompt="{q}",
+    target_field="answer",
+)
+class TinyExactMatch(TemplateMetric):
+    """Exact-match after normalization (lowercase + strip)."""
+
+    type: Literal["tiny-exact-match"] = "tiny-exact-match"
+
+    def _score(self, input: MetricInput) -> float:
+        return 1.0 if self._norm(input.response) == self._norm(input.target) else 0.0
+
+    @staticmethod
+    def _norm(s: object) -> str:
+        return str(s).strip().lower()
+
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# End of user code — that's 16 LOC of logic + decorator config for a full
+# working benchmark registered in the NEL BYOB system.
+
+
+def test_real_exact_match_metric_registered_and_callable():
+    defn = _BYOB_REGISTRY["tiny-exact-match"]
+    scorer_fn = defn.scorer_fn
+
+    assert scorer_fn(MetricInput(response="4", target="4"))["score"] == 1.0
+    assert scorer_fn(MetricInput(response="  4 ", target="4"))["score"] == 1.0  # normalization
+    assert scorer_fn(MetricInput(response="five", target="4"))["score"] == 0.0
+
+
+def test_real_exact_match_metric_registered_in_environment_registry():
+    """The @benchmark decorator also creates an EvalEnvironment in the registry."""
+    from nemo_evaluator.environments.registry import get_environment
+
+    env = get_environment("tiny-exact-match")
+    assert env is not None
+
+
+async def test_real_exact_match_metric_end_to_end_via_environment():
+    """Full flow: instantiate the environment, call verify() -> the metric evaluates."""
+    from nemo_evaluator.environments.registry import get_environment
+
+    env = get_environment("tiny-exact-match")
+    result = await env.verify(response="4", expected="4", sandbox=None)
+    assert result.reward == 1.0
+
+    result_wrong = await env.verify(response="five", expected="4", sandbox=None)
+    assert result_wrong.reward == 0.0


### PR DESCRIPTION
Extends the @benchmark decorator in environments/custom.py so users can wire a TemplateMetric directly into a BYOB benchmark without manually bridging via metric_as_scorer.

Three decoration styles now supported:

  # 1. Classic function scorer (unchanged, regression-tested)
  @benchmark(name=..., dataset=..., prompt=..., target_field=...)
  @scorer
  def score(sample): return {...}

  # 2. TemplateMetric class (auto-instantiated with no args)
  @benchmark(name=..., dataset=..., prompt=..., target_field=...)
  class MyMetric(TemplateMetric):
      type: Literal['my-metric'] = 'my-metric'
      def _score(self, input): return ...

  # 3. Pre-configured Metric instance via metric= kwarg
  @benchmark(name=..., ..., metric=BLEU(references='{{ reference }}'))
  def _placeholder(): ...

Changes:
- custom.py imports Metric + metric_as_scorer from scoring.contracts
- @benchmark dispatches on target type (class vs callable vs kwarg)
- _class_satisfies_metric() helper handles Pydantic v2 BaseModel subclasses where 'type' is a field (not a class attribute) — checks model_fields for the 'type' key
- metric_as_scorer() output now includes both 'score' and 'reward' keys for the single-score case so ByobEnvironment.verify() can extract the numeric value without matching against 'metric_type' (string).

Tests (+8 new, 50 total across contracts test files):
- Classic function path still works (regression guard)
- TemplateMetric class path: decorated class wires as scorer_fn
- Rejects classes needing constructor args with helpful message
- Rejects classes not satisfying Metric contract
- metric= kwarg with pre-configured instance
- End-to-end real 'tiny-exact-match' metric in 16 LOC of user code (proof of the 20-30 LOC authoring promise): registered in both _BYOB_REGISTRY and the environments registry, verify() returns correct reward via the full NEL BYOB pipeline.