### PR TITLE
fix(docs): use dynamic version from package_info in conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,17 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath("../src"))
+
+from nemo_eval.package_info import __version__
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "NeMo Eval"
 copyright = "2025, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "0.1.0"
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -98,3 +102,17 @@ html_theme_options = {
     },
 }
 html_extra_path = ["project.json", "versions1.json"]
+
+
+def setup(app):
+    """Sphinx setup function that runs before building documentation."""
+    import json
+    import pathlib
+
+    docs_dir = pathlib.Path(__file__).parent.resolve()
+
+    project_json = docs_dir / "project.json"
+    project_json.write_text(
+        json.dumps({"name": "nemo-evaluator", "version": release}, indent=None) + "\n",
+        encoding="utf-8",
+    )


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Backports the `conf.py` patch from `main` to the `r0.1.0` release branch.

**Changes:**
- Inserts `../src` into `sys.path` so `nemo_eval` is importable at conf-load time
- Imports `__version__` from `nemo_eval.package_info` and uses it for `release` instead of the hardcoded `"0.1.0"` string
- Adds a `setup()` Sphinx hook that generates `project.json` (already declared in `html_extra_path`) with the current package version at build time

</details>
