### PR TITLE
chore(ci): port cicd-main.yml + install-test.yml from main (trimmed)

### DIFF
--- a/.github/config/.coveragerc
+++ b/.github/config/.coveragerc
@@ -1,0 +1,5 @@
+[paths]
+source = 
+    .
+    /workspace
+    /home/runner/work/Eval/Eval

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -1,0 +1,279 @@
+# Copyright (c) 2020-2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: CICD NeMo
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to run tests on"
+        required: false
+        default: "main"
+  schedule:
+    - cron: 0 0 * * *
+  push:
+    branches:
+      - main
+      - dev/0.3.0
+      - "pull-request/[0-9]+"
+      - "deploy-release/*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name || 'main' }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  pre-flight:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_cicd_preflight.yml@v0.80.1
+    with:
+      default_runner_prefix: nemo-ci-aws-gpu-x2
+      non_nvidia_runner_prefix: nemo-ci-aws-gpu-x2-ephemeral
+      default_test_data_path: /mnt/datadrive/TestData/nemo-fw/TestData
+      non_nvidia_test_data_path: /mnt/datadrive/TestData/nemo-fw/TestData
+      sso_users_filename: ${{ vars.SSO_USERS_FILENAME }}
+    secrets:
+      NVIDIA_MANAGEMENT_ORG_PAT: ${{ secrets.NVIDIA_MANAGEMENT_ORG_PAT }}
+
+  linting:
+    runs-on: ubuntu-latest
+    needs: [pre-flight]
+    if: |
+      (
+        needs.pre-flight.outputs.is_deployment_workflow == 'false'
+          && needs.pre-flight.outputs.is_ci_workload == 'true'
+      ) || (
+        needs.pre-flight.outputs.is_deployment_workflow == 'false'
+          && needs.pre-flight.outputs.is_ci_workload == 'false'
+          && needs.pre-flight.outputs.docs_only == 'false'
+      )
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install ruff
+        run: |
+          pip install ruff
+
+      - name: Check lint
+        run: |
+          pip install pre-commit==3.6.0
+          pre-commit install
+          pre-commit run --all-files --show-diff-on-failure --color=always
+
+  cicd-wait-in-queue:
+    runs-on: ubuntu-latest
+    needs: [pre-flight, linting]
+    environment: test
+    if: |
+      !(needs.pre-flight.outputs.is_ci_workload == 'true'
+      || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+      || needs.pre-flight.outputs.docs_only == 'true')
+    steps:
+      - name: Running CI tests
+        run: |
+          echo "Running CI tests"
+
+  cicd-unit-tests-nemo-evaluator:
+    needs: [pre-flight, cicd-wait-in-queue]
+    runs-on: ubuntu-latest
+    name: unit-tests
+    environment: nemo-ci
+    strategy:
+      fail-fast: false
+      matrix:
+        # py3.11 is gated out: the [dev] extras pull in `harbor>=0.3.0,<0.4.0`
+        # which only ships wheels for Python >=3.12. Mirrors oss-pr-checks.yml.
+        python-version: ["3.12"]
+    if: |
+      (
+        success()
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || needs.pre-flight.outputs.force_run_all == 'true'
+      )
+      && !cancelled()
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml') }}
+          restore-keys: pip-${{ matrix.python-version }}-
+
+      - name: Install with dev extras
+        run: pip install -e ".[dev]"
+
+      - name: Run pytest with coverage (offline tests only)
+        run: |
+          pytest tests/ \
+            -m "not network and not slow and not e2e" \
+            --tb=short \
+            -q \
+            -n auto \
+            --cov=nemo_evaluator \
+            --cov-report= \
+            --cov-report=term-missing
+
+      - name: Upload coverage artifact
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-unit-test-${{ github.run_id }}-py${{ matrix.python-version }}
+          path: .coverage
+          include-hidden-files: true
+
+  Nemo_CICD_Test:
+    needs:
+      - pre-flight
+      - cicd-unit-tests-nemo-evaluator
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+        || needs.pre-flight.outputs.is_ci_workload == 'true'
+        || always()
+      )
+      && !cancelled()
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get workflow result
+        id: result
+        shell: bash -x -e -u -o pipefail {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          IS_CI_WORKLOAD: ${{ needs.pre-flight.outputs.is_ci_workload == 'true' }}
+          SKIPPING_IS_ALLOWED: ${{ needs.pre-flight.outputs.docs_only == 'true' || needs.pre-flight.outputs.is_deployment_workflow == 'true' || needs.pre-flight.outputs.is_ci_workload == 'true' }}
+        run: |
+          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
+          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
+              echo "✅ All previous jobs completed successfully"
+              exit 0
+          else
+              echo "❌ Found $FAILED_JOBS failed job(s)"
+              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              exit 1
+          fi
+
+  Coverage_Fake:
+    runs-on: ubuntu-latest
+    needs: [Nemo_CICD_Test, pre-flight]
+    if: |
+      (
+        needs.pre-flight.outputs.docs_only == 'true'
+        || needs.pre-flight.outputs.is_deployment_workflow == 'true'
+      )
+      && needs.pre-flight.outputs.is_ci_workload == 'false'
+      && !cancelled()
+    environment: nemo-ci
+    steps:
+      - name: Generate fake coverage report
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.PAT }}
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha,
+              state: 'success',
+              context: 'codecov/patch',
+              description: 'Skipped - docs/deployment only'
+            });
+            await github.rest.repos.createCommitStatus({
+              owner,
+              repo,
+              sha,
+              state: 'success',
+              context: 'codecov/project',
+              description: 'Skipped - docs/deployment only'
+            });
+
+  Coverage:
+    runs-on: ubuntu-latest
+    needs: [Nemo_CICD_Test, pre-flight]
+    if: |
+      (
+        (needs.pre-flight.outputs.is_ci_workload == 'true' && !failure())
+        || success()
+      )
+      && !cancelled()
+    strategy:
+      matrix:
+        flag: [unit-test]
+    steps:
+      - name: Get PR info
+        id: get-pr-info
+        if: startsWith(github.ref, 'refs/heads/pull-request/')
+        uses: nv-gha-runners/get-pr-info@main
+
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download coverage reports of current branch
+        uses: actions/download-artifact@v7
+        with:
+          pattern: coverage-${{ matrix.flag }}-*
+          merge-multiple: true
+
+      - name: List coverage files
+        run: find . -type f -name "*.xml" -o -name "*.lcov"
+
+      - name: Get total coverage of current branch
+        shell: bash -x -e -u -o pipefail {0}
+        if: always()
+        run: |
+          pip install coverage
+
+          ls -al .
+          coverage combine --rcfile .github/config/.coveragerc
+          coverage report -i --rcfile .github/config/.coveragerc
+          coverage xml --rcfile .github/config/.coveragerc
+          rm -rf coverage-*
+          ls -al
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          verbose: true
+          flags: ${{ matrix.flag }}
+          base_sha: ${{ fromJSON(steps.get-pr-info.outputs.pr-info || '{}').base.sha }}
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage-${{ matrix.flag }}-aggregated
+          path: |
+            .coverage
+          include-hidden-files: true

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -1,0 +1,127 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow verifies that the basic install works across all supported platforms.
+# For basic install, all imports need to either be successful or appropriately guarded.
+
+name: Installation Test
+
+on:
+  push:
+    branches:
+      - main
+      - dev/0.3.0
+      - "pull-request/[0-9]+"
+      - "deploy-release/*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-nemo-evaluator:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: |
+          for i in 1 2 3; do
+            curl -LsSf https://astral.sh/uv/install.sh | sh && break
+            echo "uv install attempt $i failed, retrying..."
+            sleep 10
+          done
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install nemo-evaluator
+        run: |
+          uv pip install --system -e .
+
+      - name: Verify installation
+        run: |
+          python -c "import nemo_evaluator; print(f'nemo-evaluator version: {nemo_evaluator.__version__}')"
+          which nel
+          nel --help
+
+  check-imports:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Checkout FW-CI-templates
+        uses: actions/checkout@v6
+        with:
+          repository: NVIDIA-NeMo/FW-CI-templates
+          path: ./FW-CI-templates
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: |
+          for i in 1 2 3; do
+            curl -LsSf https://astral.sh/uv/install.sh | sh && break
+            echo "uv install attempt $i failed, retrying..."
+            sleep 10
+          done
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+      - name: Install package
+        run: |
+          uv pip install --system -e .
+
+      - name: Check imports
+        uses: ./FW-CI-templates/.github/actions/check-imports
+        with:
+          package-name: nemo_evaluator
+          python-binary: python3
+
+  install-test-summary:
+    needs: [test-nemo-evaluator, check-imports]
+    runs-on: ubuntu-latest
+    name: Install test summary
+    if: always() && !cancelled()
+    steps:
+      - name: Get workflow result
+        id: result
+        shell: bash -x -e -u -o pipefail {0}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
+
+          if [ "${FAILED_JOBS:-0}" -eq 0 ]; then
+              echo "✅ All previous jobs completed successfully"
+              exit 0
+          else
+              echo "❌ Found $FAILED_JOBS failed job(s)"
+              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              exit 1
+          fi


