### PR TITLE
Add custom BYOB logprob scoring support

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/api/api_dataclasses.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/api/api_dataclasses.py
@@ -39,6 +39,7 @@ class EndpointType(str, Enum):
     UNDEFINED = "undefined"
     CHAT = "chat"
     COMPLETIONS = "completions"
+    COMPLETIONS_LOGPROB = "completions_logprob"
     EMBEDDING = "embedding"
 
 

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/__init__.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/__init__.py
@@ -48,6 +48,26 @@ Scorer composition::
 
 from nemo_evaluator.contrib.byob.decorators import ScorerInput, benchmark, scorer
 from nemo_evaluator.contrib.byob.judge import judge_score
-from nemo_evaluator.contrib.byob.scorers import all_of, any_of
+from nemo_evaluator.contrib.byob.scorers import (
+    all_of,
+    any_of,
+    boolean_yesno,
+    chrf,
+    gsm8k_answer,
+    mcq_letter_extract,
+    multiple_choice_acc,
+)
 
-__all__ = ["benchmark", "scorer", "ScorerInput", "any_of", "all_of", "judge_score"]
+__all__ = [
+    "benchmark",
+    "scorer",
+    "ScorerInput",
+    "any_of",
+    "all_of",
+    "judge_score",
+    "multiple_choice_acc",
+    "mcq_letter_extract",
+    "gsm8k_answer",
+    "boolean_yesno",
+    "chrf",
+]

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/compiler.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/compiler.py
@@ -41,11 +41,27 @@ _logger = get_logger(__name__)
 
 # Jinja2 command template for runner invocation
 # NOTE: Use plain string concatenation to avoid f-string escaping issues with {{ }}
+#
+# Dataset resolution precedence (Req 2 - "swap the input file, keep same
+# task name / prompt / scoring"):
+#
+#   1. config.params.extra.dataset_uri   (override; hf:// URI or local path)
+#   2. config.params.extra.dataset       (compile-time default from @benchmark)
+#
+# When dataset_uri is set on a run (e.g. via
+# ``evaluation.tasks[0].nemo_evaluator_config.config.params.extra.dataset_uri=...``)
+# the runner fetches that URI instead, without any change to the benchmark
+# module, prompt template, scorer, or task name.
 COMMAND_TEMPLATE = (
     "python -m nemo_evaluator.contrib.byob.runner"
     " --benchmark-module {{config.params.extra.benchmark_module}}"
     " --benchmark-name {{config.params.task}}"
+    "{% if config.params.extra.dataset_uri is defined"
+    " and config.params.extra.dataset_uri is not none %}"
+    " --dataset {{config.params.extra.dataset_uri}}"
+    "{% else %}"
     " --dataset {{config.params.extra.dataset}}"
+    "{% endif %}"
     " --output-dir {{config.output_dir}}"
     " --model-url {{target.api_endpoint.url}}"
     " --model-id {{target.api_endpoint.model_id}}"
@@ -67,6 +83,10 @@ COMMAND_TEMPLATE = (
     "{% endif %}"
     "{% if config.params.request_timeout is not none %}"
     " --request-timeout {{config.params.request_timeout}}"
+    "{% endif %}"
+    "{% if config.params.extra.num_fewshot is defined"
+    " and config.params.extra.num_fewshot is not none %}"
+    " --num-fewshot {{config.params.extra.num_fewshot}}"
     "{% endif %}"
 )
 
@@ -91,11 +111,26 @@ def _build_fdf(
     extra_params: dict = {
         "benchmark_module": benchmark_module_ref,
         "dataset": dataset_path,
+        # ``dataset_uri`` is the Req 2 override slot: setting it at run
+        # time (e.g. to a different hf:// URI with the same schema) makes
+        # the BYOB runner load that dataset instead of ``dataset`` while
+        # keeping task name, prompt template, and scorer unchanged. Null
+        # by default so the compile-time ``dataset`` is used.
+        "dataset_uri": None,
         "requirements": bench.requirements,
     }
     # Propagate field_mapping if declared
     if bench.field_mapping:
         extra_params["field_mapping"] = bench.field_mapping
+    # Few-shot defaults (lm-eval-harness parity)
+    if bench.num_fewshot:
+        extra_params["num_fewshot"] = bench.num_fewshot
+    # Multiple-choice loglikelihood metadata (informational; the runner
+    # picks up choices/choices_field from the @benchmark itself)
+    if bench.choices is not None:
+        extra_params["choices"] = list(bench.choices)
+    if bench.choices_field is not None:
+        extra_params["choices_field"] = bench.choices_field
     # Propagate judge config(s) from @benchmark kwargs
     # Supports: judge={...}, judge_1={...}, judge_2={...}, etc.
     for key, value in bench.extra_config.items():

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/dataset.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/dataset.py
@@ -44,6 +44,7 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Protocol, runtime_checkable
+from urllib.parse import parse_qsl
 
 from nemo_evaluator.logging import get_logger
 
@@ -168,7 +169,7 @@ class HuggingFaceFetcher:
                 "Install it with:  pip install datasets"
             ) from exc
 
-        dataset_name, config, split = self._parse_uri(uri)
+        dataset_name, config, split, options = self._parse_uri(uri)
         cache = cache_dir or self._default_cache_dir
         cache.mkdir(parents=True, exist_ok=True)
 
@@ -179,6 +180,9 @@ class HuggingFaceFetcher:
             parts.append(config)
         if split is not None:
             parts.append(split)
+        filters = _extract_filters(options)
+        for field_name, value in filters:
+            parts.append(f"{field_name}-{value}")
         out_path = cache / ("_".join(parts) + ".jsonl")
 
         if out_path.exists():
@@ -191,6 +195,7 @@ class HuggingFaceFetcher:
                     "dataset": dataset_name,
                     "config": config,
                     "split": split,
+                    **options,
                 },
             )
 
@@ -201,11 +206,13 @@ class HuggingFaceFetcher:
             split=split,
         )
 
-        load_kwargs: Dict[str, str] = {}
+        load_kwargs: Dict[str, object] = {}
         if config is not None:
             load_kwargs["name"] = config
         if split is not None:
             load_kwargs["split"] = split
+        if options.get("trust_remote_code", "").lower() in {"1", "true", "yes"}:
+            load_kwargs["trust_remote_code"] = True
 
         ds = hf_datasets.load_dataset(dataset_name, **load_kwargs)
 
@@ -217,6 +224,19 @@ class HuggingFaceFetcher:
                 "No split specified; using first available split", split=first_split
             )
             ds = ds[first_split]
+
+        for filter_field, filter_value in filters:
+            before_count = len(ds)
+            ds = ds.filter(
+                lambda row, f=filter_field, v=filter_value: str(row.get(f)) == v
+            )
+            logger.info(
+                "Filtered HuggingFace dataset",
+                field=filter_field,
+                value=filter_value,
+                records_before=before_count,
+                records_after=len(ds),
+            )
 
         # Write out as JSONL.
         with open(out_path, "w", encoding="utf-8") as fout:
@@ -237,6 +257,7 @@ class HuggingFaceFetcher:
                 "dataset": dataset_name,
                 "config": config,
                 "split": split,
+                **options,
             },
         )
 
@@ -272,26 +293,58 @@ class HuggingFaceFetcher:
 
         # Extract ?split=X query parameter if present
         query_split = None
+        options: Dict[str, str] = {}
         if "?" in body:
             body, query = body.split("?", 1)
-            for param in query.split("&"):
-                if param.startswith("split="):
-                    query_split = param[len("split=") :]
+            for key, value in parse_qsl(query, keep_blank_values=True):
+                if key == "split":
+                    query_split = value
+                else:
+                    options[key] = value
 
         segments = [s for s in body.split("/") if s]
         if not segments:
             raise ValueError(f"Invalid HuggingFace URI (empty body): {uri}")
 
         if len(segments) == 1:
-            return (segments[0], None, query_split)
+            return (segments[0], None, query_split, options)
         elif len(segments) == 2:
