### PR TITLE
fix(ci): upgrade release-docs to v0.74.0 + add github-ref input

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -39,6 +39,11 @@ on:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
+      github-ref:
+        description: Github ref to checkout
+        required: false
+        type: string
+        default: ""
   workflow_call:
     inputs:
       dry-run:
@@ -64,6 +69,11 @@ on:
         description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
         required: false
         type: string
+      github-ref:
+        description: Github ref to checkout
+        required: false
+        type: string
+        default: ""
     secrets:
       AWS_ASSUME_ROLE_ARN:
         required: false
@@ -84,8 +94,9 @@ on:
 
 jobs:
   build-docs:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.66.6
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.67.0
     with:
+      ref: ${{ inputs.github-ref }}
       requirements-file: .github/config/requirements.txt
 
   publish-docs:
@@ -95,7 +106,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           repository: NVIDIA-NeMo/FW-CI-templates
-          ref: v0.72.0
+          ref: v0.74.0
           path: FW-CI-templates
 
       - uses: ./FW-CI-templates/.github/actions/publish-docs

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,17 +1,17 @@
 [
-    {
-        "name": "nightly",
-        "version": "nightly",
-        "url": "../nightly"
-    },
-    {
-        "name": "0.2.5 (latest)",
-        "preferred": true,
-        "version": "0.2.5",
-        "url": "../0.2.5"
-    },
-    {
-        "version": "0.1.0",
-        "url": "../0.1.0"
-    }
+  {
+    "version": "nightly",
+    "url": "https://docs.nvidia.com/nemo/evaluator/nightly/"
+  },
+  {
+    "name": "0.2.5 (latest)",
+    "version": "0.2.5",
+    "url": "https://docs.nvidia.com/nemo/evaluator/latest/",
+    "preferred": true
+  },
+  {
+    "name": "0.1.0",
+    "version": "0.1.0",
+    "url": "https://docs.nvidia.com/nemo/evaluator/0.1.0/"
+  }
 ]


### PR DESCRIPTION
<details><summary>Claude summary</summary>

Two fixes for `main` (nightly):

**`release-docs.yml`** — upgrades to match Megatron-Bridge:
- `_build_docs.yml`: `v0.66.6` → `v0.67.0` (adds `ref` input support)
- `publish-docs` action: `v0.72.0` → `v0.74.0` (adds native `update-version-picker` support; at `v0.72.0` this was unrecognised and nothing published when using `docs-version-override` + `run-on-version-tag-only: true`)
- Adds `github-ref` input to both `workflow_dispatch` and `workflow_call`

**`docs/versions1.json`** — fixes relative URLs (`../nightly`, `../0.2.5`, `../0.1.0`) → absolute `docs.nvidia.com` URLs. The nightly docs publish runs daily with `update-version-picker: true`, so this file is uploaded to the docs root on every nightly run. With relative URLs it was overwriting the root and breaking the version picker for all published versions (including `0.1.0` and `0.2.5`).

</details>