### PR DESCRIPTION
## Summary

Stacked on #958. Brings dev/0.3.0 onto main's CI scaffold: FW-CI-templates `_cicd_preflight.yml`, `linting`, queue gate, `Nemo_CICD_Test` summary, `Coverage` / `Coverage_Fake`. Same job names and structure as main so the dev/0.3.0 → main swap is a no-op for downstream consumers reading status checks.

## What's in this PR

| File | What |
|---|---|
| `.github/workflows/cicd-main.yml` | Trimmed port of main's cicd-main.yml |
| `.github/workflows/install-test.yml` | V2-adapted port of main's install-test.yml |
| `.github/config/.coveragerc` | Path mapping for the Coverage job |

## What I trimmed from main's cicd-main.yml

| Dropped | Why |
|---|---|
| `validate-container-digests` | Launcher-only — `cd packages/nemo-evaluator-launcher` doesn't exist |
| `cicd-unit-tests-nemo-evaluator-launcher` | Launcher doesn't exist |
| `cicd-e2e-tests-nemo-evaluator` | Deferred — needs functional-test runners + test-data path |
| `cicd-integration-tests` | Deferred — GPU-runner setup |
| `cleanup-taint-node` | Only relevant for ephemeral runners we're not using yet |

## What I adapted

**`cicd-unit-tests-nemo-evaluator`**: replaced the Docker-based test-template path with non-Docker pytest on ubuntu-latest. Same coverage as `oss-pr-checks.yml::test` from #956 but wired through main's job structure. A follow-up PR will swap this body back to Docker-based once `docker/Dockerfile.ci`, `docker/common/install.sh`, `tests/unit_tests/Launch_Unit_Tests.sh`, and the test-template local action are ported (separate concern).