-            return ("/".join(segments[:2]), None, query_split)
+            return ("/".join(segments[:2]), None, query_split, options)
         elif len(segments) == 3:
-            return ("/".join(segments[:2]), segments[2], query_split)
+            return ("/".join(segments[:2]), segments[2], query_split, options)
         elif len(segments) >= 4:
-            return ("/".join(segments[:2]), segments[2], query_split or segments[3])
+            return (
+                "/".join(segments[:2]),
+                segments[2],
+                query_split or segments[3],
+                options,
+            )
 
-        return (body, None, query_split)  # pragma: no cover
+        return (body, None, query_split, options)  # pragma: no cover
+
+
+def _extract_filters(options: Dict[str, str]) -> List[tuple[str, str]]:
+    """Return HuggingFace row filters encoded in a dataset URI.
+
+    Supports one filter via filter_field/filter_value and additional filters
+    with numeric suffixes, e.g. filter_field_1/filter_value_1.
+    """
+    filters = []
+    first_field = options.get("filter_field")
+    first_value = options.get("filter_value")
+    if first_field and first_value is not None:
+        filters.append((first_field, first_value))
+
+    idx = 1
+    while True:
+        field_name = options.get(f"filter_field_{idx}")
+        value = options.get(f"filter_value_{idx}")
+        if not field_name and value is None:
+            break
+        if field_name and value is not None:
+            filters.append((field_name, value))
+        idx += 1
+    return filters
 
 
 # --- Format detection ---

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/decorators.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/decorators.py
@@ -47,7 +47,14 @@ class ScorerInput:
 
     This is the single argument passed to all BYOB scorer functions.
     Standard scorers use response, target, and metadata.
-    Advanced scorers (judge, multi-turn) use the optional fields.
+    Advanced scorers (judge, multi-turn, multiple-choice loglikelihood)
+    use the optional fields.
+
+    For multiple-choice loglikelihood evaluation (lm-eval-harness style),
+    ``MultipleChoiceStrategy`` populates ``choices``, ``choices_logprobs``,
+    and ``choices_is_greedy`` before invoking the scorer. ``response`` is
+    set to ``choices[argmax(choices_logprobs)]`` so legacy text-based
+    scorers also work.
     """
 
     response: str
@@ -58,6 +65,10 @@ class ScorerInput:
     config: Dict[str, Any] = field(default_factory=dict)
     conversation: Optional[List[dict]] = None
     turn_index: Optional[int] = None
+    # Multiple-choice loglikelihood fields (mirrors lm-eval-harness)
+    choices: Optional[List[str]] = None
+    choices_logprobs: Optional[List[float]] = None
+    choices_is_greedy: Optional[List[bool]] = None
 
 
 @dataclass
@@ -78,6 +89,14 @@ class BenchmarkDefinition:
     _is_jinja2: bool = False
     system_prompt: Optional[str] = None
     _is_system_prompt_jinja2: bool = False
+    # Multiple-choice loglikelihood support (mirrors lm-eval-harness)
+    choices: Optional[List[str]] = None
+    choices_field: Optional[str] = None
+    # Few-shot prompting (mirrors lm-eval-harness --num_fewshot)
+    num_fewshot: int = 0
+    fewshot_split: Optional[str] = None
+    fewshot_template: Optional[str] = None
+    fewshot_separator: str = "\n\n"
 
 
 _BENCHMARK_REGISTRY: Dict[str, BenchmarkDefinition] = {}
@@ -150,6 +169,12 @@ def benchmark(
     extra=None,
     response_field=None,
     system_prompt=None,
+    choices: Optional[List[str]] = None,
+    choices_field: Optional[str] = None,
+    num_fewshot: int = 0,
+    fewshot_split: Optional[str] = None,
+    fewshot_template: Optional[str] = None,
+    fewshot_separator: str = "\n\n",
     **kwargs,
 ):
     """Decorator that registers a function as a BYOB benchmark.
