### PR TITLE
fix(ci): py3.11+ baseline, lazy ray import, suffix coverage file

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -138,12 +138,20 @@ jobs:
             --cov-report= \
             --cov-report=term-missing
 
+      # Suffix the .coverage file so the downstream Coverage job's
+      # ``coverage combine`` step recognises it. ``coverage combine``
+      # expects ``.coverage.<suffix>`` files (e.g. ``.coverage.unit-test``)
+      # and refuses to combine a bare ``.coverage`` ("No data to combine").
+      - name: Rename .coverage for combine compatibility
+        if: matrix.python-version == '3.12'
+        run: mv .coverage .coverage.unit-test
+
       - name: Upload coverage artifact
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v6
         with:
           name: coverage-unit-test-${{ github.run_id }}-py${{ matrix.python-version }}
-          path: .coverage
+          path: .coverage.unit-test
           include-hidden-files: true
 
   Nemo_CICD_Test:

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nemo-evaluator"
 version = "0.13.0"
 description = "NeMo Evaluator — benchmark environments, pluggable solvers, interceptor proxy, and decision-grade scoring for LLMs"
 readme = "README.md"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 license = "Apache-2.0"
 authors = [
     { name = "NVIDIA" },

--- a/src/nemo_evaluator/engine/ray_launcher.py
+++ b/src/nemo_evaluator/engine/ray_launcher.py
@@ -32,12 +32,40 @@ import os
 import tempfile
 from pathlib import Path
 
-import ray
+# ``ray`` lives behind the optional ``[ray]`` extra. Importing this module
+# without ray installed should not raise — only attempts to actually launch
+# Ray tasks should fail with a clear hint about the missing extra. This lets
+# tools that walk the import graph (e.g. FW-CI-templates' check-imports
+# action) resolve nemo_evaluator.engine.ray_launcher cleanly on a base install.
+try:
+    import ray  # type: ignore[import-not-found]
+
+    _RAY_IMPORT_ERROR: ImportError | None = None
+except ImportError as _e:
+    ray = None  # type: ignore[assignment]
+    _RAY_IMPORT_ERROR = _e
 
 logger = logging.getLogger(__name__)
 
 
-@ray.remote
+def _require_ray() -> None:
+    if ray is None:
+        raise RuntimeError(
+            f"ray is not installed; install with `pip install -e '.[ray]'` (original ImportError: {_RAY_IMPORT_ERROR})"
+        )
+
+
+def _ray_remote(fn):
+    """Apply ``@ray.remote`` if ray is available, otherwise return ``fn`` unchanged.
+
+    The unwrapped form is never callable as a Ray task — calling
+    ``run_shard.remote(...)`` will AttributeError, which is fine because the
+    caller (``main()`` below) already routes through ``_require_ray()``.
+    """
+    return ray.remote(fn) if ray is not None else fn
+
+
+@_ray_remote
 def run_shard(
     benchmark: str,
     shard_idx: int,
@@ -85,6 +113,7 @@ def run_shard(
 
 
 def main():
+    _require_ray()
     parser = argparse.ArgumentParser()
     parser.add_argument("--benchmark", "-b", required=True)
     parser.add_argument("--shards", "-s", type=int, default=4)


### PR DESCRIPTION
## Summary

Three pre-existing dev/0.3.0 bugs surfaced by the post-#959 push runs:

### Bug 1: py3.10 fails on `typing.Self`

`src/nemo_evaluator/sandbox/base.py:26` does `from typing import Self`. `typing.Self` is **3.11+**. Manifest claimed `>=3.10` but code never worked there.

**Fix**: bump `requires-python = ">=3.11,<3.14"`, drop py3.10 from `install-test.yml`'s matrix.

### Bug 2: `check-imports` fails on top-level `import ray`

FW-CI-templates' `check-imports` recursively imports every submodule. `engine/ray_launcher.py:35` does eager top-level `import ray` — but `ray` is in the optional `[ray]` extra, not base requirements (heavy, niche use). `solvers/harbor.py` already lazy-imports its optional dep correctly via `_check_harbor_installed()`; ray_launcher just didn't follow the pattern.

**Fix**: port the harbor pattern to ray_launcher.py:
- `try: import ray; except ImportError: ray = None`
- `@_ray_remote` decorator that no-ops to plain `fn` when ray is unavailable
- `_require_ray()` guard at the top of `main()` for a clear CLI error

### Bug 3: `CICD NeMo::Coverage (unit-test)` fails with "No data to combine"

The `cicd-unit-tests-nemo-evaluator` job uploads a bare `.coverage` file. The downstream `Coverage` job runs `coverage combine` — which expects `.coverage.<suffix>` files (multiple shards are merged via the suffix). A single bare `.coverage` is ignored → "No data to combine" → exit 1.

**Fix**: rename `.coverage → .coverage.unit-test` before upload. Combine then sees the suffixed file and merges it (no-op for single file) into the main `.coverage`.

## Verification

- ✅ Module imports cleanly on a base install — verified by mocking `__import__('ray')` to raise `ImportError`.
- ✅ Ruff lint + format pass.
- ✅ YAML syntax valid.
- 🔁 Will be validated when this PR's CI runs and on the post-merge dev/0.3.0 push.

## Files changed

- `pyproject.toml` — `requires-python = ">=3.11,<3.14"`
- `.github/workflows/install-test.yml` — matrix `["3.11", "3.12", "3.13"]`
- `.github/workflows/cicd-main.yml` — add `.coverage → .coverage.unit-test` rename step before upload
- `src/nemo_evaluator/engine/ray_launcher.py` — lazy ray import + `_ray_remote` no-op decorator + `_require_ray()` guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)