**`install-test.yml`**: dropped V1 `working-directory: packages/nemo-evaluator`, dropped launcher job, root install on the same py 3.10/3.11/3.12/3.13 matrix as main. `check-imports` step preserved, points at `NVIDIA-NeMo/FW-CI-templates`.

## Trigger pattern

Both workflows include `dev/0.3.0` alongside main's existing branches:

```yaml
push:
  branches:
    - main
    - dev/0.3.0
    - "pull-request/[0-9]+"
    - "deploy-release/*"
```

Future-proofs the dev/0.3.0 → main swap — same workflow files keep working on either name.

## Stack

```
dev/0.3.0
  └─ #956  chore(ci): plug OSS PR checks
       └─ #957  chore(lint): apply isort
            └─ #958  chore(ci): port Group A workflows
                 └─ THIS PR  chore(ci): port cicd-main + install-test (trimmed)
```

Land in stack order: #956 → #957 → #958 → this.

## Test plan

- [x] YAML syntax valid (validated via `yaml.safe_load`)
- [x] No references to dropped jobs in `needs:` lists across remaining jobs
- [x] Coverage job matrix narrowed to `[unit-test]` (was `[unit-test, e2e]`)
- [ ] First CI run validates the workflow itself (post-merge)
- [ ] Real success case once #956 + #957 + #958 land and the chain rebases

## Followup PR (separate, not blocking)

When dev/0.3.0 ships docker harness, swap `cicd-unit-tests-nemo-evaluator`'s body back to use the Docker-based test-template action. That PR brings:
- `.github/actions/test-template/action.yml` (V2-adapted)
- `docker/Dockerfile.ci` (V2-adapted)
- `docker/common/install.sh` (V2-adapted)
- `tests/unit_tests/Launch_Unit_Tests.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)