### PR TITLE
feat(slurm): expose HEAD_NODE_IPS_CSV to eval client for per-instance…

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -1037,9 +1037,22 @@ def _create_slurm_sbatch_script(
     # bypass the haproxy load balancer. URLS_CSV is pre-formatted as
     # `http://ip1:<port>/v1,http://ip2:<port>/v1,...` and is the easier
     # variable to plug straight into `++policy_base_url=[$HEAD_NODE_URLS_CSV]`.
+    #
+    # On slurm + pyxis with env isolation, `--container-env VAR` only forwards
+    # the value if VAR is exported in the immediate parent shell of the srun
+    # command. They are exported earlier in
+    # `_generate_deployment_srun_command` after the per-instance loop, but
+    # ~hundreds of lines and a secrets-reexport block separate that export
+    # from the eval srun below. Re-export them here, right before the srun,
+    # following the same pattern that `build_reexport_commands` uses for
+    # YAML-declared env vars (HF_TOKEN, etc.).
     if cfg.deployment.type != "none" and cfg.execution.get("num_instances", 1) > 1:
         extra_eval_env_names.append("HEAD_NODE_IPS_CSV")
         extra_eval_env_names.append("HEAD_NODE_URLS_CSV")
+        s += (
+            'export HEAD_NODE_IPS_CSV="${HEAD_NODE_IPS_CSV}" ; '
+            'export HEAD_NODE_URLS_CSV="${HEAD_NODE_URLS_CSV}"\n'
+        )
     s += "srun --mpi pmix --overlap "
     s += '--nodelist "${PRIMARY_NODE}" --nodes 1 --ntasks 1 '
     s += "--container-image {} ".format(eval_image)

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -1031,6 +1031,11 @@ def _create_slurm_sbatch_script(
     if gpu_devices is not None:
         s += f"export NVIDIA_VISIBLE_DEVICES={gpu_devices}\n"
         extra_eval_env_names.append("NVIDIA_VISIBLE_DEVICES")
+    # Forward HEAD_NODE_IPS_CSV (set in `_generate_deployment_srun` when
+    # num_instances > 1) into the eval container so eval-side code can do
+    # per-instance routing if it wants to bypass the haproxy load balancer.
+    if cfg.deployment.type != "none" and cfg.execution.get("num_instances", 1) > 1:
+        extra_eval_env_names.append("HEAD_NODE_IPS_CSV")
     s += "srun --mpi pmix --overlap "
     s += '--nodelist "${PRIMARY_NODE}" --nodes 1 --ntasks 1 '
     s += "--container-image {} ".format(eval_image)
@@ -1971,6 +1976,13 @@ def _generate_deployment_srun_command(
     s += "    SERVER_PIDS+=($!)\n"
     s += "done\n\n"
 
+    # Export HEAD_NODE_IPS as a comma-separated string so it can be propagated
+    # via `--container-env` to the evaluation client. Eval-side code that wants
+    # to do its own per-instance routing (e.g. consistent-hashing requests from
+    # the same agentic trajectory to the same vLLM instance, bypassing the
+    # haproxy round-robin) can read $HEAD_NODE_IPS_CSV and address each head
+    # directly.
+    s += 'export HEAD_NODE_IPS_CSV=$(IFS=,; echo "${HEAD_NODE_IPS[*]}")\n'
     s += 'echo "HEAD_NODE_IPS: ${HEAD_NODE_IPS[@]}"\n'
     s += "SERVER_PID=${SERVER_PIDS[0]}  # reference to first instance PID for health check\n\n"
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -1031,11 +1031,15 @@ def _create_slurm_sbatch_script(
     if gpu_devices is not None:
         s += f"export NVIDIA_VISIBLE_DEVICES={gpu_devices}\n"
         extra_eval_env_names.append("NVIDIA_VISIBLE_DEVICES")
-    # Forward HEAD_NODE_IPS_CSV (set in `_generate_deployment_srun` when
-    # num_instances > 1) into the eval container so eval-side code can do
-    # per-instance routing if it wants to bypass the haproxy load balancer.
+    # Forward HEAD_NODE_IPS_CSV and HEAD_NODE_URLS_CSV (set in
+    # `_generate_deployment_srun` when num_instances > 1) into the eval
+    # container so eval-side code can do per-instance routing if it wants to
+    # bypass the haproxy load balancer. URLS_CSV is pre-formatted as
+    # `http://ip1:<port>/v1,http://ip2:<port>/v1,...` and is the easier
+    # variable to plug straight into `++policy_base_url=[$HEAD_NODE_URLS_CSV]`.
     if cfg.deployment.type != "none" and cfg.execution.get("num_instances", 1) > 1:
         extra_eval_env_names.append("HEAD_NODE_IPS_CSV")
+        extra_eval_env_names.append("HEAD_NODE_URLS_CSV")
     s += "srun --mpi pmix --overlap "
     s += '--nodelist "${PRIMARY_NODE}" --nodes 1 --ntasks 1 '
     s += "--container-image {} ".format(eval_image)
@@ -1983,7 +1987,17 @@ def _generate_deployment_srun_command(
     # haproxy round-robin) can read $HEAD_NODE_IPS_CSV and address each head
     # directly.
     s += 'export HEAD_NODE_IPS_CSV=$(IFS=,; echo "${HEAD_NODE_IPS[*]}")\n'
+    # Also export pre-formatted per-instance URLs so eval-side YAML can use
+    # `++policy_base_url=[$HEAD_NODE_URLS_CSV]` directly without bash sed
+    # juggling. Port comes from cfg.deployment.port (the same port the eval
+    # client would otherwise hit through haproxy).
+    deployment_port = cfg.deployment.get("port", 8000)
+    s += (
+        f'export HEAD_NODE_URLS_CSV=$(printf "http://%s:{deployment_port}/v1," '
+        f'"${{HEAD_NODE_IPS[@]}}" | sed "s/,$//")\n'
+    )
     s += 'echo "HEAD_NODE_IPS: ${HEAD_NODE_IPS[@]}"\n'
+    s += 'echo "HEAD_NODE_URLS_CSV: ${HEAD_NODE_URLS_CSV}"\n'
     s += "SERVER_PID=${SERVER_PIDS[0]}  # reference to first instance PID for health check\n\n"
 
     return s, is_potentially_unsafe, debug_comment

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -609,6 +609,61 @@ class TestSlurmExecutorFeatures:
         assert "proxy" not in script.lower()
 
     @pytest.mark.parametrize(
+        "num_instances,num_nodes,expect_csv_in_eval_env",
+        [
+            (1, 1, False),  # single instance — CSV exported but not forwarded to eval
+            (1, 2, False),  # single instance, 2 nodes — same
+            (2, 2, True),  # 2 instances → forward to eval
+            (4, 4, True),  # 4 instances → forward to eval
+        ],
+        ids=["ni1_n1", "ni1_n2", "ni2_n2", "ni4_n4"],
+    )
+    def test_head_node_ips_csv_exposed_to_eval_for_multi_instance(
+        self,
+        base_config,
+        mock_task,
+        mock_dependencies,
+        num_instances,
+        num_nodes,
+        expect_csv_in_eval_env,
+    ):
+        """HEAD_NODE_IPS_CSV is always exported in the slurm script after the
+        per-instance deployment-srun loop, but it is only forwarded into the
+        eval container env when num_instances > 1 (single-instance deployments
+        don't need it because there is no per-instance routing to do)."""
+        base_config["execution"]["num_nodes"] = num_nodes
+        base_config["execution"]["num_instances"] = num_instances
+
+        cfg = OmegaConf.create(base_config)
+
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+            task_idx=0,
+        ).cmd
+
+        # Always exported at the slurm-script level (no harm for single instance)
+        assert 'export HEAD_NODE_IPS_CSV=$(IFS=,; echo "${HEAD_NODE_IPS[*]}")' in script
+
+        # Only added to the eval-container --container-env when multi-instance.
+        # The eval srun command spans multiple `s +=` calls but ends up as a
+        # single shell command; we slice the script to the eval-client section
+        # (between the "# evaluation client" marker and the closing `bash -c`)
+        # and check whether HEAD_NODE_IPS_CSV appears there.
+        eval_marker = "# evaluation client"
+        eval_start = script.index(eval_marker)
+        eval_end = script.index("bash -c", eval_start)
+        eval_section = script[eval_start:eval_end]
+        if expect_csv_in_eval_env:
+            assert "HEAD_NODE_IPS_CSV" in eval_section
+        else:
+            assert "HEAD_NODE_IPS_CSV" not in eval_section
+
+    @pytest.mark.parametrize(
         "gres_value, expect_gres_in_script",
         [
             ("gpu:8", True),

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -663,12 +663,20 @@ class TestSlurmExecutorFeatures:
         eval_start = script.index(eval_marker)
         eval_end = script.index("bash -c", eval_start)
         eval_section = script[eval_start:eval_end]
+        immediate_reexport = (
+            'export HEAD_NODE_IPS_CSV="${HEAD_NODE_IPS_CSV}" ; '
+            'export HEAD_NODE_URLS_CSV="${HEAD_NODE_URLS_CSV}"'
+        )
         if expect_csv_in_eval_env:
             assert "HEAD_NODE_IPS_CSV" in eval_section
             assert "HEAD_NODE_URLS_CSV" in eval_section
+            # Re-export must be in the immediate scope of the eval srun so
+            # pyxis --container-env actually forwards the value.
+            assert immediate_reexport in eval_section
         else:
             assert "HEAD_NODE_IPS_CSV" not in eval_section
             assert "HEAD_NODE_URLS_CSV" not in eval_section
+            assert immediate_reexport not in eval_section
 
     @pytest.mark.parametrize(
         "gres_value, expect_gres_in_script",

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -648,20 +648,27 @@ class TestSlurmExecutorFeatures:
 
         # Always exported at the slurm-script level (no harm for single instance)
         assert 'export HEAD_NODE_IPS_CSV=$(IFS=,; echo "${HEAD_NODE_IPS[*]}")' in script
+        # Pre-formatted URL list using cfg.deployment.port (default 8000)
+        assert (
+            'export HEAD_NODE_URLS_CSV=$(printf "http://%s:8000/v1," '
+            '"${HEAD_NODE_IPS[@]}" | sed "s/,$//")'
+        ) in script
 
         # Only added to the eval-container --container-env when multi-instance.
         # The eval srun command spans multiple `s +=` calls but ends up as a
         # single shell command; we slice the script to the eval-client section
         # (between the "# evaluation client" marker and the closing `bash -c`)
-        # and check whether HEAD_NODE_IPS_CSV appears there.
+        # and check whether HEAD_NODE_IPS_CSV / HEAD_NODE_URLS_CSV appear there.
         eval_marker = "# evaluation client"
         eval_start = script.index(eval_marker)
         eval_end = script.index("bash -c", eval_start)
         eval_section = script[eval_start:eval_end]
         if expect_csv_in_eval_env:
             assert "HEAD_NODE_IPS_CSV" in eval_section
+            assert "HEAD_NODE_URLS_CSV" in eval_section
         else:
             assert "HEAD_NODE_IPS_CSV" not in eval_section
+            assert "HEAD_NODE_URLS_CSV" not in eval_section
 
     @pytest.mark.parametrize(
         "gres_value, expect_gres_in_script",


### PR DESCRIPTION
For num_instances > 1, the slurm executor already builds HEAD_NODE_IPS as a bash array of one head IP per instance. Currently this array stays in the slurm script context — the eval client only ever sees the haproxy load balancer URL via target.api_endpoint.url and has no way to bypass it for sticky routing.

This commit:

1. After the per-instance deployment-srun for-loop closes, exports HEAD_NODE_IPS_CSV as a comma-separated string of head IPs.

2. When num_instances > 1, adds HEAD_NODE_IPS_CSV to extra_eval_env_names so it is passed via --container-env into the eval container.

Eval-side code (e.g. NeMo-Gym) can then do consistent-hashing or any other per-instance routing strategy on its own, addressing each head directly at $HEAD_NODE_IPS_CSV instead of going through the haproxy load balancer. Useful when requests from the same agentic trajectory should hit the same vLLM instance (which round-robin haproxy doesn't guarantee).

No-op for single-instance deployments (HEAD_NODE_IPS_CSV is exported but not added to the eval container env).