### PR TITLE
chore(ci): port Group A workflows from main (verbatim)

### DIFF
--- a/.github/workflows/cherry-pick-release-commit.yml
+++ b/.github/workflows/cherry-pick-release-commit.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Create PR to main with cherry-pick from release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  cherry-pick:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cherry_pick.yml@v0.63.0
+    secrets:
+      PAT: ${{ secrets.PAT }}
+      SLACK_WEBHOOK_ADMIN: ${{ secrets.SLACK_WEBHOOK_ADMIN }}
+      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,39 @@
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude-review:
+    if: github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.88.0
+    with:
+      prompt: |
+        You are doing a light code review. Keep it concise and actionable.
+
+        Focus ONLY on:
+        - Critical bugs or logic errors
+        - Typos in code, comments, or strings
+        - Missing or insufficient test coverage for changed code
+        - Outdated or inaccurate documentation affected by the changes
+
+        Do NOT comment on:
+        - Style preferences or formatting
+        - Minor naming suggestions
+        - Architectural opinions or refactoring ideas
+        - Performance unless there is a clear, measurable issue
+
+        Provide feedback using inline comments for specific code suggestions.
+        Use top-level comments for general observations.
+
+        It's perfectly acceptable to not have anything to comment on.
+        If you do not have anything to comment on, post "LGTM".
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/close-inactive-issue-pr.yml
+++ b/.github/workflows/close-inactive-issue-pr.yml
@@ -1,0 +1,8 @@
+name: Stale-Close-Inactive-Issues-PRs
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+jobs:
+  close-issues:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_close_inactive_issue_pr.yml@v0.44.0

--- a/.github/workflows/community-bot.yml
+++ b/.github/workflows/community-bot.yml
@@ -1,0 +1,15 @@
+name: Community Bot
+
+on:
+  issues:
+    types: [opened, edited, reopened, closed, deleted]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  community-bot:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_community_bot.yml@v0.54.4
+    with:
+      community_project_id: ${{ vars.COMMUNITY_PROJECT_ID }}
+    secrets:
+      GH_TOKEN: ${{ secrets.PAT }}

