### PR TITLE
feat: [EVAL-878] allow custom HTTP headers in payload_modifier

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/adapter_config.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/adapter_config.py
@@ -127,6 +127,16 @@ class LegacyAdapterConfig(BaseModel):
     params_to_rename: dict[str, str] | None = Field(
         default=None, description="Parameters to rename"
     )
+    headers_to_add: dict[str, str] | None = Field(
+        default=None, description="HTTP headers to add to upstream requests"
+    )
+    headers_to_remove: list[str] | None = Field(
+        default=None, description="HTTP headers to remove (case-insensitive)"
+    )
+    headers_to_rename: dict[str, str] | None = Field(
+        default=None,
+        description="HTTP headers to rename (old -> new, case-insensitive)",
+    )
 
     # Optional integer limits
     max_logged_requests: int | None = Field(
@@ -393,12 +403,23 @@ class AdapterConfig(BaseModel):
                 )
             )
 
-        # Add payload modifier interceptor if any payload modification parameters are specified (RequestToResponse)
+        # Add payload modifier interceptor if any payload or header modification
+        # parameters are specified (RequestToResponse)
         params_to_add = legacy_config["params_to_add"]
         params_to_remove = legacy_config["params_to_remove"]
         params_to_rename = legacy_config["params_to_rename"]
+        headers_to_add = legacy_config["headers_to_add"]
+        headers_to_remove = legacy_config["headers_to_remove"]
+        headers_to_rename = legacy_config["headers_to_rename"]
 
-        if params_to_add or params_to_remove or params_to_rename:
+        if (
+            params_to_add
+            or params_to_remove
+            or params_to_rename
+            or headers_to_add
+            or headers_to_remove
+            or headers_to_rename
+        ):
             config = {}
             if params_to_add:
                 config["params_to_add"] = params_to_add
@@ -406,6 +427,12 @@ class AdapterConfig(BaseModel):
                 config["params_to_remove"] = params_to_remove
             if params_to_rename:
                 config["params_to_rename"] = params_to_rename
+            if headers_to_add:
+                config["headers_to_add"] = headers_to_add
+            if headers_to_remove:
+                config["headers_to_remove"] = headers_to_remove
+            if headers_to_rename:
+                config["headers_to_rename"] = headers_to_rename
 
             interceptors.append(
                 InterceptorConfig(

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/payload_modifier_interceptor.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/payload_modifier_interceptor.py
@@ -66,7 +66,7 @@ class PayloadParamsModifierInterceptor(RequestInterceptor):
                 "Dictionary of HTTP headers to add to the upstream request. "
                 "Existing headers with the same name (case-insensitive) are overridden. "
                 "Hop-by-hop headers (Host, Content-Length, Connection, Transfer-Encoding) "
-                "are silently dropped."
+                "are dropped with a warning."
             ),
         )
         headers_to_remove: Optional[List[str]] = Field(

--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/payload_modifier_interceptor.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/payload_modifier_interceptor.py
@@ -30,14 +30,22 @@ from nemo_evaluator.adapters.types import (
 )
 from nemo_evaluator.logging import BaseLoggingParams, get_logger
 
+# Transport-level headers that must not be set by user config — they are
+# managed by the HTTP layer (Werkzeug / requests) and overriding them breaks
+# message framing or routing. Authorization is intentionally NOT included so
+# users can override auth for inference-gateway style deployments.
+_HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
+    {"host", "content-length", "connection", "transfer-encoding"}
+)
+
 
 @register_for_adapter(
     name="payload_modifier",
-    description="Modifies request payload by removing, adding, and renaming parameters",
+    description="Modifies request payload by removing, adding, and renaming parameters and headers",
 )
 @final
 class PayloadParamsModifierInterceptor(RequestInterceptor):
-    """Adapter for modifying request payload by removing, adding, and renaming parameters"""
+    """Adapter for modifying request payload by removing, adding, and renaming parameters and headers"""
 
     class Params(BaseLoggingParams):
         """Configuration parameters for payload modifier interceptor."""
