### PR TITLE
feat(launcher): per-task deployment_overrides

### DIFF
--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/config_models.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/config_models.py
@@ -207,3 +207,16 @@ class EvaluationModel(BaseModel):
             "Task-level ``post_cmd`` overrides this per task. Runs even if evaluation fails."
         ),
     )
+    task_overrides: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict,
+        description=(
+            "Per-task overrides keyed by task name. Each value is deep-merged "
+            "into the matching ``evaluation.tasks[]`` entry before any of the "
+            "existing ``task.deployment_overrides`` / "
+            "``task.execution_overrides`` machinery runs. Lets a downstream "
+            "config (e.g. an inheriting profile) override specific tasks of a "
+            "shared evaluation list without redefining the entire list. If "
+            "multiple tasks share a name, the override applies to every "
+            "matching entry."
+        ),
+    )

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/config_models.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/config_models.py
@@ -152,6 +152,17 @@ class TaskModel(BaseModel):
             "OmegaConf deep merge."
         ),
     )
+    execution_overrides: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Per-task overrides deeply merged into ``cfg.execution`` for this "
+            "task only. Same semantics as ``deployment_overrides`` but targets "
+            "the execution section — lets a single task override topology "
+            "fields like ``num_instances`` and ``num_nodes`` (e.g. nemo_gym "
+            "CBRNE attaches to one Ray cluster and needs num_instances=1, "
+            "while sibling tasks fan out for throughput)."
+        ),
+    )
 
 
 class EvaluationModel(BaseModel):

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/config_models.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/config_models.py
@@ -140,6 +140,18 @@ class TaskModel(BaseModel):
             "Runs even if evaluation fails (EXIT trap)."
         ),
     )
+    deployment_overrides: Dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Per-task overrides deeply merged into ``cfg.deployment`` for this "
+            "task only (other tasks in the same invocation see the unmodified "
+            "deployment). Useful when one benchmark needs a different image, "
+            "pre_cmd, command, extra_args, env_vars, or topology than the "
+            "default deployment, while keeping the rest of the invocation "
+            "unchanged. Free-form pass-through; the merge is the standard "
+            "OmegaConf deep merge."
+        ),
+    )
 
 
 class EvaluationModel(BaseModel):

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
@@ -125,6 +125,51 @@ def apply_task_execution_overrides(cfg: DictConfig, task: DictConfig) -> DictCon
     return _apply_task_section_overrides(cfg, task, "execution")
 
 
