### PR TITLE
feat(scoring): expose item/sample/jinja_context on ScorerInput 

### DIFF
--- a/src/nemo_evaluator/scoring/contracts.py
+++ b/src/nemo_evaluator/scoring/contracts.py
@@ -315,27 +315,21 @@ class TemplateMetric(BaseModel):
     def _render(self, template: str, input: MetricInput) -> str:
         """Render a Jinja2 template against a :class:`MetricInput`.
 
-        The rendering context exposes both NEL-native names and SDK-native
-        aliases, so templates authored against either vocabulary work::
+        Uses :meth:`MetricInput.jinja_context` so both NEL-native and
+        NMP-native template vocabularies work::
 
             # NEL-native
             "{{ response }}", "{{ target }}", "{{ metadata.<key> }}"
-            # SDK-native aliases
+            # NMP-native
+            "{{ item.reference }}", "{{ sample.output_text }}"
+            # Aliases for compatibility
             "{{ output_text }}"  (== response)
             "{{ reference }}"    (== target)
 
         Raises :class:`jinja2.exceptions.UndefinedError` if the template
         references a variable not in the context (strict mode).
         """
-        ctx: dict[str, Any] = {
-            "response": input.response,
-            "target": input.target,
-            "output_text": input.response,
-            "reference": input.target,
-            "metadata": dict(input.metadata or {}),
-            "config": dict(input.config or {}),
-        }
-        return self._jinja_env.from_string(template).render(**ctx)
+        return self._jinja_env.from_string(template).render(**input.jinja_context())
 
 
 # ============================================================================

--- a/src/nemo_evaluator/scoring/types.py
+++ b/src/nemo_evaluator/scoring/types.py
@@ -25,12 +25,38 @@ if TYPE_CHECKING:
 
 @dataclass
 class ScorerInput:
-    """Input passed to scorer functions.
+    """Input passed to scorer functions and object-style metrics.
 
