### PR TITLE
ci: Ensure dependabot checkout does not have dupe credentials

### DIFF
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -93,6 +93,7 @@ jobs:
         with:
           token: ${{ secrets.PAT }}
           ref: ${{ env.TARGET_BRANCH }}
+          persist-credentials: false
 
       - name: Install GPG
         run: sudo apt-get install -y gnupg2


### PR DESCRIPTION
ci: Ensure dependabot checkout does not have dupe credentials

Potentially some behavior changed with this PR:
https://github.com/NVIDIA-NeMo/Evaluator/pull/881

We need to pass `persist-credentials: false` to the checkout step to not persist credentials for when the PR step happens and also adds credentials to the header.

Was able to manually run job on this branch:
https://github.com/NVIDIA-NeMo/Evaluator/pull/941
https://github.com/NVIDIA-NeMo/Evaluator/actions/runs/24998599211