### PR TITLE
feat(byob): add completions_logprob endpoint and extend scorers/datasets   

### DIFF
--- a/docs/libraries/nemo-evaluator/extending/byob/benchmark-decorator.md
+++ b/docs/libraries/nemo-evaluator/extending/byob/benchmark-decorator.md
@@ -21,12 +21,18 @@ def check(sample: ScorerInput) -> dict:
 | `dataset` | `str` | required | Path to JSONL file or `hf://` URI |
 | `prompt` | `str` | required | Format string with `{field}` placeholders, or path to template file |
 | `target_field` | `str` | `"target"` | Dataset field containing ground truth |
-| `endpoint_type` | `str` | `"chat"` | `"chat"` or `"completions"` |
+| `endpoint_type` | `str` | `"chat"` | `"chat"`, `"completions"`, or `"completions_logprob"` |
 | `requirements` | `list` or `str` | `None` | Pip deps (list or path to requirements.txt) |
 | `field_mapping` | `dict` | `None` | Maps source columns to prompt field names |
 | `extra` | `dict` | `None` | Framework-specific params (judge config, etc.) |
 | `response_field` | `str` | `None` | JSONL field with pre-generated responses (eval-only mode) |
 | `system_prompt` | `str` | `None` | System prompt string or path to template file |
+| `choices` | `list[str]` | `None` | Static candidate continuations for `endpoint_type="completions_logprob"` |
+| `choices_field` | `str` | `None` | Dataset field containing per-row candidate continuations for `endpoint_type="completions_logprob"`; dotted paths such as `choices.text` are supported |
+| `num_fewshot` | `int` | `0` | Number of few-shot examples to prepend to each prompt |
+| `fewshot_split` | `str` | `None` | Optional split to sample few-shot examples from |
+| `fewshot_template` | `str` | `None` | Optional template for rendering few-shot examples |
+| `fewshot_separator` | `str` | `"\n\n"` | Separator between rendered few-shot examples |
 
 ## Name Normalization
 
@@ -140,6 +146,39 @@ def review(sample: ScorerInput) -> dict:
 :::{note}
 System prompts support Jinja2 templates with the same detection rules as user prompts.
 :::
+
+## Logprob Multiple-Choice Benchmarks
+
+Use `endpoint_type="completions_logprob"` when the benchmark should score
+candidate answers by likelihood instead of asking the model to generate a
+free-form answer. This mode calls an OpenAI-compatible `/v1/completions`
+endpoint with `max_tokens=0`, `echo=true`, and `logprobs=1`.
+
+Static choices:
+
+```python
+@benchmark(
+    name="mmlu-mini",
+    dataset="data.jsonl",
+    prompt="Question: {question}\nAnswer:",
+    target_field="answer",
+    endpoint_type="completions_logprob",
+    choices=[" A", " B", " C", " D"],
+)
+```
+
+Per-row choices, including nested HuggingFace fields:
+
+```python
+@benchmark(
+    name="arc-mini",
+    dataset="hf://my-org/arc-hi?split=test",
+    prompt="Question: {{question}}\nAnswer:",
+    target_field="answerKey",
+    endpoint_type="completions_logprob",
+    choices_field="choices.text",
+)
+```
 
 ## See Also
 

--- a/docs/libraries/nemo-evaluator/extending/byob/cli.md
+++ b/docs/libraries/nemo-evaluator/extending/byob/cli.md
@@ -97,6 +97,19 @@ Use `nemo-evaluator-byob --list` to see the exact `eval_type` for each installed
 benchmark. This avoids guessing the normalized name.
 :::
 
+For logprob-based multiple-choice benchmarks, use a completions endpoint that
+supports `echo` and `logprobs`:
+
+```bash
+nemo-evaluator run_eval \
+  --eval_type byob_<normalized_name>.<normalized_name> \
+  --model_url http://localhost:8000 \
+  --model_id my-model \
+  --model_type completions_logprob \
+  --output_dir ./results \
+  --api_key_name API_KEY
+```
+
 ## See Also
 
 - {ref}`byob` -- BYOB overview and quickstart

--- a/docs/libraries/nemo-evaluator/extending/byob/datasets.md
+++ b/docs/libraries/nemo-evaluator/extending/byob/datasets.md
@@ -45,6 +45,15 @@ hf://org/dataset?split=validation
 hf://org/dataset/config?split=test
 ```
 
+BYOB also accepts selected HuggingFace `load_dataset` options as query
+parameters:
+
+```
+hf://org/dataset?split=test&trust_remote_code=true
+hf://org/dataset?split=validation&filter_field=language&filter_value=hi
+hf://org/dataset?split=test&data_files=file.json&field=examples
+```
+
 ### Examples
 
 ```python
@@ -66,6 +75,39 @@ hf://org/dataset/config?split=test
 )
 ```
 
+Load a gated or custom-code dataset by allowing remote code execution:
+
+```python
+@benchmark(
+    name="indommlu",
+    dataset="hf://indolem/IndoMMLU?split=test&trust_remote_code=true",
+    prompt="{question}\n\n{options}\n\nAnswer:",
+    target_field="answer",
+)
+```
+
+Filter a multilingual dataset to one language:
+
+```python
+@benchmark(
+    name="boolq-hi",
+    dataset="hf://sarvamai/boolq-indic?split=validation&filter_field=language&filter_value=hi",
+    prompt="Passage: {passage}\nQuestion: {question}\nAnswer:",
+    target_field="answer",
+)
+```
+
+Load a nested JSON field from a specific dataset file:
+
+```python
+@benchmark(
+    name="flores-hi",
+    dataset="hf://google/IndicGenBench_flores_in?split=test&data_files=flores_en_hi_test.json&field=examples",
+    prompt="Translate to Hindi: {source}",
+    target_field="target",
+)
+```
+
 :::{note}
 HuggingFace dataset fetching requires the `datasets` pip package. Install it with `pip install datasets`.
 :::
@@ -77,6 +119,69 @@ Downloaded datasets are cached at `~/.cache/nemo_evaluator/hf_datasets/` by defa
 ### Split Selection
 
 When no split is specified, the HuggingFace `datasets` library defaults are used. If the result is a `DatasetDict` (multiple splits), the first available split is selected automatically.
+
+### Query Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `split` | Split passed to `datasets.load_dataset`, for example `test` or `validation`. |
+| `trust_remote_code=true` | Passes `trust_remote_code=True` to `datasets.load_dataset`. Required by some datasets with custom loading scripts. |
+| `filter_field` / `filter_value` | Filters rows after loading, keeping rows where `str(row[filter_field]) == filter_value`. |
+| `filter_field_1` / `filter_value_1`, etc. | Additional row filters applied in order. |
+| `data_files` | Passes `data_files` to `datasets.load_dataset`, useful for repositories that store examples in individual JSON files. |
+| `field` | Passes `field` to `datasets.load_dataset`, useful for JSON files where examples live under a top-level key such as `examples`. |
+
+::::{warning}
+If you put `hf://` URIs with `&` query parameters in shell command
+templates, quote the dataset argument:
+
+```bash
+--dataset "{{config.params.extra.dataset.path}}"
+```
+
+Otherwise the shell treats `&` as a background-command separator.
+::::
+
+### `extra.dataset.*` namespace
+
+BYOB groups dataset-related configuration under
+`config.params.extra.dataset.*` in the FDF / run_config:
+
+| Key | Description |
+|-----|-------------|
+| `path` | Dataset file path or `hf://` URI (compile-time default from `@benchmark(dataset=...)`). |
+| `num_fewshot` | Optional few-shot example count (lm-eval-harness parity). |
+| `field_mapping` | Informational mirror of `@benchmark(field_mapping=...)`. |
+| `choices` / `choices_field` | Informational mirror of `@benchmark(choices=...)` / `@benchmark(choices_field=...)`. |
+
+### Overriding the dataset at run time
+
+The `@benchmark` decorator's `dataset=` value is the compile-time default. To
+swap it for a single run without rebuilding the benchmark, set
+`config.params.extra.dataset.path` via the launcher's run_config or CLI. The
+launcher deep-merges via OmegaConf, so sibling keys under `extra.dataset`
+(`num_fewshot`, `field_mapping`, etc.) and under `extra` (`benchmark_module`,
+`requirements`, …) are preserved.
+
+```bash
+nemo-evaluator-launcher run --config my_config.yaml \
+  -o 'evaluation.tasks.<task_name>.nemo_evaluator_config.config.params.extra.dataset.path=hf://other/foo?split=test'
+```
+
+Or in a run_config YAML:
+
+```yaml
+evaluation:
+  tasks:
+    - name: <task_name>
+      nemo_evaluator_config:
+        config:
+          params:
+            extra:
+              dataset:
+                path: hf://other/foo?split=test
+                num_fewshot: 5
+```
 
 ## Field Mapping
 

--- a/docs/libraries/nemo-evaluator/extending/byob/scorers.md
+++ b/docs/libraries/nemo-evaluator/extending/byob/scorers.md
@@ -11,9 +11,9 @@ Every scorer receives a single `ScorerInput` dataclass importable from `nemo_eva
 ```python
 @dataclass
 class ScorerInput:
-    response: str              # Model output
+    response: str              # Model output (or argmax choice in logprob mode)
     target: Any                # Ground truth from dataset
-    metadata: dict             # Full dataset row as a dict
+    metadata: dict             # Dataset row + per-call response metadata
     model_call_fn: Optional[Callable] = None
     config: Dict[str, Any] = field(default_factory=dict)
     conversation: Optional[List[dict]] = None
@@ -22,13 +22,25 @@ class ScorerInput:
 
 | Field | Description |
 |-------|-------------|
-| `response` | The model output text for the current sample. |
+| `response` | The model output text for the current sample. In `completions_logprob` mode this is set to the choice with the highest sum-logprob (i.e. the argmax). |
 | `target` | The ground-truth value read from the field specified by `target_field` in `@benchmark`. |
-| `metadata` | The entire dataset row as a dictionary, useful for accessing additional fields beyond the target. |
+| `metadata` | Shared bag for **dataset-row fields and per-call response metadata**. Standard scorers use it to access any column on the row (e.g. `sample.metadata["passage"]`). Strategies that produce extra per-call data write namespaced keys (prefixed with `_`) into this dict before invoking the scorer. |
 | `model_call_fn` | Reserved for multi-turn evaluation (not yet implemented). |
 | `config` | Extra configuration passed through `extra=` in `@benchmark` (e.g. judge settings). |
 | `conversation` | Reserved for multi-turn benchmarks (not yet implemented). |
 | `turn_index` | Reserved for multi-turn benchmarks (not yet implemented). |
+
+### Reserved metadata keys
+
+`MultipleChoiceStrategy` (selected by `endpoint_type="completions_logprob"`) writes the following keys into `ScorerInput.metadata` before invoking the scorer:
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `_choices` | `list[str]` | Candidate continuations resolved from `choices=` or `choices_field=` on `@benchmark`. |
+| `_choices_logprobs` | `list[float]` | Per-choice sum log-probabilities returned by the loglikelihood call. Same length as `_choices`. |
+| `_choices_is_greedy` | `list[bool]` | Per-choice booleans: `True` when every continuation token equals the top-1 prediction (i.e. the choice would have been produced under greedy decoding). Same length as `_choices`. |
+
+`response` is also set to `_choices[argmax(_choices_logprobs)]` so legacy text-based scorers continue to work in logprob mode.
 
 ## The @scorer Decorator
 
@@ -57,6 +69,11 @@ Import built-in scorers from `nemo_evaluator.contrib.byob.scorers`:
 | `bleu` | `{"bleu_1": float, "bleu_2": float, "bleu_3": float, "bleu_4": float}` | Sentence-level BLEU-1 through BLEU-4 with add-1 smoothing |
 | `rouge` | `{"rouge_1": float, "rouge_2": float, "rouge_l": float}` | ROUGE-1, ROUGE-2, ROUGE-L F1 scores |
 | `retrieval_metrics` | `{"precision_at_k": float, "recall_at_k": float, "mrr": float, "ndcg": float}` | Retrieval quality metrics |
+| `multiple_choice_acc` | `{"acc": float, "acc_norm": float, "acc_greedy": float}` | Multiple-choice loglikelihood ranking. `acc` matches lm-evaluation-harness MMLU-style raw argmax; `acc_norm` is per-byte length-normalized argmax (ARC/BoolQ style); `acc_greedy` is the highest-loglikelihood greedy choice. Requires `endpoint_type="completions_logprob"` and either `choices=` or `choices_field=` on `@benchmark`. |
+| `mcq_letter_extract` | `{"correct": bool, "parsed": bool}` | Extracts an A-J letter from free-form text (handles "A", "A)", "The answer is B", "(C)", "Option D", and `\boxed{E}`). Targets may be letters, integer indices, or verbatim choice text from the metadata `a`/`b`/`c`/`d` keys. Empty or `None` responses are treated as unparsed rather than raising. |
+| `gsm8k_answer` | `{"correct": bool, "parsed": bool}` | Canonical GSM8K numeric extractor. Tries the `#### <number>` marker first, then `\boxed{<number>}`, then falls back to the last number in the response. Strips commas and normalizes trailing zeros. |
+| `boolean_yesno` | `{"correct": bool, "parsed": bool}` | Extracts English yes/no decisions from free-form text. Recognizes tokens such as yes/no/yep/nope/true/false. |
+| `chrf` | `{"chrf": float, "chrf_pp": float}` | Sentence-level chrF and chrF++ in [0, 100]. Pure-Python sacrebleu-style formula (character 1- to 6-gram F2; chrF++ adds word 1- and 2-gram F2). |
 
 ### Usage example
 
@@ -118,6 +135,88 @@ def combined(sample: ScorerInput) -> dict:
     f1 = f1_token(sample)
     return {**em, **f1}
 ```
+
+## Multiple-choice loglikelihood ranking
+
+For MMLU-, ARC-, and BoolQ-style benchmarks, BYOB supports per-choice
+loglikelihood ranking with **lm-evaluation-harness parity**:
+
+```python
+from nemo_evaluator.contrib.byob import benchmark, scorer, ScorerInput
+from nemo_evaluator.contrib.byob.scorers import multiple_choice_acc
+
+@benchmark(
+    name="mmlu-mini",
+    dataset="hf://my-org/my-mmlu?split=test",
+    prompt="Question: {question}\nAnswer:",
+    target_field="answer",                    # gold letter, e.g. "B"
+    endpoint_type="completions_logprob",      # enables loglikelihood scoring
+    choices=[" A", " B", " C", " D"],         # static candidates per row
+    num_fewshot=5,                            # optional fewshot prefix
+)
+@scorer
+def mmlu_score(sample: ScorerInput) -> dict:
+    return multiple_choice_acc(sample)        # {acc, acc_norm, acc_greedy}
+```
+
+For datasets with **per-row variable choices** (e.g. ARC), set
+`choices_field` instead of `choices`:
+
+```python
+@benchmark(
+    ...,
+    choices_field="choices_text",             # row[choices_text] is a list[str]
+)
+```
+
+Nested/dotted fields are also supported for HuggingFace datasets that store
+choices under a struct-like column:
+
+```python
+@benchmark(
+    ...,
+    choices_field="choices.text",             # row["choices"]["text"]
+)
+```
+
+### How it works
+
+`MultipleChoiceStrategy` (selected automatically when
+`endpoint_type="completions_logprob"`) calls the OpenAI-compatible
+`/v1/completions` endpoint once per choice, exactly like lm-eval's
+`local-completions` adapter:
+
+```text
+POST /v1/completions
+{
+  "model": "...",
+  "prompt": "<context><continuation>",
+  "max_tokens": 0,
+  "logprobs": 1,
+  "echo": true,
+  "temperature": 0
+}
+```
+
+The runner inspects `logprobs.text_offset` to locate the continuation
+token span, sums `token_logprobs` over that span, and decides
+`is_greedy` by checking whether each continuation token matches the
+top-1 entry of `top_logprobs`. The resulting per-choice
+`(sum_logprob, is_greedy)` tuples are written into `ScorerInput.metadata`
+under the reserved keys `_choices`, `_choices_logprobs`, and
+`_choices_is_greedy`. `multiple_choice_acc` then computes:
+
+- `acc` -- 1.0 iff `argmax(metadata["_choices_logprobs"]) == gold_index`
+  (MMLU canonical).
+- `acc_norm` -- 1.0 iff
+  `argmax(metadata["_choices_logprobs"][i] /
+  max(len(metadata["_choices"][i].encode("utf-8")), 1)) == gold_index`
+  (ARC/BoolQ canonical, per-byte length normalization).
+- `acc_greedy` -- 1.0 iff the highest-loglikelihood **greedy** choice
+  matches gold (diagnostic).
+
+The gold answer can be a letter (`"A"`..`"J"`), an integer index, or
+the verbatim choice string -- `multiple_choice_acc` handles all three.
 
 ## See Also
 

--- a/packages/nemo-evaluator/.claude/skills/byob/SKILL.md
+++ b/packages/nemo-evaluator/.claude/skills/byob/SKILL.md
@@ -71,6 +71,11 @@ Import from `nemo_evaluator.contrib.byob.scorers`:
 | `bleu` | `{"bleu_1"..4: float}` | Sentence-level BLEU-1 through BLEU-4 (add-1 smoothing) |
 | `rouge` | `{"rouge_1": float, "rouge_2": float, "rouge_l": float}` | ROUGE-1, ROUGE-2, ROUGE-L F1 |
 | `retrieval_metrics` | `{"precision_at_k": float, "recall_at_k": float, "mrr": float, "ndcg": float}` | Retrieval quality (expects `metadata.retrieved` + `metadata.relevant`) |
+| `multiple_choice_acc` | `{"acc": float, "acc_norm": float, "acc_greedy": float}` | lm-eval-harness-style multiple-choice loglikelihood. Requires `endpoint_type="completions_logprob"` and `choices=` / `choices_field=`. `acc` = raw argmax (MMLU); `acc_norm` = per-byte length-normalized argmax (ARC/BoolQ). |
+| `mcq_letter_extract` | `{"correct": bool, "parsed": bool}` | Extract A/B/C/D from text response and compare to target letter/index/choice text |
+| `gsm8k_answer` | `{"correct": bool, "parsed": bool}` | GSM8K numeric extractor: `#### N` marker, `\boxed{N}`, or last-number fallback |
+| `boolean_yesno` | `{"correct": bool, "parsed": bool}` | English yes/no extraction |
+| `chrf` | `{"chrf": float, "chrf_pp": float}` | sacreBLEU-style chrF / chrF++ for translation quality |
 
 All built-in scorers accept a single `ScorerInput` argument.
 
@@ -89,13 +94,51 @@ strict = all_of(contains, exact_match)   # Correct only if BOTH match
 - Exact string match -> `exact_match` built-in
 - Target appears in response -> `contains` built-in
 - Token overlap / partial credit -> `f1_token` built-in
-- Translation / summarization quality -> `bleu` or `rouge` built-in
+- Translation quality (BLEU) -> `bleu` built-in
+- Translation quality (chrF / chrF++) -> `chrf` built-in
+- Summarization quality (ROUGE) -> `rouge` built-in
 - Retrieval / RAG quality -> `retrieval_metrics` built-in
