### PR TITLE
fix(ci): drop gitleaks job + narrow pytest matrix to py3.12

### DIFF
--- a/.github/workflows/oss-pr-checks.yml
+++ b/.github/workflows/oss-pr-checks.yml
@@ -64,7 +64,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.11", "3.12"]
+        # py3.11 is gated out: the [dev] extras pull in `harbor>=0.3.0,<0.4.0`
+        # which only ships wheels for Python >=3.12. Base install (without
+        # [dev]) still works on 3.11 — see the install-test job above.
+        python: ["3.12"]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -110,16 +113,3 @@ jobs:
             exit 1
           fi
           echo "All changed Python files carry SPDX headers."
-
-  secrets:
-    name: Secrets scan (gitleaks)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false
-          GITLEAKS_ENABLE_SUMMARY: true


### PR DESCRIPTION
## Summary

Two related fixes to make `oss-pr-checks.yml` actually run cleanly on dev/0.3.0 PRs.

### Fix 1: drop gitleaks job

`gitleaks/gitleaks-action@v2` isn't on NVIDIA-NeMo/Evaluator's allowed-actions allowlist — every PR run hit `startup_failure` before any job started, blocking lint/test/install visibility on stacked PRs (#957, #958, #959).

Secrets scanning is already covered by `detect-secrets.yml` (#958), which uses the FW-CI-templates path that IS allowlisted. Dropping the gitleaks job here removes the blocker without losing coverage.

### Fix 2: narrow pytest matrix to py3.12 only

After fix 1 landed and the workflow actually started running, the `pytest (py3.11)` job failed with:

```
ERROR: Could not find a version that satisfies the requirement harbor<0.4.0,>=0.3.0
       (from versions: none)
```

Root cause: `[dev]` extras pull in `harbor>=0.3.0,<0.4.0` which only ships wheels for Python ≥ 3.12. So `pip install -e ".[dev]"` only succeeds on py3.12+. The base install (`pip install -e .`) still works on py3.11 — that job is left intact.

If py3.11 dev support matters, the proper fix is splitting `harbor` out of `[dev]` and adding `pytest.importorskip("harbor")` in the harbor test module. That's a separate refactor PR; this one keeps the fix tight.

## Verification

- ✅ YAML parses (`yaml.safe_load`)
- ✅ `pytest (py3.12)` was already passing on the previous push
- 🔁 Re-runs after force-push will validate the matrix narrowing

🤖 Generated with [Claude Code](https://claude.com/claude-code)