-    The ``sandbox`` field is available for scorers that need to inspect or
-    execute commands inside a per-problem sandbox (e.g., running test suites
-    after an agent modifies code).  Existing scorers that don't use it are
-    unaffected -- the field defaults to ``None``.
+    Two access idioms are supported:
+
+    **NEL-native (function-style scorers)** — named fields::
+
+        sample.response           # model output
+        sample.target             # ground truth
+        sample.metadata[...]      # per-row dataset extras
+        sample.config[...]        # per-benchmark settings (legacy)
+
+    **NMP-native (object-style metrics)** — dict namespaces::
+
+        sample.item[...]          # full dataset row (target + metadata)
+        sample.sample[...]        # full inference payload (output_text, response)
+
+    The dict namespaces (:attr:`item`, :attr:`sample`) are derived from the
+    named fields; there is a single source of truth. The :meth:`jinja_context`
+    helper produces a rendering context compatible with both NEL-native
+    (``{{ response }}``, ``{{ target }}``, ``{{ metadata.x }}``) and
+    NMP-native (``{{ item.reference }}``, ``{{ sample.output_text }}``)
+    template vocabularies — so Jinja templates authored against either shape
+    work without modification.
+
+    The ``sandbox`` field is NEL-specific (no NMP equivalent) — for scorers
+    that need to execute commands inside a per-problem container (e.g.,
+    running test suites after an agent modifies code). Defaults to ``None``.
+
+    Roadmap: the primary fields will flip at v1.0 — ``item`` and ``sample``
+    become authoritative, ``response`` / ``target`` / ``metadata`` / ``config``
+    become legacy accessors. Existing downstream code keeps working through
+    deprecation; see the integration RFC for the migration plan.
     """
 
     response: str
@@ -38,3 +64,56 @@ class ScorerInput:
     metadata: dict[str, Any] = field(default_factory=dict)
     config: dict[str, Any] = field(default_factory=dict)
     sandbox: Sandbox | None = None
+
+    @property
+    def item(self) -> dict[str, Any]:
+        """Dataset-row view of the input (NMP-native access).
+
+        Constructed as ``{"reference": self.target, **self.metadata}``.
+        NMP metric authors who template with ``{{ item.reference }}`` or
+        ``{{ item.<custom_field> }}`` can access their expected shape
+        through this property.
+        """
+        return {"reference": self.target, **self.metadata}
+
+    @property
+    def sample(self) -> dict[str, Any]:
+        """Inference-payload view of the input (NMP-native access).
+
+        Constructed as ``{"output_text": self.response, "response": self.response}``.
+        NMP metric authors who template with ``{{ sample.output_text }}`` or
+        read ``sample["output_text"]`` directly get their expected shape.
+        """
+        return {"output_text": self.response, "response": self.response}
+
+    def jinja_context(self) -> dict[str, Any]:
+        """Build a Jinja rendering context supporting both NEL and NMP vocabularies.
+
+        Returned dict includes:
+
+        - Flat keys from :attr:`item` and :attr:`sample` (so
+          ``{{ reference }}`` and ``{{ output_text }}`` work)
+        - Explicit ``item`` and ``sample`` namespaces (so
+          ``{{ item.reference }}`` and ``{{ sample.output_text }}`` work)
+        - NEL-native aliases: ``response``, ``target``, ``metadata``,
+          ``config`` (so ``{{ response }}`` and ``{{ target }}`` work)
+
+        Use this as the rendering context when rendering templates defined
+        on metric classes that need to support both vocabularies::
+
+            from jinja2 import Environment
+            ctx = scorer_input.jinja_context()
+            rendered = Environment().from_string(template).render(**ctx)
+        """
+        item = self.item
+        sample = self.sample
+        return {
+            **item,
+            **sample,
+            "item": item,
+            "sample": sample,
+            "response": self.response,
+            "target": self.target,
+            "metadata": self.metadata,
+            "config": self.config,
+        }

--- a/tests/test_scoring/test_scorer_input_nmp_shape.py
+++ b/tests/test_scoring/test_scorer_input_nmp_shape.py
@@ -1,0 +1,169 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for NMP-shape access on :class:`ScorerInput`.
+
+This is Phase 1 of the ScorerInput → NMP shape migration. The named NEL
+fields (``response``, ``target``, ``metadata``, ``config``, ``sandbox``)
+remain the authoritative source. We add derived properties :attr:`item`
+and :attr:`sample`, plus a :meth:`jinja_context` helper, so NMP-style
+metric classes and Jinja templates can read the input in their native
+vocabulary without any change to NEL's existing scorer functions.
+
+See also: the integration RFC (`Metrics resolution and Milestone 1`).
+"""
+
+from __future__ import annotations
+
+from jinja2 import Environment, StrictUndefined
+
+from nemo_evaluator.scoring.types import ScorerInput
+
+
+# ---------------------------------------------------------------------------
+# .item property — NMP-native dataset-row view
+# ---------------------------------------------------------------------------
+
+
+def test_item_contains_reference_from_target():
+    s = ScorerInput(response="foo", target="bar")
+    assert s.item == {"reference": "bar"}
+
+
+def test_item_merges_metadata():
+    s = ScorerInput(
+        response="foo",
+        target="bar",
+        metadata={"problem_id": 42, "category": "safety"},
+    )
+    assert s.item == {"reference": "bar", "problem_id": 42, "category": "safety"}
+
+
+def test_item_does_not_leak_config_or_response():
+    s = ScorerInput(response="r", target="t", metadata={"m": 1}, config={"c": 2})
+    assert "c" not in s.item
+    assert "response" not in s.item
+    assert "output_text" not in s.item
+
+
+def test_item_reference_key_can_be_overridden_via_metadata():
+    """If metadata already has a 'reference' key, it overrides target — callers
+    with their own target-field conventions can populate metadata directly."""
+    s = ScorerInput(
+        response="foo",
+        target="ignored",
+        metadata={"reference": "from-metadata"},
+    )
+    assert s.item["reference"] == "from-metadata"
+
+
+# ---------------------------------------------------------------------------
+# .sample property — NMP-native inference-payload view
+# ---------------------------------------------------------------------------
+
+
+def test_sample_contains_output_text_from_response():
+    s = ScorerInput(response="hello world", target="irrelevant")
+    assert s.sample["output_text"] == "hello world"
+    assert s.sample["response"] == "hello world"
+
+
+def test_sample_does_not_leak_target_or_metadata():
+    s = ScorerInput(response="r", target="t", metadata={"m": 1})
+    assert "target" not in s.sample
+    assert "m" not in s.sample
+    assert "reference" not in s.sample
+
+
+# ---------------------------------------------------------------------------
+# .jinja_context() — template rendering context
+# ---------------------------------------------------------------------------
+
+
+def test_jinja_context_exposes_flat_nel_keys():
+    s = ScorerInput(response="r", target="t", metadata={"m": 1}, config={"c": 2})
+    ctx = s.jinja_context()
+    assert ctx["response"] == "r"
+    assert ctx["target"] == "t"
+    assert ctx["metadata"] == {"m": 1}
+    assert ctx["config"] == {"c": 2}
+
+
+def test_jinja_context_exposes_flat_nmp_keys():
+    s = ScorerInput(response="model output", target="ground truth")
+    ctx = s.jinja_context()
+    assert ctx["reference"] == "ground truth"
+    assert ctx["output_text"] == "model output"
+
+
+def test_jinja_context_exposes_item_and_sample_namespaces():
+    s = ScorerInput(
+        response="model output",
+        target="ground truth",
+        metadata={"problem_id": 7},
+    )
+    ctx = s.jinja_context()
+    assert ctx["item"] == {"reference": "ground truth", "problem_id": 7}
+    assert ctx["sample"] == {"output_text": "model output", "response": "model output"}
+
+
+def test_jinja_render_nel_native_template():
+    """NEL-native templates render unchanged."""
+    s = ScorerInput(response="hi", target="hello", metadata={"k": "v"})
+    env = Environment(undefined=StrictUndefined)
+    out = env.from_string("{{ response }} / {{ target }} / {{ metadata.k }}").render(
+        **s.jinja_context()
+    )
+    assert out == "hi / hello / v"
+
+
+def test_jinja_render_nmp_native_template():
+    """NMP-style templates using item/sample namespaces render unchanged."""
+    s = ScorerInput(
+        response="model said this",
+        target="gold answer",
+        metadata={"problem_id": 42, "context": "paragraph"},
+    )
+    env = Environment(undefined=StrictUndefined)
+    template = "ref={{ item.reference }} | out={{ sample.output_text }} | id={{ item.problem_id }}"
+    out = env.from_string(template).render(**s.jinja_context())
+    assert out == "ref=gold answer | out=model said this | id=42"
+
+
+def test_jinja_render_mixed_vocabulary_template():
+    """A template mixing NEL and NMP names renders consistently."""
+    s = ScorerInput(response="A", target="B")
+    env = Environment(undefined=StrictUndefined)
+    out = env.from_string("{{ response }}-{{ reference }}-{{ output_text }}-{{ target }}").render(
+        **s.jinja_context()
+    )
+    # response == output_text == "A"; target == reference == "B"
+    assert out == "A-B-A-B"
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: existing named-field access still works
+# ---------------------------------------------------------------------------
+
+
+def test_existing_field_access_unchanged():
+    """E2e guarantee: code reading .response / .target / .metadata / .config /
+    .sandbox works exactly as before. Phase 1 only adds properties."""
+    s = ScorerInput(
+        response="r",
+        target="t",
+        metadata={"m": 1},
+        config={"c": 2},
+    )
+    assert s.response == "r"
+    assert s.target == "t"
+    assert s.metadata == {"m": 1}
+    assert s.config == {"c": 2}
+    assert s.sandbox is None
+
+
+def test_dataclass_construction_accepts_only_required_fields():
+    """Minimal construction still works — properties are opt-in."""
+    s = ScorerInput(response="r", target="t")
+    assert s.item == {"reference": "t"}
+    assert s.sample == {"output_text": "r", "response": "r"}