-- Number extraction (math answers) -> custom: extract last number with regex
-- Letter extraction (A/B/C/D) -> custom: extract first letter A-D
-- Yes/No (boolean QA) -> custom: detect yes/no with startswith + contains
+- GSM8K-style math (#### N) -> `gsm8k_answer` built-in
+- Letter extraction (A/B/C/D) -> `mcq_letter_extract` built-in
+- Yes/No (boolean QA) -> `boolean_yesno` built-in (English)
+- MMLU/ARC/BoolQ canonical (logprob ranking) -> `multiple_choice_acc` built-in with `endpoint_type="completions_logprob"` and `choices=` (or `choices_field=`)
 - Subjective quality -> LLM-as-Judge (see below)
 - Custom logic -> ask user to describe rules, generate scorer
+
+## Multiple-Choice Loglikelihood (lm-eval-harness parity)
+
+For MMLU / ARC / BoolQ-style benchmarks where the canonical metric is
+per-choice loglikelihood ranking, set `endpoint_type="completions_logprob"`
+and declare candidate continuations:
+
+```python
+from nemo_evaluator.contrib.byob import benchmark, scorer, ScorerInput
+from nemo_evaluator.contrib.byob.scorers import multiple_choice_acc
+
+@benchmark(
+    name="my-mmlu",
+    dataset="hf://my-org/mmlu?split=test",
+    prompt="Question: {question}\nAnswer:",
+    target_field="answer",                 # gold "A".."D" or 0..3
+    endpoint_type="completions_logprob",
+    choices=[" A", " B", " C", " D"],      # static list (MMLU)
+    # OR per-row variable choices (ARC):
+    # choices_field="choices_text",
+    num_fewshot=5,                         # optional fewshot prefix
+)
+@scorer
+def mmlu_score(s: ScorerInput) -> dict:
+    return multiple_choice_acc(s)          # acc + acc_norm + acc_greedy
+```
+
+The runner POSTs `/v1/completions` once per choice with
+`echo=true, logprobs=1, max_tokens=0` -- exact same shape as lm-eval's
+`local-completions`. `multiple_choice_acc` returns:
+
+- `acc` -- argmax of raw sum-logprobs (MMLU canonical).
+- `acc_norm` -- argmax of per-byte length-normalized sum-logprobs
+  (ARC / BoolQ canonical).
+- `acc_greedy` -- highest-loglikelihood greedy choice (diagnostic).
 
 ## LLM-as-Judge
 

--- a/packages/nemo-evaluator/src/nemo_evaluator/api/api_dataclasses.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/api/api_dataclasses.py
@@ -39,6 +39,7 @@ class EndpointType(str, Enum):
     UNDEFINED = "undefined"
     CHAT = "chat"
     COMPLETIONS = "completions"
+    COMPLETIONS_LOGPROB = "completions_logprob"
     EMBEDDING = "embedding"
 
 

--- a/packages/nemo-evaluator/src/nemo_evaluator/client/client.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/client/client.py
@@ -232,6 +232,36 @@ class NeMoEvaluatorClient:
         response = await self._retry_with_backoff(_make_request)
         return response.choices[0].text or ""
 
+    async def loglikelihood(self, prompt: str, **kwargs) -> dict:
+        """Score *prompt* for per-token loglikelihoods (lm-eval-harness contract).
+
+        Posts ``/v1/completions`` with ``echo=true, logprobs=1, max_tokens=0``
+        so the server returns per-token log-probabilities for the entire
+        prompt without generating new tokens. Returns the full response body
+        as a dict so callers can inspect ``logprobs.tokens``,
+        ``logprobs.token_logprobs``, ``logprobs.text_offset``, and
+        ``logprobs.top_logprobs``.
+
+        Honours ``self.semaphore`` and ``self._retry_with_backoff`` exactly
+        like ``chat_completion`` / ``completion``.
+        """
+        params = {
+            "model": self.model_id,
+            "prompt": prompt,
+            "max_tokens": 0,
+            "temperature": 0.0,
+            "logprobs": 1,
+            "echo": True,
+            **kwargs,
+        }
+
+        async def _make_request():
+            async with self.semaphore:
+                return await self.client.completions.create(**params)
+
+        response = await self._retry_with_backoff(_make_request)
+        return response.model_dump()
+
     def completions(
         self,
         prompts: List[str],

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/__init__.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/__init__.py
@@ -48,6 +48,26 @@ Scorer composition::
 
 from nemo_evaluator.contrib.byob.decorators import ScorerInput, benchmark, scorer
 from nemo_evaluator.contrib.byob.judge import judge_score
-from nemo_evaluator.contrib.byob.scorers import all_of, any_of
+from nemo_evaluator.contrib.byob.scorers import (
+    all_of,
+    any_of,
+    boolean_yesno,
+    chrf,
+    gsm8k_answer,
+    mcq_letter_extract,
+    multiple_choice_acc,
+)
 
-__all__ = ["benchmark", "scorer", "ScorerInput", "any_of", "all_of", "judge_score"]
+__all__ = [
+    "benchmark",
+    "scorer",
+    "ScorerInput",
+    "any_of",
+    "all_of",
+    "judge_score",
+    "multiple_choice_acc",
+    "mcq_letter_extract",
+    "gsm8k_answer",
+    "boolean_yesno",
+    "chrf",
+]

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/cli.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/cli.py
@@ -202,7 +202,8 @@ def byob_compile(args=None):
         for name, fdf in compiled.items():
             eval_entry = fdf["evaluations"][0]
             print(f"  - {eval_entry['name']} (normalized: {name})")
-            ds = fdf["defaults"]["config"]["params"]["extra"]["dataset"]
+            ds_cfg = fdf["defaults"]["config"]["params"]["extra"]["dataset"]
+            ds = ds_cfg["path"] if isinstance(ds_cfg, dict) else ds_cfg
             print(f"    Dataset: {ds}")
             if os.path.exists(ds):
                 with open(ds) as f:

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/compiler.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/compiler.py
@@ -41,11 +41,23 @@ _logger = get_logger(__name__)
 
 # Jinja2 command template for runner invocation
 # NOTE: Use plain string concatenation to avoid f-string escaping issues with {{ }}
+#
+# Dataset-related config is grouped under ``config.params.extra.dataset.*``:
+#
+#   - ``path``        -- dataset file path or ``hf://`` URI (compile-time
+#                        default from ``@benchmark(dataset=...)``)
+#   - ``num_fewshot`` -- optional few-shot example count (lm-eval-harness
+#                        parity)
+#   - ``field_mapping``, ``choices``, ``choices_field`` -- informational
+#                        metadata; the runner picks up the live values from
+#                        the ``@benchmark`` registry, but they appear in the
+#                        FDF for inspection / override.
+#
 COMMAND_TEMPLATE = (
     "python -m nemo_evaluator.contrib.byob.runner"
     " --benchmark-module {{config.params.extra.benchmark_module}}"
     " --benchmark-name {{config.params.task}}"
-    " --dataset {{config.params.extra.dataset}}"
+    ' --dataset "{{config.params.extra.dataset.path}}"'
     " --output-dir {{config.output_dir}}"
     " --model-url {{target.api_endpoint.url}}"
     " --model-id {{target.api_endpoint.model_id}}"
@@ -68,6 +80,10 @@ COMMAND_TEMPLATE = (
     "{% if config.params.request_timeout is not none %}"
     " --request-timeout {{config.params.request_timeout}}"
     "{% endif %}"
+    "{% if config.params.extra.dataset.num_fewshot is defined"
+    " and config.params.extra.dataset.num_fewshot is not none %}"
+    " --num-fewshot {{config.params.extra.dataset.num_fewshot}}"
+    "{% endif %}"
 )
 
 
@@ -88,14 +104,27 @@ def _build_fdf(
     Returns:
         FDF dict ready for YAML serialization.
     """
+    # Dataset-specific config grouped under ``extra.dataset.*`` so that all
+    # dataset-shaped settings (path, fewshot count, field mapping, candidate
+    # choices) live under one namespace and don't pollute the top level of
+    # ``extra``.
+    dataset_params: dict = {"path": dataset_path}
+    if bench.field_mapping:
+        dataset_params["field_mapping"] = bench.field_mapping
+    if bench.num_fewshot:
+        dataset_params["num_fewshot"] = bench.num_fewshot
+    # Multiple-choice loglikelihood metadata (informational; the runner
+    # picks up choices/choices_field from the @benchmark registry itself).
+    if bench.choices is not None:
+        dataset_params["choices"] = list(bench.choices)
+    if bench.choices_field is not None:
+        dataset_params["choices_field"] = bench.choices_field
+
     extra_params: dict = {
         "benchmark_module": benchmark_module_ref,
-        "dataset": dataset_path,
+        "dataset": dataset_params,
         "requirements": bench.requirements,
     }
-    # Propagate field_mapping if declared
-    if bench.field_mapping:
-        extra_params["field_mapping"] = bench.field_mapping
     # Propagate judge config(s) from @benchmark kwargs
     # Supports: judge={...}, judge_1={...}, judge_2={...}, etc.
     for key, value in bench.extra_config.items():

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/containerize.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/containerize.py
@@ -118,7 +118,7 @@ LABEL com.nvidia.nemo-evaluator.integration-type=".nemo_evaluator"
 def rewrite_fdf_paths(fdf: dict, pkg_name: str) -> dict:
     """Rewrite host-local paths in an FDF dict to container paths.
 
-    Transforms ``extra.benchmark_module`` and ``extra.dataset`` from
+    Transforms ``extra.benchmark_module`` and ``extra.dataset.path`` from
     absolute host paths to container-relative paths under ``/opt/byob/``.
 
     Args:
@@ -136,12 +136,13 @@ def rewrite_fdf_paths(fdf: dict, pkg_name: str) -> dict:
         filename = os.path.basename(benchmark_module)
         extra["benchmark_module"] = f"/opt/byob/code/{filename}"
 
-    dataset = extra.get("dataset", "")
+    dataset_cfg = extra.get("dataset") or {}
+    dataset = dataset_cfg.get("path", "") if isinstance(dataset_cfg, dict) else ""
     if dataset and not dataset.startswith(
         ("hf://", "s3://", "gs://", "http://", "https://")
     ):
         filename = os.path.basename(dataset)
-        extra["dataset"] = f"/opt/byob/data/{filename}"
+        dataset_cfg["path"] = f"/opt/byob/data/{filename}"
 
     return fdf
 
@@ -193,7 +194,8 @@ def prepare_build_context(
     # Copy or fetch dataset to data/
     data_dir = context / "data"
     data_dir.mkdir(parents=True, exist_ok=True)
-    dataset = extra.get("dataset", "")
+    dataset_cfg = extra.get("dataset") or {}
+    dataset = dataset_cfg.get("path", "") if isinstance(dataset_cfg, dict) else ""
     if dataset:
         if os.path.isfile(dataset):
             # Local file — copy directly
@@ -207,7 +209,7 @@ def prepare_build_context(
                 result = fetcher.fetch(dataset, cache_dir=data_dir)
                 # Update the FDF to point to the local filename inside /opt/byob/data/
                 local_name = result.local_path.name
-                extra["dataset"] = f"/opt/byob/data/{local_name}"
+                dataset_cfg["path"] = f"/opt/byob/data/{local_name}"
                 # Move/copy if fetched to a different location than data_dir
                 if result.local_path.parent != data_dir:
                     shutil.copy2(str(result.local_path), str(data_dir / local_name))

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/dataset.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/dataset.py
@@ -44,6 +44,7 @@ import json
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Protocol, runtime_checkable
+from urllib.parse import parse_qsl
 
 from nemo_evaluator.logging import get_logger
 
@@ -168,7 +169,7 @@ class HuggingFaceFetcher:
                 "Install it with:  pip install datasets"
             ) from exc
 
-        dataset_name, config, split = self._parse_uri(uri)
+        dataset_name, config, split, options = self._parse_uri(uri)
         cache = cache_dir or self._default_cache_dir
         cache.mkdir(parents=True, exist_ok=True)
 
@@ -179,6 +180,9 @@ class HuggingFaceFetcher:
             parts.append(config)
         if split is not None:
             parts.append(split)
+        filters = _extract_filters(options)
+        for field_name, value in filters:
+            parts.append(f"{field_name}-{value}")
         out_path = cache / ("_".join(parts) + ".jsonl")
 
         if out_path.exists():
@@ -191,6 +195,7 @@ class HuggingFaceFetcher:
                     "dataset": dataset_name,
                     "config": config,
                     "split": split,
+                    **options,
                 },
             )
 
@@ -201,11 +206,18 @@ class HuggingFaceFetcher:
             split=split,
         )
 
-        load_kwargs: Dict[str, str] = {}
+        load_kwargs: Dict[str, object] = {}
         if config is not None:
             load_kwargs["name"] = config
         if split is not None:
             load_kwargs["split"] = split
+        if options.get("data_files"):
+            data_files = options["data_files"]
+            load_kwargs["data_files"] = {split: data_files} if split else data_files
+        if options.get("field"):
+            load_kwargs["field"] = options["field"]
+        if options.get("trust_remote_code", "").lower() in {"1", "true", "yes"}:
+            load_kwargs["trust_remote_code"] = True
 
         ds = hf_datasets.load_dataset(dataset_name, **load_kwargs)
 
@@ -217,6 +229,19 @@ class HuggingFaceFetcher:
                 "No split specified; using first available split", split=first_split
             )
             ds = ds[first_split]
+
+        for filter_field, filter_value in filters:
+            before_count = len(ds)
+            ds = ds.filter(
+                lambda row, f=filter_field, v=filter_value: str(row.get(f)) == v
+            )
+            logger.info(
+                "Filtered HuggingFace dataset",
+                field=filter_field,
+                value=filter_value,
+                records_before=before_count,
+                records_after=len(ds),
+            )
 
         # Write out as JSONL.
         with open(out_path, "w", encoding="utf-8") as fout:
@@ -237,6 +262,7 @@ class HuggingFaceFetcher:
                 "dataset": dataset_name,
                 "config": config,
                 "split": split,
+                **options,
             },
         )
 
@@ -272,26 +298,58 @@ class HuggingFaceFetcher:
 
         # Extract ?split=X query parameter if present
         query_split = None
+        options: Dict[str, str] = {}
         if "?" in body:
             body, query = body.split("?", 1)
-            for param in query.split("&"):
-                if param.startswith("split="):
-                    query_split = param[len("split=") :]
+            for key, value in parse_qsl(query, keep_blank_values=True):
+                if key == "split":
+                    query_split = value
+                else:
+                    options[key] = value
 
         segments = [s for s in body.split("/") if s]
         if not segments:
             raise ValueError(f"Invalid HuggingFace URI (empty body): {uri}")
 
         if len(segments) == 1:
-            return (segments[0], None, query_split)
+            return (segments[0], None, query_split, options)
         elif len(segments) == 2:
-            return ("/".join(segments[:2]), None, query_split)
+            return ("/".join(segments[:2]), None, query_split, options)
         elif len(segments) == 3:
-            return ("/".join(segments[:2]), segments[2], query_split)
+            return ("/".join(segments[:2]), segments[2], query_split, options)
         elif len(segments) >= 4:
-            return ("/".join(segments[:2]), segments[2], query_split or segments[3])
+            return (
+                "/".join(segments[:2]),
+                segments[2],
+                query_split or segments[3],
+                options,
+            )
 
-        return (body, None, query_split)  # pragma: no cover
+        return (body, None, query_split, options)  # pragma: no cover
+
+
+def _extract_filters(options: Dict[str, str]) -> List[tuple[str, str]]:
+    """Return HuggingFace row filters encoded in a dataset URI.
+
+    Supports one filter via filter_field/filter_value and additional filters
+    with numeric suffixes, e.g. filter_field_1/filter_value_1.
+    """
+    filters = []
+    first_field = options.get("filter_field")
+    first_value = options.get("filter_value")
+    if first_field and first_value is not None:
+        filters.append((first_field, first_value))
+
+    idx = 1
+    while True:
+        field_name = options.get(f"filter_field_{idx}")
+        value = options.get(f"filter_value_{idx}")
+        if not field_name and value is None:
+            break
+        if field_name and value is not None:
+            filters.append((field_name, value))
+        idx += 1
+    return filters
 
 
 # --- Format detection ---

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/dataset.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/dataset.py
@@ -180,6 +180,11 @@ class HuggingFaceFetcher:
             parts.append(config)
         if split is not None:
             parts.append(split)
+        if options.get("data_files"):
+            df = str(options["data_files"]).replace("/", "_").replace(".", "_")
+            parts.append(f"datafile-{df}")
+        if options.get("field"):
+            parts.append(f"field-{options['field']}")
         filters = _extract_filters(options)
         for field_name, value in filters:
             parts.append(f"{field_name}-{value}")

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/decorators.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/decorators.py
@@ -48,6 +48,17 @@ class ScorerInput:
     This is the single argument passed to all BYOB scorer functions.
     Standard scorers use response, target, and metadata.
     Advanced scorers (judge, multi-turn) use the optional fields.
+
+    (e.g. ``MultipleChoiceStrategy``) write namespaced keys into
+    ``metadata`` before invoking the scorer. Reserved keys currently in
+    use:
+
+    * ``_choices`` -- candidate continuations (list[str])
+    * ``_choices_logprobs`` -- per-choice sum log-probabilities (list[float])
+    * ``_choices_is_greedy`` -- per-choice greedy flags (list[bool])
+
+    ``response`` is set to ``choices[argmax(choices_logprobs)]`` for
+    multiple-choice mode so legacy text-based scorers also work.
     """
 
     response: str
@@ -78,6 +89,12 @@ class BenchmarkDefinition:
     _is_jinja2: bool = False
     system_prompt: Optional[str] = None
     _is_system_prompt_jinja2: bool = False
+    choices: Optional[List[str]] = None
+    choices_field: Optional[str] = None
+    num_fewshot: int = 0
+    fewshot_split: Optional[str] = None
+    fewshot_template: Optional[str] = None
+    fewshot_separator: str = "\n\n"
 
 
 _BENCHMARK_REGISTRY: Dict[str, BenchmarkDefinition] = {}
@@ -150,6 +167,12 @@ def benchmark(
     extra=None,
     response_field=None,
     system_prompt=None,
+    choices: Optional[List[str]] = None,
+    choices_field: Optional[str] = None,
+    num_fewshot: int = 0,
+    fewshot_split: Optional[str] = None,
+    fewshot_template: Optional[str] = None,
+    fewshot_separator: str = "\n\n",
     **kwargs,
 ):
     """Decorator that registers a function as a BYOB benchmark.
