### PR TITLE
chore(launcher): add exclude_patterns to mlflow exporter (EVAL-632)

### DIFF
--- a/docs/libraries/nemo-evaluator-launcher/exporters/mlflow.md
+++ b/docs/libraries/nemo-evaluator-launcher/exporters/mlflow.md
@@ -271,7 +271,7 @@ nemo-evaluator-launcher export 8abcd123 --dest mlflow --log-metrics accuracy pas
   - `true`
 * - `exclude_patterns`
   - list[str]
-  - Extra glob-style patterns (matched on basename, case-insensitive) to exclude from artifact upload, in addition to the always-on defaults (`*cache*`, `*.db`, `*.lock`, `synthetic`, `debug.json`, ...). Useful when `only_required: false` and you want to drop large sub-directories such as `deliverables`. Same pattern syntax as the defaults: `*foo*` (contains), `*foo` (suffix), `foo` (exact).
+  - Extra patterns (extends `EXCLUDED_PATTERNS`) to skip during artifact upload. See [Excluding extra artifacts](#excluding-extra-artifacts).
   - `[]`
 * - `log_config_params`
   - bool
@@ -281,4 +281,23 @@ nemo-evaluator-launcher export 8abcd123 --dest mlflow --log-metrics accuracy pas
   - int
   - Max depth for nested config params logging
   - `10`
+```
+
+(excluding-extra-artifacts)=
+
+## Excluding extra artifacts
+
+Use `exclude_patterns` to extend the hardcoded `EXCLUDED_PATTERNS` defaults (defined in `nemo_evaluator_launcher.exporters.utils`) with patterns of your own. Match is on basename, case-insensitive, using `fnmatch.fnmatchcase` — so `*`, `?`, and `[seq]` character classes all work.
+
+**Applied only when `only_required: false`.** Under `only_required: true` the exporter uploads a fixed list of required artifacts (`results.yml`, `eval_factory_metrics.json`, `omni-info.json`, ...) and the patterns are not consulted.
+
+```yaml
+export:
+  mlflow:
+    tracking_uri: "http://mlflow.example.com:5000"
+    only_required: false
+    copy_artifacts: true
+    exclude_patterns:
+      - deliverables           # drop the gdpval deliverables sub-tree
+      - "*.parquet"            # drop large columnar dumps
 ```

--- a/docs/libraries/nemo-evaluator-launcher/exporters/mlflow.md
+++ b/docs/libraries/nemo-evaluator-launcher/exporters/mlflow.md
@@ -269,6 +269,10 @@ nemo-evaluator-launcher export 8abcd123 --dest mlflow --log-metrics accuracy pas
   - bool
   - Copy only required artifacts
   - `true`
+* - `exclude_patterns`
+  - list[str]
+  - Extra glob-style patterns (matched on basename, case-insensitive) to exclude from artifact upload, in addition to the always-on defaults (`*cache*`, `*.db`, `*.lock`, `synthetic`, `debug.json`, ...). Useful when `only_required: false` and you want to drop large sub-directories such as `deliverables`. Same pattern syntax as the defaults: `*foo*` (contains), `*foo` (suffix), `foo` (exact).
+  - `[]`
 * - `log_config_params`
   - bool
   - Include flattened configuration settings in run parameters

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
@@ -56,6 +56,7 @@ class MLflowExporterConfig(ExportConfig):
     description: Optional[str] = Field(default=None)
     tags: Optional[Dict[str, str]] = Field(default=None)
     extra_metadata: Optional[Dict[str, Any]] = Field(default=None)
+    exclude_patterns: List[str] = Field(default_factory=list)
 
     @model_validator(mode="before")
     @classmethod
@@ -299,7 +300,7 @@ class MLflowExporter(BaseExporter):
                 shutil.copytree(
                     job_data.artifacts_dir,
                     staged,
-                    ignore=get_copytree_ignore(),
+                    ignore=get_copytree_ignore(self.config.exclude_patterns),
                     dirs_exist_ok=True,
                 )
                 # Upload entire staged directory

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/utils.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/utils.py
@@ -20,7 +20,7 @@ import re
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
 import yaml
 
@@ -99,10 +99,14 @@ def get_relevant_artifacts() -> List[str]:
     return REQUIRED_ARTIFACTS + OPTIONAL_ARTIFACTS
 
 
-def should_exclude_artifact(name: str) -> bool:
-    """Check if artifact should be excluded based on glob patterns."""
+def should_exclude_artifact(name: str, extra_patterns: Sequence[str] = ()) -> bool:
+    """Check if artifact should be excluded based on glob patterns.
+
+    ``extra_patterns`` extends (does not replace) the always-on
+    ``EXCLUDED_PATTERNS`` defaults; same glob style is used for both.
+    """
     name_lower = name.lower()
-    for pattern in EXCLUDED_PATTERNS:
+    for pattern in (*EXCLUDED_PATTERNS, *extra_patterns):
         p = pattern.lower()
         if p.startswith("*") and p.endswith("*"):
             # *cache* - contains match
@@ -118,11 +122,15 @@ def should_exclude_artifact(name: str) -> bool:
     return False
 
 
-def get_copytree_ignore() -> Callable[[str, List[str]], List[str]]:
+def get_copytree_ignore(
+    extra_patterns: Sequence[str] = (),
+) -> Callable[[str, List[str]], List[str]]:
     """Return ignore function for shutil.copytree() that excludes artifacts recursively."""
 
     def ignore_func(directory: str, contents: List[str]) -> List[str]:
-        return [name for name in contents if should_exclude_artifact(name)]
+        return [
+            name for name in contents if should_exclude_artifact(name, extra_patterns)
+        ]
 
     return ignore_func
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/utils.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/utils.py
@@ -15,6 +15,7 @@
 #
 """Shared utilities for metrics and configuration handling."""
 
+import fnmatch
 import hashlib
 import re
 import subprocess
@@ -100,26 +101,18 @@ def get_relevant_artifacts() -> List[str]:
 
 
 def should_exclude_artifact(name: str, extra_patterns: Sequence[str] = ()) -> bool:
-    """Check if artifact should be excluded based on glob patterns.
+    """Check if artifact should be excluded based on fnmatch-style patterns.
 
-    ``extra_patterns`` extends (does not replace) the always-on
-    ``EXCLUDED_PATTERNS`` defaults; same glob style is used for both.
+    Match is on basename (case-insensitive) using ``fnmatch.fnmatchcase``,
+    so patterns support ``*`` (any run), ``?`` (single char), and ``[seq]``
+    character classes. ``extra_patterns`` extends (does not replace) the
+    always-on ``EXCLUDED_PATTERNS`` defaults.
     """
     name_lower = name.lower()
-    for pattern in (*EXCLUDED_PATTERNS, *extra_patterns):
-        p = pattern.lower()
-        if p.startswith("*") and p.endswith("*"):
-            # *cache* - contains match
-            if p[1:-1] in name_lower:
-                return True
-        elif p.startswith("*"):
-            # *.db, *.lock - suffix match
-            if name_lower.endswith(p[1:]):
-                return True
-        elif name_lower == p:
-            # exact match at any depth (synthetic, debug.json)
-            return True
-    return False
+    return any(
+        fnmatch.fnmatchcase(name_lower, pattern.lower())
+        for pattern in (*EXCLUDED_PATTERNS, *extra_patterns)
+    )
 
 
 def get_copytree_ignore(

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/exporters/test_mlflow_exporter.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/exporters/test_mlflow_exporter.py
@@ -15,6 +15,7 @@
 #
 """MLFlow exporter tests."""
 
+import os
 from unittest.mock import patch
 
 import pytest
@@ -175,6 +176,85 @@ class TestMLflowExporter:
         assert logged_params["config.deployment.model"] == "test-model"
         assert logged_params.get("launcher_command") == "nel run test004"
         assert "results_dir" in logged_params
+
+    def test_exclude_patterns_extend_default_exclusions(
+        self, monkeypatch, mlflow_fake, make_mlflow_job, tmp_path
+    ):
+        """exclude_patterns config knob extends EXCLUDED_PATTERNS during recursive upload."""
+        _ML, _RunCtx = mlflow_fake
+        jd = make_mlflow_job("test006")
+
+        artifacts_dir = tmp_path / "test006" / "test006.0" / "artifacts"
+        (artifacts_dir / "deliverables").mkdir()
+        (artifacts_dir / "deliverables" / "out.txt").write_text("payload")
+        (artifacts_dir / "kept_dir").mkdir()
+        (artifacts_dir / "kept_dir" / "data.json").write_text("{}")
+        # default exclusion (matches "*cache*") must still apply
+        (artifacts_dir / "lm_cache_rank0.db").write_text("cache")
+
+        staged_contents: list[str] = []
+
+        def fake_log_artifacts(local_dir, artifact_path=None):
+            staged_contents.extend(sorted(os.listdir(local_dir)))
+
+        monkeypatch.setattr(
+            "nemo_evaluator_launcher.exporters.mlflow.mlflow.log_artifacts",
+            fake_log_artifacts,
+            raising=False,
+        )
+
+        result = MLflowExporter(
+            {
+                "tracking_uri": "http://mlflow",
+                "only_required": False,
+                "copy_artifacts": True,
+                "exclude_patterns": ["deliverables"],
+            }
+        ).export([jd.job_id])
+        assert result.successful_jobs == [jd.job_id]
+        # User-supplied pattern wins
+        assert "deliverables" not in staged_contents
+        # Default exclusion still applies (extends, doesn't replace)
+        assert "lm_cache_rank0.db" not in staged_contents
+        # Untouched files survive
+        assert "kept_dir" in staged_contents
+        assert "results.yml" in staged_contents
+
+    def test_exclude_patterns_default_empty_preserves_behavior(
+        self, monkeypatch, mlflow_fake, make_mlflow_job, tmp_path
+    ):
+        """Without exclude_patterns, only the hardcoded defaults are excluded."""
+        _ML, _RunCtx = mlflow_fake
+        jd = make_mlflow_job("test007")
+
+        artifacts_dir = tmp_path / "test007" / "test007.0" / "artifacts"
+        (artifacts_dir / "deliverables").mkdir()
+        (artifacts_dir / "deliverables" / "out.txt").write_text("payload")
+        (artifacts_dir / "lm_cache_rank0.db").write_text("cache")
+
+        staged_contents: list[str] = []
+
+        def fake_log_artifacts(local_dir, artifact_path=None):
+            staged_contents.extend(sorted(os.listdir(local_dir)))
+
+        monkeypatch.setattr(
+            "nemo_evaluator_launcher.exporters.mlflow.mlflow.log_artifacts",
+            fake_log_artifacts,
+            raising=False,
+        )
+
+        result = MLflowExporter(
+            {
+                "tracking_uri": "http://mlflow",
+                "only_required": False,
+                "copy_artifacts": True,
+            }
+        ).export([jd.job_id])
+        assert result.successful_jobs == [jd.job_id]
+        # Default exclusion applies
+        assert "lm_cache_rank0.db" not in staged_contents
+        # No user-supplied pattern: deliverables stays
+        assert "deliverables" in staged_contents
 
     def test_log_config_params_with_max_depth(
         self, monkeypatch, mlflow_fake, make_mlflow_job

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/exporters/test_utils.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/exporters/test_utils.py
@@ -139,6 +139,76 @@ class TestArtifactExclusions:
         assert "task_output" not in excluded
         assert "report.json" not in excluded
 
+    def test_extra_patterns_extend_defaults(self):
+        """User-supplied patterns extend (not replace) the hardcoded defaults."""
+        # Defaults still apply when extra_patterns is provided
+        assert should_exclude_artifact("cache", extra_patterns=["deliverables"]) is True
+        assert (
+            should_exclude_artifact("data.db", extra_patterns=["deliverables"]) is True
+        )
+        # Extra exact-match pattern excludes
+        assert (
+            should_exclude_artifact("deliverables", extra_patterns=["deliverables"])
+            is True
+        )
+        # Unrelated names still pass through
+        assert (
+            should_exclude_artifact("results.yml", extra_patterns=["deliverables"])
+            is False
+        )
+
+    def test_extra_patterns_glob_styles(self):
+        """Extra patterns honor the same glob styles as EXCLUDED_PATTERNS."""
+        # *foo* contains-match
+        assert (
+            should_exclude_artifact(
+                "my_deliverable_x", extra_patterns=["*deliverable*"]
+            )
+            is True
+        )
+        # *foo suffix-match
+        assert (
+            should_exclude_artifact("trace.parquet", extra_patterns=["*.parquet"])
+            is True
+        )
+        # exact match
+        assert should_exclude_artifact("traces", extra_patterns=["traces"]) is True
+        assert should_exclude_artifact("traces_dir", extra_patterns=["traces"]) is False
+
+    def test_extra_patterns_case_insensitive(self):
+        """Extra patterns match case-insensitively, like the defaults."""
+        assert (
+            should_exclude_artifact("Deliverables", extra_patterns=["deliverables"])
+            is True
+        )
+        assert (
+            should_exclude_artifact("deliverables", extra_patterns=["DELIVERABLES"])
+            is True
+        )
+
+    def test_extra_patterns_default_unchanged(self):
+        """Calling without extra_patterns matches the original behaviour exactly."""
+        # Default-only call still excludes hardcoded patterns and lets others through
+        assert should_exclude_artifact("cache") is True
+        assert should_exclude_artifact("deliverables") is False
+
+    def test_get_copytree_ignore_with_extra_patterns(self):
+        """get_copytree_ignore threads extra_patterns into the returned filter."""
+        ignore_func = get_copytree_ignore(["deliverables", "*.parquet"])
+        contents = [
+            "results.yml",
+            "cache",  # default exclusion still applies
+            "deliverables",
+            "trace.parquet",
+            "report.json",
+        ]
+        excluded = ignore_func("/some/dir", contents)
+        assert "cache" in excluded
+        assert "deliverables" in excluded
+        assert "trace.parquet" in excluded
+        assert "results.yml" not in excluded
+        assert "report.json" not in excluded
+
 
 class TestArtifactUtils:
     def test_get_relevant_artifacts(self):

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/exporters/test_utils.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/exporters/test_utils.py
@@ -186,6 +186,24 @@ class TestArtifactExclusions:
             is True
         )
 
+    def test_extra_patterns_fnmatch_syntax(self):
+        """Full fnmatch syntax is supported: prefix, ?, character classes."""
+        # prefix-only (X*)
+        assert should_exclude_artifact("foo_bar", extra_patterns=["foo*"]) is True
+        assert should_exclude_artifact("bar_foo", extra_patterns=["foo*"]) is False
+        # single-character wildcard
+        assert should_exclude_artifact("file1", extra_patterns=["file?"]) is True
+        assert should_exclude_artifact("file12", extra_patterns=["file?"]) is False
+        # character class
+        assert (
+            should_exclude_artifact("rank0.txt", extra_patterns=["rank[0-3].txt"])
+            is True
+        )
+        assert (
+            should_exclude_artifact("rank9.txt", extra_patterns=["rank[0-3].txt"])
+            is False
+        )
+
     def test_extra_patterns_default_unchanged(self):
         """Calling without extra_patterns matches the original behaviour exactly."""
         # Default-only call still excludes hardcoded patterns and lets others through


### PR DESCRIPTION
what: [EVAL-632](https://linear.app/nvidia/issue/EVAL-632/update-exporter-cli-to-use-includeexclude-arguments): extends `should_exclude_artifact` / `get_copytree_ignore` with an optional `extra_patterns` kwarg, and adds an `exclude_patterns: list[str]` field to `MLflowExporterConfig` 

why: so users can suppress additional artifacts (e.g. GDPVal `deliverables/`) from upload without losing the hardcoded `EXCLUDED_PATTERNS` defaults. Default behaviour is preserved