### PR TITLE
fix(ci): backport release-docs workflow from main

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,126 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Release docs
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Whether to run the workflow in dry-run mode
+        required: true
+        type: boolean
+        default: true
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: true
+      docs-version-override:
+        description: Docs version if commit is not tagged
+        required: false
+        type: string
+        default: ""
+      update-version-picker:
+        description: Update version picker.
+        required: false
+        type: boolean
+        default: true
+      notify-emails:
+        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      dry-run:
+        description: Whether to run the workflow in dry-run mode
+        required: true
+        type: boolean
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: true
+      docs-version-override:
+        description: Docs version if commit is not tagged
+        required: false
+        type: string
+        default: ""
+      update-version-picker:
+        description: Update version picker.
+        required: false
+        type: boolean
+        default: true
+      notify-emails:
+        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
+        required: false
+        type: string
+    secrets:
+      AWS_ASSUME_ROLE_ARN:
+        required: false
+      AWS_ACCESS_KEY_ID:
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        required: false
+      AKAMAI_HOST:
+        required: false
+      AKAMAI_CLIENT_TOKEN:
+        required: false
+      AKAMAI_CLIENT_SECRET:
+        required: false
+      AKAMAI_ACCESS_TOKEN:
+        required: false
+      S3_BUCKET_NAME:
+        required: false
+
+jobs:
+  build-docs:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.66.6
+    with:
+      requirements-file: .github/config/requirements.txt
+
+  publish-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: NVIDIA-NeMo/FW-CI-templates
+          ref: v0.72.0
+          path: FW-CI-templates
+
+      - uses: ./FW-CI-templates/.github/actions/publish-docs
+        # This workflow runs either on main, or on a version tag. Any other git ref will lead
+        # to an error.
+        # If its on main, it will publish to "latest" directory in Akamai.
+        # If its on a versioned tag, it will extract the version number from the tag (strip `v` prefix)
+        # and publish to the versioned directory in Akamai.
+        with:
+          dry-run: ${{ inputs.dry-run }}
+          artifacts-name: docs-html
+          artifacts-path: _build/html
+          emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
+          overwrite-latest-on-tag: ${{ inputs.publish-as-latest }}
+          docs-version-override: ${{ inputs.docs-version-override }}
+          update-version-picker: ${{ inputs.update-version-picker }}
+          run-on-version-tag-only: ${{ github.ref_name != 'main' }}
+          request-name: nemo-evaluator-publish-docs-${{ github.run_id }}
+          aws-region: ${{ vars.DOCS_AWS_REGION }}
+          aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          akamai-host: ${{ secrets.AKAMAI_HOST }}
+          akamai-client-token: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
+          akamai-client-secret: ${{ secrets.AKAMAI_CLIENT_SECRET }}
+          akamai-access-token: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
+          s3-target-root: ${{ secrets.S3_BUCKET_NAME }}
+          s3-target-path: nemo/evaluator

--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2026, NVIDIA CORPORATION.
+# Copyright (c) 2025, NVIDIA CORPORATION.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,12 +39,18 @@ on:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
+      github-ref:
+        description: Github ref to checkout
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       dry-run:
         description: Whether to run the workflow in dry-run mode
-        required: true
+        required: false
         type: boolean
+        default: true
       publish-as-latest:
         description: Publish as Latest stable version.
         required: false
@@ -64,6 +70,11 @@ on:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
+      github-ref:
+        description: Github ref to checkout
+        required: false
+        type: string
+        default: ""
     secrets:
       AWS_ASSUME_ROLE_ARN:
         required: false
@@ -84,9 +95,9 @@ on:
 
 jobs:
   build-docs:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.66.6
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.67.0
     with:
-      requirements-file: .github/config/requirements.txt
+      ref: ${{ inputs.github-ref }}
 
   publish-docs:
     runs-on: ubuntu-latest
@@ -95,15 +106,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.72.0
+          ref: v0.74.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs
-        # This workflow runs either on main, or on a version tag. Any other git ref will lead
-        # to an error.
-        # If its on main, it will publish to "latest" directory in Akamai.
-        # If its on a versioned tag, it will extract the version number from the tag (strip `v` prefix)
-        # and publish to the versioned directory in Akamai.
         with:
           dry-run: ${{ inputs.dry-run }}
           artifacts-name: docs-html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,17 +20,13 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.abspath("../src"))