@@ -161,7 +184,7 @@ def benchmark(
         prompt: Python format string with {field} placeholders, or path to
                 a template file (.txt, .md, .jinja, .jinja2).
         target_field: JSONL field containing ground truth.
-        endpoint_type: "chat" or "completions".
+        endpoint_type: ``"chat"``, ``"completions"``, or ``"completions_logprob"``.
         requirements: Pip dependencies. Either a list of specifiers
                       (e.g., ["rouge-score>=0.1.2"]) or a path to a
                       requirements.txt file. None means no extra deps.
@@ -177,6 +200,26 @@ def benchmark(
                         responses are read directly from the dataset (eval-only mode).
         system_prompt: Optional system prompt string or path to a template file.
                        When set, a system message is prepended to model calls.
+        choices: Static list of candidate continuations evaluated in
+            loglikelihood mode (e.g. ``["A", "B", "C", "D"]`` for MMLU).
+            Used for ``endpoint_type="completions_logprob"``.
+        choices_field: Per-row dataset field whose value is a list of
+            candidate continuations (e.g. ARC has variable-length choice
+            lists). Mutually exclusive with ``choices``; takes precedence
+            when both are set on a per-row basis.
+        num_fewshot: Number of few-shot examples to prepend to each
+            prompt. Examples are sampled deterministically from
+            ``fewshot_split`` (or the first ``num_fewshot`` rows of the
+            evaluation dataset when ``fewshot_split`` is None).
+        fewshot_split: HuggingFace split name to sample few-shot examples
+            from (e.g. ``"train"`` or ``"dev"``). Only meaningful when the
+            primary ``dataset`` is an ``hf://`` URI.
+        fewshot_template: Optional template string used to render each
+            few-shot example. ``None`` reuses the main ``prompt`` template
+            and appends the rendered ``target_field`` value.
+        fewshot_separator: String inserted between rendered few-shot
+            examples and between the few-shot block and the test prompt.
+            Defaults to ``"\\n\\n"``.
         **kwargs: Also merged into extra config (for backward compat).
                   ``extra`` takes precedence over ``**kwargs`` on conflicts.
     """
@@ -191,6 +234,18 @@ def benchmark(
         if normalized in _BENCHMARK_REGISTRY:
             raise ValueError(
                 f"Benchmark '{name}' (normalized: '{normalized}') is already registered."
+            )
+        if endpoint_type not in ("chat", "completions", "completions_logprob"):
+            raise ValueError(
+                f"Invalid endpoint_type '{endpoint_type}'. "
+                f"Must be one of: 'chat', 'completions', 'completions_logprob'."
+            )
+        if endpoint_type == "completions_logprob" and not (choices or choices_field):
+            raise ValueError(
+                f"Benchmark '{name}' uses endpoint_type='completions_logprob' "
+                f"but neither 'choices' (static list) nor 'choices_field' "
+                f"(per-row field) is set. Loglikelihood ranking requires "
+                f"candidate continuations."
             )
 
         # Resolve base_dir from decorated function's source file
@@ -230,6 +285,11 @@ def benchmark(
         if extra:
             merged_extra.update(extra)
 
+        # Resolve few-shot template (file path or inline string)
+        resolved_fewshot_template = None
+        if fewshot_template is not None:
+            resolved_fewshot_template = _resolve_prompt(fewshot_template, base_dir)
+
         defn = BenchmarkDefinition(
             name=name,
             normalized_name=normalized,
@@ -245,6 +305,12 @@ def benchmark(
             _is_jinja2=is_jinja2,
             system_prompt=resolved_system_prompt,
             _is_system_prompt_jinja2=is_system_prompt_jinja2,
+            choices=list(choices) if choices is not None else None,
+            choices_field=choices_field,
+            num_fewshot=num_fewshot,
+            fewshot_split=fewshot_split,
+            fewshot_template=resolved_fewshot_template,
+            fewshot_separator=fewshot_separator,
         )
 
         _BENCHMARK_REGISTRY[normalized] = defn

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/eval_logic.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/eval_logic.py
@@ -16,6 +16,7 @@
 """Shared BYOB evaluation logic for both subprocess and native modes."""
 
 import importlib
+import random
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -133,8 +134,9 @@ def import_benchmark(benchmark_module: str, benchmark_name: str) -> BenchmarkDef
 class EvalStrategy(Protocol):
     """Protocol for evaluation strategies.
 
-    Different evaluation modes (standard, judge, multi-turn, agentic)
-    implement this protocol to define how each sample is evaluated.
+    Different evaluation modes (standard, judge, multi-turn, agentic,
+    multiple-choice loglikelihood) implement this protocol to define how
+    each sample is evaluated.
     """
 
     def evaluate_sample(
@@ -142,9 +144,10 @@ class EvalStrategy(Protocol):
         idx: int,
         row: Dict,
         bench: BenchmarkDefinition,
-        model_call_fn: Callable[[str, str], str],
+        model_call_fn: Callable[..., Any],
         endpoint_type: str,
         request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
     ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
         """Evaluate a single sample.
 
@@ -163,9 +166,10 @@ class StandardStrategy:
         idx: int,
         row: Dict,
         bench: BenchmarkDefinition,
-        model_call_fn: Callable[[str, str], str],
+        model_call_fn: Callable[..., Any],
         endpoint_type: str,
         request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
     ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
         """Render prompt, call model, score the response.
 
@@ -196,6 +200,9 @@ class StandardStrategy:
                 error=str(e),
                 metadata=row,
             )
+
+        if fewshot_prefix:
+            prompt = fewshot_prefix + prompt
 
         # Render system prompt if configured
         rendered_system_prompt = None
@@ -283,9 +290,10 @@ class EvalOnlyStrategy:
         idx: int,
         row: Dict,
         bench: BenchmarkDefinition,
-        model_call_fn: Callable[[str, str], str],
+        model_call_fn: Callable[..., Any],
         endpoint_type: str,
         request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
     ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
         """Score a pre-generated response from the dataset (no model call).
 
@@ -296,6 +304,7 @@ class EvalOnlyStrategy:
             model_call_fn: Not used (present for protocol compliance).
             endpoint_type: Not used (present for protocol compliance).
             request_timeout: Not used (present for protocol compliance).
+            fewshot_prefix: Not used (present for protocol compliance).
 
         Returns:
             Tuple of (scores_dict, SampleResult) on success, or
@@ -358,10 +367,330 @@ class EvalOnlyStrategy:
         return sample_scores, prediction
 
 
+def _resolve_choices_from_row(row: Dict, choices_field: str) -> Optional[List[str]]:
+    """Resolve per-row choices from a field name or dotted path.
+
+    Resolution order:
+
+    1. Treat ``choices_field`` as a dotted path (e.g. ``"choices.text"``)
+       and walk it through nested dicts.
+    2. If that fails, look up ``choices_field`` as a literal key
+       (supports keys that themselves contain dots).
+    3. **Convenience:** if the resolved value is a dict (HuggingFace's
+       ``{"label": [...], "text": [...]}`` schema), pull the ``"text"``
+       field automatically. Datasets that store choices under a
+       different sub-key (e.g. ``"options"``) should use the dotted
+       path form (``"choices.options"``).
+
+    Returns the list of stringified choices, or ``None`` if the field
+    cannot be resolved to a list.
+    """
+    raw: Any = row
+    for part in choices_field.split("."):
+        if isinstance(raw, dict) and part in raw:
+            raw = raw[part]
+        else:
+            raw = None
+            break
+
+    if raw is None:
+        raw = row.get(choices_field)
+
+    if isinstance(raw, dict):
+        raw = raw.get("text")
+
+    if isinstance(raw, list):
+        return [str(c) for c in raw]
+    return None
+
+
+class MultipleChoiceStrategy:
+    """Per-choice loglikelihood ranking (lm-eval-harness ``local-completions`` parity).
+
+    For each row:
+
+    1. Render the context from ``bench.prompt``.
+    2. Resolve the candidate continuations (from ``bench.choices`` or
+       ``row[bench.choices_field]``).
+    3. Call ``model_call_fn(context, "completions_logprob",
+       continuation=cont)`` for each candidate, collecting
+       ``(sum_logprob, is_greedy)`` tuples.
+    4. Inject ``_choices``, ``_choices_logprobs``, ``_choices_is_greedy``
+       into ``ScorerInput.metadata`` (the shared row + response-metadata
+       bag). ``response`` is set to the argmax choice so legacy
+       text-based scorers (``exact_match`` etc.) still work.
+    5. Hand off to the user scorer (commonly :func:`multiple_choice_acc`).
+    """
+
+    def evaluate_sample(
+        self,
+        idx: int,
+        row: Dict,
+        bench: BenchmarkDefinition,
+        model_call_fn: Callable[..., Any],
+        endpoint_type: str,
+        request_timeout: Optional[float] = None,
+        fewshot_prefix: str = "",
+    ) -> Tuple[Optional[Dict], Optional[SampleResult]]:
+        try:
+            prompt = render_prompt(bench.prompt, row, bench._is_jinja2)
+        except KeyError as e:
+            target = row.get(bench.target_field, "")
+            return None, SampleResult(
+                sample_id=idx,
+                prompt="",
+                response=None,
+                target=target,
+                scores=None,
+                status="skipped_missing_field",
+                error=str(e),
+                metadata=row,
+            )
+
+        if fewshot_prefix:
+            prompt = fewshot_prefix + prompt
+
+        # Resolve choices: per-row field takes precedence over static list
+        choices: Optional[List[str]] = None
+        if bench.choices_field:
+            choices = _resolve_choices_from_row(row, bench.choices_field)
+        if not choices and bench.choices:
+            choices = list(bench.choices)
+        if not choices:
+            target = row.get(bench.target_field, "")
+            return None, SampleResult(
+                sample_id=idx,
+                prompt=prompt,
+                response=None,
+                target=target,
+                scores=None,
+                status="skipped_missing_field",
+                error=(
+                    f"No choices available: choices_field "
+                    f"'{bench.choices_field}' missing from row and no static "
+                    f"choices declared on @benchmark."
+                ),
+                metadata=row,
+            )
+
+        rendered_system_prompt = None
+        if bench.system_prompt:
+            try:
+                rendered_system_prompt = render_prompt(
+                    bench.system_prompt, row, bench._is_system_prompt_jinja2
+                )
+            except KeyError as e:
+                logger.warning(
+                    "System prompt rendering failed, skipping",
+                    sample_id=idx,
+                    error=str(e),
+                )
+
+        choices_logprobs: List[float] = []
+        choices_is_greedy: List[bool] = []
+        for cont in choices:
+            try:
+                ll, greedy = model_call_fn(
+                    prompt,
+                    "completions_logprob",
+                    system_prompt=rendered_system_prompt,
+                    timeout=request_timeout,
+                    continuation=cont,
+                )
+            except Exception as e:
+                target = row.get(bench.target_field, "")
+                return None, SampleResult(
+                    sample_id=idx,
+                    prompt=prompt,
+                    response=None,
+                    target=target,
+                    scores=None,
+                    status="skipped_model_error",
+                    error=str(e),
+                    metadata=row,
+                )
+            choices_logprobs.append(float(ll))
+            choices_is_greedy.append(bool(greedy))
+
+        argmax_idx = max(range(len(choices)), key=lambda i: choices_logprobs[i])
+        response = choices[argmax_idx]
+
+        target = row.get(bench.target_field, "")
+        # Build a shared metadata dict carrying both row fields and per-call
+        # response metadata under reserved ``_`` keys. Both the scorer and
+        # the prediction record see the same shape.
+        merged_metadata = {
+            **row,
+            "_choices": choices,
+            "_choices_logprobs": choices_logprobs,
+            "_choices_is_greedy": choices_is_greedy,
+        }
+        scorer_input = ScorerInput(
+            response=response,
+            target=target,
+            metadata=merged_metadata,
+            model_call_fn=model_call_fn,
+            config=bench.extra_config,
+        )
+
+        try:
+            sample_scores = bench.scorer_fn(scorer_input)
+        except Exception as e:
+            return None, SampleResult(
+                sample_id=idx,
+                prompt=prompt,
+                response=response,
+                target=target,
+                scores=None,
+                status="skipped_scorer_error",
+                error=str(e),
+                metadata=row,
+            )
+
+        prediction = SampleResult(
+            sample_id=idx,
+            prompt=prompt,
+            response=response,
+            target=target,
+            scores=sample_scores,
+            status="scored",
+            metadata=merged_metadata,
+        )
+        return sample_scores, prediction
+
+
+def render_fewshot_example(bench: BenchmarkDefinition, row: Dict) -> Optional[str]:
+    """Render a single few-shot example for *row*.
+
+    If ``bench.fewshot_template`` is set, render that with the row dict.
+    Otherwise reuse the main ``bench.prompt`` template and append the
+    target value (fetched from ``bench.target_field``).
+
+    Returns None on missing-field errors so the caller can skip cleanly.
+    """
+    try:
+        if bench.fewshot_template:
+            return render_prompt(bench.fewshot_template, row, bench._is_jinja2)
+        prompt_part = render_prompt(bench.prompt, row, bench._is_jinja2)
+        target_part = row.get(bench.target_field, "")
+        return f"{prompt_part} {target_part}".rstrip()
+    except KeyError:
+        return None
+
+
+def build_fewshot_prefix(bench: BenchmarkDefinition, examples: List[Dict]) -> str:
+    """Render *examples* into a prefix string ready to prepend to each prompt.
+
+    Skips examples that fail to render (missing fields). Always appends the
+    benchmark's ``fewshot_separator`` after the last example so the test
+    prompt starts on a fresh boundary.
+    """
+    if not examples:
+        return ""
+    rendered: List[str] = []
+    for ex in examples:
+        text = render_fewshot_example(bench, ex)
+        if text is not None:
+            rendered.append(text)
+    if not rendered:
+        return ""
+    # Use ``is None`` rather than ``or`` so an explicit empty-string
+    # separator (concat with no delimiter) is honoured.
+    sep = bench.fewshot_separator if bench.fewshot_separator is not None else "\n\n"
+    return sep.join(rendered) + sep
+
+
+def build_fewshot_examples(
+    primary_dataset_uri: str,
+    primary_dataset: List[Dict],
+    num_fewshot: int,
+    fewshot_split: Optional[str],
+    field_mapping: Optional[Dict[str, str]] = None,
+    seed: int = 42,
+) -> List[Dict]:
+    """Sample ``num_fewshot`` examples deterministically (lm-eval style).
+
+    Selection rules (in order):
+
+    1. If ``fewshot_split`` is set and the primary dataset URI is an
+       ``hf://`` URI, load that split via the dataset module and sample
+       ``num_fewshot`` rows. This is the **safe** path — examples come
+       from a different split than the test set, so there is no
+       contamination.
+    2. Otherwise, sample ``num_fewshot`` rows from the **tail** of
+       ``primary_dataset`` (i.e. the rows least likely to be evaluated
+       when ``--limit-samples`` is set). A loud warning is logged
+       because the fewshot pool overlaps with the evaluation set when
+       running the full dataset, which can leak gold answers into the
+       prompt.
+
+    To guarantee no contamination, declare a ``fewshot_split`` on the
+    ``@benchmark`` (e.g. ``"train"`` or ``"dev"``) so this function
+    samples from a disjoint split.
+    """
+    if num_fewshot <= 0:
+        return []
+
+    pool: List[Dict] = []
+    if fewshot_split and primary_dataset_uri.startswith("hf://"):
+        try:
+            from nemo_evaluator.contrib.byob.dataset import load_dataset
+
+            # Replace or inject ?split= in the URI
+            if "?" in primary_dataset_uri:
+                base, _ = primary_dataset_uri.split("?", 1)
+            else:
+                base = primary_dataset_uri
+            fs_uri = f"{base}?split={fewshot_split}"
+            pool = load_dataset(
+                fs_uri, limit=max(num_fewshot * 4, 16), field_mapping=field_mapping
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to load fewshot_split, falling back to primary dataset",
+                fewshot_split=fewshot_split,
+                error=str(e),
+            )
+            pool = []
+
+    if not pool:
+        # Fallback: no separate fewshot split is available. Sample from
+        # the tail of the primary dataset to minimise overlap with the
+        # eval set when the user passes --limit-samples (which iterates
+        # from the head). When the full dataset is evaluated, the
+        # fewshot pool is a strict subset of the eval set and gold
+        # answers can leak — warn loudly so the user knows to declare
+        # ``fewshot_split=`` on the @benchmark.
+        logger.warning(
+            "fewshot_split not available; sampling from primary dataset. "
+            "This risks test-set contamination because the fewshot pool "
+            "overlaps with rows being evaluated. Declare a separate "
+            "fewshot_split on @benchmark (e.g. 'train' or 'dev') to "
+            "eliminate the overlap.",
+            num_fewshot=num_fewshot,
+            primary_dataset_size=len(primary_dataset),
+        )
+        pool_size = max(num_fewshot * 4, num_fewshot)
+        # Tail slice — falls back to the head only if the dataset is
+        # smaller than the desired pool.
+        if len(primary_dataset) > pool_size:
+            pool = primary_dataset[-pool_size:]
+        else:
+            pool = list(primary_dataset)
+
+    if not pool:
+        return []
+
+    rng = random.Random(seed)
+    if len(pool) <= num_fewshot:
+        return list(pool)
+    return rng.sample(pool, num_fewshot)
+
+
 def run_eval_loop(
     bench: BenchmarkDefinition,
     dataset: List[Dict],
-    model_call_fn: Callable[[str, str], str],
+    model_call_fn: Callable[..., Any],
     endpoint_type: str,
     strategy: Optional[EvalStrategy] = None,
     save_predictions: bool = False,
@@ -370,6 +699,7 @@ def run_eval_loop(
     fail_on_skip: bool = False,
     parallelism: int = 1,
     request_timeout: Optional[float] = None,
+    fewshot_examples: Optional[List[Dict]] = None,
 ) -> Tuple[List[Dict], List[SampleResult]]:
     """Core evaluation loop shared between subprocess and native modes.
 
@@ -399,8 +729,22 @@ def run_eval_loop(
     if strategy is None:
         if bench.response_field:
             strategy = EvalOnlyStrategy(bench.response_field)
+        elif (
+            endpoint_type == "completions_logprob"
+            or bench.endpoint_type == "completions_logprob"
+        ):
+            # Logprob-mode MCQ ranking is the only strategy that requires
+            # ``choices`` / ``choices_field``; the @benchmark decorator
+            # already validates that pairing. Don't auto-pick MCQ just
+            # because choices are declared — a user may declare them as
+            # informational metadata while running the chat endpoint.
+            strategy = MultipleChoiceStrategy()
         else:
             strategy = StandardStrategy()
+
+    fewshot_prefix = (
+        build_fewshot_prefix(bench, fewshot_examples) if fewshot_examples else ""
+    )
 
     if parallelism > 1 and len(dataset) > 1:
         if max_consecutive_errors > 0:
@@ -420,6 +764,7 @@ def run_eval_loop(
             fail_on_skip=fail_on_skip,
             parallelism=parallelism,
             request_timeout=request_timeout,
+            fewshot_prefix=fewshot_prefix,
         )
 
     return _run_eval_loop_sequential(
@@ -433,13 +778,14 @@ def run_eval_loop(
         max_consecutive_errors=max_consecutive_errors,
         fail_on_skip=fail_on_skip,
         request_timeout=request_timeout,
+        fewshot_prefix=fewshot_prefix,
     )
 
 
 def _run_eval_loop_sequential(
     bench: BenchmarkDefinition,
     dataset: List[Dict],
-    model_call_fn: Callable[[str, str], str],
+    model_call_fn: Callable[..., Any],
     endpoint_type: str,
     strategy: EvalStrategy,
     save_predictions: bool = False,
@@ -447,6 +793,7 @@ def _run_eval_loop_sequential(
     max_consecutive_errors: int = 0,
     fail_on_skip: bool = False,
     request_timeout: Optional[float] = None,
+    fewshot_prefix: str = "",
 ) -> Tuple[List[Dict], List[SampleResult]]:
     """Sequential evaluation loop. See :func:`run_eval_loop` for parameter docs."""
     if request_timeout is not None:
@@ -461,8 +808,17 @@ def _run_eval_loop_sequential(
     progress_interval = max(1, min(10, total // 10)) if total > 0 else 1
 
     for idx, row in enumerate(dataset):
+        # Pass fewshot_prefix only when non-empty so legacy strategy
+        # implementations (without the kwarg) continue to work.
+        kwargs = {"fewshot_prefix": fewshot_prefix} if fewshot_prefix else {}
         scores, prediction = strategy.evaluate_sample(
-            idx, row, bench, model_call_fn, endpoint_type, request_timeout
+            idx,
+            row,
+            bench,
+            model_call_fn,
+            endpoint_type,
+            request_timeout,
+            **kwargs,
         )
 
         if scores is None:
@@ -525,7 +881,7 @@ def _run_eval_loop_sequential(
 def _run_eval_loop_parallel(
     bench: BenchmarkDefinition,
     dataset: List[Dict],
-    model_call_fn: Callable[[str, str], str],
+    model_call_fn: Callable[..., Any],
     endpoint_type: str,
     strategy: EvalStrategy,
     save_predictions: bool = False,
@@ -534,6 +890,7 @@ def _run_eval_loop_parallel(
     fail_on_skip: bool = False,
     parallelism: int = 4,
     request_timeout: Optional[float] = None,
+    fewshot_prefix: str = "",
 ) -> Tuple[List[Dict], List[SampleResult]]:
     """Parallel evaluation loop. See :func:`run_eval_loop` for parameter docs."""
     if request_timeout is not None:
@@ -557,8 +914,15 @@ def _run_eval_loop_parallel(
     def evaluate_one(
         idx: int, row: Dict
     ) -> Tuple[int, Optional[Dict], Optional[SampleResult]]:
+        kwargs = {"fewshot_prefix": fewshot_prefix} if fewshot_prefix else {}
         scores, prediction = strategy.evaluate_sample(
-            idx, row, bench, model_call_fn, endpoint_type, request_timeout
+            idx,
+            row,
+            bench,
+            model_call_fn,
+            endpoint_type,
+            request_timeout,
+            **kwargs,
         )
         return idx, scores, prediction
 

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/eval_logic.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/eval_logic.py
@@ -455,6 +455,14 @@ class MultipleChoiceStrategy:
         if bench.choices_field:
             choices = _resolve_choices_from_row(row, bench.choices_field)
         if not choices and bench.choices:
+            if bench.choices_field:
+                logger.warning(
+                    f"choices_field '{bench.choices_field}' missing or empty "
+                    f"for sample {idx}; falling back to static "
+                    f"@benchmark(choices=...)",
+                    sample_id=idx,
+                    choices_field=bench.choices_field,
+                )
             choices = list(bench.choices)
         if not choices:
             target = row.get(bench.target_field, "")

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/runner.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/runner.py
@@ -36,7 +36,11 @@ from nemo_evaluator.contrib.byob.defaults import (
     DEFAULT_TIMEOUT_SECONDS,
     DEFAULT_TOP_P,
 )
-from nemo_evaluator.contrib.byob.eval_logic import import_benchmark, run_eval_loop
+from nemo_evaluator.contrib.byob.eval_logic import (
+    build_fewshot_examples,
+    import_benchmark,
+    run_eval_loop,
+)
 from nemo_evaluator.core.utils import get_api_key_from_env
 from nemo_evaluator.logging import get_logger
 
@@ -131,6 +135,151 @@ def call_model_chat(
     response.raise_for_status()
 
     return response.json()["choices"][0]["message"]["content"]
+
+
+def call_model_loglikelihood(
+    url: str,
+    model_id: str,
+    context: str,
+    continuation: str,
+    api_key: Optional[str] = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    session: Optional[requests.Session] = None,
+    *,
+    system_prompt: Optional[str] = None,
+) -> tuple:
+    """Compute (sum_logprob, is_greedy) for ``continuation`` given ``context``.
+
+    This mirrors lm-evaluation-harness's ``loglikelihood`` contract for the
+    ``local-completions`` model adapter. It POSTs to ``/v1/completions`` with
+    ``prompt = context + continuation``, ``max_tokens=0``, ``echo=true``,
+    ``logprobs=1``, ``temperature=0`` so the server returns per-token log
+    probabilities for the entire prompt without generating new tokens.
+
+    The continuation token span is determined via the OpenAI-compatible
+    ``logprobs.text_offset`` field: the first token whose ``text_offset`` is
+    >= ``len(context)`` (in characters) marks the start of the continuation.
+    The summed log-prob over that span is the loglikelihood; ``is_greedy`` is
+    True when each continuation token equals the argmax of its
+    ``top_logprobs`` entry (i.e. the sequence would have been produced under
+    greedy decoding).
+
+    Args:
+        url: Base URL for the model endpoint.
+        model_id: Model identifier.
+        context: Prompt context (everything up to but not including the
+            continuation tokens).
+        continuation: The candidate continuation whose loglikelihood is
+            being scored.
+        api_key: Optional Bearer token.
+        timeout: Per-request timeout in seconds.
+        session: Optional requests.Session for connection pooling.
+        system_prompt: Optional system prompt prepended to ``context``.
+            Length is included when locating the continuation start, so the
+            same character-offset logic applies.
+
+    Returns:
+        Tuple of ``(sum_logprob, is_greedy)``:
+
+        * ``sum_logprob``: float, sum of ``token_logprobs`` over the
+          continuation token span. Returns ``-float('inf')`` if the server
+          response cannot be parsed.
+        * ``is_greedy``: bool, True if every continuation token equals the
+          top-1 token from its ``top_logprobs`` entry.
+
+    Raises:
+        requests.HTTPError: On non-2xx response.
+        requests.Timeout: On timeout.
+    """
+    endpoint = f"{url}/completions"
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    full_context = f"{system_prompt}\n{context}" if system_prompt else context
+    full_prompt = full_context + continuation
+
+    payload = {
+        "model": model_id,
+        "prompt": full_prompt,
+        "max_tokens": 0,
+        "temperature": 0.0,
+        "logprobs": 1,
+        "echo": True,
+    }
+
+    http = session or requests
+    response = http.post(endpoint, json=payload, headers=headers, timeout=timeout)
+    response.raise_for_status()
+
+    body = response.json()
+    return _parse_loglikelihood_response(body, full_context)
+
+
+def _parse_loglikelihood_response(body: dict, context: str) -> tuple:
+    """Parse an OpenAI-compatible /completions response into (sum_logprob, is_greedy).
+
+    Mirrors lm-eval-harness's ``local-completions`` parsing:
+
+    1. Locate the continuation start via ``text_offset >= len(context)``.
+    2. Sum ``token_logprobs`` from that index onward.
+    3. ``is_greedy`` is True if each continuation token matches the top-1
+       entry in ``top_logprobs`` for its position.
+
+    Returns ``(-inf, False)`` when the response is missing logprobs or the
+    continuation is empty (zero tokens).
+    """
+    try:
+        choice = body["choices"][0]
+        logprobs = choice.get("logprobs") or {}
+    except (KeyError, IndexError, TypeError):
+        return (float("-inf"), False)
+
+    tokens = logprobs.get("tokens") or []
+    token_logprobs = logprobs.get("token_logprobs") or []
+    text_offset = logprobs.get("text_offset") or []
+    top_logprobs = logprobs.get("top_logprobs") or []
+
+    if not tokens or not token_logprobs:
+        return (float("-inf"), False)
+
+    ctx_len = len(context)
+    start_idx = None
+    for i, off in enumerate(text_offset):
+        if off is not None and off >= ctx_len:
+            start_idx = i
+            break
+
+    # Fallback: if text_offset is missing or all offsets are < ctx_len
+    # (e.g. continuation tokenized into the last context token), assume
+    # the very last token is the continuation.
+    if start_idx is None:
+        start_idx = max(len(tokens) - 1, 0)
+
+    cont_token_logprobs = [lp for lp in token_logprobs[start_idx:] if lp is not None]
+    if not cont_token_logprobs:
+        return (float("-inf"), False)
+
+    sum_logprob = float(sum(cont_token_logprobs))
+
+    is_greedy = True
+    for i in range(start_idx, len(tokens)):
+        top = top_logprobs[i] if i < len(top_logprobs) else None
+        if not top:
+            is_greedy = False
+            break
+        # ``top_logprobs[i]`` is a dict {token: logprob}. The top-1 token
+        # is the one with the highest logprob value.
+        try:
+            best_token = max(top.items(), key=lambda kv: kv[1])[0]
+        except (AttributeError, ValueError):
+            is_greedy = False
+            break
+        if best_token != tokens[i]:
+            is_greedy = False
+            break
+
+    return (sum_logprob, is_greedy)
 
 
 def call_model_completions(
@@ -344,8 +493,26 @@ def _create_session_model_call_fn(
         *,
         system_prompt: Optional[str] = None,
         timeout: Optional[float] = None,
-    ) -> str:
+        continuation: Optional[str] = None,
+    ):
         effective_timeout = timeout if timeout is not None else default_timeout
+        if endpoint_type == "completions_logprob":
+            if continuation is None:
+                raise ValueError(
+                    "endpoint_type='completions_logprob' requires a "
+                    "'continuation' kwarg (the candidate continuation "
+                    "whose loglikelihood is being scored)."
+                )
+            return call_model_loglikelihood(
+                url=args.model_url,
+                model_id=args.model_id,
+                context=prompt,
+                continuation=continuation,
+                api_key=api_key,
+                timeout=effective_timeout,
+                session=session,
+                system_prompt=system_prompt,
+            )
         if endpoint_type == "chat":
             return call_model_chat(
                 url=args.model_url,
@@ -422,7 +589,18 @@ def create_client_model_call_fn(
         *,
         system_prompt: Optional[str] = None,
         timeout: Optional[float] = None,
-    ) -> str:
+        continuation: Optional[str] = None,
+    ):
+        if endpoint_type == "completions_logprob":
+            if continuation is None:
+                raise ValueError(
+                    "endpoint_type='completions_logprob' requires a "
+                    "'continuation' kwarg."
+                )
+            full_context = f"{system_prompt}\n{prompt}" if system_prompt else prompt
+            full_prompt = full_context + continuation
+            body = asyncio.run(client.loglikelihood(prompt=full_prompt))
+            return _parse_loglikelihood_response(body, full_context)
         if endpoint_type == "chat":
             messages = []
             if system_prompt:
@@ -481,8 +659,13 @@ def main():
     parser.add_argument(
         "--model-type",
         default="chat",
-        choices=["chat", "completions"],
-        help="Endpoint type: 'chat' or 'completions'",
+        choices=["chat", "completions", "completions_logprob"],
+        help=(
+            "Endpoint type. 'chat' uses /v1/chat/completions, 'completions' "
+            "uses /v1/completions for text generation, and "
+            "'completions_logprob' uses /v1/completions with "
+            "echo=true,logprobs=1,max_tokens=0 for per-choice loglikelihood "
+        ),
     )
     parser.add_argument(
         "--temperature",
@@ -561,6 +744,23 @@ def main():
         default=None,
         help="Per-request timeout in seconds (default: None, falls back to --timeout-per-sample)",
     )
+    parser.add_argument(
+        "--num-fewshot",
+        type=int,
+        default=0,
+        help=(
+            "Number of few-shot examples to prepend to each prompt "
+            "(default: 0). Examples are sampled deterministically from the "
+            "benchmark's fewshot_split (or the first --num-fewshot rows of "
+            "the same dataset when fewshot_split is not declared)."
+        ),
+    )
+    parser.add_argument(
+        "--fewshot-seed",
+        type=int,
+        default=42,
+        help="Random seed for few-shot example sampling (default: 42).",
+    )
 
     args = parser.parse_args()
 
@@ -580,6 +780,35 @@ def main():
         limit=args.limit_samples,
         field_mapping=bench.field_mapping,
     )
+
+    # Resolve few-shot examples: precedence is CLI flag > benchmark default.
+    # Robust to mocked benchmark objects (tests use MagicMock) where
+    # ``bench.num_fewshot`` may not be a real int.
+    effective_num_fewshot = 0
+    try:
+        effective_num_fewshot = int(args.num_fewshot or 0)
+    except (TypeError, ValueError):
+        effective_num_fewshot = 0
+    if not effective_num_fewshot:
+        try:
+            effective_num_fewshot = int(getattr(bench, "num_fewshot", 0) or 0)
+        except (TypeError, ValueError):
+            effective_num_fewshot = 0
+    fewshot_examples: List[Dict] = []
+    if effective_num_fewshot > 0:
+        fewshot_examples = build_fewshot_examples(
+            primary_dataset_uri=args.dataset,
+            primary_dataset=dataset,
+            num_fewshot=effective_num_fewshot,
+            fewshot_split=bench.fewshot_split,
+            field_mapping=bench.field_mapping,
+            seed=args.fewshot_seed,
+        )
+        logger.info(
+            "Few-shot examples prepared",
+            num_fewshot=effective_num_fewshot,
+            sampled=len(fewshot_examples),
+        )
 
     # Create model call function — try NeMoEvaluatorClient, fall back to raw HTTP
     cleanup_fn = None
@@ -622,6 +851,7 @@ def main():
                 if args.request_timeout is not None
                 else args.timeout_per_sample
             ),
+            fewshot_examples=fewshot_examples,
         )
 
         # Offset sample_id and add _repeat metadata for repeats

--- a/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/scorers.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/contrib/byob/scorers.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import math
 import re
 from collections import Counter
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from nemo_evaluator.contrib.byob.decorators import ScorerInput
@@ -319,6 +319,408 @@ def retrieval_metrics(sample: ScorerInput) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# Multiple-choice loglikelihood scorer (lm-evaluation-harness parity)
+# ---------------------------------------------------------------------------
+
+
+def multiple_choice_acc(sample: ScorerInput) -> dict:
+    """Score multiple-choice loglikelihood ranking with lm-eval-harness metrics.
+
+    Expects ``MultipleChoiceStrategy`` to have populated
+    ``sample.metadata['_choices']`` and ``sample.metadata['_choices_logprobs']``
+    (and optionally ``_choices_is_greedy``). Returns:
+
+    * ``acc``: 1.0 if argmax of raw loglikelihoods matches gold, else 0.0
+      (the canonical MMLU metric).
+    * ``acc_norm``: 1.0 if argmax of length-normalized loglikelihoods
+      matches gold, else 0.0. Normalization divides each loglikelihood by
+      ``max(len(choice.encode("utf-8")), 1)`` — this is the exact
+      per-byte normalization used by lm-eval-harness for ARC and BoolQ.
+    * ``acc_greedy``: 1.0 if the greedy choice (the one whose continuation
+      tokens were all top-1 predictions) is also gold, else 0.0. Useful
+      for diagnostic comparison against lm-eval.
+
+    Resolves gold to an integer index by accepting any of:
+
+    * an integer index already (``sample.target == 1``).
+    * a letter ``"A"``..``"Z"`` (offset from ``"A"``).
+    * a literal choice string that appears verbatim in the choice list.
+    * a stringified integer (``"0"``, ``"1"``, ...).
+
+    Returns ``{"acc": 0.0, "acc_norm": 0.0, "acc_greedy": 0.0}`` if no
+    choices were supplied (e.g. user wired this scorer to a benchmark
+    that didn't go through MultipleChoiceStrategy).
+    """
+    metadata = sample.metadata or {}
+    choices = metadata.get("_choices") or []
+    logprobs = metadata.get("_choices_logprobs") or []
+    is_greedy = metadata.get("_choices_is_greedy") or []
+
+    zero = {"acc": 0.0, "acc_norm": 0.0, "acc_greedy": 0.0}
+    if not choices or not logprobs or len(choices) != len(logprobs):
+        return zero
+
+    gold_idx = _resolve_gold_index(sample.target, choices)
+    if gold_idx is None:
+        return zero
+
+    raw_argmax = max(range(len(logprobs)), key=lambda i: logprobs[i])
+
+    norm_scores = [
+        logprobs[i] / max(len(choices[i].encode("utf-8")), 1)
+        for i in range(len(choices))
+    ]
+    norm_argmax = max(range(len(norm_scores)), key=lambda i: norm_scores[i])
+
+    greedy_argmax: Optional[int] = None
+    if is_greedy and any(is_greedy):
+        # Pick highest-loglikelihood choice that is also greedy
+        greedy_indices = [i for i, g in enumerate(is_greedy) if g]
+        if greedy_indices:
+            greedy_argmax = max(greedy_indices, key=lambda i: logprobs[i])
+
+    return {
+        "acc": 1.0 if raw_argmax == gold_idx else 0.0,
+        "acc_norm": 1.0 if norm_argmax == gold_idx else 0.0,
+        "acc_greedy": (
+            1.0 if greedy_argmax is not None and greedy_argmax == gold_idx else 0.0
+        ),
+    }
+
+
+def _resolve_gold_index(target, choices: list) -> "int | None":
+    """Map a heterogeneous ``target`` value to an index into ``choices``."""
+    if target is None:
+        return None
+    if isinstance(target, bool):
+        return int(target) if int(target) < len(choices) else None
+    if isinstance(target, int):
+        return target if 0 <= target < len(choices) else None
+    if isinstance(target, str):
+        s = target.strip()
+        if not s:
+            return None
+        # Letter (A-Z)
+        if len(s) == 1 and s.upper().isalpha():
+            idx = ord(s.upper()) - ord("A")
+            if 0 <= idx < len(choices):
+                return idx
+        # Stringified int
+        if s.lstrip("-").isdigit():
+            try:
+                idx = int(s)
+                if 0 <= idx < len(choices):
+                    return idx
+            except ValueError:
+                pass
+        # Verbatim choice text
+        for i, c in enumerate(choices):
+            if c.strip() == s:
+                return i
+        # Case-insensitive verbatim
+        s_low = s.lower()
+        for i, c in enumerate(choices):
+            if c.strip().lower() == s_low:
+                return i
+    return None
+
+
+# ---------------------------------------------------------------------------
+# MCQ letter extraction (text-mode) — hoisted from example benchmarks
+# ---------------------------------------------------------------------------
+
+
+_MCQ_LETTER_PATTERNS = (
+    re.compile(r"\\boxed\{\s*([A-Ja-j])\s*\}"),
+    re.compile(r"(?:answer\s+is\s*[:\-]?\s*\(?)\s*([A-Ja-j])\b", re.IGNORECASE),
+    re.compile(r"\boption\s*\(?([A-Ja-j])\)", re.IGNORECASE),
+    re.compile(r"^\s*\(?([A-Ja-j])[\)\.\:]", re.IGNORECASE),
+    re.compile(r"\b([A-Ja-j])\b"),
+)
+
+
+def _extract_letter(response: str | None) -> str:
+    """Best-effort extract a single A-J letter from a free-form response.
+
+    Tries the regex patterns in declared precedence (LaTeX boxed, "answer
+    is X", "Option (X)", leading "X)/X./X:", then a final word-boundary
+    fallback).
+    """
+    text = (response or "").strip()
+    if not text:
+        return ""
+    for pat in _MCQ_LETTER_PATTERNS:
+        m = pat.search(text[:200])
+        if m:
+            return m.group(1).upper()
+    return ""
+
+
+# Letter-coded choices for common MCQ datasets. Some newer MMLU-Pro style
+# datasets expose up to ten options (A-J).
+_INT_TO_LETTER = {i: chr(ord("A") + i) for i in range(10)}
+
+
+def mcq_letter_extract(sample: ScorerInput) -> dict:
+    """Extract A-J from response and compare against target.
+
+    Handles common response formats (``"A"``, ``"A)"``, ``"The answer is B"``,
+    ``"B. Because..."``, ``"(C)"``, ``"Option D"``, ``"\\boxed{E}"``).
+    Targets may be:
+
+    * a letter (``"A"``..``"J"``).
+    * an integer index (``0``..``9``) or its string form.
+    * a verbatim choice text — matched against ``sample.metadata`` keys
+      ``a``/``b``/``c``/``d`` if available.
+
+    Returns ``{"correct": bool, "parsed": bool}``.
+    """
+    predicted = _extract_letter(sample.response)
+
+    raw = sample.target
+    target_letter = ""
+    if isinstance(raw, bool):
+        raw = int(raw)
+    if isinstance(raw, int):
+        target_letter = _INT_TO_LETTER.get(raw, "")
+    elif isinstance(raw, str):
+        s = raw.strip()
+        if s.isdigit():
+            target_letter = _INT_TO_LETTER.get(int(s), s.upper())
+        elif s and s[0].upper() in "ABCDEFGHIJ" and len(s) <= 2:
+            target_letter = s[0].upper()
+        else:
+            # Try matching against choice text in metadata
+            for letter, key in zip("ABCD", ("a", "b", "c", "d")):
+                cand = sample.metadata.get(key)
+                if isinstance(cand, str) and cand.strip().lower() == s.lower():
+                    target_letter = letter
+                    break
+
+    return {
+        "correct": bool(predicted) and predicted == target_letter,
+        "parsed": bool(predicted),
+    }
+
+
+# ---------------------------------------------------------------------------
+# GSM8K numeric-answer extraction (#### marker)
+# ---------------------------------------------------------------------------
+
+
+_GSM8K_HASH_PATTERN = re.compile(r"####\s*(-?\d[\d,]*(?:\.\d+)?)")
+_NUMBER_PATTERN = re.compile(r"-?\d[\d,]*(?:\.\d+)?")
+_BOXED_PATTERN = re.compile(r"\\boxed\{\s*(-?\d[\d,]*(?:\.\d+)?)\s*\}")
+
+
+def _normalize_number(s: str) -> "str | None":
+    """Strip commas, trim trailing zeros after decimal, return canonical form."""
+    if s is None:
+        return None
+    s = s.replace(",", "").strip()
+    if not _NUMBER_PATTERN.fullmatch(s):
+        return None
+    if "." in s:
+        # 12.300 -> 12.3, 12.000 -> 12
+        s = s.rstrip("0").rstrip(".")
+    return s or "0"
+
+
+def gsm8k_answer(sample: ScorerInput) -> dict:
+    """Extract the canonical GSM8K numeric answer and compare to target.
+
+    Extraction precedence:
+
+    1. ``#### <number>`` marker (the canonical GSM8K answer format).
+    2. ``\\boxed{<number>}`` (LaTeX-style answer markers, common in
+       chain-of-thought prompts).
+    3. The last number in the response (fallback for free-form output).
+
+    The target string is parsed the same way (so gold answers stored as
+    full GSM8K solutions like ``"... #### 42"`` work directly).
+
+    Returns ``{"correct": bool, "parsed": bool}`` after stripping commas
+    and normalizing trailing zeros.
+    """
+    response = sample.response or ""
+
+    predicted_raw = None
+    m = _GSM8K_HASH_PATTERN.search(response)
+    if m:
+        predicted_raw = m.group(1)
+    else:
+        m = _BOXED_PATTERN.search(response)
+        if m:
+            predicted_raw = m.group(1)
+        else:
+            matches = _NUMBER_PATTERN.findall(response)
+            if matches:
+                predicted_raw = matches[-1]
+
+    predicted = _normalize_number(predicted_raw) if predicted_raw else None
+
+    target_raw = sample.target
+    if isinstance(target_raw, (int, float)):
+        gold = _normalize_number(str(target_raw))
+    else:
+        target_str = str(target_raw or "")
+        m = _GSM8K_HASH_PATTERN.search(target_str)
+        if m:
+            gold = _normalize_number(m.group(1))
+        else:
+            matches = _NUMBER_PATTERN.findall(target_str)
+            gold = _normalize_number(matches[-1]) if matches else None
+
+    return {
+        "correct": bool(
+            predicted is not None and gold is not None and predicted == gold
+        ),
+        "parsed": predicted is not None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Boolean yes/no extraction
+# ---------------------------------------------------------------------------
+
+
+_YES_TOKENS = {"yes", "true", "correct", "right", "yeah", "yep"}
+_NO_TOKENS = {"no", "false", "incorrect", "wrong", "nope", "nah"}
+_TOKEN_RE = re.compile(r"[A-Za-z]+", re.UNICODE)
+
+
+def boolean_yesno(sample: ScorerInput) -> dict:
+    """Extract a yes/no decision from the response and compare to target.
+
+    Heuristic: scans the first ~20 alphabetic tokens of the response and
+    picks the first match in ``_YES_TOKENS`` / ``_NO_TOKENS`` (case
+    insensitive). Targets may be booleans, ``"yes"``/``"no"`` strings,
+    or stringified bools.
+
+    Returns ``{"correct": bool, "parsed": bool}``.
+    """
+    response = (sample.response or "").lower()
+    tokens = _TOKEN_RE.findall(response)[:20]
+    predicted: "str | None" = None
+    for tok in tokens:
+        tl = tok.lower()
+        if tl in _YES_TOKENS:
+            predicted = "yes"
+            break
+        if tl in _NO_TOKENS:
+            predicted = "no"
+            break
+
+    raw = sample.target
+    gold: "str | None"
+    if isinstance(raw, bool):
+        gold = "yes" if raw else "no"
+    elif isinstance(raw, (int, float)):
+        gold = "yes" if int(raw) == 1 else "no" if int(raw) == 0 else None
+    else:
+        s = str(raw).strip().lower()
+        if s in _YES_TOKENS or s in {"1", "true"}:
+            gold = "yes"
+        elif s in _NO_TOKENS or s in {"0", "false"}:
+            gold = "no"
+        else:
+            gold = None
+
+    return {
+        "correct": bool(
+            predicted is not None and gold is not None and predicted == gold
+        ),
+        "parsed": predicted is not None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# chrF / chrF++ (sacreBLEU-style character n-gram F-score)
+# ---------------------------------------------------------------------------
+
+
+def _char_ngrams(text: str, n: int) -> Counter:
+    if not text or len(text) < n:
+        return Counter()
+    return Counter(text[i : i + n] for i in range(len(text) - n + 1))
+
+
+def _word_ngrams(tokens: list, n: int) -> Counter:
+    if len(tokens) < n:
+        return Counter()
+    return Counter(tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1))
+
+
+def _chrf_score(
+    hyp: str, ref: str, max_char_n: int = 6, max_word_n: int = 0, beta: float = 2.0
+) -> float:
+    """Compute chrF or chrF++ score in [0, 100].
+
+    Mirrors the sacreBLEU formula: arithmetic mean of per-n F-beta scores
+    over character n-grams (and optionally word n-grams when
+    ``max_word_n > 0``, which gives chrF++).
+    """
+    if not hyp or not ref:
+        return 0.0
+
+    f_scores: list = []
+
+    for n in range(1, max_char_n + 1):
+        h_ng = _char_ngrams(hyp, n)
+        r_ng = _char_ngrams(ref, n)
+        if not h_ng or not r_ng:
+            f_scores.append(0.0)
+            continue
+        overlap = sum((h_ng & r_ng).values())
+        h_total = sum(h_ng.values())
+        r_total = sum(r_ng.values())
+        prec = overlap / h_total if h_total else 0.0
+        rec = overlap / r_total if r_total else 0.0
+        if prec + rec == 0:
+            f_scores.append(0.0)
+        else:
+            f_scores.append((1 + beta**2) * prec * rec / (beta**2 * prec + rec))
+
+    if max_word_n > 0:
+        h_tok = hyp.split()
+        r_tok = ref.split()
+        for n in range(1, max_word_n + 1):
+            h_ng = _word_ngrams(h_tok, n)
+            r_ng = _word_ngrams(r_tok, n)
+            if not h_ng or not r_ng:
+                f_scores.append(0.0)
+                continue
+            overlap = sum((h_ng & r_ng).values())
+            h_total = sum(h_ng.values())
+            r_total = sum(r_ng.values())
+            prec = overlap / h_total if h_total else 0.0
+            rec = overlap / r_total if r_total else 0.0
+            if prec + rec == 0:
+                f_scores.append(0.0)
+            else:
+                f_scores.append((1 + beta**2) * prec * rec / (beta**2 * prec + rec))
+
+    return 100.0 * sum(f_scores) / len(f_scores) if f_scores else 0.0
+
+
+def chrf(sample: ScorerInput) -> dict:
+    """Compute sentence-level chrF and chrF++ scores (sacreBLEU style).
+
+    Returns ``{"chrf": float, "chrf_pp": float}`` in the [0, 100] range.
+
+    * ``chrf``: chrF6 — character 1- to 6-gram F2 (the sacreBLEU default).
+    * ``chrf_pp``: chrF++ — chrF6 plus word 1- and 2-gram F2, averaged.
+    """
+    hyp = sample.response or ""
+    target = _to_str(sample.target)
+
+    return {
+        "chrf": _chrf_score(hyp, target, max_char_n=6, max_word_n=0, beta=2.0),
+        "chrf_pp": _chrf_score(hyp, target, max_char_n=6, max_word_n=2, beta=2.0),
+    }
+
+
 BUILTIN_SCORERS = {
     "contains": contains,
     "exact_match": exact_match,
@@ -327,4 +729,9 @@ BUILTIN_SCORERS = {
     "bleu": bleu,
     "rouge": rouge,
     "retrieval_metrics": retrieval_metrics,
+    "multiple_choice_acc": multiple_choice_acc,
+    "mcq_letter_extract": mcq_letter_extract,
+    "gsm8k_answer": gsm8k_answer,
+    "boolean_yesno": boolean_yesno,
+    "chrf": chrf,
 }

--- a/packages/nemo-evaluator/src/nemo_evaluator/core/entrypoint.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/core/entrypoint.py
@@ -56,7 +56,7 @@ def get_parser():
         "--model_type",
         type=str,
         help="Run config.: endpoint type",
-        choices=["chat", "completions", "embedding"],
+        choices=["chat", "completions", "completions_logprob", "embedding"],
     )
     parser_run.add_argument("--model_url", type=str, help="Run config.: model URI")
     parser_run.add_argument(
@@ -185,7 +185,7 @@ def run_eval() -> None:
         --eval_type: Type of evaluation to run (e.g., "mmlu_pro", "gsm8k")
         --model_id: Model identifier (e.g "meta/llama-3.1-8b-instruct")
         --model_url: API endpoint URL (e.g "https://integrate.api.nvidia.com/v1/chat/completions" for chat endpoint type)
-        --model_type: Endpoint type ("chat", "completions", "vlm", "embedding")
+        --model_type: Endpoint type ("chat", "completions", "completions_logprob", "vlm", "embedding")
         --api_key_name: Environment variable name for API key integration with endpoints (optional)
         --output_dir: Output directory for results
         --run_config: Path to YAML Run Configuration file (optional)

--- a/packages/nemo-evaluator/src/nemo_evaluator/core/utils.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/core/utils.py
@@ -335,7 +335,7 @@ def get_api_key_from_env(api_key_env_var_name: Optional[str]) -> Optional[str]:
 
 def check_endpoint(
     endpoint_url: str,
-    endpoint_type: Literal["completions", "chat"],
+    endpoint_type: Literal["completions", "completions_logprob", "chat"],
     model_name: str,
     api_key_name: Optional[str] = None,
     max_retries: int = 600,
@@ -345,13 +345,13 @@ def check_endpoint(
 
     Args:
         endpoint_url (str): Full endpoint URL. For most servers that means either ``/v1/chat/completions`` or ``/completions`` must be provided
-        endpoint_type (Literal[completions, chat]): indicates if the model is instruction-tuned (chat) or a base model (completions). Used to constuct a proper payload structure.
+        endpoint_type (Literal[completions, completions_logprob, chat]): indicates if the model is instruction-tuned (chat) or a base model/completions-logprob endpoint. Used to constuct a proper payload structure.
         model_name (str): model name that is linked to payload. Might be required by some endpoint.
         max_retries (int, optional): How many attempt before returning false. Defaults to 600.
         retry_interval (int, optional): How many seconds to wait between attempts. Defaults to 2.
 
     Raises:
-        ValueError: if endpoint_type was not one of "completions", "chat"
+        ValueError: if endpoint_type was not one of "completions", "completions_logprob", "chat"
 
     Returns:
         bool: whether the endpoint is alive
@@ -364,7 +364,7 @@ def check_endpoint(
     if api_key is not None:
         headers["Authorization"] = f"Bearer {api_key}"
     payload = {"model": model_name, "max_tokens": 1}
-    if endpoint_type == "completions":
+    if endpoint_type in ("completions", "completions_logprob"):
         payload["prompt"] = "hello, my name is"
     elif endpoint_type == "chat":
         payload["messages"] = [{"role": "user", "content": "hello, what is your name?"}]

--- a/packages/nemo-evaluator/tests/integration/byob/test_byob_e2e.py
+++ b/packages/nemo-evaluator/tests/integration/byob/test_byob_e2e.py
@@ -19,19 +19,33 @@ This module tests the full BYOB workflow including:
 - TruthfulQA scorer logic with mocked judge
 - Compiler integration (compile + install)
 - Runner E2E with mock server subprocess calls
+- Multiple-choice loglikelihood E2E with an in-process mock /v1/completions
 """
 
+import hashlib
 import importlib.util
 import json
 import subprocess
 import sys
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
+from nemo_evaluator.contrib.byob.aggregation import aggregate_scores
 from nemo_evaluator.contrib.byob.compiler import compile_benchmark, install_benchmark
-from nemo_evaluator.contrib.byob.decorators import ScorerInput
+from nemo_evaluator.contrib.byob.decorators import (
+    BenchmarkDefinition,
+    ScorerInput,
+)
+from nemo_evaluator.contrib.byob.eval_logic import run_eval_loop
+from nemo_evaluator.contrib.byob.runner import (
+    _create_session_model_call_fn,
+    create_session,
+)
+from nemo_evaluator.contrib.byob.scorers import multiple_choice_acc
 
 
 def _get_truthfulqa_benchmark_path():
@@ -299,3 +313,193 @@ def simple_scorer(sample):
             "Help output should mention --benchmark-module"
         )
         assert "--model-url" in result.stdout, "Help output should mention --model-url"
+
+
+# ---------------------------------------------------------------------------
+# Multiple-choice loglikelihood E2E
+#
+# Spins up an in-process OpenAI-compatible /v1/completions server that
+# returns deterministic ``echo+logprobs`` payloads, then runs
+# ``MultipleChoiceStrategy`` over a 4-question synthetic MMLU-style
+# dataset. Verifies the wire payload (``echo=true, logprobs=1, max_tokens=0``),
+# aggregated metrics (``acc``, ``acc_norm``, ``acc_greedy``), and
+# per-prediction diagnostics.
+# ---------------------------------------------------------------------------
+
+
+class _LogprobHandler(BaseHTTPRequestHandler):
+    """Deterministic mock that returns echo+logprobs payloads.
+
+    Tokenizes the incoming prompt by whitespace, assigns a fixed
+    log-prob to each token (``-len(token) * 0.5``), then patches the
+    log-prob of the token whose lowercase form matches ``GOLD_TOKEN``
+    to ``-0.1`` so a known choice wins argmax.
+    """
+
+    GOLD_TOKEN = "b"
+    requests_log: list = []
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+        type(self).requests_log.append({"path": self.path, "body": body})
+
+        if self.path != "/completions":
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        prompt = body.get("prompt", "")
+        tokens, offsets = [], []
+        i = 0
+        n = len(prompt)
+        while i < n:
+            start = i
+            while i < n and prompt[i].isspace() and i == start:
+                i += 1
+            while i < n and not prompt[i].isspace():
+                i += 1
+            tok = prompt[start:i]
+            if tok:
+                tokens.append(tok)
+                offsets.append(start)
+
+        token_logprobs = [None]
+        top_logprobs = [None]
+        for tok in tokens[1:]:
+            stripped = tok.strip().lower()
+            if stripped == self.GOLD_TOKEN:
+                lp = -0.1
+            else:
+                h = hashlib.md5(stripped.encode()).hexdigest()
+                lp = -0.5 - (int(h[:4], 16) % 100) / 100.0
+            token_logprobs.append(lp)
+            top_logprobs.append({tok: lp})
+
+        resp = {
+            "choices": [
+                {
+                    "text": "",
+                    "logprobs": {
+                        "tokens": tokens,
+                        "token_logprobs": token_logprobs,
+                        "text_offset": offsets,
+                        "top_logprobs": top_logprobs,
+                    },
+                }
+            ]
+        }
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(resp).encode())
+
+    def log_message(self, *_args, **_kwargs):  # silence
+        pass
+
+
+class _LogprobServer:
+    def __init__(self):
+        self.server = HTTPServer(("localhost", 0), _LogprobHandler)
+        self.port = self.server.server_address[1]
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+
+    def __enter__(self):
+        _LogprobHandler.requests_log = []
+        self.thread.start()
+        return self
+
+    def __exit__(self, *_):
+        self.server.shutdown()
+        self.thread.join(timeout=5)
+
+    @property
+    def url(self):
+        return f"http://localhost:{self.port}"
+
+
+@pytest.fixture
+def loglikelihood_server():
+    with _LogprobServer() as s:
+        yield s
+
+
+def _make_logprob_args(server_url: str):
+    """Build a minimal Namespace shaped like argparse output."""
+    import argparse
+
+    return argparse.Namespace(
+        model_url=server_url,
+        model_id="mock",
+        api_key_name=None,
+        temperature=0.0,
+        max_tokens=0,
+        top_p=None,
+        request_timeout=None,
+        timeout_per_sample=30.0,
+    )
+
+
+class TestMultipleChoiceLogprobE2E:
+    """End-to-end loglikelihood evaluation against an in-process server."""
+
+    def test_multiple_choice_loglikelihood_e2e(self, loglikelihood_server):
+        bench = BenchmarkDefinition(
+            name="mock-mmlu",
+            normalized_name="mock_mmlu",
+            dataset="x",
+            prompt="Q: {q} Answer:",
+            scorer_fn=multiple_choice_acc,
+            target_field="answer",
+            endpoint_type="completions_logprob",
+            # Leading space so each choice tokenizes as a single token in
+            # the mock server's whitespace-based tokenizer.
+            choices=[" A", " B", " C", " D"],
+        )
+
+        # Target stored as a verbatim choice so multiple_choice_acc
+        # resolves the gold index by string match.
+        dataset = [
+            {"q": "what?", "answer": " B"},
+            {"q": "where?", "answer": " B"},
+            {"q": "when?", "answer": " B"},
+            {"q": "why?", "answer": " B"},
+        ]
+
+        args = _make_logprob_args(loglikelihood_server.url)
+        session = create_session(max_retries=1, backoff_factor=0.0)
+        model_call_fn = _create_session_model_call_fn(args, None, session)
+
+        scores, predictions = run_eval_loop(
+            bench=bench,
+            dataset=dataset,
+            model_call_fn=model_call_fn,
+            endpoint_type="completions_logprob",
+            save_predictions=True,
+        )
+
+        # Rigged: token "B" gets the highest logprob so all 4 samples score 1.
+        assert len(scores) == 4
+        assert all(s["acc"] == 1.0 for s in scores), scores
+        assert all(s["acc_norm"] == 1.0 for s in scores), scores
+
+        # Each sample triggers exactly 4 server calls (one per choice).
+        assert len(_LogprobHandler.requests_log) == 16
+        payload = _LogprobHandler.requests_log[0]["body"]
+        assert payload["max_tokens"] == 0
+        assert payload["echo"] is True
+        assert payload["logprobs"] == 1
+        assert payload["temperature"] == 0.0
+
+        aggregated = aggregate_scores(scores, "mock_mmlu")
+        out_scores = aggregated["tasks"]["mock_mmlu"]["metrics"]["pass@1"]["scores"]
+        assert "acc" in out_scores
+        assert "acc_norm" in out_scores
+        assert "acc_greedy" in out_scores
+        assert out_scores["acc"]["value"] == 1.0
+        assert out_scores["acc_norm"]["value"] == 1.0
+
+        # All predictions captured per-choice diagnostic metadata.
+        for pred in predictions:
+            assert pred.metadata["_choices"] == [" A", " B", " C", " D"]
+            assert len(pred.metadata["_choices_logprobs"]) == 4

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_compiler.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_compiler.py
@@ -205,7 +205,7 @@ class TestInstallBenchmark:
                         "extra": {
                             "benchmark_module": "/path/to/module.py",
                             "benchmark_name": "test_pkg",
-                            "dataset": "/path/to/data.jsonl",
+                            "dataset": {"path": "/path/to/data.jsonl"},
                         },
                     }
                 },
