### PR TITLE
docs: fix 0.3.0 docs URL, version switcher, and add publish workflow

### DIFF
--- a/.github/workflows/release-docs.yml
+++ b/.github/workflows/release-docs.yml
@@ -1,0 +1,85 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: Release docs
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Whether to run the workflow in dry-run mode
+        required: true
+        type: boolean
+        default: true
+      publish-as-latest:
+        description: Publish as Latest stable version.
+        required: false
+        type: boolean
+        default: false
+      docs-version-override:
+        description: Docs version if commit is not tagged
+        required: false
+        type: string
+        default: "0.3.0"
+      update-version-picker:
+        description: Update version picker.
+        required: false
+        type: boolean
+        default: true
+      notify-emails:
+        description: Email addresses to send the notification to. Format as "me@me.com,you@you.com".
+        required: false
+        type: string
+      github-ref:
+        description: Github ref to checkout
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build-docs:
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_build_docs.yml@v0.67.0
+    with:
+      ref: ${{ inputs.github-ref }}
+      requirements-file: .github/config/requirements.txt
+
+  publish-docs:
+    runs-on: ubuntu-latest
+    needs: [build-docs]
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          repository: NVIDIA-NeMo/FW-CI-templates
+          ref: v0.74.0
+          path: FW-CI-templates
+
+      - uses: ./FW-CI-templates/.github/actions/publish-docs
+        with:
+          dry-run: ${{ inputs.dry-run }}
+          artifacts-name: docs-html
+          artifacts-path: _build/html
+          emails-csv: ${{ inputs.notify-emails && format('{0},{1}', vars.docs_release_emails, inputs.notify-emails) || vars.docs_release_emails }}
+          overwrite-latest-on-tag: ${{ inputs.publish-as-latest }}
+          docs-version-override: ${{ inputs.docs-version-override }}
+          update-version-picker: ${{ inputs.update-version-picker }}
+          run-on-version-tag-only: false
+          request-name: nemo-evaluator-publish-docs-${{ github.run_id }}
+          aws-region: ${{ vars.DOCS_AWS_REGION }}
+          aws-role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          akamai-host: ${{ secrets.AKAMAI_HOST }}
+          akamai-client-token: ${{ secrets.AKAMAI_CLIENT_TOKEN }}
+          akamai-client-secret: ${{ secrets.AKAMAI_CLIENT_SECRET }}
+          akamai-access-token: ${{ secrets.AKAMAI_ACCESS_TOKEN }}
+          s3-target-root: ${{ secrets.S3_BUCKET_NAME }}
+          s3-target-path: nemo/evaluator

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,5 @@
-# Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -54,6 +54,7 @@ myst_substitutions = {
     "product_name_short": "NeMo Evaluator",
     "company": "NVIDIA",
     "version": release,
+    "docs_url": "https://docs.nvidia.com/nemo/evaluator/0.3.0/index.html",
 }
 
 # -- HTML output (NVIDIA Sphinx Theme) -----------------------------------------
@@ -61,7 +62,7 @@ html_theme = "nvidia_sphinx_theme"
 
 html_theme_options = {
     "switcher": {
-        "json_url": "./versions1.json",
+        "json_url": "../versions1.json",
         "version_match": release,
     },
     "search_bar_text": "Search NeMo Evaluator docs...",

--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -1,7 +1,6 @@
 [
-    {
-        "preferred": true,
-        "version": "0.12.0",
-        "url": "../0.12.0"
-    }
+    { "version": "nightly", "url": "https://docs.nvidia.com/nemo/evaluator/nightly/" },
+    { "name": "0.3.0 (dev)", "version": "0.3.0", "url": "https://docs.nvidia.com/nemo/evaluator/0.3.0/" },
+    { "name": "0.2.5 (latest)", "version": "0.2.5", "url": "https://docs.nvidia.com/nemo/evaluator/latest/", "preferred": true },
+    { "name": "0.1.0", "version": "0.1.0", "url": "https://docs.nvidia.com/nemo/evaluator/0.1.0/" }
 ]


### PR DESCRIPTION
## Summary

- **`docs/versions1.json`**: replace stale `0.12.0` placeholder (relative URL) with real versioned entries — `0.3.0` listed as dev (not preferred), `0.2.5` stays as preferred latest
- **`docs/conf.py`**: add missing `docs_url` to `myst_substitutions` pointing to `https://docs.nvidia.com/nemo/evaluator/0.3.0/index.html`; fix `json_url` path from `./versions1.json` → `../versions1.json`
- **`.github/workflows/release-docs.yml`**: copy from `main` with three adaptations for the dev branch: `publish-as-latest` defaults to `false`, `docs-version-override` defaults to `"0.3.0"`, and `run-on-version-tag-only: false` so publishing works via `workflow_dispatch` without a git tag

## Test plan

- [ ] Trigger `Release docs` workflow with `dry-run: true` on this branch to verify the build and publish steps pass
- [ ] Verify version switcher shows 0.3.0 as dev (not preferred) and 0.2.5 as latest
- [ ] Confirm `docs_url` substitution resolves correctly in any doc pages that use `{{ docs_url }}`