### PR TITLE
fix(docs,ci): backport conf.py version + release-docs workflow from main

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2025, NVIDIA CORPORATION.
+# Copyright (c) 2026, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,19 +20,67 @@ on:
         required: true
         type: boolean
         default: true
-      version-number:
-        description: Version number to release this as (use `latest` for main branch)
-        required: true
-        type: string
-      notify-emails:
-        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
-        required: true
-        type: string
-      aws-region:
-        description: AWS region
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: true
+      docs-version-override:
+        description: Docs version if commit is not tagged
         required: false
         type: string
-        default: us-east-1
+        default: ""
+      update-version-picker:
+        description: Update version picker.
+        required: false
+        type: boolean
+        default: true
+      notify-emails:
+        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      dry-run:
+        description: Whether to run the workflow in dry-run mode
+        required: true
+        type: boolean
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: true
+      docs-version-override:
+        description: Docs version if commit is not tagged
+        required: false
+        type: string
+        default: ""
+      update-version-picker:
+        description: Update version picker.
+        required: false
+        type: boolean
+        default: true
+      notify-emails:
+        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
+        required: false
+        type: string
+    secrets:
+      AWS_ASSUME_ROLE_ARN:
+        required: false
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      AKAMAI_HOST:
+        required: false
+      AKAMAI_CLIENT_TOKEN:
+        required: false
+      AKAMAI_CLIENT_SECRET:
+        required: false
+      AKAMAI_ACCESS_TOKEN:
+        required: false
+      S3_BUCKET_NAME:
+        required: false
 
 jobs:
   build-docs:
@@ -47,7 +95,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.67.2
+          ref: v0.72.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs
@@ -60,11 +108,13 @@ jobs:
           dry-run: ${{ inputs.dry-run }}
           artifacts-name: docs-html
           artifacts-path: _build/html
-          emails-csv: ${{ inputs.notify-emails }}
-          overwrite-latest-on-tag: false
+          emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
+          overwrite-latest-on-tag: ${{ inputs.publish-as-latest }}
+          docs-version-override: ${{ inputs.docs-version-override }}
+          update-version-picker: ${{ inputs.update-version-picker }}
           run-on-version-tag-only: ${{ github.ref_name != 'main' }}
-          request-name: megatron-bridge-publish-docs-${{ github.run_id }}
-          aws-region: ${{ inputs.aws-region }}
+          request-name: nemo-evaluator-publish-docs-${{ github.run_id }}
+          aws-region: ${{ vars.DOCS_AWS_REGION }}
           aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2026, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,12 +39,18 @@ on:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
+      github-ref:
+        description: Github ref to checkout
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       dry-run:
         description: Whether to run the workflow in dry-run mode
-        required: true
+        required: false
         type: boolean
+        default: true
       publish-as-latest:
         description: Publish as Latest stable version.
         required: false
@@ -64,6 +70,11 @@ on:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
+      github-ref:
+        description: Github ref to checkout
+        required: false
+        type: string
+        default: ""
     secrets:
       AWS_ASSUME_ROLE_ARN:
         required: false
@@ -84,8 +95,9 @@ on:
 
 jobs:
   build-docs:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.66.6
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.67.0
     with:
+      ref: ${{ inputs.github-ref }}
       requirements-file: .github/config/requirements.txt
 
   publish-docs:
@@ -95,15 +107,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.72.0
+          ref: v0.74.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs
-        # This workflow runs either on main, or on a version tag. Any other git ref will lead
-        # to an error.
-        # If its on main, it will publish to "latest" directory in Akamai.
-        # If its on a versioned tag, it will extract the version number from the tag (strip `v` prefix)
-        # and publish to the versioned directory in Akamai.
         with:
           dry-run: ${{ inputs.dry-run }}
           artifacts-name: docs-html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -197,7 +197,7 @@ html_theme = "nvidia_sphinx_theme"
 
 html_theme_options = {
     "switcher": {
-        "json_url": "./versions1.json",
+        "json_url": "../versions1.json",
         "version_match": release,
     },
     # Configure PyData theme search

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,12 +26,10 @@ import sys
 # Add custom extensions directory to Python path
 sys.path.insert(0, os.path.abspath("_extensions"))
 
-from nemo_evaluator_launcher.package_info import __version__
-
 project = "NeMo Evaluator SDK"
 copyright = "2025, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = __version__
+release = "0.2.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemo-evaluator", "version": "0.1.0"}
+{"name": "nemo-evaluator", "version": "0.2.5"}

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,7 +1,17 @@
 [
-    {
-        "preferred": true,
-        "version": "0.1.0",
-        "url": "../0.1.0"
-    }
+  {
+    "version": "nightly",
+    "url": "https://docs.nvidia.com/nemo/evaluator/nightly/"
+  },
+  {
+    "name": "0.2.5 (latest)",
+    "version": "0.2.5",
+    "url": "https://docs.nvidia.com/nemo/evaluator/latest/",
+    "preferred": true
+  },
+  {
+    "name": "0.1.0",
+    "version": "0.1.0",
+    "url": "https://docs.nvidia.com/nemo/evaluator/0.1.0/"
+  }
 ]


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Backports three fixes from `main` to `r0.2.5`:

- `json_url`: `./versions1.json` → `../versions1.json` in the Sphinx theme switcher
- `release`: removes dynamic `__version__` import, replaces with static `"0.2.5"`
- `docs/project.json`: updates stale version `"0.1.0"` → `"0.2.5"`
- `release-docs.yml`: backports full workflow from main (adds `workflow_call` trigger, `publish-as-latest`/`docs-version-override`/`update-version-picker` inputs, explicit secret declarations, `v0.72.0` template ref, fixed `request-name`)

</details>