@@ -223,7 +223,7 @@ class TestInstallBenchmark:
                                 "extra": {
                                     "benchmark_module": "/path/to/module.py",
                                     "benchmark_name": "test_pkg",
-                                    "dataset": "/path/to/data.jsonl",
+                                    "dataset": {"path": "/path/to/data.jsonl"},
                                 }
                             },
                         }
@@ -394,7 +394,7 @@ class TestInstallWithRequirements:
         extra = {
             "benchmark_module": "/path/to/module.py",
             "benchmark_name": "test_pkg",
-            "dataset": "/path/to/data.jsonl",
+            "dataset": {"path": "/path/to/data.jsonl"},
         }
         if requirements is not None:
             extra["requirements"] = requirements
@@ -565,4 +565,83 @@ def check(sample):
         assert params["temperature"] == DEFAULT_TEMPERATURE, (
             f"FDF temperature should be {DEFAULT_TEMPERATURE}, "
             f"got {params['temperature']}"
+        )
+
+    def test_fdf_groups_dataset_config_under_extra_dataset(self, tmp_path):
+        """Locks in the `extra.dataset.*` namespace contract.
+
+        Dataset path, num_fewshot, field_mapping, choices, choices_field
+        all live under ``extra.dataset.*``. Top-level ``extra`` only
+        carries ``benchmark_module``, ``dataset``, and ``requirements``.
+        """
+        benchmark_code = """
+from nemo_evaluator.contrib.byob import benchmark, scorer
+from nemo_evaluator.contrib.byob.scorers import multiple_choice_acc
+
+@benchmark(
+    name="ds-namespace",
+    dataset="hf://test/data?split=test",
+    prompt="Q: {q}\\nA:",
+    target_field="answer",
+    endpoint_type="completions_logprob",
+    choices=[" A", " B", " C", " D"],
+    num_fewshot=5,
+    field_mapping={"question": "q"},
+)
+@scorer
+def s(sample):
+    return multiple_choice_acc(sample)
+"""
+        benchmark_file = tmp_path / "ds_namespace.py"
+        benchmark_file.write_text(benchmark_code)
+
+        result = compile_benchmark(str(benchmark_file))
+        extra = result["ds_namespace"]["defaults"]["config"]["params"]["extra"]
+
+        # Top-level extra carries only non-dataset config.
+        assert "benchmark_module" in extra
+        assert "requirements" in extra
+        # Dataset-shaped keys must not leak to the top level.
+        for stale_key in ("num_fewshot", "field_mapping", "choices", "choices_field"):
+            assert stale_key not in extra, (
+                f"'{stale_key}' should be nested under extra.dataset.*, "
+                f"not at top level of extra."
+            )
+
+        # extra.dataset is a dict carrying path + dataset-shaped keys.
+        ds = extra["dataset"]
+        assert isinstance(ds, dict), f"extra.dataset must be a dict, got {type(ds)}"
+        assert ds["path"] == "hf://test/data?split=test"
+        assert ds["num_fewshot"] == 5
+        assert ds["field_mapping"] == {"question": "q"}
+        assert ds["choices"] == [" A", " B", " C", " D"]
+
+    def test_fdf_command_template_references_nested_dataset(self, tmp_path):
+        """The Jinja COMMAND_TEMPLATE must use the nested path/num_fewshot keys."""
+        benchmark_code = """
+from nemo_evaluator.contrib.byob import benchmark, scorer
+
+@benchmark(name="cmd-ds", dataset="d.jsonl", prompt="{q}", num_fewshot=3)
+@scorer
+def s(sample):
+    return {"acc": 1.0}
+"""
+        benchmark_file = tmp_path / "cmd_ds.py"
+        benchmark_file.write_text(benchmark_code)
+
+        result = compile_benchmark(str(benchmark_file))
+        cmd = result["cmd_ds"]["defaults"]["command"]
+
+        assert "config.params.extra.dataset.path" in cmd, (
+            "COMMAND_TEMPLATE should reference extra.dataset.path"
+        )
+        assert "config.params.extra.dataset.num_fewshot" in cmd, (
+            "COMMAND_TEMPLATE should reference extra.dataset.num_fewshot"
+        )
+        # No flat extra.dataset (string) or extra.num_fewshot reference.
+        assert '{{config.params.extra.dataset}}"' not in cmd, (
+            "COMMAND_TEMPLATE should not reference flat extra.dataset (string)"
+        )
+        assert "config.params.extra.num_fewshot" not in cmd, (
+            "COMMAND_TEMPLATE should not reference top-level extra.num_fewshot"
         )

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_containerize.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_containerize.py
@@ -107,7 +107,7 @@ class TestRewriteFdfPaths:
                     "params": {
                         "extra": {
                             "benchmark_module": "/home/user/benchmarks/benchmark.py",
-                            "dataset": "/home/user/data/test.jsonl",
+                            "dataset": {"path": "/home/user/data/test.jsonl"},
                         }
                     }
                 }
