### PR TITLE
feat(mlflow/exporter): default to proxied multipart upload

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py
@@ -43,6 +43,33 @@ from nemo_evaluator_launcher.exporters.utils import (
 
 DEFAULT_EXPERIMENT_NAME = "nemo-evaluator-launcher"
 
+# MLflow proxied multipart upload defaults. The MLflow client reads these env
+# vars just before each upload (mlflow/store/artifact/http_artifact_repo.py:75-83)
+# and, if the server does not advertise multipart endpoints, falls back to a
+# single streaming PUT via _UnsupportedMultipartUploadException — so flipping
+# the flag on by default is safe regardless of server version.
+#
+# We override upstream's defaults (False / 10 MiB / 500 MiB) to engage parallel
+# direct-to-S3 chunk upload on artifacts >= 100 MiB with 50 MiB chunks. Measured
+# 85x speed-up on 1 GiB vs single-part on prod (2026-04-30), and lifts the
+# effective cap above the ingress proxy-body-size for >2 GiB artifacts.
+_MLFLOW_MULTIPART_UPLOAD_DEFAULTS = {
+    "MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD": "true",
+    "MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE": str(50 * 1024 * 1024),
+    "MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE": str(100 * 1024 * 1024),
+}
+
+
+def _enable_proxy_multipart_upload_defaults() -> None:
+    """Set proxied multipart upload defaults if the user hasn't overridden them.
+
+    Uses os.environ.setdefault so values from the calling environment
+    (including the launcher's export.env_vars config block, which arrives via
+    --container-env in the Slurm executor) take precedence.
+    """
+    for name, default in _MLFLOW_MULTIPART_UPLOAD_DEFAULTS.items():
+        os.environ.setdefault(name, default)
+
 
 class MLflowExporterConfig(ExportConfig):
     """Configuration for MLflowExporter."""
@@ -257,6 +284,8 @@ class MLflowExporter(BaseExporter):
         job_data: DataForExport,
     ) -> List[str]:
         """Log evaluation artifacts to MLflow using LocalExporter for transfer."""
+
+        _enable_proxy_multipart_upload_defaults()
 
         # Log config at root level (or synthesize)
         fname = "config.yml"


### PR DESCRIPTION
## Summary

Enable MLflow's proxied multipart upload by default in `MLflowExporter`, so artifact uploads to a tracking server backed by S3 (or any cloud store with multipart support) go client → S3 directly in parallel chunks instead of single streaming PUT through the server.

The MLflow client already has automatic fallback to single-part PUT (`mlflow/store/artifact/http_artifact_repo.py:75-83` — catches `_UnsupportedMultipartUploadException`), so this is safe to flip on regardless of server version. Servers without `--serve-artifacts` or older MLflow simply degrade to today's behaviour.

Defaults are applied via `os.environ.setdefault`, so any value already in the environment — including the launcher's `export.env_vars` block (which arrives via `--container-env` on the export `srun`) — still wins.

## What changed

```diff
+ MLFLOW_ENABLE_PROXY_MULTIPART_UPLOAD       true     (upstream default: false)
+ MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE         50 MiB   (upstream default: 10 MiB)
+ MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE  100 MiB  (upstream default: 500 MiB)
```

One file touched: `packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/exporters/mlflow.py`. New module-level constant + helper, called once at the entry of `_log_artifacts()`.

## Why

Bench against `mlflow-nemo-evaluator.nvidia.com` on 2026-04-30:

| size  | mode              | duration | min/GiB | speedup |
|-------|-------------------|---------:|--------:|--------:|
| 1 GiB | single-part       | 1385.6 s |   23.09 |    1.0× |
| 1 GiB | proxied multipart |   16.2 s |    0.27 |   **85.7×** |
| 3 GiB | proxied multipart |   30.6 s |    0.17 |   n/a   |

The 3 GiB single-part was deliberately not benched: prod nginx caps `proxy-body-size: 2048m`, so any single PUT ≥ 2 GiB would 413 at the ingress. Multipart sidesteps that — each part is `chunk_size` (50 MiB), well under the cap. So this PR also unblocks artifact sizes above 2 GiB (rollouts, per-sample metrics for terminal-bench, etc.).

Direct-to-S3 was confirmed mid-flight: 6 parallel TCP sessions to AWS IPs (`3.5.x.x`, `52.219.x.x`); the MLflow ingress only saw the small Create / Complete control calls.

## Fallback path

If the tracking server doesn't advertise multipart endpoints, MLflow's client raises `_UnsupportedMultipartUploadException` and the surrounding code retries via single-part PUT — see `http_artifact_repo.py:75-83`. No further code is needed in this exporter; the upstream behaviour is exactly what we want.

## Test plan

- [x] CI passes
- [ ] Manual: run an export against a tracking server with multipart enabled (e.g. prod) — verify upload completes; should see `mlflow-artifacts/.../create-multipart-upload` calls in server logs and direct PUTs to S3 from the export job
- [ ] Manual: run an export against a server *without* multipart (e.g. older mlflow) — verify the upload still completes via single-part fallback

## Refs

- Slack discussion: #frontier-eval-platform — "Speeding up MLFlow / S3"
- RFC: `mlflow-s3-upload-speedup.md` in `frontier-eval-rfcs` (MR !94)

🤖 Generated with [Claude Code](https://claude.com/claude-code)