### PR TITLE
fix(launcher): give auto-export more CPU time

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/slurm/default.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/execution/slurm/default.yaml
@@ -20,7 +20,7 @@ username: ${oc.env:USER} # Defaults to $USER env var
 account: ??? # SLURM account allocation (required)
 output_dir: ??? # Absolute path accessible on compute nodes (required)
 partition: batch
-cpu_partition: null  # CPU-only partition for export jobs. Falls back to execution.partition when null.
+cpu_partition: cpu  # CPU-only partition for export jobs. Falls back to execution.partition when null.
 num_nodes: 1             # Total SLURM nodes (num_nodes_per_instance = num_nodes / num_instances)
 num_instances: 1         # Number of independent deployment instances
 ntasks_per_node: 1

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -1177,9 +1177,11 @@ def _generate_auto_export_section(
     auto_export_cfg = cfg.execution.get("auto_export", {}) or {}
     launcher_install_cmd = None
     export_mounts = {}
+    export_walltime = "04:00:00"
     if isinstance(auto_export_cfg, dict) or OmegaConf.is_config(auto_export_cfg):
         launcher_install_cmd = auto_export_cfg.get("launcher_install_cmd")
         export_mounts = auto_export_cfg.get("export_mounts") or {}
+        export_walltime = auto_export_cfg.get("export_walltime", export_walltime)
         configured_image = auto_export_cfg.get("export_image")
         if configured_image:
             export_image = configured_image
@@ -1197,7 +1199,7 @@ def _generate_auto_export_section(
     export_sbatch += f"#SBATCH --job-name=nel-export-{remote_task_subdir.name}\n"
     export_sbatch += "#SBATCH --nodes=1\n"
     export_sbatch += "#SBATCH --ntasks=1\n"
-    export_sbatch += "#SBATCH --time=00:30:00\n"
+    export_sbatch += f"#SBATCH --time={export_walltime}\n"
     export_sbatch += f"#SBATCH --account {cfg.execution.account}\n"
     export_sbatch += f"#SBATCH --partition {export_partition}\n"
     export_sbatch += "#SBATCH --no-requeue\n"

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -1488,6 +1488,60 @@ class TestSlurmExecutorDryRun:
         assert "my-registry.com/uv-git:latest" in section
         assert "python:3.12.7-slim" not in section
 
+    def test_generate_auto_export_section_with_custom_walltime(self):
+        cfg = OmegaConf.create(
+            {
+                "execution": {
+                    "account": "test_account",
+                    "partition": "gpu_partition",
+                    "output_dir": "/tmp/out",
+                    "auto_export": {
+                        "destinations": ["mlflow"],
+                        "export_walltime": "06:00:00",
+                    },
+                },
+                "export": {},
+            }
+        )
+
+        section = _generate_auto_export_section(
+            cfg=cfg,
+            job_id="abc12345.0",
+            destinations=["mlflow"],
+            env_var_names=[],
+            secrets=SecretsEnvResult(secrets_content=""),
+            remote_task_subdir=Path("/tmp/out/test_task"),
+        )
+
+        assert "#SBATCH --time=06:00:00" in section
+        assert "#SBATCH --time=04:00:00" not in section
+        assert "#SBATCH --time=00:30:00" not in section
+
+    def test_generate_auto_export_section_default_walltime_is_four_hours(self):
+        cfg = OmegaConf.create(
+            {
+                "execution": {
+                    "account": "test_account",
+                    "partition": "gpu_partition",
+                    "output_dir": "/tmp/out",
+                    "auto_export": {"destinations": ["mlflow"]},
+                },
+                "export": {},
+            }
+        )
+
+        section = _generate_auto_export_section(
+            cfg=cfg,
+            job_id="abc12345.0",
+            destinations=["mlflow"],
+            env_var_names=[],
+            secrets=SecretsEnvResult(secrets_content=""),
+            remote_task_subdir=Path("/tmp/out/test_task"),
+        )
+
+        assert "#SBATCH --time=04:00:00" in section
+        assert "#SBATCH --time=00:30:00" not in section
+
     def test_sbatch_script_exits_nonzero_on_interrupted_marker(
         self, sample_config, mock_tasks_mapping, tmpdir
     ):


### PR DESCRIPTION
## Summary

- add `execution.auto_export.export_walltime` for Slurm auto-export jobs
- default Slurm auto-export walltime to 4 hours instead of 30 minutes
- default `execution.cpu_partition` to `cpu`

## Why

CPU partitions are pretty much free, while failed auto-export jobs are painful to recover from. Large benchmark artifacts, especially CLU-style outputs like `nemo-evaluator-per-sample-outputs/`, can take longer than 30 minutes to stage and upload. When auto-export runs out of time after a successful eval, the benchmark itself is done but the result still needs manual export intervention.

Using the CPU partition by default keeps export work off GPU partitions, and a 4 hour default gives large artifact uploads enough room without making users set the same boilerplate in every Slurm config. The new `export_walltime` knob keeps the behavior configurable for clusters or workflows that need a different limit.

## Test

```bash
uv run pytest tests/unit_tests/test_slurm_executor.py -k walltime
```