@@ -52,10 +60,36 @@ class PayloadParamsModifierInterceptor(RequestInterceptor):
             default=None,
             description="Dictionary mapping old parameter names to new names",
         )
+        headers_to_add: Optional[Dict[str, str]] = Field(
+            default=None,
+            description=(
+                "Dictionary of HTTP headers to add to the upstream request. "
+                "Existing headers with the same name (case-insensitive) are overridden. "
+                "Hop-by-hop headers (Host, Content-Length, Connection, Transfer-Encoding) "
+                "are silently dropped."
+            ),
+        )
+        headers_to_remove: Optional[List[str]] = Field(
+            default=None,
+            description=(
+                "List of HTTP headers to remove from the upstream request "
+                "(case-insensitive)."
+            ),
+        )
+        headers_to_rename: Optional[Dict[str, str]] = Field(
+            default=None,
+            description=(
+                "Dictionary mapping old header names to new names (case-insensitive "
+                "match on the old name)."
+            ),
+        )
 
     _params_to_remove: List[str]
     _params_to_add: Dict[str, Any]
     _params_to_rename: Dict[str, str]
+    _headers_to_add: Dict[str, str]
+    _headers_to_remove_lc: set[str]
+    _headers_to_rename_lc: Dict[str, str]
 
     def __init__(self, params: Params):
         """
@@ -71,6 +105,25 @@ class PayloadParamsModifierInterceptor(RequestInterceptor):
         # Get logger for this interceptor with interceptor context
         self.logger = get_logger(self.__class__.__name__)
 
+        # Header config: validate against hop-by-hop list at init so the warning
+        # fires once instead of on every request.
+        self._headers_to_add = {}
+        for name, value in (params.headers_to_add or {}).items():
+            if name.lower() in _HOP_BY_HOP_HEADERS:
+                self.logger.warning(
+                    f"Dropping hop-by-hop header from headers_to_add: {name}"
+                )
+                continue
+            self._headers_to_add[name] = value
+
+        self._headers_to_remove_lc = {
+            name.lower() for name in (params.headers_to_remove or [])
+        }
+
+        self._headers_to_rename_lc = {
+            old.lower(): new for old, new in (params.headers_to_rename or {}).items()
+        }
+
         self.logger.info(
             "Payload modifier interceptor initialized",
             params_to_remove=self._params_to_remove,
@@ -80,6 +133,9 @@ class PayloadParamsModifierInterceptor(RequestInterceptor):
             params_to_rename=(
                 list(self._params_to_rename.keys()) if self._params_to_rename else []
             ),
+            headers_to_add=list(self._headers_to_add.keys()),
+            headers_to_remove=sorted(self._headers_to_remove_lc),
+            headers_to_rename=list(self._headers_to_rename_lc.keys()),
         )
 
     @final
@@ -146,12 +202,40 @@ class PayloadParamsModifierInterceptor(RequestInterceptor):
                 new_data[new_key] = new_data.pop(old_key)
                 self.logger.debug("Renamed parameter", old_key=old_key, new_key=new_key)
 
+        # Apply header modifications. Order matches body params (remove -> rename
+        # -> add) so add wins over rename, rename wins over remove. Header names
+        # are case-insensitive per RFC 7230 §3.2; we match accordingly but
+        # preserve user-specified casing on the output side.
+        new_headers: Dict[str, str] = dict(ar.r.headers)
+
+        if self._headers_to_remove_lc:
+            new_headers = {
+                k: v
+                for k, v in new_headers.items()
+                if k.lower() not in self._headers_to_remove_lc
+            }
+
+        if self._headers_to_rename_lc:
+            renamed: Dict[str, str] = {}
+            for k, v in new_headers.items():
+                new_name = self._headers_to_rename_lc.get(k.lower())
+                renamed[new_name if new_name is not None else k] = v
+            new_headers = renamed
+
+        if self._headers_to_add:
+            # Override existing values case-insensitively.
+            add_lc = {k.lower() for k in self._headers_to_add}
+            new_headers = {
+                k: v for k, v in new_headers.items() if k.lower() not in add_lc
+            }
+            new_headers.update(self._headers_to_add)
+
         # Create new request with modified data
         new_request = cast(
             Request,
             Request.from_values(
                 method=ar.r.method,
-                headers=dict(ar.r.headers),
+                headers=new_headers,
                 data=json.dumps(new_data),
             ),
         )
@@ -166,7 +250,10 @@ class PayloadParamsModifierInterceptor(RequestInterceptor):
             ),
             modifications_made=len(self._params_to_remove)
             + len(self._params_to_add)
-            + len(self._params_to_rename),
+            + len(self._params_to_rename)
+            + len(self._headers_to_add)
+            + len(self._headers_to_remove_lc)
+            + len(self._headers_to_rename_lc),
         )
 
         return AdapterRequest(

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_payload_modifier.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_payload_modifier.py
@@ -247,6 +247,147 @@ def test_chat_template_kwargs_with_existing_payload(tmpdir):
     assert set(modified_data.keys()) == expected_keys
 
 
+def _make_request_with_headers(headers, body=None):
+    request = Request.from_values(
+        method="POST",
+        headers=headers,
+        data=json.dumps(body if body is not None else {"messages": []}),
+    )
+    return AdapterRequest(r=request, rctx=AdapterRequestContext())
+
+
+def test_headers_to_add(tmpdir):
+    interceptor = PayloadParamsModifierInterceptor(
+        params=PayloadParamsModifierInterceptor.Params(
+            headers_to_add={
+                "X-NMP-Principal-Id": "service:evaluator",
+                "X-Inference-Priority": "batch",
+            }
+        )
+    )
+    adapter_request = _make_request_with_headers(
+        {"Content-Type": "application/json", "Authorization": "Bearer original"}
+    )
+
+    result = interceptor.intercept_request(adapter_request, mock_context(tmpdir))
+
+    assert result.r.headers["X-NMP-Principal-Id"] == "service:evaluator"
+    assert result.r.headers["X-Inference-Priority"] == "batch"
+    # Existing headers untouched
+    assert result.r.headers["Authorization"] == "Bearer original"
+
+
+def test_headers_to_add_overrides_existing_case_insensitively(tmpdir):
+    interceptor = PayloadParamsModifierInterceptor(
+        params=PayloadParamsModifierInterceptor.Params(
+            headers_to_add={"authorization": "Bearer overridden"}
+        )
+    )
+    adapter_request = _make_request_with_headers(
+        {"Content-Type": "application/json", "Authorization": "Bearer original"}
+    )
+
+    result = interceptor.intercept_request(adapter_request, mock_context(tmpdir))
+
+    auth_values = [
+        v for k, v in result.r.headers.items() if k.lower() == "authorization"
+    ]
+    assert auth_values == ["Bearer overridden"]
+
+
+def test_headers_to_remove_case_insensitive(tmpdir):
+    interceptor = PayloadParamsModifierInterceptor(
+        params=PayloadParamsModifierInterceptor.Params(
+            headers_to_remove=["x-internal", "AUTHORIZATION"]
+        )
+    )
+    adapter_request = _make_request_with_headers(
+        {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer secret",
+            "X-Internal": "trace-1",
+            "X-Keep": "1",
+        }
+    )
+
+    result = interceptor.intercept_request(adapter_request, mock_context(tmpdir))
+
+    assert "Authorization" not in result.r.headers
+    assert "X-Internal" not in result.r.headers
+    assert result.r.headers["X-Keep"] == "1"
+
+
+def test_headers_to_rename_case_insensitive(tmpdir):
+    interceptor = PayloadParamsModifierInterceptor(
+        params=PayloadParamsModifierInterceptor.Params(
+            headers_to_rename={"X-Old-Auth": "X-New-Auth"}
+        )
+    )
+    adapter_request = _make_request_with_headers(
+        {"Content-Type": "application/json", "x-old-auth": "token123"}
+    )
+
+    result = interceptor.intercept_request(adapter_request, mock_context(tmpdir))
+
+    assert "x-old-auth" not in {k.lower() for k in result.r.headers.keys()}
+    assert result.r.headers["X-New-Auth"] == "token123"
+
+
+def test_hop_by_hop_headers_dropped_from_add(tmpdir, caplog):
+    import logging
+
+    caplog.set_level(logging.WARNING)
+    interceptor = PayloadParamsModifierInterceptor(
+        params=PayloadParamsModifierInterceptor.Params(
+            headers_to_add={
+                "Host": "evil.example.com",
+                "Content-Length": "9999",
+                "Connection": "close",
+                "Transfer-Encoding": "chunked",
+                "X-Inference-Priority": "batch",
+            }
+        )
+    )
+    adapter_request = _make_request_with_headers({"Content-Type": "application/json"})
+
+    result = interceptor.intercept_request(adapter_request, mock_context(tmpdir))
+
+    # Werkzeug may auto-populate Host/Content-Length on Request.from_values;
+    # the contract is that the user-provided hop-by-hop values were not honoured.
+    assert result.r.headers["X-Inference-Priority"] == "batch"
+    assert "evil.example.com" not in result.r.headers.get("Host", "")
+    assert result.r.headers.get("Connection") != "close"
+    assert "chunked" not in result.r.headers.get("Transfer-Encoding", "")
+
+
+def test_combined_param_and_header_modifications(tmpdir):
+    interceptor = PayloadParamsModifierInterceptor(
+        params=PayloadParamsModifierInterceptor.Params(
+            params_to_add={"temperature": 0.0},
+            params_to_remove=["top_k"],
+            headers_to_add={"X-Inference-Priority": "batch"},
+            headers_to_remove=["X-Trace-Id"],
+        )
+    )
+    adapter_request = _make_request_with_headers(
+        headers={
+            "Content-Type": "application/json",
+            "X-Trace-Id": "abc",
+            "Authorization": "Bearer t",
+        },
+        body={"messages": [{"role": "user", "content": "hi"}], "top_k": 10},
+    )
+
+    result = interceptor.intercept_request(adapter_request, mock_context(tmpdir))
+
+    body = json.loads(result.r.get_data())
+    assert body["temperature"] == 0.0
+    assert "top_k" not in body
+    assert result.r.headers["X-Inference-Priority"] == "batch"
+    assert "X-Trace-Id" not in result.r.headers
+    assert result.r.headers["Authorization"] == "Bearer t"
+
+
 def test_remove_params_recursively(tmpdir):
     payload_modifier = PayloadParamsModifierInterceptor(
         params=PayloadParamsModifierInterceptor.Params(

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/test_adapter_config.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/test_adapter_config.py
@@ -1711,3 +1711,65 @@ def test_legacy_with_interceptors_validation(
         # Verify expected fields
         for field, expected_value in expected_fields.items():
             assert getattr(config, field) == expected_value
+
+
+def test_from_legacy_config_with_headers():
+    """headers_to_* in flat legacy config map to the payload_modifier interceptor."""
+    legacy_config = {
+        "headers_to_add": {
+            "X-NMP-Principal-Id": "service:evaluator",
+            "X-Inference-Priority": "batch",
+        },
+        "headers_to_remove": ["X-Trace-Id"],
+        "headers_to_rename": {"X-Old-Auth": "X-New-Auth"},
+    }
+
+    config = AdapterConfig.from_legacy_config(legacy_config)
+
+    payload_modifier = next(
+        (ic for ic in config.interceptors if ic.name == "payload_modifier"), None
+    )
+    assert payload_modifier is not None, (
+        "headers_to_* should produce a payload_modifier interceptor"
+    )
+    assert payload_modifier.config["headers_to_add"] == {
+        "X-NMP-Principal-Id": "service:evaluator",
+        "X-Inference-Priority": "batch",
+    }
+    assert payload_modifier.config["headers_to_remove"] == ["X-Trace-Id"]
+    assert payload_modifier.config["headers_to_rename"] == {"X-Old-Auth": "X-New-Auth"}
+    # Body-param fields should not appear when only headers were configured.
+    assert "params_to_add" not in payload_modifier.config
+    assert "params_to_remove" not in payload_modifier.config
+    assert "params_to_rename" not in payload_modifier.config
+
+
+def test_from_legacy_config_headers_merged_with_params():
+    """headers_to_* and params_to_* coexist on a single payload_modifier."""
+    legacy_config = {
+        "params_to_remove": ["max_tokens"],
+        "params_to_add": {"temperature": 0.0},
+        "headers_to_add": {"X-Inference-Priority": "batch"},
+    }
+
+    config = AdapterConfig.from_legacy_config(legacy_config)
+
+    payload_modifiers = [
+        ic for ic in config.interceptors if ic.name == "payload_modifier"
+    ]
+    assert len(payload_modifiers) == 1, (
+        "params and headers should share one payload_modifier interceptor"
+    )
+    cfg = payload_modifiers[0].config
+    assert cfg["params_to_remove"] == ["max_tokens"]
+    assert cfg["params_to_add"] == {"temperature": 0.0}
+    assert cfg["headers_to_add"] == {"X-Inference-Priority": "batch"}
+
+
+def test_from_legacy_config_no_payload_modifier_when_only_unrelated_fields():
+    """Without any params_to_*/headers_to_*, no payload_modifier is emitted."""
+    legacy_config = {"use_caching": True}
+
+    config = AdapterConfig.from_legacy_config(legacy_config)
+
+    assert not any(ic.name == "payload_modifier" for ic in config.interceptors)


### PR DESCRIPTION
## Summary

Adds three optional fields to `PayloadParamsModifierInterceptor.Params` — `headers_to_add`, `headers_to_remove`, `headers_to_rename` — mirroring the existing body-`params_*` surface. Unblocks NMP inference-gateway integration (Linear: [EVAL-878](https://linear.app/nvidia/issue/EVAL-878)), where eval clients need to inject headers like `X-NMP-Principal-Id: service:evaluator` on outgoing chat-completions requests.

- Header names are matched case-insensitively per RFC 7230 §3.2.
- Hop-by-hop headers (`Host`, `Content-Length`, `Connection`, `Transfer-Encoding`) are dropped at init with a warning; `Authorization` is intentionally allowed through so callers can override auth for inference-gateway deployments.
- Headers flow to upstream via the existing `EndpointInterceptor`, which already forwards `ar.r.headers` to `requests.request(...)`. No new request-flow code paths.

### Example config

```yaml
target:
  api_endpoint:
    adapter_config:
      interceptors:
        - name: payload_modifier
          config:
            headers_to_add:
              X-NMP-Principal-Id: "service:evaluator"
              X-Inference-Priority: "batch"
        - name: endpoint
```

## Test plan

- [x] 14/14 unit tests pass in `tests/unit_tests/adapters/interceptors/test_payload_modifier.py` (7 new + 7 pre-existing)
- [x] Full adapter test suite green (340/340)
- [x] `pre-commit run` clean
- [x] **End-to-end with real vLLM (Qwen3-1.7B):** spun up `AdapterServerProcess` standalone with `payload_modifier` injecting `X-Inference-Priority: batch` + `X-NMP-Principal-Id: service:evaluator`, posted a chat-completions request through it via a header-capturing sniffer proxy. Both injected headers were observed at the upstream side with original `Authorization` preserved; vLLM returned a real completion. (Companion change in nemo-evaluator-next coming via separate MR.)