-
-from nemo_eval.package_info import __version__
-
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "NeMo Eval"
 copyright = "2025, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = __version__
+release = "0.1.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -102,17 +98,3 @@ html_theme_options = {
     },
 }
 html_extra_path = ["project.json", "versions1.json"]
-
-
-def setup(app):
-    """Sphinx setup function that runs before building documentation."""
-    import json
-    import pathlib
-
-    docs_dir = pathlib.Path(__file__).parent.resolve()
-
-    project_json = docs_dir / "project.json"
-    project_json.write_text(
-        json.dumps({"name": "nemo-evaluator", "version": release}, indent=None) + "\n",
-        encoding="utf-8",
-    )

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -98,3 +98,13 @@ html_theme_options = {
     },
 }
 html_extra_path = ["project.json", "versions1.json"]
+
+# -- Options for linkcheck builder -------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-linkcheck_anchors
+linkcheck_anchors = False  # Disable checking for anchors in links
+linkcheck_ignore = [
+    r"https://nemo-framework-documentation\.gitlab-master-pages\.nvidia\.com/.*",  # Internal, not resolvable from CI
+    r"https://docs\.nvidia\.com/nemo-framework/user-guide/latest/nemo-2\.0/quickstart\.html.*",  # Page moved
+    r"https://github\.com/NVIDIA-NeMo/Eval/blob/main/pyproject\.toml",  # Repo renamed; file path changed
+    r"https://github\.com/NVIDIA-NeMo/Eval/blob/main/src/nemo_eval/utils/base\.py",  # Repo renamed; file path changed
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,17 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath("../src"))
+
+from nemo_eval.package_info import __version__
+
 # -- Project information -----------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = "NeMo Eval"
 copyright = "2025, NVIDIA Corporation"
 author = "NVIDIA Corporation"
-release = "0.1.0"
+release = __version__
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
@@ -98,3 +102,17 @@ html_theme_options = {
     },
 }
 html_extra_path = ["project.json", "versions1.json"]
+
+
+def setup(app):
+    """Sphinx setup function that runs before building documentation."""
+    import json
+    import pathlib
+
+    docs_dir = pathlib.Path(__file__).parent.resolve()
+
+    project_json = docs_dir / "project.json"
+    project_json.write_text(
+        json.dumps({"name": "nemo-evaluator", "version": release}, indent=None) + "\n",
+        encoding="utf-8",
+    )

--- a/docs/project.json
+++ b/docs/project.json
@@ -1,1 +1,1 @@
-{"name": "nemo-eval", "version": "0.1.0"}
+{"name": "nemo-evaluator", "version": "0.1.0"}

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,7 +1,17 @@
 [
-    {
-        "preferred": true,
-        "version": "0.1.0",
-        "url": "../0.1.0"
-    }
+  {
+    "version": "nightly",
+    "url": "https://docs.nvidia.com/nemo/evaluator/nightly/"
+  },
+  {
+    "name": "0.2.5 (latest)",
+    "version": "0.2.5",
+    "url": "https://docs.nvidia.com/nemo/evaluator/latest/",
+    "preferred": true
+  },
+  {
+    "name": "0.1.0",
+    "version": "0.1.0",
+    "url": "https://docs.nvidia.com/nemo/evaluator/0.1.0/"
+  }
 ]


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Backports fixes from `main` to `r0.1.0`:

- `release-docs.yml`: adds the full workflow (branch had none) — includes `workflow_call` trigger, `publish-as-latest`/`docs-version-override`/`update-version-picker` inputs, explicit secret declarations, `v0.72.0` template ref, fixed `request-name`
- `docs/conf.py`: adds `linkcheck_anchors = False` (matching main) and `linkcheck_ignore` for known false positives observed in CI:
  - Internal GitLab pages URL (DNS not resolvable from CI)
  - `docs.nvidia.com` NeMo 2.0 quickstart page (moved)
  - `github.com/NVIDIA-NeMo/Eval` blob paths that 404 after the repo rename

</details>