### PR TITLE
fix(tests): seed test_mmlu_style_grouping deterministically

### DIFF
--- a/tests/test_scoring/test_confidence.py
+++ b/tests/test_scoring/test_confidence.py
@@ -111,11 +111,16 @@ class TestClusteredCI:
 
     def test_mmlu_style_grouping(self):
         """Simulate MMLU-like structure: 4 subjects, 25 questions each.
-        Within each subject, scores are correlated (all high or all low)."""
+        Within each subject, scores are correlated (all high or all low).
+
+        Uses index-based seeding (not ``hash(subj)``) for determinism —
+        Python's ``hash(str)`` is randomized per-process via PYTHONHASHSEED,
+        which made this test flake on the SE-ratio assertion below.
+        """
         scores = []
         clusters = []
-        for subj, acc in [("math", 0.9), ("history", 0.6), ("science", 0.8), ("art", 0.5)]:
-            rng = np.random.default_rng(hash(subj) % 2**32)
+        for i, (subj, acc) in enumerate([("math", 0.9), ("history", 0.6), ("science", 0.8), ("art", 0.5)]):
+            rng = np.random.default_rng(42 + i)
             scores.extend(list(rng.choice([0.0, 1.0], size=25, p=[1 - acc, acc])))
             clusters.extend([subj] * 25)
 


### PR DESCRIPTION
## Summary

`TestClusteredCI::test_mmlu_style_grouping` flakes on CI roughly 5-10% of runs (caught one on #958). Root cause: it seeded numpy via Python's process-randomized `hash(str)`:

```python
rng = np.random.default_rng(hash(subj) % 2**32)
```

`hash(str)` randomization is on by default since Python 3.3 (`PYTHONHASHSEED=random`, security against hash-collision DoS). Each Python process gets a different seed → different Bernoulli samples → different SE → ratio bounces around the `1.2` threshold.

The fix is one-line: index-based deterministic seeds.

```diff
-for subj, acc in [("math", 0.9), ...]:
-    rng = np.random.default_rng(hash(subj) % 2**32)
+for i, (subj, acc) in enumerate([("math", 0.9), ...]):
+    rng = np.random.default_rng(42 + i)
```

## What the test verifies (unchanged)

`clustered_ci()` should inflate the standard error vs `normal_ci()` when given correlated-within-cluster data — by **at least 20%** with 4 diverse-mean clusters.

This matters for MMLU-style benchmarks where 57 subjects × ~50 questions create correlation. Reporting `mean ± naive_SE` underestimates real uncertainty; `clustered_ci` accounts for the reduced effective sample size.

## Verification

Ran the test 5× back-to-back locally, all green.

```
1 passed in 8.57s
1 passed in 3.89s
1 passed in 3.15s
1 passed in 2.23s
1 passed in 1.96s
```

## Why a separate PR

Caught while merging the chain (#956 → #957 → #958 → #959). Pre-existing flake, not introduced by the chain. Splitting it out keeps the chore PRs scoped to "what they actually do" and lets this fix land independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)