--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -1,0 +1,367 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "GitLabTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    },
+    {
+      "path": "detect_secrets.filters.regex.should_exclude_file",
+      "pattern": [
+        "pyproject\\.toml|\\.github/workflows/config/\\.secrets\\.baseline"
+      ]
+    }
+  ],
+  "results": {
+    "docs/api/index.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/api/index.md",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 76
+      }
+    ],
+    "docs/get-started/quickstart.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/get-started/quickstart.md",
+        "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
+        "is_verified": false,
+        "line_number": 8
+      }
+    ],
+    "docs/tutorials/walkthrough.md": [
+      {
+        "type": "Secret Keyword",
+        "filename": "docs/tutorials/walkthrough.md",
+        "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
+        "is_verified": false,
+        "line_number": 9
+      }
+    ],
+    "examples/configs/conf/services/nemotron_fp8_vllm.yaml": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "examples/configs/conf/services/nemotron_fp8_vllm.yaml",
+        "hashed_secret": "ed6271c85374eb62d536189cbee1ca303ff7cbd6",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "src/nemo_evaluator/environments/container.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/nemo_evaluator/environments/container.py",
+        "hashed_secret": "499224054c6bf4153347ae50fc73271227053cd7",
+        "is_verified": false,
+        "line_number": 61
+      }
+    ],
+    "src/nemo_evaluator/solvers/harbor.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/nemo_evaluator/solvers/harbor.py",
+        "hashed_secret": "aba587d0ca054afc6656ee19c938be86b9bff6a4",
+        "is_verified": false,
+        "line_number": 848
+      }
+    ],
+    "tests/fixtures/pinchbench.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/fixtures/pinchbench.json",
+        "hashed_secret": "4995474fb11499d329cd48fe17b53fdd996fc953",
+        "is_verified": false,
+        "line_number": 11
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/fixtures/pinchbench.json",
+        "hashed_secret": "fe6425ef8200effd05210ab6a4cbbe50d5d5c407",
+        "is_verified": false,
+        "line_number": 35
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/fixtures/pinchbench.json",
+        "hashed_secret": "61bbc0fa71f63799ca87e21a36528204fb5e7d45",
+        "is_verified": false,
+        "line_number": 64
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/fixtures/pinchbench.json",
+        "hashed_secret": "e71e43ad15e0d823215dd9c8837afda455c68ef6",
+        "is_verified": false,
+        "line_number": 93
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "tests/fixtures/pinchbench.json",
+        "hashed_secret": "e4ad58facb0a00d69aa5be4eb68c31f8e9d7d79d",
+        "is_verified": false,
+        "line_number": 117
+      }
+    ],
+    "tests/generate_fixtures.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/generate_fixtures.py",
+        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "tests/test_adapters/test_cache_keys.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_adapters/test_cache_keys.py",
+        "hashed_secret": "2627a8a99ffe7d7013a01f652465ef8c70bd6689",
+        "is_verified": false,
+        "line_number": 26
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "tests/test_adapters/test_cache_keys.py",
+        "hashed_secret": "d4f68778b82c1e4853837d5b8ecdf2625256429f",
+        "is_verified": false,
+        "line_number": 37
+      }
+    ],
+    "tests/test_adapters/test_interceptors_extended.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_adapters/test_interceptors_extended.py",
+        "hashed_secret": "fb0123cbab73d8a58896fbe39b8b7b5b6df15c5e",
+        "is_verified": false,
+        "line_number": 58
+      }
+    ],
+    "tests/test_config/test_config_schema.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config/test_config_schema.py",
+        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
+        "is_verified": false,
+        "line_number": 700
+      }
+    ],
+    "tests/test_config/test_ssm_autodiscovery.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config/test_ssm_autodiscovery.py",
+        "hashed_secret": "ba24b4dca3523679452cbe20dab9eaa9f50c6f16",
+        "is_verified": false,
+        "line_number": 37
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config/test_ssm_autodiscovery.py",
+        "hashed_secret": "51268d9109e2b52a7c4b53775b1560c138b4d6b4",
+        "is_verified": false,
+        "line_number": 43
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config/test_ssm_autodiscovery.py",
+        "hashed_secret": "92a8159fa2ade5dc0d3e3975d4ac26bcf1e4efdf",
+        "is_verified": false,
+        "line_number": 44
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config/test_ssm_autodiscovery.py",
+        "hashed_secret": "7378bd4307a3e05617b530844ca33163fdcc49bb",
+        "is_verified": false,
+        "line_number": 304
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_config/test_ssm_autodiscovery.py",
+        "hashed_secret": "9e1c50f264cff2dcb7ce59c030babfe1a0b45c0a",
+        "is_verified": false,
+        "line_number": 305
+      }
+    ],
+    "tests/test_orchestration/test_slurm_sharding.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_orchestration/test_slurm_sharding.py",
+        "hashed_secret": "e85b3f19ba65dae3aa220232f23dd669ca75b0a3",
+        "is_verified": false,
+        "line_number": 545
+      }
+    ],
+    "tests/test_sandbox/test_ecs_fargate.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_sandbox/test_ecs_fargate.py",
+        "hashed_secret": "4b72fe9b2ca9a73f7b9c92399fc0bc66a6a1ba46",
+        "is_verified": false,
+        "line_number": 33
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_sandbox/test_ecs_fargate.py",
+        "hashed_secret": "32b7fff7855ef49f519751298add56327b6fda80",
+        "is_verified": false,
+        "line_number": 34
+      }
+    ],
+    "tests/test_solvers/test_harbor_solver.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_solvers/test_harbor_solver.py",
+        "hashed_secret": "9e52503a0984e613e6ed5f6f9a3cf0b93b2d826b",
+        "is_verified": false,
+        "line_number": 94
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_solvers/test_harbor_solver.py",
+        "hashed_secret": "d53bc841bc79960df8f8bd2b261f11abb1157138",
+        "is_verified": false,
+        "line_number": 103
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_solvers/test_harbor_solver.py",
+        "hashed_secret": "aba587d0ca054afc6656ee19c938be86b9bff6a4",
+        "is_verified": false,
+        "line_number": 110
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_solvers/test_harbor_solver.py",
+        "hashed_secret": "d17f1ab3e20d30ec8e0ec98bc91e03091f0573e1",
+        "is_verified": false,
+        "line_number": 144
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "tests/test_solvers/test_harbor_solver.py",
+        "hashed_secret": "04d2297e558a68a20a32eaca04908e6d6b0b6300",
+        "is_verified": false,
+        "line_number": 151
+      }
+    ]
+  },
+  "generated_at": "2026-05-04T12:29:46Z"
+}