@@ -116,7 +116,7 @@ class TestRewriteFdfPaths:
         result = rewrite_fdf_paths(fdf, "byob_test")
         extra = result["defaults"]["config"]["params"]["extra"]
         assert extra["benchmark_module"] == "/opt/byob/code/benchmark.py"
-        assert extra["dataset"] == "/opt/byob/data/test.jsonl"
+        assert extra["dataset"]["path"] == "/opt/byob/data/test.jsonl"
 
     def test_does_not_mutate_original(self):
         """Test that original FDF is not mutated."""
@@ -127,7 +127,7 @@ class TestRewriteFdfPaths:
                     "params": {
                         "extra": {
                             "benchmark_module": "/original/path.py",
-                            "dataset": "/original/data.jsonl",
+                            "dataset": {"path": "/original/data.jsonl"},
                         }
                     }
                 }
@@ -136,7 +136,7 @@ class TestRewriteFdfPaths:
         rewrite_fdf_paths(fdf, "byob_test")
         extra = fdf["defaults"]["config"]["params"]["extra"]
         assert extra["benchmark_module"] == "/original/path.py"
-        assert extra["dataset"] == "/original/data.jsonl"
+        assert extra["dataset"]["path"] == "/original/data.jsonl"
 
     def test_handles_empty_extra(self):
         """Test graceful handling when extra is empty."""