@@ -161,7 +186,10 @@ def benchmark(
         prompt: Python format string with {field} placeholders, or path to
                 a template file (.txt, .md, .jinja, .jinja2).
         target_field: JSONL field containing ground truth.
-        endpoint_type: "chat" or "completions".
+        endpoint_type: ``"chat"``, ``"completions"``, or
+            ``"completions_logprob"``. The last value enables per-choice
+            loglikelihood ranking (lm-evaluation-harness ``local-completions``
+            parity) and requires either ``choices`` or ``choices_field``.
         requirements: Pip dependencies. Either a list of specifiers
                       (e.g., ["rouge-score>=0.1.2"]) or a path to a
                       requirements.txt file. None means no extra deps.
@@ -177,6 +205,27 @@ def benchmark(
                         responses are read directly from the dataset (eval-only mode).
         system_prompt: Optional system prompt string or path to a template file.
                        When set, a system message is prepended to model calls.
+        choices: Static list of candidate continuations evaluated in
+            loglikelihood mode (e.g. ``["A", "B", "C", "D"]`` for MMLU).
+            Used for ``endpoint_type="completions_logprob"``.
+        choices_field: Per-row dataset field whose value is a list of
+            candidate continuations (e.g. ARC has variable-length choice
+            lists). Mutually exclusive with ``choices``; takes precedence
+            when both are set on a per-row basis.
+        num_fewshot: Number of few-shot examples to prepend to each
+            prompt. Examples are sampled deterministically from
+            ``fewshot_split`` (or the first ``num_fewshot`` rows of the
+            evaluation dataset when ``fewshot_split`` is None). Mirrors
+            lm-eval-harness's ``--num_fewshot`` flag.
+        fewshot_split: HuggingFace split name to sample few-shot examples
+            from (e.g. ``"train"`` or ``"dev"``). Only meaningful when the
+            primary ``dataset`` is an ``hf://`` URI.
+        fewshot_template: Optional template string used to render each
+            few-shot example. ``None`` reuses the main ``prompt`` template
+            and appends the rendered ``target_field`` value.
+        fewshot_separator: String inserted between rendered few-shot
+            examples and between the few-shot block and the test prompt.
+            Defaults to ``"\\n\\n"``.
         **kwargs: Also merged into extra config (for backward compat).
                   ``extra`` takes precedence over ``**kwargs`` on conflicts.
     """
@@ -191,6 +240,18 @@ def benchmark(
         if normalized in _BENCHMARK_REGISTRY:
             raise ValueError(
                 f"Benchmark '{name}' (normalized: '{normalized}') is already registered."
+            )
+        if endpoint_type not in ("chat", "completions", "completions_logprob"):
+            raise ValueError(
+                f"Invalid endpoint_type '{endpoint_type}'. "
+                f"Must be one of: 'chat', 'completions', 'completions_logprob'."
+            )
+        if endpoint_type == "completions_logprob" and not (choices or choices_field):
+            raise ValueError(
+                f"Benchmark '{name}' uses endpoint_type='completions_logprob' "
+                f"but neither 'choices' (static list) nor 'choices_field' "
+                f"(per-row field) is set. Loglikelihood ranking requires "
+                f"candidate continuations."
             )
 
         # Resolve base_dir from decorated function's source file
@@ -230,6 +291,11 @@ def benchmark(
         if extra:
             merged_extra.update(extra)
 
+        # Resolve few-shot template (file path or inline string)
+        resolved_fewshot_template = None
+        if fewshot_template is not None:
+            resolved_fewshot_template = _resolve_prompt(fewshot_template, base_dir)
+
         defn = BenchmarkDefinition(
             name=name,
             normalized_name=normalized,
@@ -245,6 +311,12 @@ def benchmark(
             _is_jinja2=is_jinja2,
             system_prompt=resolved_system_prompt,
             _is_system_prompt_jinja2=is_system_prompt_jinja2,
+            choices=list(choices) if choices is not None else None,
+            choices_field=choices_field,
+            num_fewshot=num_fewshot,
+            fewshot_split=fewshot_split,
+            fewshot_template=resolved_fewshot_template,
+            fewshot_separator=fewshot_separator,
         )
 
         _BENCHMARK_REGISTRY[normalized] = defn

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/eval_logic.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/eval_logic.py
@@ -16,6 +16,7 @@
 """Shared BYOB evaluation logic for both subprocess and native modes."""
 
 import importlib
+import random
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -133,8 +134,9 @@ def import_benchmark(benchmark_module: str, benchmark_name: str) -> BenchmarkDef
 class EvalStrategy(Protocol):
     """Protocol for evaluation strategies.
 
-    Different evaluation modes (standard, judge, multi-turn, agentic)
-    implement this protocol to define how each sample is evaluated.
+    Different evaluation modes (standard, judge, multi-turn, agentic,
+    multiple-choice loglikelihood) implement this protocol to define how
+    each sample is evaluated.
     """
 
     def evaluate_sample(
@@ -142,9 +144,10 @@ class EvalStrategy(Protocol):
         idx: int,
         row: Dict,
         bench: BenchmarkDefinition,
-        model_call_fn: Callable[[str, str], str],
+        model_call_fn: Callable[..., Any],
         endpoint_type: str,
         request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
     ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
         """Evaluate a single sample.
 
@@ -163,9 +166,10 @@ class StandardStrategy:
         idx: int,
         row: Dict,
         bench: BenchmarkDefinition,
-        model_call_fn: Callable[[str, str], str],
+        model_call_fn: Callable[..., Any],
         endpoint_type: str,
         request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
     ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
         """Render prompt, call model, score the response.
 
@@ -196,6 +200,9 @@ class StandardStrategy:
                 error=str(e),
                 metadata=row,
             )
+
+        if fewshot_prefix:
+            prompt = fewshot_prefix + prompt
 
         # Render system prompt if configured
         rendered_system_prompt = None
@@ -283,9 +290,10 @@ class EvalOnlyStrategy:
         idx: int,
         row: Dict,
         bench: BenchmarkDefinition,
-        model_call_fn: Callable[[str, str], str],
+        model_call_fn: Callable[..., Any],
         endpoint_type: str,
         request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
     ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
         """Score a pre-generated response from the dataset (no model call).
 
@@ -296,6 +304,7 @@ class EvalOnlyStrategy:
             model_call_fn: Not used (present for protocol compliance).
             endpoint_type: Not used (present for protocol compliance).
             request_timeout: Not used (present for protocol compliance).
+            fewshot_prefix: Not used (present for protocol compliance).
 
         Returns:
             Tuple of (scores_dict, SampleResult) on success, or
@@ -358,10 +367,286 @@ class EvalOnlyStrategy:
         return sample_scores, prediction
 
 
+def _resolve_choices_from_row(row: Dict, choices_field: str) -> Optional[List[str]]:
+    """Resolve per-row choices from a field name or dotted path.
+
+    Hugging Face multiple-choice datasets commonly store choices as
+    {"label": [...], "text": [...]}; dotted paths let benchmarks select the
+    actual candidate continuations without a preprocessing step.
+    """
+    raw: Any = row
+    for part in choices_field.split("."):
+        if isinstance(raw, dict) and part in raw:
+            raw = raw[part]
+        else:
+            raw = None
+            break
+
+    if raw is None:
+        raw = row.get(choices_field)
+
+    if isinstance(raw, dict):
+        raw = raw.get("text")
+
+    if isinstance(raw, list):
+        return [str(c) for c in raw]
+    return None
+
+
+class MultipleChoiceStrategy:
+    """Per-choice loglikelihood ranking (lm-eval-harness ``local-completions`` parity).
+
+    For each row:
+
+    1. Render the context from ``bench.prompt``.
+    2. Resolve the candidate continuations (from ``bench.choices`` or
+       ``row[bench.choices_field]``).
+    3. Call ``model_call_fn(context, "completions_logprob",
+       continuation=cont)`` for each candidate, collecting
+       ``(sum_logprob, is_greedy)`` tuples.
+    4. Set ``ScorerInput.choices``, ``choices_logprobs``,
+       ``choices_is_greedy``; ``response`` is set to the argmax choice so
+       legacy text-based scorers (``exact_match`` etc.) still work.
+    5. Hand off to the user scorer (commonly :func:`multiple_choice_acc`).
+    """
+
+    def evaluate_sample(
+        self,
+        idx: int,
+        row: Dict,
+        bench: BenchmarkDefinition,
+        model_call_fn: Callable[..., Any],
+        endpoint_type: str,
+        request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
+    ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
+        try:
+            prompt = render_prompt(bench.prompt, row, bench._is_jinja2)
+        except KeyError as e:
+            target = row.get(bench.target_field, "")
+            return None, SampleResult(
+                sample_id=idx,
+                prompt="",
+                response=None,
+                target=target,
+                scores=None,
+                status="skipped_missing_field",
+                error=str(e),
+                metadata=row,
+            )
+
+        if fewshot_prefix:
+            prompt = fewshot_prefix + prompt
+
+        # Resolve choices: per-row field takes precedence over static list
+        choices: Optional[List[str]] = None
+        if bench.choices_field:
+            choices = _resolve_choices_from_row(row, bench.choices_field)
+        if not choices and bench.choices:
+            choices = list(bench.choices)
+        if not choices:
+            target = row.get(bench.target_field, "")
+            return None, SampleResult(
+                sample_id=idx,
+                prompt=prompt,
+                response=None,
+                target=target,
+                scores=None,
+                status="skipped_missing_field",
+                error=(
+                    f"No choices available: choices_field "
+                    f"'{bench.choices_field}' missing from row and no static "
+                    f"choices declared on @benchmark."
+                ),
+                metadata=row,
+            )
+
+        rendered_system_prompt = None
+        if bench.system_prompt:
+            try:
+                rendered_system_prompt = render_prompt(
+                    bench.system_prompt, row, bench._is_system_prompt_jinja2
+                )
+            except KeyError as e:
+                logger.warning(
+                    "System prompt rendering failed, skipping",
+                    sample_id=idx,
+                    error=str(e),
+                )
+
+        choices_logprobs: List[float] = []
+        choices_is_greedy: List[bool] = []
+        for cont in choices:
+            try:
+                ll, greedy = model_call_fn(
+                    prompt,
+                    "completions_logprob",
+                    system_prompt=rendered_system_prompt,
+                    timeout=request_timeout,
+                    continuation=cont,
+                )
+            except Exception as e:
+                target = row.get(bench.target_field, "")
+                return None, SampleResult(
+                    sample_id=idx,
+                    prompt=prompt,
+                    response=None,
+                    target=target,
+                    scores=None,
+                    status="skipped_model_error",
+                    error=str(e),
+                    metadata=row,
+                )
+            choices_logprobs.append(float(ll))
+            choices_is_greedy.append(bool(greedy))
+
+        argmax_idx = max(range(len(choices)), key=lambda i: choices_logprobs[i])
+        response = choices[argmax_idx]
+
+        target = row.get(bench.target_field, "")
+        scorer_input = ScorerInput(
+            response=response,
+            target=target,
+            metadata=row,
+            model_call_fn=model_call_fn,
+            config=bench.extra_config,
+            choices=choices,
+            choices_logprobs=choices_logprobs,
+            choices_is_greedy=choices_is_greedy,
+        )
+
+        try:
+            sample_scores = bench.scorer_fn(scorer_input)
+        except Exception as e:
+            return None, SampleResult(
+                sample_id=idx,
+                prompt=prompt,
+                response=response,
+                target=target,
+                scores=None,
+                status="skipped_scorer_error",
+                error=str(e),
+                metadata=row,
+            )
+
+        prediction = SampleResult(
+            sample_id=idx,
+            prompt=prompt,
+            response=response,
+            target=target,
+            scores=sample_scores,
+            status="scored",
+            metadata={
+                **row,
+                "_choices": choices,
+                "_choices_logprobs": choices_logprobs,
+                "_choices_is_greedy": choices_is_greedy,
+            },
+        )
+        return sample_scores, prediction
+
+
+def render_fewshot_example(bench: BenchmarkDefinition, row: Dict) -> Optional[str]:
+    """Render a single few-shot example for *row*.
+
+    If ``bench.fewshot_template`` is set, render that with the row dict.
+    Otherwise reuse the main ``bench.prompt`` template and append the
+    target value (fetched from ``bench.target_field``).
+
+    Returns None on missing-field errors so the caller can skip cleanly.
+    """
+    try:
+        if bench.fewshot_template:
+            return render_prompt(bench.fewshot_template, row, bench._is_jinja2)
+        prompt_part = render_prompt(bench.prompt, row, bench._is_jinja2)
+        target_part = row.get(bench.target_field, "")
+        return f"{prompt_part} {target_part}".rstrip()
+    except KeyError:
+        return None
+
+
+def build_fewshot_prefix(bench: BenchmarkDefinition, examples: List[Dict]) -> str:
+    """Render *examples* into a prefix string ready to prepend to each prompt.
+
+    Skips examples that fail to render (missing fields). Always appends the
+    benchmark's ``fewshot_separator`` after the last example so the test
+    prompt starts on a fresh boundary.
+    """
+    if not examples:
+        return ""
+    rendered: List[str] = []
+    for ex in examples:
+        text = render_fewshot_example(bench, ex)
+        if text is not None:
+            rendered.append(text)
+    if not rendered:
+        return ""
+    sep = bench.fewshot_separator or "\n\n"
+    return sep.join(rendered) + sep
+
+
+def build_fewshot_examples(
+    primary_dataset_uri: str,
+    primary_dataset: List[Dict],
+    num_fewshot: int,
+    fewshot_split: Optional[str],
+    field_mapping: Optional[Dict[str, str]] = None,
+    seed: int = 42,
+) -> List[Dict]:
+    """Sample ``num_fewshot`` examples deterministically (lm-eval style).
+
+    Selection rules (in order):
+
+    1. If ``fewshot_split`` is set and the primary dataset URI is an
+       ``hf://`` URI, load that split via the dataset module and sample
+       ``num_fewshot`` rows.
+    2. Otherwise, sample ``num_fewshot`` rows from the head of
+       ``primary_dataset`` (deterministic offset; matches lm-eval's
+       behavior when no separate fewshot split is declared).
+    """
+    if num_fewshot <= 0:
+        return []
+
+    pool: List[Dict] = []
+    if fewshot_split and primary_dataset_uri.startswith("hf://"):
+        try:
+            from nemo_evaluator.contrib.byob.dataset import load_dataset
+
+            # Replace or inject ?split= in the URI
+            if "?" in primary_dataset_uri:
+                base, _ = primary_dataset_uri.split("?", 1)
+            else:
+                base = primary_dataset_uri
+            fs_uri = f"{base}?split={fewshot_split}"
+            pool = load_dataset(
+                fs_uri, limit=max(num_fewshot * 4, 16), field_mapping=field_mapping
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to load fewshot_split, falling back to primary dataset head",
+                fewshot_split=fewshot_split,
+                error=str(e),
+            )
+            pool = []
+
+    if not pool:
+        # Fall back to primary dataset (skip the first row to reduce
+        # exact contamination with the test prompt; lm-eval does similar).
+        pool = primary_dataset[: max(num_fewshot * 4, num_fewshot)]
+
+    if not pool:
+        return []
+
+    rng = random.Random(seed)
+    if len(pool) <= num_fewshot:
+        return list(pool)
+    return rng.sample(pool, num_fewshot)
+
+
 def run_eval_loop(
     bench: BenchmarkDefinition,
     dataset: List[Dict],
-    model_call_fn: Callable[[str, str], str],
+    model_call_fn: Callable[..., Any],
     endpoint_type: str,
     strategy: Optional[EvalStrategy] = None,
     save_predictions: bool = False,
@@ -370,6 +655,7 @@ def run_eval_loop(
     fail_on_skip: bool = False,
     parallelism: int = 1,
     request_timeout: Optional[float] = None,
+    fewshot_examples: Optional[List[Dict]] = None,
 ) -> Tuple[List[Dict], List[SampleResult]]:
     """Core evaluation loop shared between subprocess and native modes.
 
@@ -399,8 +685,19 @@ def run_eval_loop(
     if strategy is None:
         if bench.response_field:
             strategy = EvalOnlyStrategy(bench.response_field)
+        elif (
+            endpoint_type == "completions_logprob"
+            or bench.endpoint_type == "completions_logprob"
+            or bench.choices is not None
+            or bench.choices_field is not None
+        ):
+            strategy = MultipleChoiceStrategy()
         else:
             strategy = StandardStrategy()
+
+    fewshot_prefix = (
+        build_fewshot_prefix(bench, fewshot_examples) if fewshot_examples else ""
+    )
 
     if parallelism > 1 and len(dataset) > 1:
         if max_consecutive_errors > 0:
@@ -420,6 +717,7 @@ def run_eval_loop(
             fail_on_skip=fail_on_skip,
             parallelism=parallelism,
             request_timeout=request_timeout,
+            fewshot_prefix=fewshot_prefix,
         )
 
     return _run_eval_loop_sequential(
@@ -433,13 +731,14 @@ def run_eval_loop(
         max_consecutive_errors=max_consecutive_errors,
         fail_on_skip=fail_on_skip,
         request_timeout=request_timeout,
+        fewshot_prefix=fewshot_prefix,
     )
 
 
 def _run_eval_loop_sequential(
     bench: BenchmarkDefinition,
     dataset: List[Dict],
-    model_call_fn: Callable[[str, str], str],
+    model_call_fn: Callable[..., Any],
     endpoint_type: str,
     strategy: EvalStrategy,
     save_predictions: bool = False,
@@ -447,6 +746,7 @@ def _run_eval_loop_sequential(
     max_consecutive_errors: int = 0,
     fail_on_skip: bool = False,
     request_timeout: Optional[float] = None,
+    fewshot_prefix: str = "",
 ) -> Tuple[List[Dict], List[SampleResult]]:
     """Sequential evaluation loop. See :func:`run_eval_loop` for parameter docs."""
     if request_timeout is not None:
@@ -461,8 +761,17 @@ def _run_eval_loop_sequential(
     progress_interval = max(1, min(10, total // 10)) if total > 0 else 1
 
     for idx, row in enumerate(dataset):
+        # Pass fewshot_prefix only when non-empty so legacy strategy
+        # implementations (without the kwarg) continue to work.
+        kwargs = {"fewshot_prefix": fewshot_prefix} if fewshot_prefix else {}
         scores, prediction = strategy.evaluate_sample(
-            idx, row, bench, model_call_fn, endpoint_type, request_timeout
+            idx,
+            row,
+            bench,
+            model_call_fn,
+            endpoint_type,
+            request_timeout,
+            **kwargs,
         )
 
         if scores is None:
@@ -525,7 +834,7 @@ def _run_eval_loop_sequential(
 def _run_eval_loop_parallel(
     bench: BenchmarkDefinition,
     dataset: List[Dict],
-    model_call_fn: Callable[[str, str], str],
+    model_call_fn: Callable[..., Any],
     endpoint_type: str,
     strategy: EvalStrategy,
     save_predictions: bool = False,
@@ -534,6 +843,7 @@ def _run_eval_loop_parallel(
     fail_on_skip: bool = False,
     parallelism: int = 4,
     request_timeout: Optional[float] = None,
+    fewshot_prefix: str = "",
 ) -> Tuple[List[Dict], List[SampleResult]]:
     """Parallel evaluation loop. See :func:`run_eval_loop` for parameter docs."""
     if request_timeout is not None:
@@ -557,8 +867,15 @@ def _run_eval_loop_parallel(
     def evaluate_one(
         idx: int, row: Dict
     ) -> Tuple[int, Optional[Dict], Optional[SampleResult]]:
+        kwargs = {"fewshot_prefix": fewshot_prefix} if fewshot_prefix else {}
         scores, prediction = strategy.evaluate_sample(
-            idx, row, bench, model_call_fn, endpoint_type, request_timeout
+            idx,
+            row,
+            bench,
+            model_call_fn,
+            endpoint_type,
+            request_timeout,
+            **kwargs,
         )
         return idx, scores, prediction
 

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/runner.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/runner.py
@@ -133,6 +133,151 @@ def call_model_chat(
     return response.json()["choices"][0]["message"]["content"]
 
 
+def call_model_loglikelihood(
+    url: str,
+    model_id: str,
+    context: str,
+    continuation: str,
+    api_key: Optional[str] = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    session: Optional[requests.Session] = None,
+    *,
+    system_prompt: Optional[str] = None,
+) -> tuple:
+    """Compute (sum_logprob, is_greedy) for ``continuation`` given ``context``.
+
+    This mirrors lm-evaluation-harness's ``loglikelihood`` contract for the
+    ``local-completions`` model adapter. It POSTs to ``/v1/completions`` with
+    ``prompt = context + continuation``, ``max_tokens=0``, ``echo=true``,
+    ``logprobs=1``, ``temperature=0`` so the server returns per-token log
+    probabilities for the entire prompt without generating new tokens.
+
+    The continuation token span is determined via the OpenAI-compatible
+    ``logprobs.text_offset`` field: the first token whose ``text_offset`` is
+    >= ``len(context)`` (in characters) marks the start of the continuation.
+    The summed log-prob over that span is the loglikelihood; ``is_greedy`` is
+    True when each continuation token equals the argmax of its
+    ``top_logprobs`` entry (i.e. the sequence would have been produced under
+    greedy decoding).
+
+    Args:
+        url: Base URL for the model endpoint.
+        model_id: Model identifier.
+        context: Prompt context (everything up to but not including the
+            continuation tokens).
+        continuation: The candidate continuation whose loglikelihood is
+            being scored.
+        api_key: Optional Bearer token.
+        timeout: Per-request timeout in seconds.
+        session: Optional requests.Session for connection pooling.
+        system_prompt: Optional system prompt prepended to ``context``.
+            Length is included when locating the continuation start, so the
+            same character-offset logic applies.
+
+    Returns:
+        Tuple of ``(sum_logprob, is_greedy)``:
+
+        * ``sum_logprob``: float, sum of ``token_logprobs`` over the
+          continuation token span. Returns ``-float('inf')`` if the server
+          response cannot be parsed.
+        * ``is_greedy``: bool, True if every continuation token equals the
+          top-1 token from its ``top_logprobs`` entry.
+
+    Raises:
+        requests.HTTPError: On non-2xx response.
+        requests.Timeout: On timeout.
+    """
+    endpoint = f"{url}/completions"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    full_context = f"{system_prompt}\n{context}" if system_prompt else context
+    full_prompt = full_context + continuation
+
+    payload = {
+        "model": model_id,
+        "prompt": full_prompt,
+        "max_tokens": 0,
+        "temperature": 0.0,
+        "logprobs": 1,
+        "echo": True,
+    }
+
+    http = session or requests
+    response = http.post(endpoint, json=payload, headers=headers, timeout=timeout)
+    response.raise_for_status()
+
+    body = response.json()
+    return _parse_loglikelihood_response(body, full_context)
+
+
+def _parse_loglikelihood_response(body: dict, context: str) -> tuple:
+    """Parse an OpenAI-compatible /completions response into (sum_logprob, is_greedy).
+
+    Mirrors lm-eval-harness's ``local-completions`` parsing:
+
+    1. Locate the continuation start via ``text_offset >= len(context)``.
+    2. Sum ``token_logprobs`` from that index onward.
+    3. ``is_greedy`` is True if each continuation token matches the top-1
+       entry in ``top_logprobs`` for its position.
+
+    Returns ``(-inf, False)`` when the response is missing logprobs or the
+    continuation is empty (zero tokens).
+    """
+    try:
+        choice = body["choices"][0]
+        logprobs = choice.get("logprobs") or {}
+    except (KeyError, IndexError, TypeError):
+        return (float("-inf"), False)
+
+    tokens = logprobs.get("tokens") or []
+    token_logprobs = logprobs.get("token_logprobs") or []
+    text_offset = logprobs.get("text_offset") or []
+    top_logprobs = logprobs.get("top_logprobs") or []
+
+    if not tokens or not token_logprobs:
+        return (float("-inf"), False)
+
+    ctx_len = len(context)
+    start_idx = None
+    for i, off in enumerate(text_offset):
+        if off is not None and off >= ctx_len:
+            start_idx = i
+            break
+
+    # Fallback: if text_offset is missing or all offsets are < ctx_len
+    # (e.g. continuation tokenized into the last context token), assume
+    # the very last token is the continuation.
+    if start_idx is None:
+        start_idx = max(len(tokens) - 1, 0)
+
+    cont_token_logprobs = [lp for lp in token_logprobs[start_idx:] if lp is not None]
+    if not cont_token_logprobs:
+        return (float("-inf"), False)
+
+    sum_logprob = float(sum(cont_token_logprobs))
+
+    is_greedy = True
+    for i in range(start_idx, len(tokens)):
+        top = top_logprobs[i] if i < len(top_logprobs) else None
+        if not top:
+            is_greedy = False
+            break
+        # ``top_logprobs[i]`` is a dict {token: logprob}. The top-1 token
+        # is the one with the highest logprob value.
+        try:
+            best_token = max(top.items(), key=lambda kv: kv[1])[0]
+        except (AttributeError, ValueError):
+            is_greedy = False
+            break
+        if best_token != tokens[i]:
+            is_greedy = False
+            break
+
+    return (sum_logprob, is_greedy)
+
+
 def call_model_completions(
     url: str,
     model_id: str,
@@ -344,8 +489,26 @@ def _create_session_model_call_fn(
         *,
         system_prompt: Optional[str] = None,
         timeout: Optional[float] = None,
-    ) -> str:
+        continuation: Optional[str] = None,
+    ):
         effective_timeout = timeout if timeout is not None else default_timeout
+        if endpoint_type == "completions_logprob":
+            if continuation is None:
+                raise ValueError(
+                    "endpoint_type='completions_logprob' requires a "
+                    "'continuation' kwarg (the candidate continuation "
+                    "whose loglikelihood is being scored)."
+                )
+            return call_model_loglikelihood(
+                url=args.model_url,
+                model_id=args.model_id,
+                context=prompt,
+                continuation=continuation,
+                api_key=api_key,
+                timeout=effective_timeout,
+                session=session,
+                system_prompt=system_prompt,
+            )
         if endpoint_type == "chat":
             return call_model_chat(
                 url=args.model_url,
@@ -422,7 +585,33 @@ def create_client_model_call_fn(
         *,
         system_prompt: Optional[str] = None,
         timeout: Optional[float] = None,
-    ) -> str:
+        continuation: Optional[str] = None,
+    ):
+        if endpoint_type == "completions_logprob":
+            if continuation is None:
+                raise ValueError(
+                    "endpoint_type='completions_logprob' requires a "
+                    "'continuation' kwarg."
+                )
+            full_context = f"{system_prompt}\n{prompt}" if system_prompt else prompt
+            full_prompt = full_context + continuation
+
+            # The async OpenAI client returns ``.text``; use the raw
+            # ``.completions.create`` so we can request logprobs+echo.
+            async def _logprob_call():
+                async with client.semaphore:  # honour parallelism guard
+                    resp = await client.client.completions.create(
+                        model=client.model_id,
+                        prompt=full_prompt,
+                        max_tokens=0,
+                        temperature=0.0,
+                        logprobs=1,
+                        echo=True,
+                    )
+                return resp.model_dump()
+
+            body = asyncio.run(_logprob_call())
+            return _parse_loglikelihood_response(body, full_context)
         if endpoint_type == "chat":
             messages = []
             if system_prompt:
@@ -481,8 +670,14 @@ def main():
     parser.add_argument(
         "--model-type",
         default="chat",
-        choices=["chat", "completions"],
-        help="Endpoint type: 'chat' or 'completions'",
+        choices=["chat", "completions", "completions_logprob"],
+        help=(
+            "Endpoint type. 'chat' uses /v1/chat/completions, 'completions' "
+            "uses /v1/completions for text generation, and "
+            "'completions_logprob' uses /v1/completions with "
+            "echo=true,logprobs=1,max_tokens=0 for per-choice loglikelihood "
+            "ranking (lm-eval-harness 'local-completions' parity)."
+        ),
     )
     parser.add_argument(
         "--temperature",
@@ -561,6 +756,24 @@ def main():
         default=None,
         help="Per-request timeout in seconds (default: None, falls back to --timeout-per-sample)",
     )
+    parser.add_argument(
+        "--num-fewshot",
+        type=int,
+        default=0,
+        help=(
+            "Number of few-shot examples to prepend to each prompt "
+            "(default: 0). Examples are sampled deterministically from the "
+            "benchmark's fewshot_split (or the first --num-fewshot rows of "
+            "the same dataset when fewshot_split is not declared). Mirrors "
+            "lm-eval-harness's --num_fewshot semantics."
+        ),
+    )
+    parser.add_argument(
+        "--fewshot-seed",
+        type=int,
+        default=42,
+        help="Random seed for few-shot example sampling (default: 42).",
+    )
 
     args = parser.parse_args()
 
@@ -580,6 +793,37 @@ def main():
         limit=args.limit_samples,
         field_mapping=bench.field_mapping,
     )
+
+    # Resolve few-shot examples: precedence is CLI flag > benchmark default.
+    # Robust to mocked benchmark objects (tests use MagicMock) where
+    # ``bench.num_fewshot`` may not be a real int.
+    effective_num_fewshot = 0
+    try:
+        effective_num_fewshot = int(args.num_fewshot or 0)
+    except (TypeError, ValueError):
+        effective_num_fewshot = 0
+    if not effective_num_fewshot:
+        try:
+            effective_num_fewshot = int(getattr(bench, "num_fewshot", 0) or 0)
+        except (TypeError, ValueError):
+            effective_num_fewshot = 0
+    fewshot_examples: List[Dict] = []
+    if effective_num_fewshot > 0:
+        from nemo_evaluator.contrib.byob.eval_logic import build_fewshot_examples
+
+        fewshot_examples = build_fewshot_examples(
+            primary_dataset_uri=args.dataset,
+            primary_dataset=dataset,
+            num_fewshot=effective_num_fewshot,
+            fewshot_split=bench.fewshot_split,
+            field_mapping=bench.field_mapping,
+            seed=args.fewshot_seed,
+        )
+        logger.info(
+            "Few-shot examples prepared",
+            num_fewshot=effective_num_fewshot,
+            sampled=len(fewshot_examples),
+        )
 
     # Create model call function — try NeMoEvaluatorClient, fall back to raw HTTP
     cleanup_fn = None
@@ -622,6 +866,7 @@ def main():
                 if args.request_timeout is not None
                 else args.timeout_per_sample
             ),
+            fewshot_examples=fewshot_examples,
         )
 
         # Offset sample_id and add _repeat metadata for repeats

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/scorers.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/scorers.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import math
 import re
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from nemo_evaluator.contrib.byob.decorators import ScorerInput
@@ -319,6 +319,404 @@ def retrieval_metrics(sample: ScorerInput) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Multiple-choice loglikelihood scorer (lm-evaluation-harness parity)
+# ---------------------------------------------------------------------------
+
+
+def multiple_choice_acc(sample: ScorerInput) -> dict:
+    """Score multiple-choice loglikelihood ranking with lm-eval-harness metrics.
+
+    Expects ``MultipleChoiceStrategy`` to have populated ``sample.choices``
+    and ``sample.choices_logprobs``. Returns:
+
+    * ``acc``: 1.0 if argmax of raw loglikelihoods matches gold, else 0.0
+      (the canonical MMLU metric).
+    * ``acc_norm``: 1.0 if argmax of length-normalized loglikelihoods
+      matches gold, else 0.0. Normalization divides each loglikelihood by
+      ``max(len(choice.encode("utf-8")), 1)`` — this is the exact
+      per-byte normalization used by lm-eval-harness for ARC and BoolQ.
+    * ``acc_greedy``: 1.0 if the greedy choice (the one whose continuation
+      tokens were all top-1 predictions) is also gold, else 0.0. Useful
+      for diagnostic comparison against lm-eval.
+
+    Resolves gold to an integer index by accepting any of:
+
+    * an integer index already (``sample.target == 1``).
+    * a letter ``"A"``..``"Z"`` (offset from ``"A"``).
+    * a literal choice string that appears verbatim in ``sample.choices``.
+    * a stringified integer (``"0"``, ``"1"``, ...).
+
+    Returns ``{"acc": 0.0, "acc_norm": 0.0, "acc_greedy": 0.0}`` if no
+    choices were supplied (e.g. user wired this scorer to a benchmark
+    that didn't go through MultipleChoiceStrategy).
+    """
+    choices = sample.choices or []
+    logprobs = sample.choices_logprobs or []
+    is_greedy = sample.choices_is_greedy or []
+
+    zero = {"acc": 0.0, "acc_norm": 0.0, "acc_greedy": 0.0}
+    if not choices or not logprobs or len(choices) != len(logprobs):
+        return zero
+
+    gold_idx = _resolve_gold_index(sample.target, choices)
+    if gold_idx is None:
+        return zero
+
+    raw_argmax = max(range(len(logprobs)), key=lambda i: logprobs[i])
+
+    norm_scores = [
+        logprobs[i] / max(len(choices[i].encode("utf-8")), 1)
+        for i in range(len(choices))
+    ]
+    norm_argmax = max(range(len(norm_scores)), key=lambda i: norm_scores[i])
+
+    greedy_argmax: Optional[int] = None
+    if is_greedy and any(is_greedy):
+        # Pick highest-loglikelihood choice that is also greedy
+        greedy_indices = [i for i, g in enumerate(is_greedy) if g]
+        if greedy_indices:
+            greedy_argmax = max(greedy_indices, key=lambda i: logprobs[i])
+
+    return {
+        "acc": 1.0 if raw_argmax == gold_idx else 0.0,
+        "acc_norm": 1.0 if norm_argmax == gold_idx else 0.0,
+        "acc_greedy": (
+            1.0 if greedy_argmax is not None and greedy_argmax == gold_idx else 0.0
+        ),
+    }
+
+
+def _resolve_gold_index(target, choices: list) -> "int | None":
+    """Map a heterogeneous ``target`` value to an index into ``choices``."""
+    if target is None:
+        return None
+    if isinstance(target, bool):
+        return int(target) if int(target) < len(choices) else None
+    if isinstance(target, int):
+        return target if 0 <= target < len(choices) else None
+    if isinstance(target, str):
+        s = target.strip()
+        if not s:
+            return None
+        # Letter (A-Z)
+        if len(s) == 1 and s.upper().isalpha():
+            idx = ord(s.upper()) - ord("A")
+            if 0 <= idx < len(choices):
+                return idx
+        # Stringified int
+        if s.lstrip("-").isdigit():
+            try:
+                idx = int(s)
+                if 0 <= idx < len(choices):
+                    return idx
+            except ValueError:
+                pass
+        # Verbatim choice text
+        for i, c in enumerate(choices):
+            if c.strip() == s:
+                return i
+        # Case-insensitive verbatim
+        s_low = s.lower()
+        for i, c in enumerate(choices):
+            if c.strip().lower() == s_low:
+                return i
+    return None
+
+
+# ---------------------------------------------------------------------------
+# MCQ letter extraction (text-mode) — hoisted from example benchmarks
+# ---------------------------------------------------------------------------
+
+
+_MCQ_LETTER_PATTERNS = (
+    re.compile(r"(?:answer\s+is\s*[:\-]?\s*\(?)\s*([A-Ja-j])\b", re.IGNORECASE),
+    re.compile(r"\boption\s*\(?([A-Ja-j])\)", re.IGNORECASE),
+    re.compile(r"^\s*\(?([A-Ja-j])[\)\.\:]", re.IGNORECASE),
+    re.compile(r"\b([A-Ja-j])\b"),
+)
+
+
+def _extract_letter(response: str | None) -> str:
+    """Best-effort extract a single A-J letter from a free-form response."""
+    text = (response or "").strip()
+    if not text:
+        return ""
+    if text[0].upper() in "ABCDEFGHIJ":
+        return text[0].upper()
+    for pat in _MCQ_LETTER_PATTERNS:
+        m = pat.search(text[:200])
+        if m:
+            return m.group(1).upper()
+    return ""
+
+
+# Letter-coded choices for common MCQ datasets. Some newer MMLU-Pro style
+# datasets expose up to ten options (A-J).
+_INT_TO_LETTER = {i: chr(ord("A") + i) for i in range(10)}
+
+
+def mcq_letter_extract(sample: ScorerInput) -> dict:
+    """Extract A-J from response and compare against target.
+
+    Handles common response formats (``"A"``, ``"A)"``, ``"The answer is B"``,
+    ``"B. Because..."``, ``"(C)"``, ``"Option D"``). Targets may be:
+
+    * a letter (``"A"``..``"J"``).
+    * an integer index (``0``..``9``) or its string form.
+    * a verbatim choice text — matched against ``sample.metadata`` keys
+      ``a``/``b``/``c``/``d`` if available.
+
+    Returns ``{"correct": bool, "parsed": bool}``.
+    """
+    predicted = _extract_letter(sample.response)
+
+    raw = sample.target
+    target_letter = ""
+    if isinstance(raw, bool):
+        raw = int(raw)
+    if isinstance(raw, int):
+        target_letter = _INT_TO_LETTER.get(raw, "")
+    elif isinstance(raw, str):
+        s = raw.strip()
+        if s.isdigit():
+            target_letter = _INT_TO_LETTER.get(int(s), s.upper())
+        elif s and s[0].upper() in "ABCDEFGHIJ" and len(s) <= 2:
+            target_letter = s[0].upper()
+        else:
+            # Try matching against choice text in metadata
+            for letter, key in zip("ABCD", ("a", "b", "c", "d")):
+                cand = sample.metadata.get(key)
+                if isinstance(cand, str) and cand.strip().lower() == s.lower():
+                    target_letter = letter
+                    break
+
+    return {
+        "correct": bool(predicted) and predicted == target_letter,
+        "parsed": bool(predicted),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GSM8K numeric-answer extraction (#### marker)
+# ---------------------------------------------------------------------------
+
+
+_GSM8K_HASH_PATTERN = re.compile(r"####\s*(-?\d[\d,]*(?:\.\d+)?)")
+_NUMBER_PATTERN = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+_BOXED_PATTERN = re.compile(r"\\boxed\{\s*(-?\d[\d,]*(?:\.\d+)?)\s*\}")
+
+
+def _normalize_number(s: str) -> "str | None":
+    """Strip commas, trim trailing zeros after decimal, return canonical form."""
+    if s is None:
+        return None
+    s = s.replace(",", "").strip()
+    if not _NUMBER_PATTERN.fullmatch(s):
+        return None
+    if "." in s:
+        # 12.300 -> 12.3, 12.000 -> 12
+        s = s.rstrip("0").rstrip(".")
+    return s or "0"
+
+
+def gsm8k_answer(sample: ScorerInput) -> dict:
+    """Extract the canonical GSM8K numeric answer and compare to target.
+
+    Extraction precedence:
+
+    1. ``#### <number>`` marker (the canonical GSM8K answer format).
+    2. ``\\boxed{<number>}`` (LaTeX-style answer markers, common in
+       chain-of-thought prompts).
+    3. The last number in the response (fallback for free-form output).
+
+    The target string is parsed the same way (so gold answers stored as
+    full GSM8K solutions like ``"... #### 42"`` work directly).
+
+    Returns ``{"correct": bool, "parsed": bool}`` after stripping commas
+    and normalizing trailing zeros.
+    """
+    response = sample.response or ""
+
+    predicted_raw = None
+    m = _GSM8K_HASH_PATTERN.search(response)
+    if m:
+        predicted_raw = m.group(1)
+    else:
+        m = _BOXED_PATTERN.search(response)
+        if m:
+            predicted_raw = m.group(1)
+        else:
+            matches = _NUMBER_PATTERN.findall(response)
+            if matches:
+                predicted_raw = matches[-1]
+
+    predicted = _normalize_number(predicted_raw) if predicted_raw else None
+
+    target_raw = sample.target
+    if isinstance(target_raw, (int, float)):
+        gold = _normalize_number(str(target_raw))
+    else:
+        target_str = str(target_raw or "")
+        m = _GSM8K_HASH_PATTERN.search(target_str)
+        if m:
+            gold = _normalize_number(m.group(1))
+        else:
+            matches = _NUMBER_PATTERN.findall(target_str)
+            gold = _normalize_number(matches[-1]) if matches else None
+
+    return {
+        "correct": bool(
+            predicted is not None and gold is not None and predicted == gold
+        ),
+        "parsed": predicted is not None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Boolean yes/no extraction
+# ---------------------------------------------------------------------------
+
+
+_YES_TOKENS = {"yes", "true", "correct", "right", "yeah", "yep", "हां", "हाँ", "जी"}
+_NO_TOKENS = {"no", "false", "incorrect", "wrong", "nope", "nah", "नहीं"}
+_TOKEN_RE = re.compile(r"[A-Za-z\u0900-\u097F]+", re.UNICODE)
+
+
+def boolean_yesno(sample: ScorerInput) -> dict:
+    """Extract a yes/no decision from the response and compare to target.
+
+    Heuristic: scans the first ~20 alphabetic tokens of the response and
+    picks the first match in ``_YES_TOKENS`` / ``_NO_TOKENS`` (case
+    insensitive, includes Devanagari hindi forms हां/नहीं). Targets may
+    be booleans, ``"yes"``/``"no"`` strings, or stringified bools.
+
+    Returns ``{"correct": bool, "parsed": bool}``.
+    """
+    response = (sample.response or "").lower()
+    tokens = _TOKEN_RE.findall(response)[:20]
+    predicted: "str | None" = None
+    for tok in tokens:
+        tl = tok.lower()
+        if tl in _YES_TOKENS:
+            predicted = "yes"
+            break
+        if tl in _NO_TOKENS:
+            predicted = "no"
+            break
+
+    raw = sample.target
+    if isinstance(raw, bool):
+        gold = "yes" if raw else "no"
+    elif isinstance(raw, (int, float)):
+        gold = "yes" if int(raw) == 1 else "no" if int(raw) == 0 else None
+    else:
+        s = str(raw).strip().lower()
+        if s in _YES_TOKENS or s in {"1", "true"}:
+            gold = "yes"
+        elif s in _NO_TOKENS or s in {"0", "false"}:
+            gold = "no"
+        else:
+            gold = None
+
+    return {
+        "correct": bool(
+            predicted is not None and gold is not None and predicted == gold
+        ),
+        "parsed": predicted is not None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# chrF / chrF++ (sacreBLEU-style character n-gram F-score)
+# ---------------------------------------------------------------------------
+
+
+def _char_ngrams(text: str, n: int) -> Counter:
+    if not text or len(text) < n:
+        return Counter()
+    return Counter(text[i : i + n] for i in range(len(text) - n + 1))
+
+
+def _word_ngrams(tokens: list, n: int) -> Counter:
+    if len(tokens) < n:
+        return Counter()
+    return Counter(tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1))
+
+
+def _chrf_score(
+    hyp: str, ref: str, max_char_n: int = 6, max_word_n: int = 0, beta: float = 2.0
+) -> float:
+    """Compute chrF or chrF++ score in [0, 100].
+
+    Mirrors the sacreBLEU formula: arithmetic mean of per-n F-beta scores
+    over character n-grams (and optionally word n-grams when
+    ``max_word_n > 0``, which gives chrF++).
+    """
+    if not hyp or not ref:
+        return 0.0
+
+    f_scores: list = []
+
+    for n in range(1, max_char_n + 1):
+        h_ng = _char_ngrams(hyp, n)
+        r_ng = _char_ngrams(ref, n)
+        if not h_ng or not r_ng:
+            f_scores.append(0.0)
+            continue
+        overlap = sum((h_ng & r_ng).values())
+        h_total = sum(h_ng.values())
+        r_total = sum(r_ng.values())
+        prec = overlap / h_total if h_total else 0.0
+        rec = overlap / r_total if r_total else 0.0
+        if prec + rec == 0:
+            f_scores.append(0.0)
+        else:
+            f_scores.append((1 + beta**2) * prec * rec / (beta**2 * prec + rec))
+
+    if max_word_n > 0:
+        h_tok = hyp.split()
+        r_tok = ref.split()
+        for n in range(1, max_word_n + 1):
+            h_ng = _word_ngrams(h_tok, n)
+            r_ng = _word_ngrams(r_tok, n)
+            if not h_ng or not r_ng:
+                f_scores.append(0.0)
+                continue
+            overlap = sum((h_ng & r_ng).values())
+            h_total = sum(h_ng.values())
+            r_total = sum(r_ng.values())
+            prec = overlap / h_total if h_total else 0.0
+            rec = overlap / r_total if r_total else 0.0
+            if prec + rec == 0:
+                f_scores.append(0.0)
+            else:
+                f_scores.append((1 + beta**2) * prec * rec / (beta**2 * prec + rec))
+
+    return 100.0 * sum(f_scores) / len(f_scores) if f_scores else 0.0
+
+
+def chrf(sample: ScorerInput) -> dict:
+    """Compute sentence-level chrF and chrF++ scores (sacreBLEU style).
+
+    Returns ``{"chrf": float, "chrf_pp": float}`` in the [0, 100] range.
+
+    * ``chrf``: chrF6 — character 1- to 6-gram F2 (the sacreBLEU default).
+    * ``chrf_pp``: chrF++ — chrF6 plus word 1- and 2-gram F2, averaged.
+
+    Pure-Python implementation (no extra dependencies). For a fully
+    standards-compliant figure, also install ``sacrebleu`` and call it
+    directly from a custom @scorer.
+    """
+    hyp = sample.response or ""
+    target = _to_str(sample.target)
+
+    return {
+        "chrf": _chrf_score(hyp, target, max_char_n=6, max_word_n=0, beta=2.0),
+        "chrf_pp": _chrf_score(hyp, target, max_char_n=6, max_word_n=2, beta=2.0),
+    }
+
+
 BUILTIN_SCORERS = {
     "contains": contains,
     "exact_match": exact_match,
@@ -327,4 +725,9 @@ BUILTIN_SCORERS = {
     "bleu": bleu,
     "rouge": rouge,
     "retrieval_metrics": retrieval_metrics,
+    "multiple_choice_acc": multiple_choice_acc,
+    "mcq_letter_extract": mcq_letter_extract,
+    "gsm8k_answer": gsm8k_answer,
+    "boolean_yesno": boolean_yesno,
+    "chrf": chrf,
 }

--- a/packages/nemo-evaluator/src/nemo_evaluator/core/entrypoint.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/core/entrypoint.py
@@ -56,7 +56,7 @@ def get_parser():
         "--model_type",
         type=str,
         help="Run config.: endpoint type",
-        choices=["chat", "completions", "embedding"],
+        choices=["chat", "completions", "completions_logprob", "embedding"],
     )
     parser_run.add_argument("--model_url", type=str, help="Run config.: model URI")
     parser_run.add_argument(
@@ -185,7 +185,7 @@ def run_eval() -> None:
         --eval_type: Type of evaluation to run (e.g., "mmlu_pro", "gsm8k")
         --model_id: Model identifier (e.g "meta/llama-3.1-8b-instruct")
         --model_url: API endpoint URL (e.g "https://integrate.api.nvidia.com/v1/chat/completions" for chat endpoint type)
-        --model_type: Endpoint type ("chat", "completions", "vlm", "embedding")
+        --model_type: Endpoint type ("chat", "completions", "completions_logprob", "vlm", "embedding")
         --api_key_name: Environment variable name for API key integration with endpoints (optional)
         --output_dir: Output directory for results
         --run_config: Path to YAML Run Configuration file (optional)

--- a/packages/nemo-evaluator/src/nemo_evaluator/core/utils.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/core/utils.py
@@ -335,7 +335,7 @@ def get_api_key_from_env(api_key_env_var_name: Optional[str]) -> Optional[str]:
 
 def check_endpoint(
     endpoint_url: str,
-    endpoint_type: Literal["completions", "chat"],
+    endpoint_type: Literal["completions", "completions_logprob", "chat"],
     model_name: str,
     api_key_name: Optional[str] = None,
     max_retries: int = 600,
@@ -345,13 +345,13 @@ def check_endpoint(
 
     Args:
         endpoint_url (str): Full endpoint URL. For most servers that means either ``/v1/chat/completions`` or ``/completions`` must be provided
-        endpoint_type (Literal[completions, chat]): indicates if the model is instruction-tuned (chat) or a base model (completions). Used to constuct a proper payload structure.
+        endpoint_type (Literal[completions, completions_logprob, chat]): indicates if the model is instruction-tuned (chat) or a base model/completions-logprob endpoint. Used to constuct a proper payload structure.
         model_name (str): model name that is linked to payload. Might be required by some endpoint.
         max_retries (int, optional): How many attempt before returning false. Defaults to 600.
         retry_interval (int, optional): How many seconds to wait between attempts. Defaults to 2.
 
     Raises:
-        ValueError: if endpoint_type was not one of "completions", "chat"
+        ValueError: if endpoint_type was not one of "completions", "completions_logprob", "chat"
 
     Returns:
         bool: whether the endpoint is alive
@@ -364,7 +364,7 @@ def check_endpoint(
     if api_key is not None:
         headers["Authorization"] = f"Bearer {api_key}"
     payload = {"model": model_name, "max_tokens": 1}
-    if endpoint_type == "completions":
+    if endpoint_type in ("completions", "completions_logprob"):
         payload["prompt"] = "hello, my name is"
     elif endpoint_type == "chat":
         payload["messages"] = [{"role": "user", "content": "hello, what is your name?"}]


### PR DESCRIPTION
BYOB support for logprob-based multiple-choice evaluation and extends dataset loading/scoring utilities needed by the Sovereign benchmark suite.

- Added completions_logprob as a supported endpoint type
  - Pydantic validation now accepts target.api_endpoint.type: completions_logprob
  - CLI --model_type completions_logprob is allowed
  - Endpoint health checks treat completions_logprob like a /v1/completions endpoint

- Added BYOB logprob evaluation flow
  - Uses /v1/completions with max_tokens=0, echo=true, and logprobs=1
  - Scores candidate continuations using returned token logprobs
  - Supports multiple-choice ranking via one request per candidate answer
  - Supports nested choice fields such as choices.text

- Added/updated BYOB scorers
  - multiple_choice_acc: returns acc, acc_norm, and acc_greedy
  - mcq_letter_extract: supports A-J options and handles empty/None responses safely
  - Added task-oriented scorers for GSM8K-style numeric answers, yes/no tasks, chrF, and ROUGE

- Extended Hugging Face dataset URI support.
  - Parses extra query params beyond split
  - Supports trust_remote_code=true
  - Supports row filtering via filter_field/filter_value, including multiple filters with suffixes
  - This allows BYOB benchmarks to consume datasets where language is stored as a row field instead of a HF config