--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,0 +1,58 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Copyright check
+
+on:
+  push:
+    branches:
+      - main
+      - "pull-request/[0-9]+"
+      - "deploy-release/*"
+
+jobs:
+  pre-flight:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.66.6
+
+  copyright-check:
+    needs: [pre-flight]
+    if: |
+      !(needs.pre-flight.outputs.docs_only == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true')
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_copyright_check.yml@v0.2.0
+
+  copyright-check-summary:
+    needs: [pre-flight, copyright-check]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || always()
+      )
+      && !cancelled()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Result
+        run: |
+          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
+
+          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
+              echo "✅ All previous jobs completed successfully"
+              exit 0
+          else
+              echo "❌ Found $FAILED_JOBS failed job(s)"
+              # Show which jobs failed
+              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              exit 1
+          fi

--- a/.github/workflows/detect-secrets.yml
+++ b/.github/workflows/detect-secrets.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2026 NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Secrets detector
+
+on:
+  pull_request:
+
+jobs:
+  # To rebuild the baseline, run:
+  # detect-secrets scan \
+  #   --exclude-files 'pyproject\.toml|\.github/workflows/config/\.secrets\.baseline' \
+  #   --disable-plugin KeywordDetector > .github/workflows/config/.secrets.baseline
+  #
+  # The KeywordDetector in this repo yields too many false positives.
+  secrets-detector:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_secrets-detector.yml@v0.70.0

--- a/.github/workflows/semantic-pull-request.yml
+++ b/.github/workflows/semantic-pull-request.yml
@@ -1,0 +1,39 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Validate PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
+
+permissions:
+  pull-requests: read
+
+jobs:
+  semantic-pull-request:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_semantic_pull_request.yml@v0.66.6


### PR DESCRIPTION
## Summary

Stacked on #957. Ports 7 workflows from main verbatim. These are layout-agnostic — they delegate to `NVIDIA-NeMo/FW-CI-templates` for the actual logic, so no V1 path baggage to adapt.

| Workflow | Triggers on | Why it fires correctly on dev/0.3.0 |
|---|---|---|
| `claude-review.yml` | `issue_comment` | event has no branch filter |
| `close-inactive-issue-pr.yml` | `schedule` | repo-level, no branch filter |
| `community-bot.yml` | `issues`, `issue_comment` | event has no branch filter |
| `detect-secrets.yml` | `pull_request` | no branch filter |
| `semantic-pull-request.yml` | `pull_request_target`, `pull_request` | no branch filter |
| `copyright-check.yml` | `push: [main, "pull-request/[0-9]+", "deploy-release/*"]` | fires via the NeMo-CI mirror-branch bot once dev/0.3.0 is main |
| `cherry-pick-release-commit.yml` | `push: [main]` | release-ops, fires after dev/0.3.0 → main |

## Why verbatim

Trigger lists are unchanged. The first 5 fire on cross-branch events (issues, PRs to anywhere, schedule); the last 2 are push-pattern-triggered and rely on the NeMo-CI repo-level mirror-branch bot — no edit needed because those patterns will fire correctly when dev/0.3.0 becomes main.

While dev/0.3.0 is still upstream of main, `oss-pr-checks.yml` (from #956) remains the active gate for dev/0.3.0 PRs. After the dev/0.3.0 → main swap, these take over.

## Stack

```
dev/0.3.0
  └─ #956  chore(ci): plug OSS PR checks
       └─ #957  chore(lint): apply isort
            └─ THIS PR  chore(ci): port Group A workflows
```

## Test plan

- [x] Files copied verbatim from `main` — no edits beyond download
- [x] Verified each workflow's `on:` block fires correctly post-swap (table above)
- [ ] Once #956+#957 land, this PR retargets `dev/0.3.0` and gets a real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)