@@ -174,7 +174,7 @@ class TestPrepareBuildContext:
                     "params": {
                         "extra": {
                             "benchmark_module": str(benchmark_file),
-                            "dataset": str(dataset_file),
+                            "dataset": {"path": str(dataset_file)},
                         }
                     }
                 }

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_dataset.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_dataset.py
@@ -579,30 +579,223 @@ class TestHuggingFaceFetcher:
                 fetcher.fetch("hf://test/dataset")
 
     def test_uri_parsing(self) -> None:
-        """Validate _parse_uri with various URI patterns returns correct tuples."""
-        # hf://org/dataset/config/split -> (org/dataset, config, split)
+        """Validate _parse_uri with various URI patterns returns correct tuples.
+
+        The fetcher returns ``(dataset_name, config, split, options)`` where
+        ``options`` is a dict of pass-through query parameters (used for
+        ``trust_remote_code``, ``filter_field``/``filter_value``,
+        ``data_files``, ``field``, etc).
+        """
+        # hf://org/dataset/config/split -> (org/dataset, config, split, {})
         result = HuggingFaceFetcher._parse_uri("hf://org/dataset/config/split")
-        assert result == ("org/dataset", "config", "split"), (
-            f"Expected ('org/dataset', 'config', 'split'), got {result}"
+        assert result == ("org/dataset", "config", "split", {}), (
+            f"Expected ('org/dataset', 'config', 'split', {{}}), got {result}"
         )
 
-        # hf://org/dataset/config -> (org/dataset, config, None)
+        # hf://org/dataset/config -> (org/dataset, config, None, {})
         result = HuggingFaceFetcher._parse_uri("hf://org/dataset/config")
-        assert result == ("org/dataset", "config", None), (
-            f"Expected ('org/dataset', 'config', None), got {result}"
+        assert result == ("org/dataset", "config", None, {}), (
+            f"Expected ('org/dataset', 'config', None, {{}}), got {result}"
         )
 
-        # hf://org/dataset -> (org/dataset, None, None)
+        # hf://org/dataset -> (org/dataset, None, None, {})
         result = HuggingFaceFetcher._parse_uri("hf://org/dataset")
-        assert result == ("org/dataset", None, None), (
-            f"Expected ('org/dataset', None, None), got {result}"
+        assert result == ("org/dataset", None, None, {}), (
+            f"Expected ('org/dataset', None, None, {{}}), got {result}"
         )
 
-        # hf://single_name -> (single_name, None, None)
+        # hf://single_name -> (single_name, None, None, {})
         result = HuggingFaceFetcher._parse_uri("hf://single_name")
-        assert result == ("single_name", None, None), (
-            f"Expected ('single_name', None, None), got {result}"
+        assert result == ("single_name", None, None, {}), (
+            f"Expected ('single_name', None, None, {{}}), got {result}"
         )
+
+    def test_uri_parsing_query_split(self) -> None:
+        """`?split=X` overrides path-segment split."""
+        result = HuggingFaceFetcher._parse_uri("hf://google/boolq?split=validation")
+        assert result == ("google/boolq", None, "validation", {})
+
+        result = HuggingFaceFetcher._parse_uri(
+            "hf://CohereForAI/Global-MMLU-Lite/en?split=test"
+        )
+        assert result == ("CohereForAI/Global-MMLU-Lite", "en", "test", {})
+
+    def test_uri_parsing_extra_query_params_passthrough(self) -> None:
+        """Non-`split` query params surface on the options dict."""
+        result = HuggingFaceFetcher._parse_uri(
+            "hf://indolem/IndoMMLU?split=test&trust_remote_code=true"
+        )
+        assert result == (
+            "indolem/IndoMMLU",
+            None,
+            "test",
+            {"trust_remote_code": "true"},
+        )
+
+    def test_uri_parsing_data_files_and_field(self) -> None:
+        """`data_files` + `field` pass through for nested-JSON datasets."""
+        uri = (
+            "hf://google/IndicGenBench_flores_in"
+            "?split=test&data_files=flores_en_hi_test.json&field=examples"
+        )
+        result = HuggingFaceFetcher._parse_uri(uri)
+        assert result == (
+            "google/IndicGenBench_flores_in",
+            None,
+            "test",
+            {"data_files": "flores_en_hi_test.json", "field": "examples"},
+        )
+
+    def test_uri_parsing_filter_params(self) -> None:
+        """`filter_field`/`filter_value` (and numeric variants) survive parsing."""
+        uri = (
+            "hf://sarvamai/boolq-indic"
+            "?split=validation&filter_field=language&filter_value=hi"
+            "&filter_field_1=domain&filter_value_1=open"
+        )
+        result = HuggingFaceFetcher._parse_uri(uri)
+        assert result[0] == "sarvamai/boolq-indic"
+        assert result[1] is None
+        assert result[2] == "validation"
+        assert result[3] == {
+            "filter_field": "language",
+            "filter_value": "hi",
+            "filter_field_1": "domain",
+            "filter_value_1": "open",
+        }
+
+    def test_extract_filters_single_pair(self) -> None:
+        from nemo_evaluator.contrib.byob.dataset import _extract_filters
+
+        assert _extract_filters({"filter_field": "language", "filter_value": "hi"}) == [
+            ("language", "hi")
+        ]
+
+    def test_extract_filters_multiple_pairs(self) -> None:
+        from nemo_evaluator.contrib.byob.dataset import _extract_filters
+
+        opts = {
+            "filter_field": "language",
+            "filter_value": "hi",
+            "filter_field_1": "domain",
+            "filter_value_1": "open",
+            "filter_field_2": "split",
+            "filter_value_2": "test",
+        }
+        assert _extract_filters(opts) == [
+            ("language", "hi"),
+            ("domain", "open"),
+            ("split", "test"),
+        ]
+
+    def test_extract_filters_ignores_unpaired_keys(self) -> None:
+        from nemo_evaluator.contrib.byob.dataset import _extract_filters
+
+        # filter_value without filter_field is silently ignored
+        assert _extract_filters({"filter_value": "hi"}) == []
+        # filter_field without filter_value is silently ignored
+        assert _extract_filters({"filter_field": "language"}) == []
+
+    def test_fetch_passes_trust_remote_code_and_filters(self, tmp_path: Path) -> None:
+        """End-to-end: query params reach `load_dataset` kwargs and `ds.filter`."""
+        captured: dict = {}
+
+        class _FakeDataset:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def __iter__(self):
+                return iter(self._rows)
+
+            def __len__(self):
+                return len(self._rows)
+
+            def filter(self, fn):
+                kept = [r for r in self._rows if fn(r)]
+                captured.setdefault("filter_calls", 0)
+                captured["filter_calls"] += 1
+                return _FakeDataset(kept)
+
+        rows = [
+            {"q": "Q1", "language": "hi"},
+            {"q": "Q2", "language": "en"},
+            {"q": "Q3", "language": "hi"},
+        ]
+
+        def fake_load_dataset(name, **kwargs):
+            captured["name"] = name
+            captured["kwargs"] = kwargs
+            return _FakeDataset(rows)
+
+        # Patch the lazy import used inside HuggingFaceFetcher.fetch()
+        fake_module = type(
+            "M",
+            (),
+            {"load_dataset": staticmethod(fake_load_dataset), "DatasetDict": dict},
+        )
+
+        fetcher = HuggingFaceFetcher()
+        with patch.dict("sys.modules", {"datasets": fake_module}):
+            uri = (
+                "hf://indolem/IndoMMLU?split=test"
+                "&trust_remote_code=true"
+                "&filter_field=language&filter_value=hi"
+            )
+            result = fetcher.fetch(uri, cache_dir=tmp_path)
+
+        assert captured["name"] == "indolem/IndoMMLU"
+        assert captured["kwargs"]["split"] == "test"
+        assert captured["kwargs"]["trust_remote_code"] is True
+        assert captured["filter_calls"] == 1
+
+        # Filtered JSONL should only contain the Hindi rows.
+        with open(result.local_path, encoding="utf-8") as fh:
+            kept = [json.loads(line) for line in fh]
+        assert kept == [
+            {"q": "Q1", "language": "hi"},
+            {"q": "Q3", "language": "hi"},
+        ]
+
+    def test_fetch_passes_data_files_and_field(self, tmp_path: Path) -> None:
+        """End-to-end: data_files + field reach `load_dataset` kwargs."""
+        captured: dict = {}
+
+        class _FakeDataset:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def __iter__(self):
+                return iter(self._rows)
+
+            def __len__(self):
+                return len(self._rows)
+
+            def filter(self, fn):  # not used in this test
+                return _FakeDataset([r for r in self._rows if fn(r)])
+
+        rows = [{"source": "hello", "target": "हैलो"}]
+
+        def fake_load_dataset(name, **kwargs):
+            captured["name"] = name
+            captured["kwargs"] = kwargs
+            return _FakeDataset(rows)
+
+        fake_module = type(
+            "M",
+            (),
+            {"load_dataset": staticmethod(fake_load_dataset), "DatasetDict": dict},
+        )
+
+        fetcher = HuggingFaceFetcher()
+        with patch.dict("sys.modules", {"datasets": fake_module}):
+            uri = (
+                "hf://google/IndicGenBench_flores_in"
+                "?split=test&data_files=flores_en_hi_test.json&field=examples"
+            )
+            fetcher.fetch(uri, cache_dir=tmp_path)
+
+        assert captured["kwargs"]["data_files"] == {"test": "flores_en_hi_test.json"}
+        assert captured["kwargs"]["field"] == "examples"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_dataset.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_dataset.py
@@ -797,6 +797,68 @@ class TestHuggingFaceFetcher:
         assert captured["kwargs"]["data_files"] == {"test": "flores_en_hi_test.json"}
         assert captured["kwargs"]["field"] == "examples"
 
+    def test_cache_key_distinguishes_data_files(self, tmp_path: Path) -> None:
+        """Different ``data_files=`` values must use distinct cache files.
+
+        Regression: previously the cache filename was built from
+        ``dataset_name + config + split + filters`` only, so two URIs that
+        differed only in ``data_files`` (e.g. per-language IndicGenBench
+        subsets) collided on the same cache entry. The first fetch's data
+        was returned for every subsequent language.
+        """
+
+        class _FakeDataset:
+            def __init__(self, rows):
+                self._rows = rows
+
+            def __iter__(self):
+                return iter(self._rows)
+
+            def __len__(self):
+                return len(self._rows)
+
+            def filter(self, fn):
+                return _FakeDataset([r for r in self._rows if fn(r)])
+
+        # Track each call so we can assert distinct cache files were written.
+        per_call_rows = {
+            "flores_en_hi_test.json": [{"source": "hi-src", "target": "hi-tgt"}],
+            "flores_en_ml_test.json": [{"source": "ml-src", "target": "ml-tgt"}],
+            "flores_en_te_test.json": [{"source": "te-src", "target": "te-tgt"}],
+        }
+
+        def fake_load_dataset(name, **kwargs):
+            df = kwargs["data_files"]["test"]
+            return _FakeDataset(per_call_rows[df])
+
+        fake_module = type(
+            "M",
+            (),
+            {"load_dataset": staticmethod(fake_load_dataset), "DatasetDict": dict},
+        )
+
+        fetcher = HuggingFaceFetcher()
+        cache_paths = []
+        with patch.dict("sys.modules", {"datasets": fake_module}):
+            for lang in ("hi", "ml", "te"):
+                uri = (
+                    "hf://google/IndicGenBench_flores_in"
+                    f"?split=test&data_files=flores_en_{lang}_test.json&field=examples"
+                )
+                result = fetcher.fetch(uri, cache_dir=tmp_path)
+                cache_paths.append(result.local_path)
+
+        # Three distinct URIs -> three distinct cache files.
+        assert len(set(cache_paths)) == 3, (
+            f"Expected unique cache files per data_files value; got {cache_paths}"
+        )
+        # And each cache file must contain its own language's rows.
+        for path, lang in zip(cache_paths, ("hi", "ml", "te")):
+            content = path.read_text(encoding="utf-8").strip()
+            assert f"{lang}-tgt" in content, (
+                f"Cache for {lang} should contain {lang}-tgt; got {content!r}"
+            )
+
 
 # ---------------------------------------------------------------------------
 # TestFieldRemapping

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_decorators.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_decorators.py
@@ -850,3 +850,123 @@ class TestSystemPromptDecorator:
 
         resolved = _resolve_prompt("system.txt", tmp_path)
         assert resolved == "You are a domain expert in {domain}."
+
+
+# ---------------------------------------------------------------------------
+# Logprob / few-shot fields on ScorerInput and BenchmarkDefinition
+#
+# These cover the new per-choice loglikelihood plumbing wired up for
+# `endpoint_type="completions_logprob"`. They verify the dataclass +
+# decorator surface only; behavioural tests live in
+# test_byob_eval_logic.py and test_byob_scorers.py.
+# ---------------------------------------------------------------------------
+
+
+class TestScorerInputLogprobFields:
+    """Tests for logprob-related fields surfaced through ``metadata``.
+
+    Per the BYOB convention, ``MultipleChoiceStrategy`` writes
+    ``_choices``, ``_choices_logprobs``, and ``_choices_is_greedy`` into
+    ``ScorerInput.metadata`` (the shared row + response-metadata bag)
+    rather than as typed dataclass fields.
+    """
+
+    def test_metadata_starts_without_logprob_keys(self):
+        inp = ScorerInput(response="r", target="t", metadata={})
+        assert "_choices" not in inp.metadata
+        assert "_choices_logprobs" not in inp.metadata
+        assert "_choices_is_greedy" not in inp.metadata
+
+    def test_logprob_metadata_round_trip(self):
+        inp = ScorerInput(
+            response="B",
+            target="B",
+            metadata={
+                "_choices": ["A", "B", "C", "D"],
+                "_choices_logprobs": [-3.0, -1.0, -2.0, -4.0],
+                "_choices_is_greedy": [False, True, False, False],
+            },
+        )
+        assert inp.metadata["_choices"] == ["A", "B", "C", "D"]
+        assert inp.metadata["_choices_logprobs"] == [-3.0, -1.0, -2.0, -4.0]
+        assert inp.metadata["_choices_is_greedy"] == [False, True, False, False]
+
+
+class TestBenchmarkLogprobFields:
+    """Tests for the @benchmark decorator's logprob / few-shot params."""
+
+    def test_completions_logprob_endpoint_type_with_static_choices(self):
+        @benchmark(
+            name="mc-static",
+            dataset="d.jsonl",
+            prompt="Q: {q}\nA:",
+            target_field="answer",
+            endpoint_type="completions_logprob",
+            choices=[" A", " B", " C", " D"],
+        )
+        @scorer
+        def fn(sample):
+            return {"acc": 0.0}
+
+        defn = get_registered_benchmarks()["mc_static"]
+        assert defn.endpoint_type == "completions_logprob"
+        assert defn.choices == [" A", " B", " C", " D"]
+        assert defn.choices_field is None
+
+    def test_completions_logprob_endpoint_type_with_choices_field(self):
+        @benchmark(
+            name="mc-perrow",
+            dataset="d.jsonl",
+            prompt="Q: {q}\nA:",
+            target_field="answer",
+            endpoint_type="completions_logprob",
+            choices_field="choices.text",
+        )
+        @scorer
+        def fn(sample):
+            return {"acc": 0.0}
+
+        defn = get_registered_benchmarks()["mc_perrow"]
+        assert defn.endpoint_type == "completions_logprob"
+        assert defn.choices_field == "choices.text"
+        assert defn.choices is None
+
+    def test_fewshot_fields_round_trip(self):
+        @benchmark(
+            name="few",
+            dataset="d.jsonl",
+            prompt="Q: {q}\nA:",
+            target_field="answer",
+            num_fewshot=5,
+            fewshot_split="train",
+            fewshot_template="Q: {q}\nA: {answer}",
+            fewshot_separator="\n---\n",
+        )
+        @scorer
+        def fn(sample):
+            return {"correct": False}
+
+        defn = get_registered_benchmarks()["few"]
+        assert defn.num_fewshot == 5
+        assert defn.fewshot_split == "train"
+        assert defn.fewshot_template == "Q: {q}\nA: {answer}"
+        assert defn.fewshot_separator == "\n---\n"
+
+    def test_logprob_fields_default_unset_on_chat_benchmarks(self):
+        @benchmark(
+            name="plain-chat",
+            dataset="d.jsonl",
+            prompt="Q: {q}\nA:",
+            target_field="answer",
+        )
+        @scorer
+        def fn(sample):
+            return {"correct": False}
+
+        defn = get_registered_benchmarks()["plain_chat"]
+        assert defn.choices is None
+        assert defn.choices_field is None
+        assert defn.num_fewshot == 0
+        assert defn.fewshot_split is None
+        assert defn.fewshot_template is None
+        assert defn.fewshot_separator == "\n\n"

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_eval_logic.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_eval_logic.py
@@ -26,12 +26,16 @@ from nemo_evaluator.contrib.byob.decorators import (
 )
 from nemo_evaluator.contrib.byob.eval_logic import (
     EvalOnlyStrategy,
+    MultipleChoiceStrategy,
     SampleResult,
     StandardStrategy,
+    build_fewshot_examples,
+    build_fewshot_prefix,
     import_benchmark,
     render_prompt,
     run_eval_loop,
 )
+from nemo_evaluator.contrib.byob.scorers import multiple_choice_acc
 
 
 class TestImportBenchmark:
@@ -1360,3 +1364,342 @@ class TestSystemPromptInStrategy:
         assert len(scores) == 2
         assert prompts_seen[0] == "Domain: math"
         assert prompts_seen[1] == "Domain: science"
+
+
+# ---------------------------------------------------------------------------
+# MultipleChoiceStrategy
+#
+# Drives logprob-based MCQ benchmarks for `endpoint_type="completions_logprob"`.
+# Issues one model_call_fn invocation per choice, populates the new
+# ScorerInput vector fields, and exposes per-choice diagnostics on
+# `SampleResult.metadata`.
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleChoiceStrategy:
+    def _bench(self, **overrides):
+        defaults = {
+            "name": "mc",
+            "normalized_name": "mc",
+            "dataset": "x",
+            "prompt": "Q: {q}\nA:",
+            "scorer_fn": multiple_choice_acc,
+            "target_field": "answer",
+            "endpoint_type": "completions_logprob",
+            "choices": ["A", "B", "C", "D"],
+        }
+        defaults.update(overrides)
+        return BenchmarkDefinition(**defaults)
+
+    def test_calls_one_per_choice_static_choices(self):
+        bench = self._bench()
+        calls = []
+
+        def fake_call(prompt, endpoint_type, **kwargs):
+            calls.append((prompt, endpoint_type, kwargs.get("continuation")))
+            cont = kwargs["continuation"]
+            return (-1.0 if cont == "B" else -3.0, cont == "B")
+
+        strategy = MultipleChoiceStrategy()
+        scores, pred = strategy.evaluate_sample(
+            idx=0,
+            row={"q": "what is 1+1?", "answer": "B"},
+            bench=bench,
+            model_call_fn=fake_call,
+            endpoint_type="completions_logprob",
+            request_timeout=None,
+        )
+        assert scores == {"acc": 1.0, "acc_norm": 1.0, "acc_greedy": 1.0}
+        assert len(calls) == 4
+        assert all(c[1] == "completions_logprob" for c in calls)
+        assert sorted(c[2] for c in calls) == ["A", "B", "C", "D"]
+        assert pred.response == "B"
+        assert pred.metadata["_choices"] == ["A", "B", "C", "D"]
+        assert pred.metadata["_choices_logprobs"] == [-3.0, -1.0, -3.0, -3.0]
+
+    def test_per_row_choices_field_takes_precedence(self):
+        bench = self._bench(choices=None, choices_field="cands")
+
+        def fake_call(prompt, endpoint_type, **kwargs):
+            return (-1.0 if kwargs["continuation"] == "x" else -2.0, False)
+
+        strategy = MultipleChoiceStrategy()
+        scores, pred = strategy.evaluate_sample(
+            idx=0,
+            row={"q": "?", "answer": "x", "cands": ["x", "y"]},
+            bench=bench,
+            model_call_fn=fake_call,
+            endpoint_type="completions_logprob",
+            request_timeout=None,
+        )
+        assert pred.response == "x"
+        assert pred.metadata["_choices"] == ["x", "y"]
+
+    def test_per_row_choices_field_supports_dotted_path(self):
+        """ARC-style HuggingFace schema: row["choices"]["text"] is a list."""
+        bench = self._bench(choices=None, choices_field="choices.text")
+
+        def fake_call(prompt, endpoint_type, **kwargs):
+            return (-1.0 if kwargs["continuation"] == "beta" else -2.0, False)
+
+        strategy = MultipleChoiceStrategy()
+        scores, pred = strategy.evaluate_sample(
+            idx=0,
+            row={
+                "q": "?",
+                "answer": "B",
+                "choices": {"label": ["A", "B"], "text": ["alpha", "beta"]},
+            },
+            bench=bench,
+            model_call_fn=fake_call,
+            endpoint_type="completions_logprob",
+            request_timeout=None,
+        )
+        assert scores["acc"] == 1.0
+        assert pred.response == "beta"
+        assert pred.metadata["_choices"] == ["alpha", "beta"]
+
+    def test_missing_choices_skips(self):
+        bench = self._bench(choices=None, choices_field="cands")
+
+        def fake_call(*a, **k):
+            raise AssertionError("unexpected call")
+
+        strategy = MultipleChoiceStrategy()
+        scores, pred = strategy.evaluate_sample(
+            idx=0,
+            row={"q": "?", "answer": "x"},  # no "cands"
+            bench=bench,
+            model_call_fn=fake_call,
+            endpoint_type="completions_logprob",
+            request_timeout=None,
+        )
+        assert scores is None
+        assert pred.status == "skipped_missing_field"
+
+    def test_model_error_propagates_as_skip(self):
+        bench = self._bench()
+
+        def boom(*a, **k):
+            raise RuntimeError("server down")
+
+        strategy = MultipleChoiceStrategy()
+        scores, pred = strategy.evaluate_sample(
+            idx=0,
+            row={"q": "?", "answer": "B"},
+            bench=bench,
+            model_call_fn=boom,
+            endpoint_type="completions_logprob",
+            request_timeout=None,
+        )
+        assert scores is None
+        assert pred.status == "skipped_model_error"
+        assert "server down" in pred.error
+
+
+# ---------------------------------------------------------------------------
+# build_fewshot_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestFewshotPrefix:
+    def test_default_template_appends_target(self):
+        bench = BenchmarkDefinition(
+            name="x",
+            normalized_name="x",
+            dataset="x",
+            prompt="Q: {q}\nA:",
+            scorer_fn=lambda s: {},
+            target_field="a",
+        )
+        examples = [
+            {"q": "1+1?", "a": "2"},
+            {"q": "2+2?", "a": "4"},
+        ]
+        prefix = build_fewshot_prefix(bench, examples)
+        assert "Q: 1+1?\nA: 2" in prefix
+        assert "Q: 2+2?\nA: 4" in prefix
+        assert prefix.endswith("\n\n")
+
+    def test_custom_separator(self):
+        bench = BenchmarkDefinition(
+            name="x",
+            normalized_name="x",
+            dataset="x",
+            prompt="Q: {q}\nA:",
+            scorer_fn=lambda s: {},
+            target_field="a",
+            fewshot_separator="\n---\n",
+        )
+        prefix = build_fewshot_prefix(bench, [{"q": "x", "a": "y"}])
+        assert prefix == "Q: x\nA: y\n---\n"
+
+    def test_skip_unrenderable(self):
+        bench = BenchmarkDefinition(
+            name="x",
+            normalized_name="x",
+            dataset="x",
+            prompt="Q: {q}\nA:",
+            scorer_fn=lambda s: {},
+            target_field="a",
+        )
+        prefix = build_fewshot_prefix(bench, [{"q": "ok", "a": "1"}, {"a": "no q"}])
+        assert "Q: ok\nA: 1" in prefix
+        assert prefix.count("\n\n") == 1
+
+    def test_explicit_empty_separator_is_honoured(self):
+        """Regression: ``fewshot_separator=""`` was clobbered to ``"\\n\\n"``
+        by an ``or`` expression. It must concatenate with no delimiter."""
+        bench = BenchmarkDefinition(
+            name="x",
+            normalized_name="x",
+            dataset="x",
+            prompt="Q: {q}\nA:",
+            scorer_fn=lambda s: {},
+            target_field="a",
+            fewshot_separator="",
+        )
+        prefix = build_fewshot_prefix(
+            bench,
+            [{"q": "1", "a": "x"}, {"q": "2", "a": "y"}],
+        )
+        # No "\n\n" anywhere; examples are concatenated directly.
+        assert prefix == "Q: 1\nA: xQ: 2\nA: y"
+
+
+# ---------------------------------------------------------------------------
+# build_fewshot_examples — contamination guard
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFewshotExamples:
+    def test_warns_when_no_fewshot_split_and_samples_from_tail(self, caplog):
+        """Regression: when no fewshot_split is declared, the function used
+        to slice the head of the primary dataset (which is exactly the eval
+        set), risking contamination. It must now sample from the tail and
+        warn loudly."""
+        primary = [{"q": f"q{i}", "a": str(i)} for i in range(20)]
+        with caplog.at_level("WARNING"):
+            examples = build_fewshot_examples(
+                primary_dataset_uri="local.jsonl",
+                primary_dataset=primary,
+                num_fewshot=2,
+                fewshot_split=None,
+                seed=42,
+            )
+        # All sampled examples must come from the tail slice (last 8 rows
+        # of a 20-row dataset given pool_size = max(2*4, 2) = 8).
+        tail = primary[-8:]
+        for ex in examples:
+            assert ex in tail, f"Sampled {ex} from outside tail slice"
+        assert len(examples) == 2
+        # Loud warning emitted.
+        assert any(
+            "fewshot_split not available" in rec.message for rec in caplog.records
+        ), "Contamination warning must be logged"
+
+    def test_no_warning_when_fewshot_split_resolves(self, monkeypatch, caplog):
+        """When fewshot_split loads cleanly, no contamination warning is
+        emitted (the pool comes from a disjoint split)."""
+        from nemo_evaluator.contrib.byob import dataset as ds_module
+
+        def fake_load(uri, **_):
+            return [{"q": f"dev{i}", "a": str(i)} for i in range(8)]
+
+        monkeypatch.setattr(ds_module, "load_dataset", fake_load)
+
+        primary = [{"q": f"test{i}", "a": str(i)} for i in range(50)]
+        with caplog.at_level("WARNING"):
+            examples = build_fewshot_examples(
+                primary_dataset_uri="hf://org/ds?split=test",
+                primary_dataset=primary,
+                num_fewshot=3,
+                fewshot_split="dev",
+                seed=42,
+            )
+        assert len(examples) == 3
+        # All examples come from the 'dev' fake split, not the primary set.
+        for ex in examples:
+            assert ex["q"].startswith("dev"), f"Sampled from primary: {ex}"
+        # No contamination warning.
+        assert not any(
+            "fewshot_split not available" in rec.message for rec in caplog.records
+        )
+
+    def test_returns_empty_when_num_fewshot_zero(self):
+        primary = [{"q": "1", "a": "1"}]
+        assert (
+            build_fewshot_examples(
+                primary_dataset_uri="x",
+                primary_dataset=primary,
+                num_fewshot=0,
+                fewshot_split=None,
+            )
+            == []
+        )
+
+
+# ---------------------------------------------------------------------------
+# Strategy auto-selection — declared choices with chat endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestStrategyAutoSelect:
+    def test_chat_endpoint_with_declared_choices_uses_standard_strategy(self):
+        """Regression: declaring ``choices=`` for documentation purposes
+        on a chat-endpoint benchmark must NOT auto-pick MCQ strategy.
+        Auto-selection of MCQ is tied to ``endpoint_type`` only."""
+        captured: list = []
+
+        def fake_model_call(prompt, endpoint_type, **kwargs):
+            captured.append((prompt, endpoint_type))
+            return "A"
+
+        bench = BenchmarkDefinition(
+            name="b",
+            normalized_name="b",
+            dataset="x",
+            prompt="Q: {q}\nA:",
+            scorer_fn=lambda s: {"acc": 1.0},
+            target_field="a",
+            endpoint_type="chat",
+            choices=["A", "B", "C", "D"],  # informational only
+        )
+        run_eval_loop(
+            bench=bench,
+            dataset=[{"q": "1+1?", "a": "A"}],
+            model_call_fn=fake_model_call,
+            endpoint_type="chat",
+        )
+        # StandardStrategy issues a single chat call; MCQ would fan out
+        # one ``completions_logprob`` call per declared choice.
+        assert len(captured) == 1
+        assert captured[0][1] == "chat"
+
+    def test_logprob_endpoint_uses_mcq_strategy(self):
+        """Sanity: when endpoint_type IS completions_logprob, MCQ is
+        still auto-selected (one call per choice)."""
+        calls: list = []
+
+        def fake_model_call(prompt, endpoint_type, **kwargs):
+            calls.append(kwargs.get("continuation"))
+            return (-1.0 if kwargs.get("continuation") == "A" else -3.0, False)
+
+        bench = BenchmarkDefinition(
+            name="b",
+            normalized_name="b",
+            dataset="x",
+            prompt="Q: {q}\nA:",
+            scorer_fn=lambda s: {"acc": 1.0},
+            target_field="a",
+            endpoint_type="completions_logprob",
+            choices=["A", "B", "C", "D"],
+        )
+        run_eval_loop(
+            bench=bench,
+            dataset=[{"q": "1+1?", "a": "A"}],
+            model_call_fn=fake_model_call,
+            endpoint_type="completions_logprob",
+        )
+        # MCQ fans out one call per choice.
+        assert sorted(calls) == ["A", "B", "C", "D"]

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_runner.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_runner.py
@@ -1389,3 +1389,273 @@ class TestCommandTemplateExtensions:
 
         assert "n_repeats" in COMMAND_TEMPLATE
         assert "--n-repeats" in COMMAND_TEMPLATE
+
+
+# ---------------------------------------------------------------------------
+# _parse_loglikelihood_response — lm-evaluation-harness parity
+#
+# Pins down the contract that lm-eval's `local-completions` adapter
+# expects from an OpenAI-compatible `/v1/completions` endpoint with
+# `echo=true, logprobs=1, max_tokens=0`. Critical invariants:
+#   1. continuation span = tokens whose `text_offset >= len(context)`
+#   2. `sum_logprob` excludes context tokens
+#   3. `is_greedy` is True iff every continuation token equals the top-1
+#      key in its `top_logprobs` entry.
+# Reference: lm_eval/models/openai_completions.py::loglikelihood
+# ---------------------------------------------------------------------------
+
+
+def _build_loglikelihood_payload(
+    context_tokens: list,
+    continuation_tokens: list,
+    ctx_logprobs: list = None,
+    cont_logprobs: list = None,
+    cont_top1_match: bool = True,
+):
+    """Build a fake OpenAI /completions response with echo+logprobs=1."""
+    if ctx_logprobs is None:
+        ctx_logprobs = [None] + [-1.0] * (len(context_tokens) - 1)
+    assert len(ctx_logprobs) == len(context_tokens)
+    assert len(cont_logprobs) == len(continuation_tokens)
+
+    tokens = list(context_tokens) + list(continuation_tokens)
+    token_logprobs = list(ctx_logprobs) + list(cont_logprobs)
+
+    text_offset, off = [], 0
+    for tok in tokens:
+        text_offset.append(off)
+        off += len(tok)
+
+    top_logprobs = [None] * len(context_tokens)
+    for tok, lp in zip(continuation_tokens, cont_logprobs):
+        if cont_top1_match:
+            top_logprobs.append({tok: lp})
+        else:
+            top_logprobs.append({"OTHER": lp + 0.001, tok: lp})
+
+    return {
+        "choices": [
+            {
+                "text": "",
+                "logprobs": {
+                    "tokens": tokens,
+                    "token_logprobs": token_logprobs,
+                    "text_offset": text_offset,
+                    "top_logprobs": top_logprobs,
+                },
+            }
+        ]
+    }
+
+
+class TestParseLoglikelihoodResponse:
+    """Test parsing of OpenAI-style /completions echo+logprobs payloads."""
+
+    def test_basic_continuation_span(self):
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = {
+            "choices": [
+                {
+                    "logprobs": {
+                        "tokens": ["The", " cat", " sat"],
+                        "token_logprobs": [None, -1.2, -2.5],
+                        "text_offset": [0, 3, 7],
+                        "top_logprobs": [
+                            None,
+                            {" cat": -1.2},
+                            {" sat": -2.5},
+                        ],
+                    }
+                }
+            ]
+        }
+        ll, greedy = _parse_loglikelihood_response(body, context="The cat")
+        assert ll == pytest.approx(-2.5)
+        assert greedy is True
+
+    def test_multi_token_continuation_sums(self):
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = {
+            "choices": [
+                {
+                    "logprobs": {
+                        "tokens": ["Q:", " 2+2=", "4", " because"],
+                        "token_logprobs": [None, -0.1, -0.5, -1.5],
+                        "text_offset": [0, 2, 7, 8],
+                        "top_logprobs": [
+                            None,
+                            {" 2+2=": -0.1},
+                            {"4": -0.5},
+                            {" because": -1.5},
+                        ],
+                    }
+                }
+            ]
+        }
+        ll, greedy = _parse_loglikelihood_response(body, context="Q: 2+2=")
+        assert ll == pytest.approx(-2.0)
+        assert greedy is True
+
+    def test_non_greedy_continuation(self):
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = {
+            "choices": [
+                {
+                    "logprobs": {
+                        "tokens": ["Q", " is", " B"],
+                        "token_logprobs": [None, -0.5, -2.0],
+                        "text_offset": [0, 1, 4],
+                        "top_logprobs": [
+                            None,
+                            {" is": -0.5},
+                            {" A": -1.0, " B": -2.0},
+                        ],
+                    }
+                }
+            ]
+        }
+        ll, greedy = _parse_loglikelihood_response(body, context="Q is")
+        assert ll == pytest.approx(-2.0)
+        assert greedy is False
+
+    def test_missing_logprobs_returns_inf(self):
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = {"choices": [{"text": "no logprobs"}]}
+        ll, greedy = _parse_loglikelihood_response(body, context="anything")
+        assert ll == float("-inf")
+        assert greedy is False
+
+    # ---- lm-eval parity invariants -----------------------------------------
+
+    def test_sum_excludes_context_tokens(self):
+        """`sum_logprob` is over continuation tokens only, never context."""
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = _build_loglikelihood_payload(
+            context_tokens=["The", " quick", " brown"],
+            continuation_tokens=[" fox"],
+            ctx_logprobs=[None, -2.0, -3.0],
+            cont_logprobs=[-0.5],
+        )
+        ll, greedy = _parse_loglikelihood_response(body, "The quick brown")
+        assert ll == pytest.approx(-0.5)
+        assert greedy is True
+
+    def test_multi_token_continuation_sums_correctly(self):
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = _build_loglikelihood_payload(
+            context_tokens=["Q:", " 2+2="],
+            continuation_tokens=["4", " is", " correct"],
+            ctx_logprobs=[None, -0.1],
+            cont_logprobs=[-0.3, -0.5, -0.7],
+        )
+        ll, greedy = _parse_loglikelihood_response(body, "Q: 2+2=")
+        assert ll == pytest.approx(-0.3 + -0.5 + -0.7)
+        assert greedy is True
+
+    def test_is_greedy_false_when_any_cont_token_not_top1(self):
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = _build_loglikelihood_payload(
+            context_tokens=["A"],
+            continuation_tokens=[" B", " C"],
+            ctx_logprobs=[None],
+            cont_logprobs=[-0.5, -0.5],
+            cont_top1_match=False,
+        )
+        ll, greedy = _parse_loglikelihood_response(body, "A")
+        assert ll == pytest.approx(-1.0)
+        assert greedy is False
+
+    def test_text_offset_locates_continuation_start(self):
+        """Use `text_offset >= len(context)` even when context spans
+        multiple tokens but happens to end exactly on a token boundary."""
+        from nemo_evaluator.contrib.byob.runner import _parse_loglikelihood_response
+
+        body = _build_loglikelihood_payload(
+            context_tokens=["He", "llo"],
+            continuation_tokens=[" world"],
+            ctx_logprobs=[None, -0.2],
+            cont_logprobs=[-1.5],
+        )
+        ll, _ = _parse_loglikelihood_response(body, "Hello")
+        assert ll == pytest.approx(-1.5)
+
+
+# ---------------------------------------------------------------------------
+# _create_session_model_call_fn — completions_logprob dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestSessionModelCallFnCompletionsLogprob:
+    def test_completions_logprob_routes_to_loglikelihood(self):
+        """The HTTP-session model_call_fn calls call_model_loglikelihood
+        when endpoint_type is 'completions_logprob'."""
+        from nemo_evaluator.contrib.byob import runner
+
+        args = MagicMock()
+        args.model_url = "http://localhost"
+        args.model_id = "x"
+        args.timeout_per_sample = 30.0
+        args.request_timeout = None
+
+        captured = {}
+
+        def fake_loglikelihood(**kwargs):
+            captured.update(kwargs)
+            return (-1.5, True)
+
+        session = MagicMock()
+
+        original = runner.call_model_loglikelihood
+        runner.call_model_loglikelihood = fake_loglikelihood
+        try:
+            fn = runner._create_session_model_call_fn(args, "key", session)
+            out = fn(
+                "context-here",
+                "completions_logprob",
+                continuation=" answer",
+            )
+        finally:
+            runner.call_model_loglikelihood = original
+
+        assert out == (-1.5, True)
+        assert captured["context"] == "context-here"
+        assert captured["continuation"] == " answer"
+
+    def test_completions_logprob_requires_continuation(self):
+        from nemo_evaluator.contrib.byob import runner
+
+        args = MagicMock()
+        args.timeout_per_sample = 30.0
+        args.request_timeout = None
+        session = MagicMock()
+        fn = runner._create_session_model_call_fn(args, "key", session)
+        with pytest.raises(ValueError, match="continuation"):
+            fn("ctx", "completions_logprob")
+
+
+# ---------------------------------------------------------------------------
+# aggregate_scores — surfaces the new logprob metric keys
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateLogprobMetrics:
+    def test_aggregate_includes_acc_acc_norm_acc_greedy(self):
+        scores = [
+            {"acc": 1.0, "acc_norm": 1.0, "acc_greedy": 1.0},
+            {"acc": 0.0, "acc_norm": 1.0, "acc_greedy": 0.0},
+            {"acc": 1.0, "acc_norm": 0.0, "acc_greedy": 1.0},
+        ]
+        out = aggregate_scores(scores, "test")
+        keys = out["tasks"]["test"]["metrics"]["pass@1"]["scores"]
+        assert "acc" in keys
+        assert "acc_norm" in keys
+        assert "acc_greedy" in keys
+        assert keys["acc"]["value"] == pytest.approx(2.0 / 3, abs=1e-3)
+        assert keys["acc_norm"]["value"] == pytest.approx(2.0 / 3, abs=1e-3)

--- a/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_scorers.py
+++ b/packages/nemo-evaluator/tests/unit_tests/byob/test_byob_scorers.py
@@ -15,15 +15,22 @@
 
 """Unit tests for BYOB built-in scorer functions."""
 
+import pytest
+
 from nemo_evaluator.contrib.byob.decorators import ScorerInput
 from nemo_evaluator.contrib.byob.scorers import (
     BUILTIN_SCORERS,
     all_of,
     any_of,
     bleu,
+    boolean_yesno,
+    chrf,
     contains,
     exact_match,
     f1_token,
+    gsm8k_answer,
+    mcq_letter_extract,
+    multiple_choice_acc,
     regex_match,
     retrieval_metrics,
     rouge,
@@ -643,3 +650,349 @@ class TestMultiTurnConversation:
         assert inp.conversation is None, (
             f"Expected conversation default to be None, got {inp.conversation}"
         )
+
+
+# ---------------------------------------------------------------------------
+# multiple_choice_acc
+#
+# lm-evaluation-harness-style multiple-choice loglikelihood ranking.
+# These tests pin down both the basic argmax/normalization formulas and
+# the lm-eval-harness contract (per-byte length normalization, target
+# resolution from letter / int / verbatim choice text).
+# Reference: lm_eval/models/openai_completions.py::loglikelihood
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleChoiceAcc:
+    """Cover argmax over raw and per-byte-normalized loglikelihoods."""
+
+    def test_acc_argmax_match(self):
+        s = ScorerInput(
+            response="B",
+            target="B",
+            metadata={
+                "_choices": ["A", "B", "C", "D"],
+                "_choices_logprobs": [-3.0, -1.0, -2.0, -4.0],
+                "_choices_is_greedy": [False, True, False, False],
+            },
+        )
+        out = multiple_choice_acc(s)
+        assert out == {"acc": 1.0, "acc_norm": 1.0, "acc_greedy": 1.0}
+
+    def test_acc_norm_breaks_ties_with_per_byte_normalization(self):
+        """A long correct choice loses raw argmax but wins on per-byte norm."""
+        s = ScorerInput(
+            response="B",
+            target="B",
+            metadata={
+                "_choices": ["A", "B" * 40],
+                "_choices_logprobs": [-3.0, -2.5],
+                "_choices_is_greedy": [False, False],
+            },
+        )
+        out = multiple_choice_acc(s)
+        assert out["acc"] == 1.0
+        assert out["acc_norm"] == 1.0
+
+    def test_acc_norm_overrides_acc_when_short_choice_dominates_raw(self):
+        s = ScorerInput(
+            response="A",
+            target="B",
+            metadata={
+                "_choices": ["A", "B" * 100],
+                "_choices_logprobs": [-1.0, -50.0],
+                "_choices_is_greedy": [False, False],
+            },
+        )
+        out = multiple_choice_acc(s)
+        assert out["acc"] == 0.0
+        assert out["acc_norm"] == 1.0
+
+    def test_int_target(self):
+        s = ScorerInput(
+            response="",
+            target=2,
+            metadata={
+                "_choices": ["A", "B", "C", "D"],
+                "_choices_logprobs": [-3.0, -2.0, -1.0, -4.0],
+                "_choices_is_greedy": [False, False, True, False],
+            },
+        )
+        assert multiple_choice_acc(s)["acc"] == 1.0
+
+    def test_string_int_target(self):
+        s = ScorerInput(
+            response="",
+            target="0",
+            metadata={
+                "_choices": ["A", "B"],
+                "_choices_logprobs": [-1.0, -2.0],
+                "_choices_is_greedy": [True, False],
+            },
+        )
+        assert multiple_choice_acc(s)["acc"] == 1.0
+
+    def test_verbatim_target(self):
+        s = ScorerInput(
+            response="",
+            target="The cat",
+            metadata={
+                "_choices": ["The dog", "The cat", "The fish"],
+                "_choices_logprobs": [-3.0, -1.0, -2.0],
+                "_choices_is_greedy": [False, True, False],
+            },
+        )
+        assert multiple_choice_acc(s)["acc"] == 1.0
+
+    def test_no_choices_returns_zero(self):
+        s = ScorerInput(response="", target="A", metadata={})
+        assert multiple_choice_acc(s) == {
+            "acc": 0.0,
+            "acc_norm": 0.0,
+            "acc_greedy": 0.0,
+        }
+
+    def test_unresolvable_target_returns_zero(self):
+        s = ScorerInput(
+            response="",
+            target=None,
+            metadata={
+                "_choices": ["A", "B"],
+                "_choices_logprobs": [-1.0, -2.0],
+            },
+        )
+        assert multiple_choice_acc(s)["acc"] == 0.0
+
+    # ---- lm-eval-harness parity invariants ---------------------------------
+
+    def test_acc_is_argmax_of_raw_logprobs(self):
+        s = ScorerInput(
+            response="",
+            target=1,
+            metadata={
+                "_choices": [" red", " blue", " green", " yellow"],
+                "_choices_logprobs": [-3.5, -1.2, -2.1, -4.0],
+                "_choices_is_greedy": [False, True, False, False],
+            },
+        )
+        assert multiple_choice_acc(s)["acc"] == 1.0
+
+    def test_acc_norm_is_argmax_of_per_byte_normalized(self):
+        """ARC/BoolQ formula: argmax(ll[i] / max(len(choice[i].encode("utf-8")), 1))."""
+        choices = [" cat", " elephant", " dog", " hippopotamus"]
+        choices_logprobs = [-2.0, -8.0, -2.5, -10.0]
+        byte_lens = [max(len(c.encode("utf-8")), 1) for c in choices]
+        norm = [choices_logprobs[i] / byte_lens[i] for i in range(4)]
+        expected_norm_argmax = max(range(4), key=lambda i: norm[i])
+
+        s = ScorerInput(
+            response="",
+            target=expected_norm_argmax,
+            metadata={
+                "_choices": choices,
+                "_choices_logprobs": choices_logprobs,
+                "_choices_is_greedy": [False] * 4,
+            },
+        )
+        assert multiple_choice_acc(s)["acc_norm"] == 1.0
+
+    def test_acc_and_acc_norm_diverge_when_choices_differ_in_length(self):
+        """ARC/BoolQ canonical: short choice wins raw argmax, long choice
+        with high enough total-logprob loses raw but wins per-byte norm."""
+        choices = [" no", " " + "x " * 50 + "yes"]
+        choices_logprobs = [-2.0, -50.0]
+        # raw: -2.0 vs -50.0 -> argmax = 0 (acc favors "no")
+        # norm: -2.0/3=-0.667 vs -50.0/103=-0.485 -> argmax = 1
+        meta = {
+            "_choices": choices,
+            "_choices_logprobs": choices_logprobs,
+            "_choices_is_greedy": [False, False],
+        }
+        s_acc = ScorerInput(response="", target=0, metadata=meta)
+        out_acc = multiple_choice_acc(s_acc)
+        assert out_acc["acc"] == 1.0
+        assert out_acc["acc_norm"] == 0.0
+
+        s_norm = ScorerInput(response="", target=1, metadata=meta)
+        out_norm = multiple_choice_acc(s_norm)
+        assert out_norm["acc"] == 0.0
+        assert out_norm["acc_norm"] == 1.0
+
+    @pytest.mark.parametrize(
+        "choice,expected_bytes",
+        [
+            (" yes", 4),
+            (" no", 3),
+            (" café", 6),
+            ("हाँ", 9),
+        ],
+    )
+    def test_per_byte_normalization_uses_utf8_byte_count(self, choice, expected_bytes):
+        """Confirm the byte denominator uses utf-8 encoding (matches lm-eval)."""
+        assert len(choice.encode("utf-8")) == expected_bytes
+
+    def test_per_byte_norm_formula_explicit_with_multibyte_choice(self):
+        """Verify acc_norm uses ``len(choice.encode("utf-8"))``, not char count."""
+        choices = ["A", "हाँ"]  # 1 byte vs 9 bytes
+        choices_logprobs = [-3.0, -3.0]
+        # Per-char would tie (-3/1 vs -3/3 = -1.0)
+        # Per-byte: -3/1=-3 vs -3/9=-0.333 -> idx 1 wins
+        meta = {
+            "_choices": choices,
+            "_choices_logprobs": choices_logprobs,
+            "_choices_is_greedy": [False, False],
+        }
+        s = ScorerInput(response="", target=1, metadata=meta)
+        assert multiple_choice_acc(s)["acc_norm"] == 1.0
+
+        s2 = ScorerInput(response="", target=0, metadata=meta)
+        assert multiple_choice_acc(s2)["acc_norm"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# gsm8k_answer
+# ---------------------------------------------------------------------------
+
+
+class TestGsm8kAnswer:
+    def test_hash_marker(self):
+        s = ScorerInput(
+            response="...calculation...\n#### 42", target="#### 42", metadata={}
+        )
+        assert gsm8k_answer(s) == {"correct": True, "parsed": True}
+
+    def test_boxed_marker(self):
+        s = ScorerInput(response="\\boxed{42}", target=42, metadata={})
+        assert gsm8k_answer(s) == {"correct": True, "parsed": True}
+
+    def test_last_number_fallback(self):
+        s = ScorerInput(response="2 plus 2 is 4", target=4, metadata={})
+        assert gsm8k_answer(s) == {"correct": True, "parsed": True}
+
+    def test_comma_stripping(self):
+        s = ScorerInput(response="#### 1,234", target=1234, metadata={})
+        assert gsm8k_answer(s) == {"correct": True, "parsed": True}
+
+    def test_decimal_normalization(self):
+        s = ScorerInput(response="#### 12.300", target="12.3", metadata={})
+        assert gsm8k_answer(s) == {"correct": True, "parsed": True}
+
+    def test_wrong_answer(self):
+        s = ScorerInput(response="#### 7", target=42, metadata={})
+        assert gsm8k_answer(s) == {"correct": False, "parsed": True}
+
+    def test_unparseable(self):
+        s = ScorerInput(response="no numbers here", target=42, metadata={})
+        out = gsm8k_answer(s)
+        assert out["correct"] is False
+        assert out["parsed"] is False
+
+
+# ---------------------------------------------------------------------------
+# mcq_letter_extract
+# ---------------------------------------------------------------------------
+
+
+class TestMcqLetterExtract:
+    @pytest.mark.parametrize(
+        "response,target,expected",
+        [
+            ("A", "A", True),
+            ("A)", "A", True),
+            ("The answer is B.", "B", True),
+            ("(C)", "C", True),
+            ("D. Because xyz", "D", True),
+            (r"\boxed{E}", "E", True),
+            ("Option A", "A", True),
+            ("D", 3, True),
+            ("A", 0, True),
+            ("not an answer", "A", False),
+        ],
+    )
+    def test_extraction(self, response, target, expected):
+        s = ScorerInput(response=response, target=target, metadata={})
+        assert mcq_letter_extract(s)["correct"] is expected
+
+    def test_none_response_is_unparsed(self):
+        """None response is treated as unparsed, not a hard error."""
+        s = ScorerInput(response=None, target="A", metadata={})
+        out = mcq_letter_extract(s)
+        assert out["correct"] is False
+        assert out["parsed"] is False
+
+    @pytest.mark.parametrize(
+        "response,target,expected_correct",
+        [
+            # Regression: prose responses starting with letters in A-J
+            # used to be returned as the answer by a first-character
+            # shortcut. The fix relies on the regex patterns instead, so
+            # the actual answer must come from a recognisable cue.
+            ("Hello, B is correct", "B", True),
+            ("Hello, B is correct", "H", False),
+            ("I think the answer is C", "C", True),
+            ("I think the answer is C", "I", False),
+            ("Definitely the answer is C", "C", True),
+            ("Definitely the answer is C", "D", False),
+            ("A nuclear reaction releases energy", "A", True),
+        ],
+    )
+    def test_first_char_shortcut_no_longer_misleads(
+        self, response, target, expected_correct
+    ):
+        """Prose starting with A-J must not be returned as the letter."""
+        s = ScorerInput(response=response, target=target, metadata={})
+        assert mcq_letter_extract(s)["correct"] is expected_correct
+
+
+# ---------------------------------------------------------------------------
+# boolean_yesno (English-only)
+# ---------------------------------------------------------------------------
+
+
+class TestBooleanYesNo:
+    @pytest.mark.parametrize(
+        "response,target,expected",
+        [
+            ("Yes, definitely.", True, True),
+            ("No, that is wrong.", False, True),
+            ("Yes!", "yes", True),
+            ("nope", False, True),
+            ("maybe", True, False),
+        ],
+    )
+    def test_extraction(self, response, target, expected):
+        s = ScorerInput(response=response, target=target, metadata={})
+        assert boolean_yesno(s)["correct"] is expected
+
+
+# ---------------------------------------------------------------------------
+# chrf — sacrebleu-style smoke
+# ---------------------------------------------------------------------------
+
+
+class TestChrf:
+    def test_identical_strings_max_score(self):
+        s = ScorerInput(
+            response="the cat sat on the mat",
+            target="the cat sat on the mat",
+            metadata={},
+        )
+        out = chrf(s)
+        assert out["chrf"] == pytest.approx(100.0, rel=1e-3)
+        assert out["chrf_pp"] == pytest.approx(100.0, rel=1e-3)
+
+    def test_disjoint_strings_low_score(self):
+        s = ScorerInput(response="abcdefg", target="zyxwvut", metadata={})
+        out = chrf(s)
+        assert out["chrf"] < 5.0
+        assert out["chrf_pp"] < 5.0
+
+    def test_partial_overlap(self):
+        s = ScorerInput(
+            response="the cat sat on the mat",
+            target="the cat sat on a mat",
+            metadata={},
+        )
+        out = chrf(s)
+        assert 50.0 < out["chrf"] < 100.0
+        assert 50.0 < out["chrf_pp"] < 100.0


### PR DESCRIPTION
BYOB support for logprob-based multiple-choice evaluation and extends dataset loading/scoring utilities needed by the Sovereign benchmark suite.

- Added completions_logprob as a supported endpoint type
  - Pydantic validation now accepts target.api_endpoint.type: completions_logprob
  - CLI --model_type completions_logprob is allowed
  - Endpoint health checks treat completions_logprob like a /v1/completions endpoint
- Added BYOB logprob evaluation flow
  - Uses /v1/completions with max_tokens=0, echo=true, and logprobs=1
  - Scores candidate continuations using returned token logprobs
  - Supports multiple-choice ranking via one request per candidate answer
  - Supports nested choice fields such as choices.text
- Added/updated BYOB scorers
  - multiple_choice_acc: returns acc, acc_norm, and acc_greedy
  - mcq_letter_extract: supports A-J options and handles empty/None responses safely
  - Added task-oriented scorers for GSM8K-style numeric answers, yes/no tasks, chrF, and ROUGE
- Extended Hugging Face dataset URI support.
  - Parses extra query params beyond split
  - Supports trust_remote_code=true
  - Supports row filtering via filter_field/filter_value, including multiple filters with suffixes
  - This allows BYOB benchmarks to consume datasets where language is stored as a row field instead of a HF config