### PR DESCRIPTION

Phase 1 of the ScorerInput → NMP-shape migration ("Option B"): add derived properties so NMP-style metrics can read the input in their native vocabulary without breaking any existing NEL scorer code.

Changes on ScorerInput:

- New property .item: returns {"reference": target, **metadata}. Gives NMP metric code natural access: sample.item["reference"], sample.item["custom_dataset_field"], etc.

- New property .sample: returns {"output_text": response, "response": response}. NMP's canonical inference-payload shape.

- New method .jinja_context(): builds a Jinja rendering context exposing both NEL-native ({{ response }}, {{ target }}, {{ metadata.x }}) and NMP-native ({{ item.reference }}, {{ sample.output_text }}) vocabularies. Both template idioms render against the same context.

Changes on TemplateMetric:

- _render(template, input) now uses input.jinja_context() internally. Concrete TemplateMetric subclasses authored against either vocabulary work without modification.

No breaking change. Existing fields (response, target, metadata, config, sandbox) remain authoritative — item/sample are derived views. 109 ScorerInput-dependent tests pass (contracts, ergonomics, byob, scorer_input_nmp_shape, benchmark_definitions, scoring_code_execution, environments).

Roadmap: the primary fields will flip at v1.0 — item/sample become authoritative, response/target/metadata/config become legacy accessors. This PR is the safe intermediate step that unblocks NMP's SDK migration to use input.item[...] / input.sample[...] directly from day one.

Tests: 14 new tests in test_scorer_input_nmp_shape.py covering:
- .item / .sample derivation + field isolation
- .jinja_context() exposes all NEL + NMP vocabularies
- NEL-native, NMP-native, and mixed templates render correctly
- All existing .response / .target / .metadata / .config / .sandbox access works unchanged