+def apply_evaluation_task_overrides(cfg: DictConfig) -> DictConfig:
+    """Return cfg with ``cfg.evaluation.task_overrides[name]`` deeply merged into
+    matching ``cfg.evaluation.tasks[]`` entries.
+
+    Lets a downstream config override specific tasks of an inherited evaluation
+    list without redefining the whole list. Each value is deep-merged into the
+    matching task entry; subsequent ``apply_task_deployment_overrides`` and
+    ``apply_task_execution_overrides`` see the merged result.
+
+    Match is by task ``name``. If multiple tasks share the same name (e.g. the
+    same benchmark configured twice with different parameters), the override
+    applies to every matching entry.
+
+    No-op if ``cfg.evaluation.task_overrides`` is missing or empty.
+    """
+    evaluation = cfg.get("evaluation") if isinstance(cfg, DictConfig) else None
+    if evaluation is None:
+        return cfg
+    overrides = evaluation.get("task_overrides")
+    if not overrides:
+        return cfg
+    new_tasks = []
+    for task in evaluation.tasks:
+        name = task.get("name") if isinstance(task, DictConfig) else task["name"]
+        ovr = overrides.get(name)
+        if ovr:
+            task_open = OmegaConf.create(OmegaConf.to_container(task, resolve=False))
+            OmegaConf.set_struct(task_open, False)
+            ovr_open = OmegaConf.create(
+                OmegaConf.to_container(ovr, resolve=False)
+                if isinstance(ovr, DictConfig)
+                else ovr
+            )
+            OmegaConf.set_struct(ovr_open, False)
+            task = OmegaConf.merge(task_open, ovr_open)
+            OmegaConf.set_struct(task, False)
+        new_tasks.append(task)
+    base_cfg = OmegaConf.create(OmegaConf.to_container(cfg, resolve=False))
+    OmegaConf.set_struct(base_cfg, False)
+    return OmegaConf.merge(
+        base_cfg,
+        OmegaConf.create({"evaluation": {"tasks": list(new_tasks)}}),
+    )
+
+
 def _apply_task_section_overrides(
     cfg: DictConfig, task: DictConfig, section: str
 ) -> DictConfig:

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
@@ -110,33 +110,46 @@ def apply_task_deployment_overrides(cfg: DictConfig, task: DictConfig) -> DictCo
     If the task has no ``deployment_overrides`` (or it is empty), ``cfg`` is
     returned unchanged.
     """
-    overrides = task.get("deployment_overrides")
+    return _apply_task_section_overrides(cfg, task, "deployment")
+
+
+def apply_task_execution_overrides(cfg: DictConfig, task: DictConfig) -> DictConfig:
+    """Return cfg with ``task.execution_overrides`` deeply merged into ``cfg.execution``.
+
+    Same semantics as ``apply_task_deployment_overrides`` but targets the
+    ``execution`` section instead. Lets a single task in a multi-task config
+    override topology fields like ``num_instances`` and ``num_nodes`` —
+    needed when a task (e.g. nemo_gym CBRNE) only attaches to one Ray
+    cluster, while siblings (e.g. HLE) want multi-instance fan-out.
+    """
+    return _apply_task_section_overrides(cfg, task, "execution")
+
+
+def _apply_task_section_overrides(
+    cfg: DictConfig, task: DictConfig, section: str
+) -> DictConfig:
+    overrides = task.get(f"{section}_overrides")
     if not overrides:
         return cfg
     # Disable struct mode on the merge target so overrides can introduce new
-    # keys (e.g. an env_var that the base ``cfg.deployment.env_vars`` does
-    # not declare). The struct-mode rejection happens both at the deployment
-    # level and inside its nested dicts (env_vars, etc.), so we open the
-    # entire subtree before merging.
-    base_deployment = OmegaConf.create(
-        OmegaConf.to_container(cfg.deployment, resolve=False)
-    )
-    OmegaConf.set_struct(base_deployment, False)
+    # keys (e.g. an env_var that the base section does not declare). The
+    # struct-mode rejection happens both at the section level and inside its
+    # nested dicts, so we open the entire subtree before merging.
+    base_section = OmegaConf.create(OmegaConf.to_container(cfg[section], resolve=False))
+    OmegaConf.set_struct(base_section, False)
     overrides_open = OmegaConf.create(
         OmegaConf.to_container(overrides, resolve=False)
         if isinstance(overrides, DictConfig)
         else overrides
     )
     OmegaConf.set_struct(overrides_open, False)
-    merged_deployment = OmegaConf.merge(base_deployment, overrides_open)
-    OmegaConf.set_struct(merged_deployment, False)
-    # Replace cfg.deployment via merge into a struct-disabled copy so the
-    # nested struct flags do not propagate back when we merge into cfg.
+    merged_section = OmegaConf.merge(base_section, overrides_open)
+    OmegaConf.set_struct(merged_section, False)
+    # Replace cfg[section] via merge into a struct-disabled copy so the nested
+    # struct flags do not propagate back when we merge into cfg.
     base_cfg = OmegaConf.create(OmegaConf.to_container(cfg, resolve=False))
     OmegaConf.set_struct(base_cfg, False)
-    return OmegaConf.merge(
-        base_cfg, OmegaConf.create({"deployment": merged_deployment})
-    )
+    return OmegaConf.merge(base_cfg, OmegaConf.create({section: merged_section}))
 
 
 _MIGRATION_MESSAGE = """

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/helpers.py
@@ -95,6 +95,50 @@ def _set_nested_optionally_overriding(
         temp[keys[-1]] = val
 
 
+def apply_task_deployment_overrides(cfg: DictConfig, task: DictConfig) -> DictConfig:
+    """Return cfg with ``task.deployment_overrides`` deeply merged into ``cfg.deployment``.
+
+    Tasks may override deployment fields (image, pre_cmd, command, extra_args,
+    env_vars, topology, etc.) by setting a ``deployment_overrides`` block. The
+    merge is deep (per OmegaConf semantics): nested dicts merge key-by-key,
+    scalars and lists in ``deployment_overrides`` replace the originals.
+
+    The returned cfg is a new object — the input ``cfg`` is not mutated, so
+    other tasks in the same invocation continue to see the unmodified
+    ``cfg.deployment``.
+
+    If the task has no ``deployment_overrides`` (or it is empty), ``cfg`` is
+    returned unchanged.
+    """
+    overrides = task.get("deployment_overrides")
+    if not overrides:
+        return cfg
+    # Disable struct mode on the merge target so overrides can introduce new
+    # keys (e.g. an env_var that the base ``cfg.deployment.env_vars`` does
+    # not declare). The struct-mode rejection happens both at the deployment
+    # level and inside its nested dicts (env_vars, etc.), so we open the
+    # entire subtree before merging.
+    base_deployment = OmegaConf.create(
+        OmegaConf.to_container(cfg.deployment, resolve=False)
+    )
+    OmegaConf.set_struct(base_deployment, False)
+    overrides_open = OmegaConf.create(
+        OmegaConf.to_container(overrides, resolve=False)
+        if isinstance(overrides, DictConfig)
+        else overrides
+    )
+    OmegaConf.set_struct(overrides_open, False)
+    merged_deployment = OmegaConf.merge(base_deployment, overrides_open)
+    OmegaConf.set_struct(merged_deployment, False)
+    # Replace cfg.deployment via merge into a struct-disabled copy so the
+    # nested struct flags do not propagate back when we merge into cfg.
+    base_cfg = OmegaConf.create(OmegaConf.to_container(cfg, resolve=False))
+    OmegaConf.set_struct(base_cfg, False)
+    return OmegaConf.merge(
+        base_cfg, OmegaConf.create({"deployment": merged_deployment})
+    )
+
+
 _MIGRATION_MESSAGE = """
 `overrides` field is no longer supported. Use `nemo_evaluator_config` field instead, e.g.:
 

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
@@ -46,6 +46,7 @@ from nemo_evaluator_launcher.common.execdb import (
     generate_job_id,
 )
 from nemo_evaluator_launcher.common.helpers import (
+    apply_task_deployment_overrides,
     check_unlisted_tasks_safeguard,
     get_api_key_name,
     get_endpoint_url,
@@ -134,7 +135,17 @@ class LocalExecutor(BaseExecutor):
 
         deployment = None
 
-        for idx, task in enumerate(cfg.evaluation.tasks):
+        # Snapshot the unmodified cfg before the per-task loop. Each iteration
+        # rebinds `cfg` to a per-task effective copy via
+        # ``apply_task_deployment_overrides`` so deployment fields (image,
+        # pre_cmd, command, extra_args, env_vars, topology, ...) can differ
+        # between tasks. The rebind is reset from this snapshot at the top of
+        # every iteration; after the loop, `cfg` reflects the last task's
+        # effective deployment but only ``cfg.evaluation.tasks`` is read past
+        # that point, which is identical in every snapshot.
+        _outer_cfg = cfg
+        for idx, task in enumerate(_outer_cfg.evaluation.tasks):
+            cfg = apply_task_deployment_overrides(_outer_cfg, task)
             timestamp = get_timestamp_string()
             task_definition = get_task_definition_for_job(
                 task_query=task.name,

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
@@ -47,6 +47,7 @@ from nemo_evaluator_launcher.common.execdb import (
 )
 from nemo_evaluator_launcher.common.helpers import (
     apply_task_deployment_overrides,
+    apply_task_execution_overrides,
     check_unlisted_tasks_safeguard,
     get_api_key_name,
     get_endpoint_url,
@@ -146,6 +147,7 @@ class LocalExecutor(BaseExecutor):
         _outer_cfg = cfg
         for idx, task in enumerate(_outer_cfg.evaluation.tasks):
             cfg = apply_task_deployment_overrides(_outer_cfg, task)
+            cfg = apply_task_execution_overrides(cfg, task)
             timestamp = get_timestamp_string()
             task_definition = get_task_definition_for_job(
                 task_query=task.name,

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/local/executor.py
@@ -46,6 +46,7 @@ from nemo_evaluator_launcher.common.execdb import (
     generate_job_id,
 )
 from nemo_evaluator_launcher.common.helpers import (
+    apply_evaluation_task_overrides,
     apply_task_deployment_overrides,
     apply_task_execution_overrides,
     check_unlisted_tasks_safeguard,
@@ -136,6 +137,9 @@ class LocalExecutor(BaseExecutor):
 
         deployment = None
 
+        # Apply evaluation.task_overrides BEFORE the per-task loop so
+        # subsequent apply_task_*_overrides calls see the merged tasks.
+        cfg = apply_evaluation_task_overrides(cfg)
         # Snapshot the unmodified cfg before the per-task loop. Each iteration
         # rebinds `cfg` to a per-task effective copy via
         # ``apply_task_deployment_overrides`` so deployment fields (image,

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -55,6 +55,7 @@ from nemo_evaluator_launcher.common.execdb import (
 from nemo_evaluator_launcher.common.helpers import (
     CmdAndReadableComment,
     _str_to_echo_command,
+    apply_evaluation_task_overrides,
     apply_task_deployment_overrides,
     apply_task_execution_overrides,
     check_unlisted_tasks_safeguard,
@@ -122,6 +123,9 @@ class SlurmExecutor(BaseExecutor):
             unlisted_task_names: list[str] = []
 
             is_potentially_unsafe = False
+            # Apply evaluation.task_overrides BEFORE the per-task loop so
+            # subsequent apply_task_*_overrides calls see the merged tasks.
+            cfg = apply_evaluation_task_overrides(cfg)
             _outer_cfg = cfg
             for idx, task in enumerate(_outer_cfg.evaluation.tasks):
                 # Apply both per-task overrides before any cfg.* read in this

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -56,6 +56,7 @@ from nemo_evaluator_launcher.common.helpers import (
     CmdAndReadableComment,
     _str_to_echo_command,
     apply_task_deployment_overrides,
+    apply_task_execution_overrides,
     check_unlisted_tasks_safeguard,
     get_api_key_name,
     get_eval_factory_command,
@@ -121,7 +122,15 @@ class SlurmExecutor(BaseExecutor):
             unlisted_task_names: list[str] = []
 
             is_potentially_unsafe = False
-            for idx, task in enumerate(cfg.evaluation.tasks):
+            _outer_cfg = cfg
+            for idx, task in enumerate(_outer_cfg.evaluation.tasks):
+                # Apply both per-task overrides before any cfg.* read in this
+                # iteration. Deployment overrides handle image/pre_cmd/topology
+                # at the deployment level; execution overrides handle topology
+                # at the SLURM level (num_instances, num_nodes). Other tasks in
+                # the same invocation see the untouched _outer_cfg.
+                cfg = apply_task_deployment_overrides(_outer_cfg, task)
+                cfg = apply_task_execution_overrides(cfg, task)
                 # calculate job_id
                 job_id = f"{invocation_id}.{idx}"
 
@@ -647,6 +656,7 @@ def _create_slurm_sbatch_script(
     # all subsequent cfg.deployment accesses below see the merged values; the
     # caller's cfg is untouched (OmegaConf.merge returns a new object).
     cfg = apply_task_deployment_overrides(cfg, task)
+    cfg = apply_task_execution_overrides(cfg, task)
 
     # deployment.multiple_instances is deprecated — use execution.num_instances and execution.num_nodes
     if cfg.deployment.get("multiple_instances") is not None:

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -55,6 +55,7 @@ from nemo_evaluator_launcher.common.execdb import (
 from nemo_evaluator_launcher.common.helpers import (
     CmdAndReadableComment,
     _str_to_echo_command,
+    apply_task_deployment_overrides,
     check_unlisted_tasks_safeguard,
     get_api_key_name,
     get_eval_factory_command,
@@ -640,6 +641,12 @@ def _create_slurm_sbatch_script(
         CmdAndReadableComment: The sbatch script content.
     """
     uname = get_unique_task_name(task.name, task_idx)
+
+    # Apply per-task deployment overrides (no-op if task has no
+    # deployment_overrides field). The local rebind shadows the parameter so
+    # all subsequent cfg.deployment accesses below see the merged values; the
+    # caller's cfg is untouched (OmegaConf.merge returns a new object).
+    cfg = apply_task_deployment_overrides(cfg, task)
 
     # deployment.multiple_instances is deprecated — use execution.num_instances and execution.num_nodes
     if cfg.deployment.get("multiple_instances") is not None:

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_helpers.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_helpers.py
@@ -705,3 +705,179 @@ class TestIsLocalImagePath:
         from nemo_evaluator_launcher.common.helpers import is_local_image_path
 
         assert is_local_image_path(image_path) is expected
+
+
+class TestApplyTaskDeploymentOverrides:
+    """Tests for ``apply_task_deployment_overrides``.
+
+    This helper enables per-task deployment customization in
+    ``cfg.evaluation.tasks[*].deployment_overrides``: tasks that need a
+    different image, pre_cmd, command, extra_args, env_vars, or topology than
+    the global ``cfg.deployment`` can declare just the diff. The merge is the
+    standard OmegaConf deep merge.
+    """
+
+    def _base_cfg(self):
+        return OmegaConf.create(
+            {
+                "deployment": {
+                    "type": "vllm",
+                    "image": "vllm/vllm-openai:default",
+                    "tensor_parallel_size": 8,
+                    "extra_args": "--enable-log-requests",
+                    "env_vars": {"HF_TOKEN": "host:HF_TOKEN"},
+                    "command": "vllm serve ...",
+                },
+                "evaluation": {},
+            }
+        )
+
+    def test_no_overrides_returns_cfg_unchanged(self):
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = self._base_cfg()
+        task = OmegaConf.create({"name": "task_a"})
+        result = apply_task_deployment_overrides(cfg, task)
+        # Same object — no merge happens when there's nothing to merge.
+        assert result is cfg
+
+    def test_empty_overrides_returns_cfg_unchanged(self):
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = self._base_cfg()
+        task = OmegaConf.create({"name": "task_a", "deployment_overrides": {}})
+        result = apply_task_deployment_overrides(cfg, task)
+        assert result is cfg
+
+    def test_scalar_override_replaces(self):
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = self._base_cfg()
+        task = OmegaConf.create(
+            {
+                "name": "task_a",
+                "deployment_overrides": {
+                    "image": "rl.nightly.sqsh",
+                    "tensor_parallel_size": 4,
+                },
+            }
+        )
+        result = apply_task_deployment_overrides(cfg, task)
+        assert result.deployment.image == "rl.nightly.sqsh"
+        assert result.deployment.tensor_parallel_size == 4
+        # untouched fields preserved
+        assert result.deployment.command == "vllm serve ..."
+
+    def test_env_vars_deep_merged(self):
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = self._base_cfg()
+        task = OmegaConf.create(
+            {
+                "name": "task_a",
+                "deployment_overrides": {
+                    "env_vars": {
+                        "NCCL_MNNVL_ENABLE": "lit:0",
+                        # override existing key
+                        "HF_TOKEN": "host:OTHER_TOKEN",
+                    }
+                },
+            }
+        )
+        result = apply_task_deployment_overrides(cfg, task)
+        # Existing key overridden, new key added.
+        assert result.deployment.env_vars.HF_TOKEN == "host:OTHER_TOKEN"
+        assert result.deployment.env_vars.NCCL_MNNVL_ENABLE == "lit:0"
+
+    def test_pre_cmd_added(self):
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = self._base_cfg()
+        custom_pre_cmd = "#!/bin/bash\nset -euo pipefail\necho running custom setup\n"
+        task = OmegaConf.create(
+            {
+                "name": "task_a",
+                "deployment_overrides": {
+                    "pre_cmd": custom_pre_cmd,
+                    "command": "echo 'handled in pre_cmd'",
+                },
+            }
+        )
+        result = apply_task_deployment_overrides(cfg, task)
+        assert result.deployment.pre_cmd == custom_pre_cmd
+        assert result.deployment.command == "echo 'handled in pre_cmd'"
+
+    def test_does_not_mutate_input_cfg(self):
+        """Other tasks in the same invocation must still see the original cfg."""
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = self._base_cfg()
+        task = OmegaConf.create(
+            {
+                "name": "task_a",
+                "deployment_overrides": {"image": "different.sqsh"},
+            }
+        )
+        _ = apply_task_deployment_overrides(cfg, task)
+        # Original untouched.
+        assert cfg.deployment.image == "vllm/vllm-openai:default"
+
+    def test_overrides_can_add_new_keys_to_struct_mode_deployment(self):
+        """A struct-mode base deployment must still accept new override keys.
+
+        In real configs ``cfg.deployment`` ends up in struct mode after Hydra
+        composition. Without explicitly opening struct on the merge target,
+        OmegaConf raises ``Key '...' is not in struct`` when an override
+        introduces a new env_var or top-level deployment field.
+        """
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = self._base_cfg()
+        OmegaConf.set_struct(cfg.deployment, True)
+        OmegaConf.set_struct(cfg.deployment.env_vars, True)
+        task = OmegaConf.create(
+            {
+                "name": "task_a",
+                "deployment_overrides": {
+                    "env_vars": {"NCCL_MNNVL_ENABLE": "lit:0"},
+                    "pre_cmd": "echo hi",
+                },
+            }
+        )
+        result = apply_task_deployment_overrides(cfg, task)
+        assert result.deployment.env_vars.NCCL_MNNVL_ENABLE == "lit:0"
+        assert result.deployment.pre_cmd == "echo hi"
+
+    def test_other_cfg_fields_preserved(self):
+        from nemo_evaluator_launcher.common.helpers import (
+            apply_task_deployment_overrides,
+        )
+
+        cfg = OmegaConf.create(
+            {
+                "deployment": {"image": "a", "type": "vllm"},
+                "execution": {"num_nodes": 2},
+                "evaluation": {"tasks": [{"name": "t"}]},
+                "env_vars": {"X": "lit:1"},
+            }
+        )
+        task = OmegaConf.create({"name": "t", "deployment_overrides": {"image": "b"}})
+        result = apply_task_deployment_overrides(cfg, task)
+        assert result.deployment.image == "b"
+        assert result.execution.num_nodes == 2
+        assert result.evaluation.tasks[0].name == "t"
+        assert result.env_vars.X == "lit:1"


### PR DESCRIPTION
Tasks listed in `cfg.evaluation.tasks` may now declare a `deployment_overrides` block that is deeply merged into `cfg.deployment` for that task only. Enables a single invocation to run benchmarks that need different deployment topology, image, pre_cmd, extra_args, or env_vars without splitting the run across multiple invocations.

Other tasks in the same invocation continue to see the unmodified `cfg.deployment` (OmegaConf.merge returns a new object). Tasks without a `deployment_overrides` field behave exactly as before.

Wired into both the SLURM executor (`_create_slurm_sbatch_script` rebinds cfg via the new `apply_task_deployment_overrides` helper) and the local executor (per-task loop snapshots cfg before iterating, rebinds inside each iteration).