### PR TITLE
feat(solvers): OracleSolver + Terminal-Bench-Hard for infra-ceiling measurement

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -180,7 +180,7 @@
         "filename": "src/nemo_evaluator/solvers/harbor.py",
         "hashed_secret": "aba587d0ca054afc6656ee19c938be86b9bff6a4",
         "is_verified": false,
-        "line_number": 848
+        "line_number": 779
       }
     ],
     "tests/fixtures/pinchbench.json": [
@@ -372,5 +372,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-11T09:36:43Z"
+  "generated_at": "2026-05-11T10:33:51Z"
 }

--- a/src/nemo_evaluator/benchmarks/pinchbench.py
+++ b/src/nemo_evaluator/benchmarks/pinchbench.py
@@ -29,17 +29,20 @@ Dataset is downloaded once from GitHub as a zip archive.
 
 from __future__ import annotations
 
+import asyncio
 import atexit
 import io
 import json
 import logging
+import random
 import re
 import shutil
 import tempfile
-import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Any
+
+import urllib.request
 
 from nemo_evaluator.environments.base import SeedResult
 from nemo_evaluator.environments.custom import benchmark, scorer
@@ -51,6 +54,10 @@ _GITHUB_ZIP = "https://github.com/pinchbench/skill/archive/refs/heads/main.zip"
 _CACHE_DIR: Path | None = None
 _TASK_DATA: dict[str, dict[str, Any]] = {}
 _WORKSPACES: list[Path] = []
+
+_JUDGE_MAX_ATTEMPTS = 5
+_JUDGE_BASE_DELAY_S = 4.0
+_JUDGE_MAX_DELAY_S = 45.0
 
 
 def _cleanup_workspaces() -> None:
@@ -126,6 +133,7 @@ def _parse_task(path: Path) -> dict[str, Any]:
         "grading_type": frontmatter.get("grading_type", "automated"),
         "timeout_seconds": frontmatter.get("timeout_seconds", 120),
         "workspace_files": frontmatter.get("workspace_files", []),
+        "grading_weights": frontmatter.get("grading_weights") or None,
         "prompt": sections.get("Prompt", ""),
         "expected_behavior": sections.get("Expected Behavior", ""),
         "grading_criteria": sections.get("Grading Criteria", ""),
@@ -216,6 +224,396 @@ def _run_grade(grading_code: str, transcript: list, workspace_path: str) -> dict
     return grade_fn(transcript, workspace_path)
 
 
+def _load_transcript(workspace_path: str, fallback_response: str) -> list[dict[str, Any]]:
+    """Load the per-task transcript in upstream envelope shape.
+
+    Prefers ``<workspace>/.nel_transcript.jsonl`` written by the solver
+    (see :func:`nemo_evaluator.solvers.openclaw._persist_session_transcript`);
+    falls back to a single synthetic assistant message so non-OpenClaw
+    solvers (ChatSolver / HarborSolver) still score deterministically.
+    """
+    transcript: list[dict[str, Any]] = []
+    transcript_file = Path(workspace_path) / ".nel_transcript.jsonl" if workspace_path else None
+    if transcript_file and transcript_file.exists():
+        for line in transcript_file.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                transcript.append(json.loads(line))
+            except json.JSONDecodeError:
+                transcript.append({"raw": line, "parse_error": True})
+        if transcript:
+            return transcript
+    return [
+        {
+            "type": "message",
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": fallback_response}],
+            },
+        },
+    ]
+
+
+_WORKSPACE_SKIP_NAMES = frozenset(
+    {
+        "BOOTSTRAP.md",
+        "SOUL.md",
+        "USER.md",
+        "IDENTITY.md",
+        "HEARTBEAT.md",
+        "TOOLS.md",
+        "AGENTS.md",
+    },
+)
+_WORKSPACE_SKIP_DIRS = frozenset({".git", ".openclaw", "__pycache__", "node_modules", "skills"})
+_WORKSPACE_FILE_MAX_CHARS = 3000
+_TRANSCRIPT_SUMMARY_MAX_CHARS = 64_000
+_WORKSPACE_BLOB_MAX_CHARS = 64_000
+
+
+def _summarize_transcript(transcript: list[dict[str, Any]]) -> str:
+    """Collapse the envelope-shape transcript into a judge-readable summary."""
+    parts: list[str] = []
+    for event in transcript:
+        if not isinstance(event, dict) or event.get("type") != "message":
+            continue
+        msg = event.get("message") or {}
+        role = msg.get("role")
+        content = msg.get("content") or []
+        if role == "assistant":
+            if not isinstance(content, list):
+                continue
+            for item in content:
+                if not isinstance(item, dict):
+                    continue
+                itype = item.get("type", "")
+                if itype in ("toolCall", "tool_use"):
+                    args = item.get("arguments") or item.get("input") or item.get("params") or {}
+                    truncated: dict[str, Any] = {}
+                    for k, v in args.items():
+                        if isinstance(v, str) and len(v) > 200:
+                            truncated[k] = v[:200] + "...[truncated]"
+                        else:
+                            truncated[k] = v
+                    parts.append(f"Tool: {item.get('name', '')}({json.dumps(truncated)})")
+                elif itype == "text":
+                    text = (item.get("text") or "").strip()
+                    if text:
+                        parts.append(f"Assistant: {text[:2000]}")
+        elif role in ("toolResult", "tool"):
+            if isinstance(content, list):
+                rendered = []
+                for block in content:
+                    if isinstance(block, dict):
+                        rendered.append(block.get("text") or str(block))
+                    else:
+                        rendered.append(str(block))
+                body = "\n".join(rendered)
+            else:
+                body = str(content)
+            parts.append(f"Result: {body[:200]}")
+        elif role == "user":
+            text: str | None = None
+            if isinstance(content, list) and content:
+                first = content[0]
+                if isinstance(first, dict):
+                    text = first.get("text") or first.get("content")
+                elif isinstance(first, str):
+                    text = first
+            elif isinstance(content, str):
+                text = content
+            if text:
+                parts.append(f"User: {text}")
+    joined = "\n".join(parts)
+    if len(joined) > _TRANSCRIPT_SUMMARY_MAX_CHARS:
+        head = _TRANSCRIPT_SUMMARY_MAX_CHARS // 2
+        tail = _TRANSCRIPT_SUMMARY_MAX_CHARS - head
+        joined = f"{joined[:head]}\n...[transcript truncated]...\n{joined[-tail:]}"
+    return joined
+
+
+def _read_workspace_files_for_judge(workspace_path: str) -> str:
+    """Collect agent-authored text file contents for the judge prompt."""
+    if not workspace_path:
+        return ""
+    workspace = Path(workspace_path)
+    if not workspace.exists():
+        return ""
+    blocks: list[str] = []
+    total = 0
+    for path in sorted(workspace.rglob("*")):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(workspace)
+        parts = rel.parts
+        if any(p.startswith(".") or p in _WORKSPACE_SKIP_DIRS for p in parts):
+            continue
+        if path.name in _WORKSPACE_SKIP_NAMES:
+            continue
+        if path.name == ".nel_transcript.jsonl":
+            continue
+        try:
+            content = path.read_text(encoding="utf-8")
+            block = f"### File: {rel}\n{content[:_WORKSPACE_FILE_MAX_CHARS]}"
+        except (OSError, UnicodeDecodeError):
+            try:
+                size = path.stat().st_size
+            except OSError:
+                size = -1
+            block = f"### File: {rel} (binary or unreadable, {size} bytes)"
+        blocks.append(block)
+        total += len(block) + 2
+        if total >= _WORKSPACE_BLOB_MAX_CHARS:
+            blocks.append("...[workspace listing truncated]")
+            break
+    return "\n\n".join(blocks)
+
+
+def _build_judge_prompt(
+    task: dict[str, Any],
+    transcript_summary: str,
+    rubric: str,
+    workspace_content: str,
+) -> str:
+    """Render the upstream-parity PinchBench judge prompt."""
+    workspace_section = (
+        f"## Workspace Files Created by Agent\n{workspace_content}\n\n" if workspace_content.strip() else ""
+    )
+    return (
+        "You are a grading function. Your ONLY job is to output a single JSON object.\n\n"
+        "CRITICAL RULES:\n"
+        "- Do NOT use any tools (no Read, Write, exec, or any other tool calls)\n"
+        "- Do NOT create files or run commands\n"
+        "- Do NOT write any prose, explanation, or commentary outside the JSON\n"
+        "- Respond with ONLY a JSON object -- nothing else\n\n"
+        "Be a strict evaluator. Reserve 1.0 for genuinely excellent performance. "
+        "An average acceptable completion should score around 0.6-0.7. "
+        "Deduct points for unnecessary steps, verbose output, and inefficient tool usage.\n\n"
+        "## Task\n"
+        f"{task.get('prompt', '')}\n\n"
+        "## Expected Behavior\n"
+        f"{task.get('expected_behavior', '')}\n\n"
+        "## Agent Transcript (summarized)\n"
+        f"{transcript_summary}\n\n"
+        f"{workspace_section}"
+        "## Grading Rubric\n"
+        f"{rubric}\n\n"
+        "Score each criterion from 0.0 to 1.0.\n"
+        'The "total" field must also be between 0.0 and 1.0, and it must be the '
+        "arithmetic mean of the criterion scores, not their sum.\n\n"
+        "Respond with ONLY this JSON structure (no markdown, no code fences, no "
+        "extra text):\n"
+        '{"scores": {"criterion_name": 0.0}, "total": 0.0, "notes": "brief justification"}'
+    )
+
+
+def _resolve_rubric(task: dict[str, Any]) -> str:
+    """Pick the most informative scoring rubric available for a task."""
+    rubric = task.get("llm_judge_rubric") or ""
+    if rubric.strip():
+        return rubric
+    criteria = task.get("grading_criteria") or ""
+    return criteria
+
+
+_FRACTIONAL_JSON_DECODER = json.JSONDecoder()
+
+
+def _iter_top_level_json_objects(raw: str) -> list[dict[str, Any]]:
+    """Extract every balanced top-level JSON object from ``raw`` text."""
+    results: list[dict[str, Any]] = []
+    i, n = 0, len(raw)
+    while i < n:
+        if raw[i] == "{":
+            try:
+                obj, end = _FRACTIONAL_JSON_DECODER.raw_decode(raw, i)
+            except json.JSONDecodeError:
+                i += 1
+                continue
+            if isinstance(obj, dict):
+                results.append(obj)
+            i = end
+        else:
+            i += 1
+    return results
+
+
+def _parse_judge_response_fractional(text: str) -> dict[str, Any]:
+    """Parse a per-criterion 0.0-1.0 judge envelope into ``{scores, total, notes}``."""
+    result: dict[str, Any] = {"scores": {}, "total": None, "notes": "", "raw": text[:2000]}
+    if not text:
+        return result
+
+    candidates: list[dict[str, Any]] = []
+    try:
+        obj = json.loads(text.strip())
+        if isinstance(obj, dict):
+            candidates.append(obj)
+    except json.JSONDecodeError:
+        fence = re.search(r"```(?:json)?\s*(.*?)\s*```", text, re.DOTALL)
+        if fence:
+            try:
+                obj = json.loads(fence.group(1))
+                if isinstance(obj, dict):
+                    candidates.append(obj)
+            except json.JSONDecodeError:
+                pass
+        candidates.extend(_iter_top_level_json_objects(text))
+
+    chosen: dict[str, Any] | None = None
+    for obj in reversed(candidates):
+        if "scores" in obj or "criteria_scores" in obj or "total" in obj or "score" in obj:
+            chosen = obj
+            break
+    if chosen is None and candidates:
+        chosen = candidates[-1]
+
+    if chosen is not None:
+        raw_scores = chosen.get("scores") or chosen.get("criteria_scores") or {}
+        if isinstance(raw_scores, dict):
+            for k, v in raw_scores.items():
+                if isinstance(v, dict) and "score" in v:
+                    v = v.get("score")
+                try:
+                    result["scores"][str(k)] = float(v)
+                except (TypeError, ValueError):
+                    continue
+
+        total = chosen.get("total")
+        if total is None and "score" in chosen:
+            try:
+                total = float(chosen["score"])
+            except (TypeError, ValueError):
+                total = None
+        try:
+            result["total"] = float(total) if total is not None else None
+        except (TypeError, ValueError):
+            result["total"] = None
+
+        result["notes"] = str(chosen.get("notes") or chosen.get("justification") or "")
+    else:
+        m = re.search(r"(?:total|score)\s*[:=]\s*([0-9]*\.?[0-9]+)", text, re.IGNORECASE)
+        if m:
+            try:
+                result["total"] = float(m.group(1))
+            except ValueError:
+                pass
+
+    scores = result["scores"]
+    total = result["total"]
+    if scores and all(0.0 <= v <= 1.0 for v in scores.values()):
+        if total is None or total > 1.0:
+            result["total"] = sum(scores.values()) / len(scores)
+    if result["total"] is not None:
+        result["total"] = max(0.0, min(1.0, float(result["total"])))
+
+    return result
+
+
+def _make_pinchbench_judge_fn(
+    judge_prompt: str,
+    automated_score: float | None,
+    grading_weights: dict[str, float] | None,
+    grading_type: str,
+):
+    """Build the closure stashed in ``scoring_details["_judge_fn"]``."""
+
+    async def _run(judge_client: Any) -> dict[str, Any]:
+        last_exc: Exception | None = None
+        model_resp = None
+        for attempt in range(_JUDGE_MAX_ATTEMPTS):
+            try:
+                model_resp = await judge_client.chat(
+                    prompt=judge_prompt,
+                    system="You are a strict evaluation judge. Always respond with valid JSON.",
+                )
+                break
+            except Exception as exc:  # noqa: BLE001
+                last_exc = exc
+                if attempt == _JUDGE_MAX_ATTEMPTS - 1:
+                    break
+                delay = min(_JUDGE_BASE_DELAY_S * (2**attempt), _JUDGE_MAX_DELAY_S)
+                delay *= 0.5 + random.random()
+                logger.warning(
+                    "PinchBench judge attempt %d/%d failed (%s: %s); sleeping %.1fs",
+                    attempt + 1,
+                    _JUDGE_MAX_ATTEMPTS,
+                    type(exc).__name__,
+                    exc,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        if model_resp is None:
+            err = f"{type(last_exc).__name__}: {last_exc}" if last_exc else "unknown"
+            logger.warning(
+                "PinchBench judge call failed after %d attempts (%s): %s",
+                _JUDGE_MAX_ATTEMPTS,
+                grading_type,
+                err,
+            )
+            judge_info = {"error": err, "total": None, "attempts": _JUDGE_MAX_ATTEMPTS}
+            if grading_type == "hybrid" and automated_score is not None:
+                return {
+                    "reward": float(automated_score),
+                    "judge": judge_info,
+                    "details": {
+                        "hybrid_combine": {
+                            "automated": float(automated_score),
+                            "judge": None,
+                            "combined": float(automated_score),
+                            "judge_failed": True,
+                        }
+                    },
+                }
+            return {"reward": None, "judge": judge_info}
+
+        parsed = _parse_judge_response_fractional(model_resp.content)
+        judge_total = parsed.get("total")
+        judge_info = {
+            "scores": parsed.get("scores", {}),
+            "total": judge_total,
+            "notes": parsed.get("notes", ""),
+            "judge_model": getattr(model_resp, "model", None),
+            "judge_tokens": getattr(model_resp, "total_tokens", None),
+            "judge_latency_ms": getattr(model_resp, "latency_ms", None),
+        }
+
+        if grading_type == "hybrid" and automated_score is not None:
+            w = grading_weights or {"automated": 0.5, "llm_judge": 0.5}
+            aw = float(w.get("automated", 0.5))
+            jw = float(w.get("llm_judge", 0.5))
+            total_w = aw + jw or 1.0
+            if judge_total is None:
+                reward = float(automated_score)
+                combine = {
+                    "automated": float(automated_score),
+                    "judge": None,
+                    "combined": reward,
+                }
+            else:
+                combined = (float(automated_score) * aw + float(judge_total) * jw) / total_w
+                reward = combined
+                combine = {
+                    "automated": float(automated_score),
+                    "judge": float(judge_total),
+                    "weights": {"automated": aw, "llm_judge": jw},
+                    "combined": combined,
+                }
+            return {
+                "reward": reward,
+                "judge": judge_info,
+                "details": {"hybrid_combine": combine},
+            }
+
+        reward = float(judge_total) if judge_total is not None else None
+        return {"reward": reward, "judge": judge_info}
+
+    return _run
+
+
 @benchmark(
     name="pinchbench",
     dataset=_load_all_tasks,
@@ -225,59 +623,86 @@ def _run_grade(grading_code: str, transcript: list, workspace_path: str) -> dict
 )
 @scorer
 def pinchbench_scorer(sample: ScorerInput) -> dict[str, Any]:
-    """Score a PinchBench task.  Solver-independent:
+    """Score a PinchBench task.
 
-    1. If ``.nel_transcript.jsonl`` exists in workspace (written by NatSolver),
-       use the rich trajectory.
-    2. Otherwise, build a minimal transcript from the solver's text response.
-       This enables ChatSolver, HarborSolver, etc. to be scored -- the grade
-       function may not find tool calls but can still check workspace files.
+    Three scoring paths:
+
+    * ``automated`` -- run embedded ``grade()`` only (no judge).
+    * ``llm_judge`` -- stash a ``_judge_fn`` closure invoked by the eval
+      loop with the judge client.
+    * ``hybrid``    -- run ``grade()`` locally and hand its score to the
+      closure, which combines via ``grading_weights`` (default 50/50).
     """
     task_id = sample.metadata.get("task_id", "")
     workspace_path = sample.metadata.get("workspace_path", "")
 
     task_info = _TASK_DATA.get(task_id, {})
+    grading_type = task_info.get("grading_type") or sample.metadata.get("grading_type", "automated")
     grading_code = task_info.get("grading_code", "")
+    grading_weights = task_info.get("grading_weights") or None
 
-    if not grading_code:
-        from nemo_evaluator.scoring.judge import needs_judge
+    transcript = _load_transcript(workspace_path, sample.response)
 
-        return needs_judge(sample)
-
-    transcript: list[dict[str, Any]] = []
-    transcript_file = Path(workspace_path) / ".nel_transcript.jsonl" if workspace_path else None
-
-    if transcript_file and transcript_file.exists():
-        for line in transcript_file.read_text(encoding="utf-8").splitlines():
-            line = line.strip()
-            if line:
-                try:
-                    transcript.append(json.loads(line))
-                except json.JSONDecodeError:
-                    transcript.append({"raw": line, "parse_error": True})
-    else:
-        transcript = [
-            {
-                "type": "message",
-                "message": {
-                    "role": "assistant",
-                    "content": [{"type": "text", "text": sample.response}],
-                },
+    automated_details: dict[str, Any] | None = None
+    if grading_code:
+        try:
+            raw_scores = _run_grade(grading_code, transcript, workspace_path)
+        except Exception as exc:
+            logger.warning("PinchBench grade() failed for %s: %s", task_id, exc)
+            raw_scores = {}
+            automated_details = {"automated_score": 0.0, "error": str(exc), "breakdown": {}}
+        if automated_details is None:
+            if raw_scores:
+                avg = sum(raw_scores.values()) / len(raw_scores)
+            else:
+                avg = 0.0
+            automated_details = {
+                "automated_score": float(avg),
+                "breakdown": {str(k): float(v) for k, v in raw_scores.items()},
             }
-        ]
 
-    try:
-        scores = _run_grade(grading_code, transcript, workspace_path)
-    except Exception as exc:
-        logger.warning("PinchBench grade() failed for %s: %s", task_id, exc)
-        return {"correct": 0.0, "error": str(exc)}
+    if grading_type in ("llm_judge", "hybrid"):
+        rubric = _resolve_rubric(task_info)
+        summary = _summarize_transcript(transcript)
+        workspace_blob = _read_workspace_files_for_judge(workspace_path)
+        judge_prompt = _build_judge_prompt(task_info, summary, rubric, workspace_blob)
+        automated_score = (
+            automated_details["automated_score"] if grading_type == "hybrid" and automated_details is not None else None
+        )
 
-    if not scores:
-        return {"correct": 0.0}
+        payload: dict[str, Any] = {
+            "correct": False,
+            "needs_judge": True,
+            "_judge_fn": _make_pinchbench_judge_fn(
+                judge_prompt=judge_prompt,
+                automated_score=automated_score,
+                grading_weights=grading_weights,
+                grading_type=grading_type,
+            ),
+            "task_id": task_id,
+            "grading_type": grading_type,
+            "extracted": sample.response[:500],
+        }
+        if grading_type == "hybrid" and automated_details is not None:
+            payload["automated_breakdown"] = automated_details["breakdown"]
+            if "error" in automated_details:
+                payload["automated_error"] = automated_details["error"]
+        return payload
 
-    avg = sum(scores.values()) / len(scores)
-    return {
-        "correct": avg,
-        "reward": avg,
-        **{f"criterion_{k}": v for k, v in scores.items()},
+    if automated_details is None:
+        logger.warning(
+            "PinchBench task %s is grading_type=automated but has no grading_code",
+            task_id,
+        )
+        return {"correct": 0.0, "error": "no grading_code for automated task"}
+
+    score = automated_details["automated_score"]
+    result: dict[str, Any] = {
+        "correct": score,
+        "reward": score,
+        "grading_type": "automated",
+        **{f"criterion_{k}": v for k, v in automated_details["breakdown"].items()},
     }
+    if "error" in automated_details:
+        result["error"] = automated_details["error"]
+    return result

--- a/src/nemo_evaluator/benchmarks/pinchbench.py
+++ b/src/nemo_evaluator/benchmarks/pinchbench.py
@@ -38,11 +38,10 @@ import random
 import re
 import shutil
 import tempfile
+import urllib.request
 import zipfile
 from pathlib import Path
 from typing import Any
-
-import urllib.request
 
 from nemo_evaluator.environments.base import SeedResult
 from nemo_evaluator.environments.custom import benchmark, scorer

--- a/src/nemo_evaluator/benchmarks/terminal_bench_hard.py
+++ b/src/nemo_evaluator/benchmarks/terminal_bench_hard.py
@@ -1,0 +1,180 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Terminal-Bench Hard — curated leaderboard subsets of TB v1.
+
+Registers ``terminal-bench-hard`` (47 tasks) and
+``terminal-bench-hard-aa-split`` (44 tasks) as built-in benchmarks.
+Both reuse :func:`~nemo_evaluator.benchmarks.terminal_bench_v1._ensure_dataset`
+to clone and map the full TB v1 repo, then filter to their task list.
+
+Config usage::
+
+    benchmarks:
+      - name: terminal-bench-hard          # 47 tasks
+      - name: terminal-bench-hard-aa-split # 44 tasks
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from nemo_evaluator.benchmarks.terminal_bench_v1 import _ensure_dataset
+from nemo_evaluator.environments.harbor import HarborEnvironment
+from nemo_evaluator.environments.registry import register
+
+logger = logging.getLogger(__name__)
+
+# Curated leaderboard subset — 47 tasks present at HEAD of
+# laude-institute/terminal-bench (original-tasks/ directory).
+_TB_HARD_TASKS: frozenset[str] = frozenset(
+    {
+        "aimo-airline-departures",
+        "blind-maze-explorer-5x5",
+        "cartpole-rl-training",
+        "causal-inference-r",
+        "chem-property-targeting",
+        "chem-rf",
+        "circuit-fibsqrt",
+        "cobol-modernization",
+        "configure-git-webserver",
+        "cross-entropy-method",
+        "extract-moves-from-video",
+        "feal-differential-cryptanalysis",
+        "feal-linear-cryptanalysis",
+        "form-filling",
+        "git-multibranch",
+        "gpt2-codegolf",
+        "install-windows-3.11",
+        "install-windows-xp",
+        "lean4-proof",
+        "make-doom-for-mips",
+        "make-mips-interpreter",
+        "mcmc-sampling-stan",
+        "model-extraction-relu-logits",
+        "movie-helper",
+        "neuron-to-jaxley-conversion",
+        "oom",
+        "organization-json-generator",
+        "parallel-particle-simulator",
+        "parallelize-graph",
+        "password-recovery",
+        "path-tracing",
+        "path-tracing-reverse",
+        "play-zork",
+        "play-zork-easy",
+        "polyglot-rust-c",
+        "prove-plus-comm",
+        "pytorch-model-cli",
+        "rare-mineral-allocation",
+        "recover-obfuscated-files",
+        "reverse-engineering",
+        "run-pdp11-code",
+        "stable-parallel-kmeans",
+        "swe-bench-astropy-1",
+        "swe-bench-astropy-2",
+        "train-fasttext",
+        "word2vec-from-scratch",
+        "write-compressor",
+    }
+)
+
+
+@register("terminal-bench-hard")
+class TerminalBenchHard(HarborEnvironment):
+    """Terminal-Bench Hard — 47-task leaderboard subset, auto-downloaded."""
+
+    _TASK_SET: frozenset[str] = _TB_HARD_TASKS
+    _LABEL: str = "terminal-bench-hard"
+
+    def __init__(self, num_examples: int | None = None) -> None:
+        dataset_path = _ensure_dataset()
+        super().__init__(dataset_path=dataset_path, num_examples=None)
+        self._tasks = self._filter_tasks(num_examples)
+
+    def _filter_tasks(self, num_examples: int | None) -> list[Path]:
+        tasks = [t for t in self._tasks if t.name in self._TASK_SET]
+        found = {t.name for t in tasks}
+        missing = self._TASK_SET - found
+        if missing:
+            logger.warning(
+                "%s: %d/%d expected tasks missing after mapping: %s",
+                self._LABEL,
+                len(missing),
+                len(self._TASK_SET),
+                sorted(missing),
+            )
+        if num_examples is not None:
+            tasks = tasks[:num_examples]
+        return tasks
+
+
+# AA-split — 44-task subset used by the AA scoring pipeline.
+_TB_HARD_AA_SPLIT_TASKS: frozenset[str] = frozenset(
+    {
+        "aimo-airline-departures",
+        "blind-maze-explorer-5x5",
+        "cartpole-rl-training",
+        "chem-property-targeting",
+        "chem-rf",
+        "circuit-fibsqrt",
+        "cobol-modernization",
+        "configure-git-webserver",
+        "cross-entropy-method",
+        "extract-moves-from-video",
+        "feal-differential-cryptanalysis",
+        "feal-linear-cryptanalysis",
+        "form-filling",
+        "git-multibranch",
+        "gpt2-codegolf",
+        "install-windows-xp",
+        "make-doom-for-mips",
+        "make-mips-interpreter",
+        "model-extraction-relu-logits",
+        "movie-helper",
+        "neuron-to-jaxley-conversion",
+        "oom",
+        "organization-json-generator",
+        "parallel-particle-simulator",
+        "parallelize-graph",
+        "password-recovery",
+        "path-tracing",
+        "path-tracing-reverse",
+        "play-zork",
+        "play-zork-easy",
+        "polyglot-rust-c",
+        "prove-plus-comm",
+        "pytorch-model-cli",
+        "rare-mineral-allocation",
+        "recover-obfuscated-files",
+        "reverse-engineering",
+        "run-pdp11-code",
+        "stable-parallel-kmeans",
+        "super-benchmark-upet",
+        "swe-bench-astropy-1",
+        "swe-bench-astropy-2",
+        "train-fasttext",
+        "word2vec-from-scratch",
+        "write-compressor",
+    }
+)
+
+
+@register("terminal-bench-hard-aa-split")
+class TerminalBenchHardAASplit(TerminalBenchHard):
+    """Terminal-Bench Hard AA-split — 44-task subset for AA scoring."""
+
+    _TASK_SET: frozenset[str] = _TB_HARD_AA_SPLIT_TASKS
+    _LABEL: str = "terminal-bench-hard-aa-split"

--- a/src/nemo_evaluator/benchmarks/terminal_bench_v1.py
+++ b/src/nemo_evaluator/benchmarks/terminal_bench_v1.py
@@ -47,6 +47,30 @@ logger = logging.getLogger(__name__)
 
 _GIT_URL = "https://github.com/laude-institute/terminal-bench.git"
 _DATASET_DIR_NAME = "terminal-bench@1.0"
+_XP_TASK = "install-windows-xp"
+_XP_ENTRYPOINT = 'ENTRYPOINT [ "supervisord", "-c", "/etc/supervisor/supervisord.conf" ]'
+_XP_WRAPPER_ENTRYPOINT = 'ENTRYPOINT ["/nel-entrypoint.sh"]'
+_XP_DOCKERFILE_PATCH = f"""\
+# NEL patch: upstream compose passes no command, but NEL sandboxes do.
+# The wrapper starts supervisord, then execs "$@".
+COPY nel-entrypoint.sh /nel-entrypoint.sh
+RUN chmod +x /nel-entrypoint.sh
+{_XP_WRAPPER_ENTRYPOINT}"""
+_XP_WRAPPER = """\
+#!/bin/sh
+set -e
+
+supervisord -c /etc/supervisor/supervisord.conf &
+pid=$!
+
+sleep 2
+if ! kill -0 "$pid" 2>/dev/null; then
+    wait "$pid"
+    exit $?
+fi
+
+exec "$@"
+"""
 
 
 def _git(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
@@ -70,10 +94,31 @@ def _git(cmd: list[str], **kwargs) -> subprocess.CompletedProcess[str]:
 
 def _find_tasks_dir(repo: Path) -> Path | None:
     """Locate the directory containing v1 tasks (subdirs with ``task.yaml``)."""
-    for candidate in [repo, repo / "tasks", repo / "benchmarks"]:
+    for candidate in [repo, repo / "tasks", repo / "benchmarks", repo / "original-tasks"]:
         if candidate.is_dir() and any((d / "task.yaml").exists() for d in candidate.iterdir() if d.is_dir()):
             return candidate
     return None
+
+
+def _patch_install_windows_xp_entrypoint(output_dir: Path) -> None:
+    """Patch upstream's service ENTRYPOINT into a command-friendly wrapper."""
+    env_dir = output_dir / _XP_TASK / "environment"
+    dockerfile = env_dir / "Dockerfile"
+    if not dockerfile.exists():
+        return
+
+    text = dockerfile.read_text(encoding="utf-8")
+    already_patched = _XP_WRAPPER_ENTRYPOINT in text
+    needs_patch = _XP_ENTRYPOINT in text
+    if not (already_patched or needs_patch):
+        logger.warning("%s Dockerfile did not match expected supervisord ENTRYPOINT; skipping patch", _XP_TASK)
+        return
+
+    wrapper = env_dir / "nel-entrypoint.sh"
+    if not wrapper.exists() or wrapper.read_text(encoding="utf-8") != _XP_WRAPPER:
+        wrapper.write_text(_XP_WRAPPER, encoding="utf-8")
+    if needs_patch:
+        dockerfile.write_text(text.replace(_XP_ENTRYPOINT, _XP_DOCKERFILE_PATCH, 1), encoding="utf-8")
 
 
 def _ensure_dataset(datasets_dir: str | None = None) -> Path:
@@ -85,6 +130,7 @@ def _ensure_dataset(datasets_dir: str | None = None) -> Path:
     marker = output_dir / ".tbv1_mapped"
 
     if marker.exists():
+        _patch_install_windows_xp_entrypoint(output_dir)
         n = sum(1 for d in output_dir.iterdir() if d.is_dir() and (d / "instruction.md").exists())
         logger.info("terminal-bench-v1: %d cached tasks", n)
         return output_dir
@@ -121,6 +167,7 @@ def _ensure_dataset(datasets_dir: str | None = None) -> Path:
                 logger.warning("Failed to map task %s", src.name, exc_info=True)
                 failed += 1
 
+        _patch_install_windows_xp_entrypoint(output_dir)
         logger.info(
             "terminal-bench-v1: mapped %d tasks (%d failed)",
             mapped,

--- a/src/nemo_evaluator/environments/harbor.py
+++ b/src/nemo_evaluator/environments/harbor.py
@@ -44,6 +44,8 @@ Registry resolution order:
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import logging
 import os
@@ -51,6 +53,7 @@ import shutil
 import subprocess
 import tempfile
 from collections import defaultdict
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -65,6 +68,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 REGISTRY_URL = "https://raw.githubusercontent.com/laude-institute/harbor/main/registry.json"
+
+# Matches upstream harbor's VerifierConfig.timeout_sec default (harbor/models/task/config.py).
+# Applied when task.toml [verifier] does not declare its own timeout_sec.
+DEFAULT_HARBOR_VERIFIER_TIMEOUT = 600
 
 # ---------------------------------------------------------------------------
 # Registry data model
@@ -205,6 +212,29 @@ def find_dataset(name: str, version: str | None = None) -> DatasetSpec:
 # ---------------------------------------------------------------------------
 
 
+@contextlib.contextmanager
+def _dataset_dir_lock(output_dir: Path) -> Iterator[None]:
+    """Hold an exclusive ``flock`` on ``<output_dir>.lock`` for the duration of the block.
+
+    Concurrent ``download_harbor_tasks`` callers targeting the same cache
+    directory race on the ``rmtree``/``copytree`` dance in
+    :func:`_download_task_group` and on the ``iterdir``-based cache scan.
+    Serializing them via a sibling lockfile means only the first caller
+    actually fetches; subsequent callers wait, then find the cache fully
+    populated and return immediately without re-downloading.
+    """
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = output_dir.parent / f".{output_dir.name}.lock"
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        with contextlib.suppress(OSError):
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
+
+
 def download_harbor_tasks(
     dataset: DatasetSpec,
     output_dir: Path,
@@ -212,10 +242,21 @@ def download_harbor_tasks(
 ) -> Path:
     """Download Harbor tasks via sparse git checkout.
 
-    Tasks that already exist on disk are skipped.
+    Tasks that already exist on disk are skipped.  Concurrent callers
+    targeting the same ``output_dir`` are serialized by a file lock so
+    the cache cannot be torn down mid-copy by a second process.
     """
     output_dir.mkdir(parents=True, exist_ok=True)
 
+    with _dataset_dir_lock(output_dir):
+        return _download_harbor_tasks_locked(dataset, output_dir, limit=limit)
+
+
+def _download_harbor_tasks_locked(
+    dataset: DatasetSpec,
+    output_dir: Path,
+    limit: int | None = None,
+) -> Path:
     tasks = dataset.tasks
     if limit:
         tasks = tasks[:limit]
@@ -541,6 +582,30 @@ _PROGRAMMING_LANGUAGES = frozenset(
 )
 
 
+# Literal marker appended by harbor/adapters/swebench_multilingual/adapter.py
+# when concatenating hints_text onto problem_statement.  Official SWE-bench
+# excludes hints_text from the eval prompt (test_spec.py:192 # Unused).
+_SWEBENCH_HINTS_MARKER = "\n\n## Hints\n\n"
+
+
+def _is_swebench_multilingual(dataset_name: str) -> bool:
+    """True for dataset dir names matching the swebench multilingual registry entry."""
+    n = dataset_name.lower()
+    return n.startswith(("swebench_multilingual", "swebench-multilingual"))
+
+
+def _strip_swebench_hints_block(instruction: str) -> tuple[str, bool]:
+    """Drop the adapter's ``## Hints`` tail; no-op when absent."""
+    idx = instruction.find(_SWEBENCH_HINTS_MARKER)
+    if idx < 0:
+        short = "\n\n## Hints"
+        tail = instruction.rstrip()
+        if tail.endswith(short):
+            return tail[: -len(short)].rstrip(), True
+        return instruction, False
+    return instruction[:idx].rstrip(), True
+
+
 def _infer_repo_language(task_dir: Path, metadata: dict[str, Any]) -> None:
     """Populate ``metadata["repo_language"]`` from available signals.
 
@@ -586,6 +651,7 @@ class HarborEnvironment(EvalEnvironment):
         self._dataset_path = Path(dataset_path)
         self._tasks: list[Path] = []
         self.name = self._dataset_path.name
+        self._hints_strip_logged = False
 
         if not self._dataset_path.is_dir():
             raise FileNotFoundError(f"Harbor dataset directory not found: {self._dataset_path}")
@@ -655,7 +721,22 @@ class HarborEnvironment(EvalEnvironment):
 
     async def seed(self, idx: int) -> SeedResult:
         task_dir = self._tasks[idx]
-        instruction = (task_dir / "instruction.md").read_text(encoding="utf-8").strip()
+        instruction = (task_dir / "instruction.md").read_text(encoding="utf-8")
+        # TODO: remove once harbor/adapters/swebench_multilingual/adapter.py
+        # stops concatenating hints_text into instruction.md.
+        hints_stripped = False
+        if _is_swebench_multilingual(self.name):
+            instruction, hints_stripped = _strip_swebench_hints_block(instruction)
+            if hints_stripped and not self._hints_strip_logged:
+                logger.info(
+                    "Harbor %s: stripping '## Hints' block (first seen on %s)",
+                    self.name,
+                    task_dir.name,
+                )
+                self._hints_strip_logged = True
+            elif hints_stripped:
+                logger.debug("Harbor %s/%s: stripped '## Hints' block", self.name, task_dir.name)
+        instruction = instruction.strip()
 
         task_toml = task_dir / "task.toml"
         config = _parse_task_config(task_toml) if task_toml.exists() else {}
@@ -735,9 +816,14 @@ class HarborEnvironment(EvalEnvironment):
             "task_id": task_dir.name,
             "task_dir": str(task_dir),
         }
+        if hints_stripped:
+            metadata["hints_stripped"] = True
         agent_timeout = config.get("agent", {}).get("timeout_sec")
         if agent_timeout is not None:
             metadata["agent_timeout_sec"] = agent_timeout
+        metadata["verifier_timeout_sec"] = config.get("verifier", {}).get(
+            "timeout_sec", DEFAULT_HARBOR_VERIFIER_TIMEOUT
+        )
         task_metadata = config.get("metadata", {})
         if task_metadata:
             metadata.update(task_metadata)
@@ -798,12 +884,13 @@ class HarborEnvironment(EvalEnvironment):
                 await sandbox.upload(test_file, f"/tests/{rel}")
 
         await sandbox.exec("chmod -R +x /tests/", timeout_sec=10)
+        verifier_timeout = float(metadata.get("verifier_timeout_sec", DEFAULT_HARBOR_VERIFIER_TIMEOUT))
         result = await sandbox.exec(
             'export PATH="/root/.local/bin:/root/.cargo/bin:/usr/local/go/bin'
             ":/usr/local/cargo/bin:$HOME/.local/bin:$HOME/.cargo/bin"
             ':$HOME/go/bin:$JAVA_HOME/bin:$PATH" && '
             "bash /tests/test.sh",
-            timeout_sec=600,
+            timeout_sec=verifier_timeout,
         )
 
         reward = 0.0

--- a/src/nemo_evaluator/solvers/byob_agent.py
+++ b/src/nemo_evaluator/solvers/byob_agent.py
@@ -34,7 +34,8 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from jinja2 import Environment as JinjaEnv, select_autoescape
+from jinja2 import Environment as JinjaEnv
+from jinja2 import select_autoescape
 
 logger = logging.getLogger(__name__)
 

--- a/src/nemo_evaluator/solvers/byob_agent.py
+++ b/src/nemo_evaluator/solvers/byob_agent.py
@@ -34,8 +34,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
-from jinja2 import Environment as JinjaEnv
-from jinja2 import select_autoescape
+from jinja2 import Environment as JinjaEnv, select_autoescape
 
 logger = logging.getLogger(__name__)
 

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -254,21 +254,13 @@ async def _patch_openhands_sdk(sandbox: "Sandbox", *, cmd_timeout: float | None 
        Both the event-to-dict conversion and ``build_trajectory`` are
        patched so reasoning appears in the output JSON.
 
-    3. **Preserve reasoning in conversation history** — some reasoning
-       parsers move ``<tool_call>`` blocks inside ``<think>`` tags into
-       ``reasoning_content`` instead of ``tool_calls``.  The SDK then
-       drops ``reasoning_content`` on the next serialization pass,
-       causing the model to lose its chain-of-thought.  The patch wraps
-       ``reasoning_content`` in ``<think>`` tags and prepends it to
-       ``content`` so it survives round-trips.
-
-    4. **Enforce 300 s hard timeout on terminal commands** — the SDK
+    3. **Enforce 300 s hard timeout on terminal commands** — the SDK
        only applies a hard timeout when the model passes an explicit
        ``timeout`` parameter.  The patch imposes a 300 s ceiling on
        every command to prevent a single long-running process from
        consuming the entire ``run_timeout`` budget.
 
-    5. **Disable default visualizer + stuck detection** — the SDK's
+    4. **Disable default visualizer + stuck detection** — the SDK's
        ``DefaultConversationVisualizer`` renders every event through
        ``rich``, whose grapheme splitter is pathologically slow on long
        text containing U+200B adjacent to URLs.  Observed on 26 django
@@ -482,68 +474,7 @@ print(f'reasoning+metrics: msg={ok_a} action={ok_b} traj={ok_c}')
             stdout3 or (r3.stderr or "")[:300],
         )
 
-    # -- Patch 3: preserve reasoning_content in conversation history -------
-    # When send_reasoning_content is False (nemotron is not in the list),
-    # the SDK silently drops reasoning_content from assistant messages.
-    # Patch to_chat_dict() to wrap reasoning_content in <think> tags and
-    # prepend to content so it survives LiteLLM serialization round-trips.
-
-    _reasoning_in_content_script = """\
-import glob, sys
-fs = glob.glob('/opt/openhands-sdk-venv/lib/python*/site-packages/openhands/sdk/llm/message.py')
-p = fs[0] if fs else ''
-assert p, 'message.py not found'
-c = open(p).read()
-
-old = (
-    '        # Required for model like kimi-k2-thinking\\n'
-    '        if send_reasoning_content and self.reasoning_content:\\n'
-    '            message_dict["reasoning_content"] = self.reasoning_content\\n'
-    '\\n'
-    '        return message_dict'
-)
-
-new = (
-    '        # Required for model like kimi-k2-thinking\\n'
-    '        if send_reasoning_content and self.reasoning_content:\\n'
-    '            message_dict["reasoning_content"] = self.reasoning_content\\n'
-    '\\n'
-    '        # [NEL] Wrap reasoning_content in <think> tags in content so the\\n'
-    '        # model sees its previous chain-of-thought on retry turns.\\n'
-    '        if not send_reasoning_content and self.role == "assistant" and self.reasoning_content:\\n'
-    '            _wrapped = f"<think>{self.reasoning_content}</think>"\\n'
-    '            _c = message_dict.get("content")\\n'
-    '            if isinstance(_c, list):\\n'
-    '                _c.insert(0, {"type": "text", "text": _wrapped})\\n'
-    '            elif isinstance(_c, str):\\n'
-    '                message_dict["content"] = _wrapped + _c\\n'
-    '            else:\\n'
-    '                message_dict["content"] = _wrapped\\n'
-    '\\n'
-    '        return message_dict'
-)
-
-ok = old in c
-if ok:
-    c = c.replace(old, new, 1)
-    open(p, 'w').write(c)
-print(f'reasoning_in_content={ok} at {p}')
-"""
-    encoded4 = base64.b64encode(_reasoning_in_content_script.encode()).decode()
-    r4 = await sandbox.exec(
-        f"echo {encoded4} | base64 -d | python3",
-        timeout_sec=10,
-    )
-    stdout4 = (r4.stdout or "").strip()
-    logger.info("Reasoning-in-content patch: %s", stdout4)
-    if r4.return_code != 0 or "False" in stdout4:
-        logger.warning(
-            "Reasoning-in-content patch problem (rc=%d): %s",
-            r4.return_code,
-            stdout4 or (r4.stderr or "")[:300],
-        )
-
-    # -- Patch 4: hard timeout ceiling on terminal commands ------------------
+    # -- Patch 3: hard timeout ceiling on terminal commands ------------------
     if cmd_timeout is not None and cmd_timeout > 0:
         _cmd_timeout_script = f"""\
 import glob, sys

--- a/src/nemo_evaluator/solvers/openclaw.py
+++ b/src/nemo_evaluator/solvers/openclaw.py
@@ -64,7 +64,8 @@ _OPENCLAW_CONFIG_DIR = "/home/node/.openclaw"
 _CONTAINER_WORKSPACE = "/home/node/workspace"
 _CONTAINER_SESSIONS_DIR = f"{_OPENCLAW_CONFIG_DIR}/agents/main/sessions"
 
-_DEFAULT_CONTEXT_WINDOW = 131_072
+_DEFAULT_CONTEXT_WINDOW: int | None = None
+_DEFAULT_IDLE_TIMEOUT_SECONDS = 600
 _DEFAULT_MAX_TOKENS = 16_384
 _DEFAULT_MAX_CONCURRENT = 4
 
@@ -74,9 +75,10 @@ def _build_openclaw_config(
     model_id: str,
     *,
     api_key: str = "",
-    context_window: int = _DEFAULT_CONTEXT_WINDOW,
+    context_window: int | None = _DEFAULT_CONTEXT_WINDOW,
     max_tokens: int | None = None,
     max_concurrent: int = _DEFAULT_MAX_CONCURRENT,
+    idle_timeout_seconds: int = _DEFAULT_IDLE_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     """Build an OpenClaw config for an OpenAI-compatible provider.
 
@@ -99,8 +101,9 @@ def _build_openclaw_config(
         "id": model_id,
         "name": model_id,
         "input": ["text"],
-        "contextWindow": context_window,
     }
+    if context_window is not None:
+        model_entry["contextWindow"] = context_window
     if max_tokens is not None:
         model_entry["maxTokens"] = max_tokens
 
@@ -110,6 +113,7 @@ def _build_openclaw_config(
         "skipBootstrap": True,
         "compaction": {"mode": "safeguard"},
         "maxConcurrent": max_concurrent,
+        "llm": {"idleTimeoutSeconds": idle_timeout_seconds},
     }
 
     provider_entry: dict[str, Any] = {
@@ -198,6 +202,29 @@ def _read_workspace_files(
             continue
         parts.append(f"--- {rel} ---\n{content}")
     return "\n\n".join(parts)
+
+
+_TRANSCRIPT_FILENAME = ".nel_transcript.jsonl"
+
+
+def _persist_session_transcript(workspace: Path, raw_jsonl: str) -> None:
+    """Write OpenClaw's session JSONL verbatim to ``<workspace>/.nel_transcript.jsonl``.
+
+    Verifiers / scorers (notably PinchBench's ``grade()`` functions) expect
+    the upstream ``{"type": "message", "message": {...}}`` envelope shape,
+    so we persist the bytes unchanged.  This is separate from the ATIF
+    trajectory written to the eval artifact bundle: the trajectory is for
+    observability/dashboards; this file is the *scoring contract* with
+    task-authored grader code.
+
+    Best-effort: a failure here must not fail the solve.
+    """
+    try:
+        if not workspace.is_dir():
+            return
+        (workspace / _TRANSCRIPT_FILENAME).write_text(raw_jsonl, encoding="utf-8")
+    except OSError as exc:
+        logger.warning("Failed to persist session transcript to %s: %s", workspace, exc)
 
 
 def _check_prerequisites(openclaw_bin: str) -> None:
@@ -369,10 +396,15 @@ def _parse_session_jsonl(raw: str) -> list[dict[str, Any]]:
             content = record.get("content", [])
             text_parts: list[str] = []
             tool_calls: list[dict[str, Any]] = []
+            reasoning_parts: list[str] = []
             for block in content if isinstance(content, list) else []:
                 btype = block.get("type", "")
                 if btype == "text" and block.get("text"):
                     text_parts.append(block["text"])
+                elif btype == "thinking" and block.get("thinking"):
+                    reasoning_parts.append(block["thinking"])
+                elif btype == "redacted_thinking":
+                    reasoning_parts.append("[redacted_thinking]")
                 elif btype == "tool_use":
                     tool_calls.append(
                         {
@@ -385,9 +417,11 @@ def _parse_session_jsonl(raw: str) -> list[dict[str, Any]]:
                 "source": "agent",
                 "message": "\n".join(text_parts),
             }
+            if reasoning_parts:
+                step["reasoning_content"] = "\n".join(reasoning_parts)
             if tool_calls:
                 step["tool_calls"] = tool_calls
-            if text_parts or tool_calls:
+            if text_parts or tool_calls or reasoning_parts:
                 steps.append(step)
         elif role == "tool":
             content = record.get("content", "")
@@ -432,9 +466,10 @@ class OpenClawSolver:
         model_url: str = "",
         model_id: str = "",
         api_key: str | None = None,
-        context_window: int = _DEFAULT_CONTEXT_WINDOW,
+        context_window: int | None = _DEFAULT_CONTEXT_WINDOW,
         max_tokens: int | None = None,
         max_concurrent: int = _DEFAULT_MAX_CONCURRENT,
+        idle_timeout_seconds: int = _DEFAULT_IDLE_TIMEOUT_SECONDS,
         config_path: str | None = None,
         *,
         skip_preflight: bool = False,
@@ -448,6 +483,7 @@ class OpenClawSolver:
         self._context_window = context_window
         self._max_tokens = max_tokens
         self._max_concurrent = max_concurrent
+        self._idle_timeout_seconds = idle_timeout_seconds
         self._config_path = Path(config_path) if config_path else None
         if self._config_path and not self._config_path.is_file():
             raise FileNotFoundError(f"openclaw_config points to {self._config_path} which does not exist")
@@ -549,9 +585,13 @@ class OpenClawSolver:
             if file_addendum:
                 response_text = f"{response_text}\n\n{file_addendum}" if response_text else file_addendum
 
-        transcript_steps = await self._read_session_transcript(sandbox, session_id)
-        if transcript_steps:
-            steps = transcript_steps + steps
+        raw_session_jsonl = await self._fetch_session_jsonl_sandbox(sandbox, session_id)
+        if raw_session_jsonl:
+            transcript_steps = _parse_session_jsonl(raw_session_jsonl)
+            if transcript_steps:
+                steps = transcript_steps + steps
+            if workspace_path:
+                _persist_session_transcript(Path(workspace_path), raw_session_jsonl)
 
         trajectory = build_atif_trajectory(
             steps,
@@ -560,6 +600,7 @@ class OpenClawSolver:
             prompt_tokens=model_response.prompt_tokens or 0,
             completion_tokens=model_response.completion_tokens or 0,
             extra=oc_extra,
+            user_prompt=effective_prompt,
         )
 
         logger.info(
@@ -575,23 +616,30 @@ class OpenClawSolver:
             trajectory=trajectory,
         )
 
-    async def _read_session_transcript(
+    async def _fetch_session_jsonl_sandbox(
         self,
         sandbox: Sandbox,
         session_id: str,
-    ) -> list[dict[str, Any]]:
-        """Read the OpenClaw session JSONL from the container."""
+    ) -> str:
+        """Return the OpenClaw session JSONL from the container as raw text.
+
+        Returns an empty string when the session file is missing or
+        unreadable.  The raw text is persisted verbatim to
+        ``<workspace>/.nel_transcript.jsonl`` so downstream graders see
+        the upstream ``{"type":"message", ...}`` envelope shape; our own
+        :func:`_parse_session_jsonl` converts it into ATIF steps for the
+        trajectory artifact.
+        """
         import base64
 
         remote_path = f"{_CONTAINER_SESSIONS_DIR}/{session_id}.jsonl"
         try:
             result = await sandbox.exec(f"base64 {shlex.quote(remote_path)} 2>/dev/null")
             if result.return_code != 0 or not result.stdout.strip():
-                return []
-            raw = base64.b64decode(result.stdout.strip()).decode("utf-8", errors="replace")
+                return ""
+            return base64.b64decode(result.stdout.strip()).decode("utf-8", errors="replace")
         except Exception:
-            return []
-        return _parse_session_jsonl(raw)
+            return ""
 
     async def _setup_config(self, sandbox: Sandbox, *, model_url_override: str | None = None) -> None:
         """Write an OpenClaw config into the container.
@@ -610,6 +658,7 @@ class OpenClawSolver:
                 context_window=self._context_window,
                 max_tokens=self._max_tokens,
                 max_concurrent=self._max_concurrent,
+                idle_timeout_seconds=self._idle_timeout_seconds,
             )
             config_json = json.dumps(config, indent=2)
         await self._write_file(sandbox, f"{_OPENCLAW_CONFIG_DIR}/openclaw.json", config_json)
@@ -827,9 +876,13 @@ class OpenClawSolver:
                 response_text = f"{response_text}\n\n{file_addendum}" if response_text else file_addendum
 
         home = env.get("HOME", str(Path.home()))
-        transcript_steps = self._read_local_session_transcript(home, session_id)
-        if transcript_steps:
-            steps = transcript_steps + steps
+        raw_session_jsonl = self._fetch_session_jsonl_local(home, session_id)
+        if raw_session_jsonl:
+            transcript_steps = _parse_session_jsonl(raw_session_jsonl)
+            if transcript_steps:
+                steps = transcript_steps + steps
+            if workspace_path:
+                _persist_session_transcript(Path(workspace_path), raw_session_jsonl)
 
         trajectory = build_atif_trajectory(
             steps,
@@ -838,6 +891,7 @@ class OpenClawSolver:
             prompt_tokens=model_response.prompt_tokens or 0,
             completion_tokens=model_response.completion_tokens or 0,
             extra=oc_extra,
+            user_prompt=effective_prompt,
         )
 
         logger.info(
@@ -858,16 +912,13 @@ class OpenClawSolver:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _read_local_session_transcript(
-        home: str,
-        session_id: str,
-    ) -> list[dict[str, Any]]:
-        """Read a session transcript from the local filesystem."""
+    def _fetch_session_jsonl_local(home: str, session_id: str) -> str:
+        """Return a local session transcript as raw JSONL text, or empty."""
         sessions_dir = Path(home) / ".openclaw" / "agents" / "main" / "sessions"
         transcript_path = sessions_dir / f"{session_id}.jsonl"
         if not transcript_path.exists():
-            return []
-        return _parse_session_jsonl(transcript_path.read_text(encoding="utf-8", errors="replace"))
+            return ""
+        return transcript_path.read_text(encoding="utf-8", errors="replace")
 
     @staticmethod
     def _build_prompt(raw_prompt: str, workspace_path: str | None) -> str:

--- a/src/nemo_evaluator/solvers/oracle.py
+++ b/src/nemo_evaluator/solvers/oracle.py
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Gold-trajectory replay solver for Harbor-style tasks.
+
+Reads the task's gold trajectory (``solution/solve.sh``) and executes it inside
+the sandbox that the Harbor environment has prepared.  Used to measure the
+infrastructure ceiling — what fraction of tasks pass when the "agent" already
+knows the answer — independent of LLM capability.
+
+Mirrors upstream harbor ``OracleAgent``: uploads the full ``solution/``
+directory to ``/solution/`` inside the sandbox and runs
+``/solution/solve.sh``.  This supports tasks whose solve.sh references sibling
+files (e.g. ``cp /solution/helper.py``).
+
+No LLM service is needed; the config schema omits ``service``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from nemo_evaluator.environments.base import SeedResult
+from nemo_evaluator.solvers.base import ErrorKind, SolveResult
+from nemo_evaluator.solvers.harbor import _resolve_agent_timeout
+
+if TYPE_CHECKING:
+    from nemo_evaluator.sandbox.base import Sandbox
+
+
+logger = logging.getLogger(__name__)
+
+
+class OracleSolver:
+    """Execute the task's own ``solution/solve.sh`` inside the sandbox.
+
+    The task directory is read from ``SeedResult.metadata["task_dir"]``
+    (populated by :class:`HarborEnvironment`).  Timeout resolution mirrors
+    :class:`HarborSolver` so ``override``/``task``/``max`` strategies behave
+    identically and ``max_agent_timeout`` caps runaway per-task budgets.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout: float = 1800.0,
+        run_timeout: float | None = None,
+        timeout_strategy: str = "override",
+        max_agent_timeout: float | None = None,
+    ) -> None:
+        self._timeout = timeout
+        self._run_timeout = run_timeout if run_timeout is not None else timeout
+        self._timeout_strategy = timeout_strategy
+        self._max_agent_timeout = max_agent_timeout
+
+    async def solve(self, task: SeedResult, sandbox: Sandbox | None = None) -> SolveResult:
+        if sandbox is None:
+            return SolveResult(
+                response="",
+                trajectory=[],
+                reward=0.0,
+                error="OracleSolver requires a sandbox",
+                error_kind=ErrorKind.INFRA,
+            )
+
+        task_dir_str = task.metadata.get("task_dir")
+        if not task_dir_str:
+            return SolveResult(
+                response="",
+                trajectory=[],
+                reward=0.0,
+                error="task_dir missing from seed metadata (needed to locate solution/solve.sh)",
+                error_kind=ErrorKind.SYSTEM,
+            )
+
+        task_id = task.metadata.get("task_id", "?")
+        solution_dir = Path(task_dir_str) / "solution"
+        solve_sh = solution_dir / "solve.sh"
+        if not solve_sh.exists():
+            return SolveResult(
+                response="",
+                trajectory=[{"error": f"no solve.sh at {solve_sh}"}],
+                reward=0.0,
+                error=f"solution/solve.sh missing for task {task_id}",
+                error_kind=ErrorKind.SYSTEM,
+            )
+
+        task_timeout: float | None = None
+        raw = task.metadata.get("agent_timeout_sec")
+        if isinstance(raw, (int, float)):
+            task_timeout = float(raw)
+        effective = _resolve_agent_timeout(
+            self._timeout_strategy,
+            self._run_timeout,
+            task_timeout,
+            self._max_agent_timeout,
+        )
+
+        # Match upstream harbor OracleAgent: upload the full solution/ dir to
+        # /solution in the sandbox so solve.sh can reference sibling files
+        # (e.g. `cp /solution/helper.py /app/`).
+        remote_dir = "/solution"
+        remote_solve = f"{remote_dir}/solve.sh"
+        await sandbox.exec(f"mkdir -p {remote_dir}", timeout_sec=10)
+        for child in sorted(solution_dir.iterdir()):
+            if child.is_file():
+                await sandbox.upload(child, f"{remote_dir}/{child.name}")
+        await sandbox.exec(f"chmod +x {remote_solve}", timeout_sec=10)
+
+        logger.info(
+            "OracleSolver: running %s (timeout=%.0fs, strategy=%s)",
+            solve_sh,
+            effective,
+            self._timeout_strategy,
+        )
+        t0 = time.monotonic()
+        try:
+            result = await sandbox.exec(f"bash {remote_solve}", timeout_sec=effective)
+        except Exception as e:
+            elapsed = time.monotonic() - t0
+            logger.warning(
+                "OracleSolver: sandbox.exec raised %s after %.1fs on %s: %s",
+                type(e).__name__,
+                elapsed,
+                task_id,
+                e,
+            )
+            return SolveResult(
+                response="",
+                trajectory=[{"type": "oracle", "script_path": str(solve_sh), "elapsed_sec": elapsed, "error": str(e)}],
+                reward=0.0,
+                error=f"sandbox.exec raised {type(e).__name__}: {e}",
+                error_kind=ErrorKind.INFRA,
+            )
+        elapsed = time.monotonic() - t0
+
+        trajectory = [
+            {
+                "type": "oracle",
+                "script_path": str(solve_sh),
+                "return_code": result.return_code,
+                "stdout": result.stdout,
+                "stderr": result.stderr,
+                "elapsed_sec": elapsed,
+            }
+        ]
+
+        if result.return_code != 0:
+            logger.warning(
+                "OracleSolver: solve.sh for %s exited %d after %.1fs",
+                task_id,
+                result.return_code,
+                elapsed,
+            )
+
+        return SolveResult(
+            response=result.stdout or "",
+            trajectory=trajectory,
+        )

--- a/src/nemo_evaluator/solvers/trajectory_util.py
+++ b/src/nemo_evaluator/solvers/trajectory_util.py
@@ -35,20 +35,32 @@ def build_atif_trajectory(
     completion_tokens: int | None = None,
     status: str | None = None,
     extra: dict[str, Any] | None = None,
+    user_prompt: str | None = None,
+    system_prompt: str | None = None,
 ) -> list[dict[str, Any]]:
     """Build a single-element list containing one ATIF-v1.6 trajectory document.
 
-    Returns ``[atif_doc]`` — the list wrapper that ``SolveResult.trajectory``
-    expects.  Each step is auto-numbered (``step_id`` 1, 2, 3, ...) and must
-    have at minimum ``source`` and ``message``.
+    Steps are auto-numbered (``step_id`` 1, 2, 3, ...). When ``user_prompt``
+    is supplied and ``steps`` does not already begin with a user/system
+    step, an initiating user step (optionally preceded by ``system_prompt``)
+    is prepended. Idempotent when the caller already seeds a user turn.
     """
+    normalized = [dict(s) for s in steps]
+    if user_prompt:
+        leading_source = normalized[0].get("source") if normalized else None
+        if leading_source not in ("user", "system"):
+            prelude: list[dict[str, Any]] = []
+            if system_prompt:
+                prelude.append({"source": "system", "message": system_prompt})
+            prelude.append({"source": "user", "message": user_prompt})
+            normalized = prelude + normalized
+
     numbered_steps = []
-    for i, step in enumerate(steps, start=1):
+    for i, step in enumerate(normalized, start=1):
         s = dict(step)
-        s.setdefault("step_id", i)
+        s["step_id"] = i
         numbered_steps.append(s)
 
-    # Auto-derive totals from per-step metrics when caller didn't provide them.
     if prompt_tokens is None and completion_tokens is None:
         prompt_tokens = 0
         completion_tokens = 0
@@ -98,12 +110,7 @@ def build_single_turn_atif(
     system: str | None = None,
     model_name: str | None = None,
 ) -> list[dict[str, Any]]:
-    """Build an ATIF trajectory for a single-turn model call (chat/completion/VLM).
-
-    Produces 2-3 steps: optional system, user prompt, and agent response.
-    The agent response ``message`` is the model output (may be empty string
-    for agent benchmarks where the result is file modifications).
-    """
+    """Build an ATIF trajectory for a single-turn model call."""
     steps: list[dict[str, Any]] = []
     if system:
         steps.append({"source": "system", "message": system})

--- a/tests/test_environments/test_harbor_dataset_lock.py
+++ b/tests/test_environments/test_harbor_dataset_lock.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the dataset-directory file lock that serializes
+``download_harbor_tasks`` callers.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from nemo_evaluator.environments.harbor import _dataset_dir_lock
+
+
+def test_lock_creates_sibling_lockfile(tmp_path: Path) -> None:
+    output_dir = tmp_path / "harbor_datasets" / "terminal-bench@2.0"
+    with _dataset_dir_lock(output_dir):
+        assert (output_dir.parent / ".terminal-bench@2.0.lock").exists()
+
+
+def test_lock_releases_after_block(tmp_path: Path) -> None:
+    output_dir = tmp_path / "ds"
+    with _dataset_dir_lock(output_dir):
+        pass
+    # Re-acquiring must not block.
+    with _dataset_dir_lock(output_dir):
+        pass
+
+
+def test_lock_propagates_exceptions(tmp_path: Path) -> None:
+    output_dir = tmp_path / "ds"
+    with pytest.raises(RuntimeError, match="boom"):
+        with _dataset_dir_lock(output_dir):
+            raise RuntimeError("boom")
+    # Lock must have been released even though the body raised.
+    with _dataset_dir_lock(output_dir):
+        pass
+
+
+def _hold_lock(output_dir: str, hold_seconds: float, started_path: str, finished_path: str) -> None:
+    with _dataset_dir_lock(Path(output_dir)):
+        Path(started_path).touch()
+        time.sleep(hold_seconds)
+        Path(finished_path).touch()
+
+
+def test_lock_serializes_concurrent_callers(tmp_path: Path) -> None:
+    output_dir = tmp_path / "ds"
+
+    a_started = tmp_path / "a_started"
+    a_finished = tmp_path / "a_finished"
+    b_started = tmp_path / "b_started"
+    b_finished = tmp_path / "b_finished"
+
+    ctx = mp.get_context("spawn")
+    proc_a = ctx.Process(target=_hold_lock, args=(str(output_dir), 0.6, str(a_started), str(a_finished)))
+    proc_b = ctx.Process(target=_hold_lock, args=(str(output_dir), 0.0, str(b_started), str(b_finished)))
+
+    proc_a.start()
+    while not a_started.exists():
+        time.sleep(0.02)
+    # A holds the lock for ~0.6s; start B which must wait until A releases.
+    proc_b.start()
+
+    proc_a.join(timeout=10)
+    proc_b.join(timeout=10)
+    assert proc_a.exitcode == 0
+    assert proc_b.exitcode == 0
+
+    a_finish_t = os.path.getmtime(a_finished)
+    b_start_t = os.path.getmtime(b_started)
+    assert b_start_t >= a_finish_t, "B entered the critical section before A released the lock"

--- a/tests/test_environments/test_harbor_instruction.py
+++ b/tests/test_environments/test_harbor_instruction.py
@@ -1,0 +1,229 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the ``## Hints`` strip applied to Harbor ``instruction.md``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nemo_evaluator.environments.harbor import (
+    HarborEnvironment,
+    _is_swebench_multilingual,
+    _strip_swebench_hints_block,
+)
+
+
+def test_strip_no_marker_returns_original():
+    text = "Just a plain problem statement.\nNo hints here."
+    out, stripped = _strip_swebench_hints_block(text)
+    assert out == text
+    assert stripped is False
+
+
+def test_strip_removes_hints_block_exact_adapter_format():
+    text = (
+        "Fix the bug in foo.py.\n"
+        "Repro steps:\n"
+        "  1. call foo(1)\n"
+        "  2. observe crash"
+        "\n\n## Hints\n\n"
+        "Maintainer: the fix is in bar.py line 42. Change x -> y."
+    )
+    out, stripped = _strip_swebench_hints_block(text)
+    assert stripped is True
+    assert "## Hints" not in out
+    assert "Maintainer" not in out
+    assert "fix is in bar.py" not in out
+    assert out.endswith("observe crash")
+
+
+def test_strip_ignores_hints_heading_with_wrong_surrounding_whitespace():
+    text = "Some issue body.\n## Hints might be relevant here\nand more text."
+    out, stripped = _strip_swebench_hints_block(text)
+    assert stripped is False
+    assert out == text
+
+
+def test_strip_ignores_inline_hints_mention():
+    text = "The word ## Hints appears but not as a heading."
+    out, stripped = _strip_swebench_hints_block(text)
+    assert stripped is False
+    assert out == text
+
+
+def test_strip_preserves_leading_content_exactly():
+    body = "line1\nline2\n```py\nprint('x')\n```"
+    text = body + "\n\n## Hints\n\nspoiler content"
+    out, stripped = _strip_swebench_hints_block(text)
+    assert stripped is True
+    assert out == body
+
+
+def test_strip_handles_marker_at_very_start():
+    text = "\n\n## Hints\n\nnothing before."
+    out, stripped = _strip_swebench_hints_block(text)
+    assert stripped is True
+    assert out == ""
+
+
+def test_strip_handles_multiple_markers_uses_first():
+    text = "body\n\n## Hints\n\nfirst\n\n## Hints\n\nsecond"
+    out, stripped = _strip_swebench_hints_block(text)
+    assert stripped is True
+    assert out == "body"
+
+
+def test_strip_empty_instruction_is_noop():
+    out, stripped = _strip_swebench_hints_block("")
+    assert stripped is False
+    assert out == ""
+
+
+def test_strip_handles_canary_empty_hints_body():
+    """Adapter with an empty ``hints_text`` leaves a bare ``\\n\\n## Hints`` tail."""
+    text = "Problem body.\n\n## Hints"
+    out, stripped = _strip_swebench_hints_block(text)
+    assert stripped is True
+    assert out == "Problem body."
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "swebench_multilingual",
+        "swebench_multilingual@1.0",
+        "swebench-multilingual@2.0",
+        "SWEBENCH_MULTILINGUAL@1.0",
+    ],
+)
+def test_gate_matches_multilingual_variants(name):
+    assert _is_swebench_multilingual(name) is True
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "swebench-verified@1.0",
+        "swebenchpro@1.0",
+        "swesmith@1.0",
+        "swe-gen-js@1.0",
+        "swe-lancer-diamond@ic",
+        "terminal-bench@2.0",
+        "usaco@1.0",
+        "ds",
+        "",
+    ],
+)
+def test_gate_rejects_non_multilingual_datasets(name):
+    assert _is_swebench_multilingual(name) is False
+
+
+def _make_task(root: Path, name: str, instruction: str, task_toml: str = "") -> Path:
+    task_dir = root / name
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text(instruction)
+    (task_dir / "task.toml").write_text(task_toml)
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    return task_dir
+
+
+@pytest.mark.asyncio
+async def test_seed_strips_multilingual_hints_block(tmp_path):
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    _make_task(
+        dataset,
+        "apache__druid-12345",
+        "Original bug report.\nSteps to reproduce.\n\n## Hints\n\nReviewer said: patch should go in X.java line 10.",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert "## Hints" not in seed.prompt
+    assert "Reviewer said" not in seed.prompt
+    assert seed.prompt.endswith("Steps to reproduce.")
+
+
+@pytest.mark.asyncio
+async def test_seed_leaves_verified_instruction_untouched(tmp_path):
+    dataset = tmp_path / "swebench-verified@1.0"
+    _make_task(
+        dataset,
+        "django__django-12345",
+        "Simplify signature of DatabaseOperations.execute_sql_flush().\nThe using argument can be dropped.",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert "## Hints" not in seed.prompt
+    assert "execute_sql_flush" in seed.prompt
+    assert seed.prompt.startswith("Simplify signature")
+
+
+@pytest.mark.asyncio
+async def test_seed_gate_preserves_hints_for_non_multilingual_datasets(tmp_path):
+    """Non-multilingual datasets never get their hint blocks stripped."""
+    dataset = tmp_path / "swebenchpro@1.0"
+    _make_task(
+        dataset,
+        "django__django-99999",
+        "Problem body.\n\n## Hints\n\nsome body.",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert "## Hints" in seed.prompt
+    assert "some body" in seed.prompt
+
+
+@pytest.mark.asyncio
+async def test_seed_records_hints_stripped_in_metadata(tmp_path):
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    _make_task(
+        dataset,
+        "apache__druid-12345",
+        "Problem body.\n\n## Hints\n\nsome body.",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert seed.metadata.get("hints_stripped") is True
+
+
+@pytest.mark.asyncio
+async def test_seed_omits_hints_stripped_when_noop(tmp_path):
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    _make_task(dataset, "apache__druid-noop", "No hints here at all.")
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert "hints_stripped" not in seed.metadata
+
+
+@pytest.mark.asyncio
+async def test_seed_handles_adapter_canary_empty_hints_bytes(tmp_path):
+    """Byte-exact regression guard for an adapter-written empty-hints tail."""
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    instruction_bytes = "Problem body text.\n\n## Hints\n\n\n"
+    _make_task(dataset, "apache__druid-canary", instruction_bytes)
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert "## Hints" not in seed.prompt
+    assert seed.prompt == "Problem body text."
+    assert seed.metadata.get("hints_stripped") is True
+
+
+@pytest.mark.asyncio
+async def test_seed_handles_adapter_normal_hints_bytes(tmp_path):
+    """Byte-exact regression guard for a normal (non-canary) adapter output."""
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    instruction_bytes = (
+        "Problem body text.\n"
+        "Second line of body.\n\n## Hints\n\n"
+        "@maintainer: this looks like bar.py line 42.\n"
+        "reply: I'll patch it tomorrow.\n"
+    )
+    _make_task(dataset, "apache__druid-hints", instruction_bytes)
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert "## Hints" not in seed.prompt
+    assert "maintainer" not in seed.prompt.lower()
+    assert "bar.py" not in seed.prompt
+    assert seed.prompt == "Problem body text.\nSecond line of body."
+    assert seed.metadata.get("hints_stripped") is True

--- a/tests/test_environments/test_harbor_timeouts.py
+++ b/tests/test_environments/test_harbor_timeouts.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for HarborEnvironment timeout handling — task.toml [verifier] timeout_sec plumbing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nemo_evaluator.environments.harbor import DEFAULT_HARBOR_VERIFIER_TIMEOUT, HarborEnvironment
+from tests.conftest import MockExecResult, MockSandbox
+
+
+class _CapturingSandbox(MockSandbox):
+    """MockSandbox that records the timeout_sec used for ``bash /tests/test.sh`` invocations."""
+
+    def __init__(self, exec_results: dict[str, MockExecResult] | None = None) -> None:
+        super().__init__(exec_results=exec_results)
+        self.captured_timeouts: list[float] = []
+
+    async def exec(
+        self,
+        command: str,
+        timeout_sec: float = 180,
+        *,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        user: str | int | None = None,
+    ) -> MockExecResult:
+        if "bash /tests/test.sh" in command:
+            self.captured_timeouts.append(timeout_sec)
+        return await super().exec(command, timeout_sec, cwd=cwd, env=env, user=user)
+
+
+def _make_task_dir(root: Path, name: str, task_toml_body: str) -> Path:
+    task_dir = root / name
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text("test instruction")
+    (task_dir / "task.toml").write_text(task_toml_body)
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    return task_dir
+
+
+@pytest.mark.asyncio
+async def test_seed_extracts_verifier_timeout_from_task_toml(tmp_path):
+    dataset = tmp_path / "ds"
+    _make_task_dir(
+        dataset,
+        "t1",
+        "[agent]\ntimeout_sec = 900\n[verifier]\ntimeout_sec = 1800\n",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert seed.metadata["agent_timeout_sec"] == 900
+    assert seed.metadata["verifier_timeout_sec"] == 1800
+
+
+@pytest.mark.asyncio
+async def test_seed_falls_back_to_default_when_task_omits_verifier_timeout(tmp_path):
+    dataset = tmp_path / "ds"
+    _make_task_dir(dataset, "t1", "[agent]\ntimeout_sec = 900\n")
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert seed.metadata["verifier_timeout_sec"] == DEFAULT_HARBOR_VERIFIER_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_verify_defaults_to_600_when_metadata_missing(tmp_path):
+    dataset = tmp_path / "ds"
+    task_dir = _make_task_dir(dataset, "t1", "")
+    env = HarborEnvironment(dataset_path=str(dataset))
+
+    sb = _CapturingSandbox()
+    await sb.start()
+    await env.verify(response="", expected="", sandbox=sb, task_dir=str(task_dir))
+    assert sb.captured_timeouts == [float(DEFAULT_HARBOR_VERIFIER_TIMEOUT)]
+
+
+@pytest.mark.asyncio
+async def test_verify_uses_1800_when_task_declares_it(tmp_path):
+    dataset = tmp_path / "ds"
+    _make_task_dir(
+        dataset,
+        "t1",
+        "[agent]\ntimeout_sec = 900\n[verifier]\ntimeout_sec = 1800\n",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset))
+
+    sb = _CapturingSandbox()
+    await sb.start()
+    seed = await env.seed(0)
+    await env.verify(response="", expected="", sandbox=sb, **seed.metadata)
+    assert sb.captured_timeouts == [1800.0]

--- a/tests/test_integration/test_terminal_bench_v1.py
+++ b/tests/test_integration/test_terminal_bench_v1.py
@@ -19,6 +19,10 @@ from unittest.mock import patch
 
 import pytest
 
+from nemo_evaluator.benchmarks.terminal_bench_hard import (
+    _TB_HARD_TASKS,
+    TerminalBenchHard,
+)
 from nemo_evaluator.benchmarks.terminal_bench_v1 import (
     TerminalBenchV1,
     _ensure_dataset,
@@ -47,16 +51,22 @@ services:
 
 MINIMAL_DOCKERFILE = "FROM ubuntu:22.04\nRUN echo hello\n"
 
+INSTALL_WINDOWS_XP_DOCKERFILE = """\
+FROM ubuntu:24.04
+COPY etc/supervisor/supervisord.conf /etc/supervisor/supervisord.conf
+ENTRYPOINT [ "supervisord", "-c", "/etc/supervisor/supervisord.conf" ]
+"""
+
 MINIMAL_RUN_TESTS = "#!/bin/bash\necho test\nexit 0\n"
 
 
-def _create_v1_task(parent: Path, name: str) -> Path:
+def _create_v1_task(parent: Path, name: str, dockerfile: str = MINIMAL_DOCKERFILE) -> Path:
     """Create a minimal Terminal-Bench v1 task directory."""
     task_dir = parent / name
     task_dir.mkdir(parents=True)
     (task_dir / "task.yaml").write_text(MINIMAL_TASK_YAML)
     (task_dir / "docker-compose.yaml").write_text(MINIMAL_DOCKER_COMPOSE)
-    (task_dir / "Dockerfile").write_text(MINIMAL_DOCKERFILE)
+    (task_dir / "Dockerfile").write_text(dockerfile)
     (task_dir / "run-tests.sh").write_text(MINIMAL_RUN_TESTS)
     return task_dir
 
@@ -124,6 +134,58 @@ class TestEnsureDataset:
         with pytest.raises(RuntimeError, match="No terminal-bench v1"):
             _ensure_dataset(datasets_dir=str(tmp_path))
 
+    @patch("nemo_evaluator.benchmarks.terminal_bench_v1._git")
+    @patch("nemo_evaluator.benchmarks.terminal_bench_v1._find_tasks_dir")
+    def test_patches_install_windows_xp_entrypoint_after_mapping(self, mock_find, mock_git, tmp_path):
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        _create_v1_task(source_dir, "install-windows-xp", dockerfile=INSTALL_WINDOWS_XP_DOCKERFILE)
+        mock_find.return_value = source_dir
+
+        output = _ensure_dataset(datasets_dir=str(tmp_path))
+
+        dockerfile = output / "install-windows-xp" / "environment" / "Dockerfile"
+        wrapper = output / "install-windows-xp" / "environment" / "nel-entrypoint.sh"
+        dockerfile_text = dockerfile.read_text()
+        wrapper_text = wrapper.read_text()
+        assert 'ENTRYPOINT ["/nel-entrypoint.sh"]' in dockerfile_text
+        assert "upstream compose passes no command" in dockerfile_text
+        assert "supervisord -c /etc/supervisor/supervisord.conf &" in wrapper_text
+        assert 'kill -0 "$pid"' in wrapper_text
+        assert 'exec "$@"' in wrapper_text
+
+    @patch("nemo_evaluator.benchmarks.terminal_bench_v1._git")
+    def test_patches_existing_cached_install_windows_xp_entrypoint(self, mock_git, tmp_path):
+        output_dir = tmp_path / "terminal-bench@1.0"
+        env_dir = output_dir / "install-windows-xp" / "environment"
+        env_dir.mkdir(parents=True)
+        (output_dir / "install-windows-xp" / "instruction.md").write_text("Install XP")
+        (output_dir / ".tbv1_mapped").touch()
+        (env_dir / "Dockerfile").write_text(INSTALL_WINDOWS_XP_DOCKERFILE)
+
+        output = _ensure_dataset(datasets_dir=str(tmp_path))
+
+        assert output == output_dir
+        assert mock_git.call_count == 0
+        assert 'ENTRYPOINT ["/nel-entrypoint.sh"]' in (env_dir / "Dockerfile").read_text()
+        assert 'exec "$@"' in (env_dir / "nel-entrypoint.sh").read_text()
+
+    @patch("nemo_evaluator.benchmarks.terminal_bench_v1._git")
+    def test_skips_install_windows_xp_patch_when_entrypoint_changes(self, mock_git, tmp_path):
+        output_dir = tmp_path / "terminal-bench@1.0"
+        env_dir = output_dir / "install-windows-xp" / "environment"
+        env_dir.mkdir(parents=True)
+        (output_dir / "install-windows-xp" / "instruction.md").write_text("Install XP")
+        (output_dir / ".tbv1_mapped").touch()
+        (env_dir / "Dockerfile").write_text('FROM ubuntu:24.04\nENTRYPOINT ["/custom-entrypoint.sh"]\n')
+
+        output = _ensure_dataset(datasets_dir=str(tmp_path))
+
+        assert output == output_dir
+        assert mock_git.call_count == 0
+        assert not (env_dir / "nel-entrypoint.sh").exists()
+        assert 'ENTRYPOINT ["/custom-entrypoint.sh"]' in (env_dir / "Dockerfile").read_text()
+
 
 class TestRegistration:
     def test_registered_as_builtin(self):
@@ -144,3 +206,41 @@ class TestRegistration:
         env = TerminalBenchV1(num_examples=1)
         assert env.name == tmp_path.name
         mock_ensure.assert_called_once()
+
+
+class TestTerminalBenchHard:
+    def test_registered_as_builtin(self):
+        from nemo_evaluator.environments.registry import _REGISTRY
+
+        assert "terminal-bench-hard" in _REGISTRY
+        assert _REGISTRY["terminal-bench-hard"] is TerminalBenchHard
+
+    def test_task_list_has_47_entries(self):
+        assert len(_TB_HARD_TASKS) == 47
+
+    @patch("nemo_evaluator.benchmarks.terminal_bench_hard._ensure_dataset")
+    def test_init_calls_ensure_dataset(self, mock_ensure, tmp_path):
+        for name in ["task-a", "task-b"]:
+            task_dir = tmp_path / name
+            task_dir.mkdir()
+            (task_dir / "instruction.md").write_text("Do something")
+
+        mock_ensure.return_value = tmp_path
+
+        TerminalBenchHard()
+        mock_ensure.assert_called_once()
+
+    @patch("nemo_evaluator.benchmarks.terminal_bench_hard._ensure_dataset")
+    def test_filters_to_known_tasks(self, mock_ensure, tmp_path):
+        for name in ["aimo-airline-departures", "unknown-task", "blind-maze-explorer-5x5"]:
+            task_dir = tmp_path / name
+            task_dir.mkdir()
+            (task_dir / "instruction.md").write_text("Do something")
+
+        mock_ensure.return_value = tmp_path
+
+        env = TerminalBenchHard()
+        task_names = {t.name for t in env._tasks}
+        assert "aimo-airline-departures" in task_names
+        assert "blind-maze-explorer-5x5" in task_names
+        assert "unknown-task" not in task_names

--- a/tests/test_pinchbench_judge.py
+++ b/tests/test_pinchbench_judge.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for PinchBench judge helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from nemo_evaluator.benchmarks.pinchbench import (
+    _TRANSCRIPT_SUMMARY_MAX_CHARS,
+    _WORKSPACE_BLOB_MAX_CHARS,
+    _make_pinchbench_judge_fn,
+    _read_workspace_files_for_judge,
+    _summarize_transcript,
+)
+
+
+class TestSummarizeTranscript:
+    def test_user_content_dict_is_unwrapped(self) -> None:
+        transcript = [
+            {
+                "type": "message",
+                "message": {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "hello there"}],
+                },
+            }
+        ]
+        out = _summarize_transcript(transcript)
+        assert "User: hello there" in out
+        assert "{'type'" not in out and "'text':" not in out
+
+    def test_user_content_plain_string_preserved(self) -> None:
+        out = _summarize_transcript(
+            [
+                {
+                    "type": "message",
+                    "message": {"role": "user", "content": "plain"},
+                }
+            ]
+        )
+        assert out == "User: plain"
+
+    def test_total_ceiling_applied_with_truncation_marker(self) -> None:
+        big_text = "x" * 5000
+        transcript = [
+            {
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": big_text}],
+                },
+            }
+            for _ in range(100)
+        ]
+        out = _summarize_transcript(transcript)
+        assert "[transcript truncated]" in out
+        assert len(out) <= _TRANSCRIPT_SUMMARY_MAX_CHARS + 64
+
+    def test_empty_transcript_returns_empty_string(self) -> None:
+        assert _summarize_transcript([]) == ""
+
+    def test_non_dict_events_skipped(self) -> None:
+        assert _summarize_transcript(["not a dict", None, 7]) == ""  # type: ignore[list-item]
+
+
+class TestReadWorkspaceFiles:
+    def test_binary_file_is_listed_not_dropped(self, tmp_path: Path) -> None:
+        (tmp_path / "report.pdf").write_bytes(b"\xff\xfe\xfd\xfc fakepdf")
+        out = _read_workspace_files_for_judge(str(tmp_path))
+        assert "report.pdf" in out
+        assert "binary or unreadable" in out
+
+    def test_boilerplate_and_transcript_are_skipped(self, tmp_path: Path) -> None:
+        (tmp_path / "BOOTSTRAP.md").write_text("boilerplate")
+        (tmp_path / ".nel_transcript.jsonl").write_text('{"type":"message"}')
+        (tmp_path / "deliverable.md").write_text("the answer")
+
+        out = _read_workspace_files_for_judge(str(tmp_path))
+        assert "deliverable.md" in out
+        assert "BOOTSTRAP.md" not in out
+        assert ".nel_transcript.jsonl" not in out
+
+    def test_total_cap_stops_listing_and_appends_marker(self, tmp_path: Path) -> None:
+        for i in range(200):
+            (tmp_path / f"f{i:03d}.txt").write_text("z" * 2000)
+
+        out = _read_workspace_files_for_judge(str(tmp_path))
+        assert "[workspace listing truncated]" in out
+        assert len(out) <= _WORKSPACE_BLOB_MAX_CHARS + 4096
+
+    def test_missing_workspace_returns_empty(self, tmp_path: Path) -> None:
+        assert _read_workspace_files_for_judge("") == ""
+        assert _read_workspace_files_for_judge(str(tmp_path / "nope")) == ""
+
+
+@dataclass
+class _FakeResp:
+    content: str
+    model: str = "fake-judge"
+    total_tokens: int = 10
+    latency_ms: float = 1.0
+
+
+class _AlwaysRaisingJudge:
+    async def chat(self, *, prompt: str, system: str) -> _FakeResp:  # noqa: ARG002
+        raise RuntimeError("gateway 429")
+
+
+class _OkJudge:
+    def __init__(self, content: str) -> None:
+        self._content = content
+
+    async def chat(self, *, prompt: str, system: str) -> _FakeResp:  # noqa: ARG002
+        return _FakeResp(content=self._content)
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("nemo_evaluator.benchmarks.pinchbench._JUDGE_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr("nemo_evaluator.benchmarks.pinchbench._JUDGE_BASE_DELAY_S", 0.0)
+    monkeypatch.setattr("nemo_evaluator.benchmarks.pinchbench._JUDGE_MAX_DELAY_S", 0.0)
+
+
+class TestJudgeFnFallback:
+    def test_hybrid_falls_back_to_automated_on_repeated_failure(self) -> None:
+        fn = _make_pinchbench_judge_fn(
+            judge_prompt="prompt",
+            automated_score=0.7,
+            grading_weights=None,
+            grading_type="hybrid",
+        )
+        result = asyncio.run(fn(_AlwaysRaisingJudge()))
+        assert result["reward"] == pytest.approx(0.7)
+        assert result["judge"]["total"] is None
+        assert "error" in result["judge"]
+        assert result["details"]["hybrid_combine"]["judge_failed"] is True
+        assert result["details"]["hybrid_combine"]["automated"] == pytest.approx(0.7)
+
+    def test_llm_judge_returns_none_reward_on_failure(self) -> None:
+        fn = _make_pinchbench_judge_fn(
+            judge_prompt="prompt",
+            automated_score=None,
+            grading_weights=None,
+            grading_type="llm_judge",
+        )
+        result = asyncio.run(fn(_AlwaysRaisingJudge()))
+        assert result["reward"] is None
+        assert "error" in result["judge"]
+
+    def test_happy_path_parses_and_combines(self) -> None:
+        payload = '{"scores": {"a": 1.0, "b": 0.5}, "total": 0.75, "notes": "ok"}'
+        fn = _make_pinchbench_judge_fn(
+            judge_prompt="prompt",
+            automated_score=0.5,
+            grading_weights={"automated": 0.5, "llm_judge": 0.5},
+            grading_type="hybrid",
+        )
+        result = asyncio.run(fn(_OkJudge(payload)))
+        assert result["reward"] == pytest.approx(0.625)
+        assert result["judge"]["total"] == pytest.approx(0.75)
+        assert result["details"]["hybrid_combine"]["judge"] == pytest.approx(0.75)

--- a/tests/test_solvers/atif_validator.py
+++ b/tests/test_solvers/atif_validator.py
@@ -1,0 +1,377 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""ATIF v1.6 trajectory validator (test-only utility).
+
+``strict=True`` additionally requires at least one user/system step
+whenever the trajectory contains meaningful agent activity.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+__all__ = [
+    "validate_atif",
+    "is_valid_atif",
+    "ATIFValidationError",
+    "assert_atif_compliant",
+]
+
+_VALID_SOURCES = frozenset({"system", "user", "agent"})
+_VALID_MEDIA_TYPES = frozenset({"image/jpeg", "image/png", "image/gif", "image/webp"})
+
+_AGENT_ONLY_FIELDS = frozenset({"model_name", "reasoning_effort", "reasoning_content", "tool_calls", "metrics"})
+
+_ISO8601_RE = re.compile(r"^\d{4}-\d{2}-\d{2}(?:T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)?$")
+
+
+class ATIFValidationError(AssertionError):
+    pass
+
+
+def is_valid_atif(doc: Any, *, strict: bool = False) -> bool:
+    return not validate_atif(doc, strict=strict)
+
+
+def assert_atif_compliant(doc: Any, *, strict: bool = False) -> None:
+    errors = validate_atif(doc, strict=strict)
+    if errors:
+        bullet_list = "\n  - ".join(errors)
+        raise ATIFValidationError(f"ATIF validation failed:\n  - {bullet_list}")
+
+
+def validate_atif(doc: Any, *, strict: bool = False) -> list[str]:
+    """Return a list of ATIF validation errors, empty if compliant.
+
+    Accepts either the root document or a single-element list wrapper.
+    """
+    if isinstance(doc, list):
+        if len(doc) != 1:
+            return [f"root: expected a single-document list wrapper, got list of length {len(doc)}"]
+        doc = doc[0]
+
+    if not isinstance(doc, dict):
+        return [f"root: expected dict, got {type(doc).__name__}"]
+
+    errors: list[str] = []
+    errors.extend(_check_root(doc))
+    steps = doc.get("steps")
+    if isinstance(steps, list):
+        errors.extend(_check_steps(steps))
+        if strict:
+            errors.extend(_check_completeness(steps))
+    errors.extend(_check_final_metrics(doc.get("final_metrics")))
+    errors.extend(_check_agent(doc.get("agent")))
+    return errors
+
+
+def _check_root(doc: dict[str, Any]) -> Iterable[str]:
+    required = {"schema_version": str, "session_id": str, "agent": dict, "steps": list}
+    for field, expected_type in required.items():
+        if field not in doc:
+            yield f"root: missing required field '{field}'"
+            continue
+        if not isinstance(doc[field], expected_type):
+            yield f"root.{field}: expected {expected_type.__name__}, got {type(doc[field]).__name__}"
+
+    schema_version = doc.get("schema_version")
+    if isinstance(schema_version, str) and not schema_version.startswith("ATIF-"):
+        yield f"root.schema_version: must start with 'ATIF-', got {schema_version!r}"
+
+    session_id = doc.get("session_id")
+    if isinstance(session_id, str) and not session_id.strip():
+        yield "root.session_id: must be non-empty"
+
+    steps = doc.get("steps")
+    if isinstance(steps, list) and len(steps) == 0:
+        yield "root.steps: must be non-empty"
+
+    for optional_obj_field in ("extra", "final_metrics"):
+        val = doc.get(optional_obj_field)
+        if val is not None and not isinstance(val, dict):
+            yield f"root.{optional_obj_field}: expected dict, got {type(val).__name__}"
+
+
+def _check_agent(agent: Any) -> Iterable[str]:
+    if agent is None:
+        return
+    if not isinstance(agent, dict):
+        return
+    for required in ("name", "version"):
+        val = agent.get(required)
+        if not isinstance(val, str) or not val.strip():
+            yield f"root.agent.{required}: missing or empty (must be non-empty string)"
+    for optional_str in ("model_name",):
+        val = agent.get(optional_str)
+        if val is not None and not isinstance(val, str):
+            yield f"root.agent.{optional_str}: expected string when present"
+    tool_defs = agent.get("tool_definitions")
+    if tool_defs is not None:
+        if not isinstance(tool_defs, list):
+            yield "root.agent.tool_definitions: expected list when present"
+        else:
+            for i, tdef in enumerate(tool_defs):
+                if not isinstance(tdef, dict):
+                    yield f"root.agent.tool_definitions[{i}]: expected dict"
+                    continue
+                if tdef.get("type") != "function":
+                    yield f"root.agent.tool_definitions[{i}].type: expected 'function'"
+                if not isinstance(tdef.get("function"), dict):
+                    yield f"root.agent.tool_definitions[{i}].function: expected dict"
+
+
+def _check_final_metrics(fm: Any) -> Iterable[str]:
+    if fm is None:
+        return
+    if not isinstance(fm, dict):
+        return
+    int_fields = ("total_prompt_tokens", "total_completion_tokens", "total_cached_tokens", "total_steps")
+    for f in int_fields:
+        v = fm.get(f)
+        if v is not None and not isinstance(v, int):
+            yield f"root.final_metrics.{f}: expected int when present, got {type(v).__name__}"
+    cost = fm.get("total_cost_usd")
+    if cost is not None and not isinstance(cost, (int, float)):
+        yield f"root.final_metrics.total_cost_usd: expected number, got {type(cost).__name__}"
+    extra = fm.get("extra")
+    if extra is not None and not isinstance(extra, dict):
+        yield "root.final_metrics.extra: expected dict when present"
+
+
+def _check_steps(steps: list[Any]) -> Iterable[str]:
+    seen_tool_call_ids: set[str] = set()
+    tool_calls_by_step: dict[int, set[str]] = {}
+
+    for idx, step in enumerate(steps):
+        prefix = f"steps[{idx}]"
+        if not isinstance(step, dict):
+            yield f"{prefix}: expected dict, got {type(step).__name__}"
+            continue
+
+        step_id = step.get("step_id")
+        if not isinstance(step_id, int) or isinstance(step_id, bool):
+            yield f"{prefix}.step_id: required int, got {type(step_id).__name__}"
+        else:
+            expected = idx + 1
+            if step_id != expected:
+                yield (f"{prefix}.step_id: expected sequential ordinal {expected} (1-based), got {step_id}")
+
+        source = step.get("source")
+        if source not in _VALID_SOURCES:
+            yield f"{prefix}.source: must be one of {sorted(_VALID_SOURCES)}, got {source!r}"
+
+        if "message" not in step:
+            yield f"{prefix}.message: required field missing"
+        else:
+            yield from _check_message_field(step["message"], f"{prefix}.message")
+
+        timestamp = step.get("timestamp")
+        if timestamp is not None:
+            if not isinstance(timestamp, str) or not _ISO8601_RE.match(timestamp):
+                yield f"{prefix}.timestamp: not a valid ISO 8601 string: {timestamp!r}"
+
+        for field_name in _AGENT_ONLY_FIELDS:
+            if field_name in step and source != "agent":
+                yield (f"{prefix}.{field_name}: only allowed on agent steps, found on {source!r} step")
+
+        tool_calls = step.get("tool_calls")
+        if tool_calls is not None:
+            if not isinstance(tool_calls, list):
+                yield f"{prefix}.tool_calls: expected list when present"
+            else:
+                step_ids: set[str] = set()
+                for ti, call in enumerate(tool_calls):
+                    if not isinstance(call, dict):
+                        yield f"{prefix}.tool_calls[{ti}]: expected dict"
+                        continue
+                    yield from _check_tool_call(call, f"{prefix}.tool_calls[{ti}]")
+                    tcid = call.get("tool_call_id")
+                    if isinstance(tcid, str):
+                        if tcid in seen_tool_call_ids:
+                            yield f"{prefix}.tool_calls[{ti}].tool_call_id: duplicate id {tcid!r}"
+                        else:
+                            seen_tool_call_ids.add(tcid)
+                            step_ids.add(tcid)
+                if step_ids:
+                    tool_calls_by_step[idx] = step_ids
+
+        observation = step.get("observation")
+        if observation is not None:
+            yield from _check_observation(
+                observation,
+                f"{prefix}.observation",
+                tool_call_ids_this_step=tool_calls_by_step.get(idx, set()),
+                all_tool_call_ids=seen_tool_call_ids,
+            )
+
+        metrics = step.get("metrics")
+        if metrics is not None:
+            if source != "agent":
+                # Already emitted by _AGENT_ONLY_FIELDS block above.
+                continue
+            yield from _check_metrics(metrics, f"{prefix}.metrics")
+
+
+def _check_message_field(msg: Any, path: str) -> Iterable[str]:
+    if isinstance(msg, str):
+        return
+    if isinstance(msg, list):
+        for i, part in enumerate(msg):
+            yield from _check_content_part(part, f"{path}[{i}]")
+        return
+    yield f"{path}: expected string or list of ContentPart objects, got {type(msg).__name__}"
+
+
+def _check_content_part(part: Any, path: str) -> Iterable[str]:
+    if not isinstance(part, dict):
+        yield f"{path}: expected dict ContentPart, got {type(part).__name__}"
+        return
+    ptype = part.get("type")
+    if ptype not in ("text", "image"):
+        yield f"{path}.type: must be 'text' or 'image', got {ptype!r}"
+        return
+    if ptype == "text":
+        if "text" not in part or not isinstance(part["text"], str):
+            yield f"{path}.text: required string for text parts"
+        if "source" in part:
+            yield f"{path}.source: must be omitted when type='text'"
+    else:
+        if "source" not in part or not isinstance(part["source"], dict):
+            yield f"{path}.source: required dict for image parts"
+        else:
+            src = part["source"]
+            if src.get("media_type") not in _VALID_MEDIA_TYPES:
+                yield f"{path}.source.media_type: must be one of {sorted(_VALID_MEDIA_TYPES)}"
+            if not isinstance(src.get("path"), str) or not src["path"]:
+                yield f"{path}.source.path: required non-empty string"
+        if "text" in part:
+            yield f"{path}.text: must be omitted when type='image'"
+
+
+def _check_tool_call(call: dict[str, Any], path: str) -> Iterable[str]:
+    tcid = call.get("tool_call_id")
+    if not isinstance(tcid, str) or not tcid:
+        yield f"{path}.tool_call_id: required non-empty string"
+    fname = call.get("function_name")
+    if not isinstance(fname, str) or not fname:
+        yield f"{path}.function_name: required non-empty string"
+    args = call.get("arguments")
+    if not isinstance(args, dict):
+        yield f"{path}.arguments: required dict (may be empty), got {type(args).__name__}"
+
+
+def _check_observation(
+    obs: Any,
+    path: str,
+    *,
+    tool_call_ids_this_step: set[str],
+    all_tool_call_ids: set[str],
+) -> Iterable[str]:
+    if not isinstance(obs, dict):
+        yield f"{path}: expected dict, got {type(obs).__name__}"
+        return
+    results = obs.get("results")
+    if not isinstance(results, list):
+        yield f"{path}.results: required list, got {type(results).__name__}"
+        return
+    for ri, res in enumerate(results):
+        if not isinstance(res, dict):
+            yield f"{path}.results[{ri}]: expected dict"
+            continue
+        scid = res.get("source_call_id")
+        if scid is not None:
+            if not isinstance(scid, str):
+                yield f"{path}.results[{ri}].source_call_id: expected string when present"
+            elif scid not in all_tool_call_ids:
+                yield (
+                    f"{path}.results[{ri}].source_call_id: {scid!r} does not reference any "
+                    f"known tool_call_id in the trajectory"
+                )
+        content = res.get("content")
+        if content is not None:
+            if isinstance(content, str):
+                pass
+            elif isinstance(content, list):
+                for ci, part in enumerate(content):
+                    yield from _check_content_part(part, f"{path}.results[{ri}].content[{ci}]")
+            else:
+                yield (
+                    f"{path}.results[{ri}].content: expected string or list of ContentPart, "
+                    f"got {type(content).__name__}"
+                )
+        sub_ref = res.get("subagent_trajectory_ref")
+        if sub_ref is not None:
+            if not isinstance(sub_ref, list):
+                yield f"{path}.results[{ri}].subagent_trajectory_ref: expected list when present"
+            else:
+                for si, sub in enumerate(sub_ref):
+                    if not isinstance(sub, dict):
+                        yield f"{path}.results[{ri}].subagent_trajectory_ref[{si}]: expected dict"
+                        continue
+                    if not isinstance(sub.get("session_id"), str) or not sub["session_id"]:
+                        yield (
+                            f"{path}.results[{ri}].subagent_trajectory_ref[{si}].session_id: required non-empty string"
+                        )
+
+
+def _check_metrics(metrics: Any, path: str) -> Iterable[str]:
+    if not isinstance(metrics, dict):
+        yield f"{path}: expected dict, got {type(metrics).__name__}"
+        return
+    int_fields = ("prompt_tokens", "completion_tokens", "cached_tokens")
+    for f in int_fields:
+        v = metrics.get(f)
+        if v is not None and (not isinstance(v, int) or isinstance(v, bool)):
+            yield f"{path}.{f}: expected int when present, got {type(v).__name__}"
+    cost = metrics.get("cost_usd")
+    if cost is not None and not isinstance(cost, (int, float)):
+        yield f"{path}.cost_usd: expected number when present, got {type(cost).__name__}"
+    for arr_field in ("prompt_token_ids", "completion_token_ids", "logprobs"):
+        v = metrics.get(arr_field)
+        if v is not None and not isinstance(v, list):
+            yield f"{path}.{arr_field}: expected list when present"
+
+    prompt_tokens = metrics.get("prompt_tokens")
+    cached_tokens = metrics.get("cached_tokens")
+    if isinstance(prompt_tokens, int) and isinstance(cached_tokens, int) and cached_tokens > prompt_tokens:
+        yield (
+            f"{path}.cached_tokens ({cached_tokens}) exceeds prompt_tokens ({prompt_tokens}); "
+            f"per ATIF v1.2, cached_tokens is a subset of prompt_tokens"
+        )
+
+
+def _check_completeness(steps: list[Any]) -> Iterable[str]:
+    """Require a user/system step when the trajectory has agent activity."""
+    has_user_or_system = False
+    has_meaningful_agent = False
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        src = step.get("source")
+        if src in ("user", "system"):
+            has_user_or_system = True
+        elif src == "agent":
+            msg = step.get("message")
+            msg_nonempty = (isinstance(msg, str) and msg.strip()) or (isinstance(msg, list) and any(msg))
+            if msg_nonempty or step.get("tool_calls"):
+                has_meaningful_agent = True
+    if has_meaningful_agent and not has_user_or_system:
+        yield (
+            "root.steps: trajectory has agent activity but no user or system step; "
+            "ATIF defines a trajectory as 'the complete interaction history, including "
+            "all user messages (initial and subsequent)' -- the initiating user turn "
+            "must be recorded"
+        )

--- a/tests/test_solvers/test_atif_compliance.py
+++ b/tests/test_solvers/test_atif_compliance.py
@@ -1,0 +1,476 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""ATIF v1.6 compliance tests for nel-next trajectory builders."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+from nemo_evaluator.solvers.trajectory_util import (
+    build_atif_trajectory,
+    build_single_turn_atif,
+)
+
+from .atif_validator import (
+    ATIFValidationError,
+    assert_atif_compliant,
+    is_valid_atif,
+    validate_atif,
+)
+
+
+def _good_doc() -> dict:
+    return {
+        "schema_version": "ATIF-v1.6",
+        "session_id": "025B810F-B3A2-4C67-93C0-FE7A142A947A",
+        "agent": {"name": "harbor-agent", "version": "1.0.0", "model_name": "gemini-2.5-flash"},
+        "steps": [
+            {
+                "step_id": 1,
+                "timestamp": "2025-10-11T10:30:00Z",
+                "source": "user",
+                "message": "What is the current trading price of Alphabet (GOOGL)?",
+            },
+            {
+                "step_id": 2,
+                "timestamp": "2025-10-11T10:30:02Z",
+                "source": "agent",
+                "model_name": "gemini-2.5-flash",
+                "message": "I will search for the current trading price and volume for GOOGL.",
+                "tool_calls": [
+                    {
+                        "tool_call_id": "call_price_1",
+                        "function_name": "financial_search",
+                        "arguments": {"ticker": "GOOGL", "metric": "price"},
+                    }
+                ],
+                "observation": {
+                    "results": [{"source_call_id": "call_price_1", "content": "GOOGL is trading at $185.35"}]
+                },
+                "metrics": {"prompt_tokens": 520, "completion_tokens": 80, "cached_tokens": 200},
+            },
+        ],
+        "final_metrics": {"total_prompt_tokens": 520, "total_completion_tokens": 80, "total_steps": 2},
+    }
+
+
+class TestHappyPath:
+    def test_rfc_example_validates_strict(self):
+        assert validate_atif(_good_doc(), strict=True) == []
+        assert is_valid_atif(_good_doc(), strict=True) is True
+
+    def test_accepts_list_wrapper(self):
+        assert validate_atif([_good_doc()]) == []
+
+    def test_minimum_viable_trajectory(self):
+        doc = {
+            "schema_version": "ATIF-v1.6",
+            "session_id": "x",
+            "agent": {"name": "a", "version": "1"},
+            "steps": [{"step_id": 1, "source": "user", "message": "hi"}],
+        }
+        assert validate_atif(doc, strict=True) == []
+
+    def test_empty_message_string_is_allowed(self):
+        """RFC: 'This field is required but can be an empty string.'"""
+        doc = _good_doc()
+        doc["steps"].append({"step_id": 3, "source": "agent", "message": ""})
+        assert validate_atif(doc, strict=True) == []
+
+    def test_assert_helper_no_error_on_valid(self):
+        assert_atif_compliant(_good_doc(), strict=True)
+
+
+class TestRootLevelViolations:
+    @pytest.mark.parametrize("field", ["schema_version", "session_id", "agent", "steps"])
+    def test_missing_required_field(self, field):
+        doc = _good_doc()
+        del doc[field]
+        errors = validate_atif(doc)
+        assert any(f"missing required field '{field}'" in e for e in errors), errors
+
+    def test_schema_version_must_start_with_atif(self):
+        doc = _good_doc()
+        doc["schema_version"] = "v1.6"
+        errors = validate_atif(doc)
+        assert any("must start with 'ATIF-'" in e for e in errors), errors
+
+    def test_empty_session_id_rejected(self):
+        doc = _good_doc()
+        doc["session_id"] = ""
+        errors = validate_atif(doc)
+        assert any("session_id: must be non-empty" in e for e in errors), errors
+
+    def test_empty_steps_rejected(self):
+        doc = _good_doc()
+        doc["steps"] = []
+        errors = validate_atif(doc)
+        assert any("steps: must be non-empty" in e for e in errors), errors
+
+    def test_wrong_root_type(self):
+        assert "expected dict" in validate_atif("not a doc")[0]
+        assert "single-document list wrapper" in validate_atif([1, 2])[0]
+
+
+class TestAgentSchema:
+    @pytest.mark.parametrize("field", ["name", "version"])
+    def test_agent_missing_required(self, field):
+        doc = _good_doc()
+        del doc["agent"][field]
+        errors = validate_atif(doc)
+        assert any(f"root.agent.{field}" in e for e in errors), errors
+
+    def test_agent_empty_name_rejected(self):
+        doc = _good_doc()
+        doc["agent"]["name"] = ""
+        errors = validate_atif(doc)
+        assert any("root.agent.name" in e for e in errors), errors
+
+    def test_agent_tool_definitions_validated(self):
+        doc = _good_doc()
+        doc["agent"]["tool_definitions"] = [{"type": "not_function", "function": {}}]
+        errors = validate_atif(doc)
+        assert any("tool_definitions[0].type" in e for e in errors), errors
+
+
+class TestStepViolations:
+    def test_non_sequential_step_ids(self):
+        doc = _good_doc()
+        doc["steps"][1]["step_id"] = 99
+        errors = validate_atif(doc)
+        assert any("step_id: expected sequential ordinal 2" in e for e in errors), errors
+
+    def test_string_step_id_rejected(self):
+        doc = _good_doc()
+        doc["steps"][0]["step_id"] = "1"
+        errors = validate_atif(doc)
+        assert any("step_id: required int" in e for e in errors), errors
+
+    def test_invalid_source_enum(self):
+        doc = _good_doc()
+        doc["steps"][0]["source"] = "assistant"
+        errors = validate_atif(doc)
+        assert any("source: must be one of" in e for e in errors), errors
+
+    def test_missing_message_rejected(self):
+        doc = _good_doc()
+        del doc["steps"][0]["message"]
+        errors = validate_atif(doc)
+        assert any("message: required field missing" in e for e in errors), errors
+
+    def test_non_string_non_list_message_rejected(self):
+        doc = _good_doc()
+        doc["steps"][0]["message"] = 42
+        errors = validate_atif(doc)
+        assert any("message: expected string or list" in e for e in errors), errors
+
+    def test_bad_timestamp_rejected(self):
+        doc = _good_doc()
+        doc["steps"][0]["timestamp"] = "10/11/2025"
+        errors = validate_atif(doc)
+        assert any("timestamp: not a valid ISO 8601" in e for e in errors), errors
+
+    @pytest.mark.parametrize("field", ["model_name", "reasoning_effort", "reasoning_content", "tool_calls", "metrics"])
+    def test_agent_only_fields_rejected_on_user_step(self, field):
+        doc = _good_doc()
+        doc["steps"][0][field] = "x" if field != "tool_calls" else []
+        errors = validate_atif(doc)
+        assert any(f".{field}: only allowed on agent steps" in e for e in errors), errors
+
+
+class TestToolCallViolations:
+    def _step_with_tool_calls(self, **overrides):
+        call = {
+            "tool_call_id": "t1",
+            "function_name": "my_fn",
+            "arguments": {"x": 1},
+        }
+        call.update(overrides)
+        doc = _good_doc()
+        doc["steps"][1]["tool_calls"] = [call]
+        doc["steps"][1]["observation"] = {"results": []}
+        return doc
+
+    def test_missing_tool_call_id(self):
+        errors = validate_atif(self._step_with_tool_calls(tool_call_id=""))
+        assert any("tool_call_id: required non-empty string" in e for e in errors), errors
+
+    def test_missing_function_name(self):
+        errors = validate_atif(self._step_with_tool_calls(function_name=""))
+        assert any("function_name: required non-empty string" in e for e in errors), errors
+
+    def test_non_dict_arguments(self):
+        errors = validate_atif(self._step_with_tool_calls(arguments="raw"))
+        assert any("arguments: required dict" in e for e in errors), errors
+
+    def test_empty_arguments_allowed(self):
+        assert validate_atif(self._step_with_tool_calls(arguments={})) == []
+
+    def test_duplicate_tool_call_ids_rejected(self):
+        doc = _good_doc()
+        doc["steps"][1]["tool_calls"] = [
+            {"tool_call_id": "dup", "function_name": "a", "arguments": {}},
+            {"tool_call_id": "dup", "function_name": "b", "arguments": {}},
+        ]
+        errors = validate_atif(doc)
+        assert any("duplicate id 'dup'" in e for e in errors), errors
+
+
+class TestObservationViolations:
+    def test_results_required(self):
+        doc = _good_doc()
+        doc["steps"][1]["observation"] = {}
+        errors = validate_atif(doc)
+        assert any("observation.results: required list" in e for e in errors), errors
+
+    def test_source_call_id_must_reference_tool_call(self):
+        doc = _good_doc()
+        doc["steps"][1]["observation"] = {"results": [{"source_call_id": "phantom_id", "content": "..."}]}
+        errors = validate_atif(doc)
+        assert any("source_call_id: 'phantom_id' does not reference any known tool_call_id" in e for e in errors), (
+            errors
+        )
+
+    def test_null_source_call_id_allowed_for_non_tool_actions(self):
+        doc = _good_doc()
+        doc["steps"][1].pop("tool_calls")
+        doc["steps"][1]["observation"] = {"results": [{"content": "raw action output"}]}
+        assert validate_atif(doc) == []
+
+    def test_subagent_trajectory_ref_requires_session_id(self):
+        doc = _good_doc()
+        doc["steps"][1].pop("tool_calls")
+        doc["steps"][1]["observation"] = {"results": [{"subagent_trajectory_ref": [{"trajectory_path": "s3://x"}]}]}
+        errors = validate_atif(doc)
+        assert any("session_id: required non-empty string" in e for e in errors), errors
+
+
+class TestMultimodalContent:
+    def test_valid_text_and_image_content_parts(self):
+        doc = _good_doc()
+        doc["steps"][0]["message"] = [
+            {"type": "text", "text": "What is in this image?"},
+            {
+                "type": "image",
+                "source": {"media_type": "image/png", "path": "images/q.png"},
+            },
+        ]
+        assert validate_atif(doc) == []
+
+    def test_image_part_rejects_text_field(self):
+        doc = _good_doc()
+        doc["steps"][0]["message"] = [
+            {"type": "image", "text": "stray", "source": {"media_type": "image/png", "path": "p"}}
+        ]
+        errors = validate_atif(doc)
+        assert any("must be omitted when type='image'" in e for e in errors), errors
+
+    def test_unsupported_media_type_rejected(self):
+        doc = _good_doc()
+        doc["steps"][0]["message"] = [{"type": "image", "source": {"media_type": "image/bmp", "path": "p"}}]
+        errors = validate_atif(doc)
+        assert any("media_type: must be one of" in e for e in errors), errors
+
+
+class TestMetrics:
+    def test_cached_tokens_exceeding_prompt_tokens_rejected(self):
+        doc = _good_doc()
+        doc["steps"][1]["metrics"] = {"prompt_tokens": 10, "cached_tokens": 20}
+        errors = validate_atif(doc)
+        assert any("cached_tokens (20) exceeds prompt_tokens" in e for e in errors), errors
+
+    def test_wrong_types_rejected(self):
+        doc = _good_doc()
+        doc["steps"][1]["metrics"] = {"prompt_tokens": "520"}
+        errors = validate_atif(doc)
+        assert any("prompt_tokens: expected int" in e for e in errors), errors
+
+
+class TestCompletenessStrict:
+    def test_agent_only_trajectory_strict_violation(self):
+        doc = {
+            "schema_version": "ATIF-v1.6",
+            "session_id": "x",
+            "agent": {"name": "openclaw", "version": "1.0.0"},
+            "steps": [
+                {"step_id": 1, "source": "agent", "message": "The answer is 42."},
+                {"step_id": 2, "source": "agent", "message": "Saved to answer.txt."},
+            ],
+        }
+        assert validate_atif(doc, strict=False) == []
+        errors = validate_atif(doc, strict=True)
+        assert any("trajectory has agent activity but no user or system step" in e for e in errors), errors
+
+    def test_error_only_trajectory_not_flagged(self):
+        doc = {
+            "schema_version": "ATIF-v1.6",
+            "session_id": "x",
+            "agent": {"name": "openclaw", "version": "1.0.0"},
+            "steps": [{"step_id": 1, "source": "system", "message": "exit code 1"}],
+        }
+        assert validate_atif(doc, strict=True) == []
+
+    def test_empty_agent_turns_not_flagged(self):
+        doc = {
+            "schema_version": "ATIF-v1.6",
+            "session_id": "x",
+            "agent": {"name": "openclaw", "version": "1.0.0"},
+            "steps": [{"step_id": 1, "source": "agent", "message": ""}],
+        }
+        assert validate_atif(doc, strict=True) == []
+
+
+class TestAssertHelper:
+    def test_raises_on_invalid(self):
+        doc = _good_doc()
+        del doc["schema_version"]
+        with pytest.raises(ATIFValidationError) as exc:
+            assert_atif_compliant(doc)
+        assert "missing required field 'schema_version'" in str(exc.value)
+
+    def test_strict_agent_only_raises(self):
+        doc = {
+            "schema_version": "ATIF-v1.6",
+            "session_id": "x",
+            "agent": {"name": "a", "version": "1"},
+            "steps": [{"step_id": 1, "source": "agent", "message": "done"}],
+        }
+        with pytest.raises(ATIFValidationError):
+            assert_atif_compliant(doc, strict=True)
+
+
+class TestBuildAtifTrajectoryCompliance:
+    def test_empty_steps_list_produces_valid_doc(self):
+        traj = build_atif_trajectory([], agent_name="a", agent_version="1")
+        errors = validate_atif(traj, strict=False)
+        assert any("steps: must be non-empty" in e for e in errors), errors
+
+    def test_minimal_user_turn_strict_compliant(self):
+        traj = build_atif_trajectory(
+            [{"source": "user", "message": "hi"}, {"source": "agent", "message": "hello"}],
+            agent_name="test",
+            agent_version="0.0.1",
+        )
+        assert_atif_compliant(traj, strict=True)
+
+    def test_step_ids_are_auto_numbered(self):
+        traj = build_atif_trajectory(
+            [{"source": "user", "message": "a"}, {"source": "agent", "message": "b"}],
+        )
+        assert [s["step_id"] for s in traj[0]["steps"]] == [1, 2]
+
+    def test_step_ids_are_renumbered_even_when_caller_provides_bad_values(self):
+        traj = build_atif_trajectory(
+            [
+                {"source": "user", "message": "a", "step_id": 99},
+                {"source": "agent", "message": "b", "step_id": 7},
+            ],
+        )
+        assert [s["step_id"] for s in traj[0]["steps"]] == [1, 2]
+        assert_atif_compliant(traj, strict=True)
+
+    def test_user_prompt_kwarg_prepends_user_step(self):
+        traj = build_atif_trajectory(
+            [{"source": "agent", "message": "I wrote the file."}],
+            user_prompt="Create a file called hello.txt",
+        )
+        steps = traj[0]["steps"]
+        assert steps[0] == {
+            "source": "user",
+            "message": "Create a file called hello.txt",
+            "step_id": 1,
+        }
+        assert_atif_compliant(traj, strict=True)
+
+    def test_user_prompt_noop_when_steps_already_begin_with_user(self):
+        traj = build_atif_trajectory(
+            [
+                {"source": "user", "message": "original"},
+                {"source": "agent", "message": "response"},
+            ],
+            user_prompt="should be ignored",
+        )
+        assert traj[0]["steps"][0]["message"] == "original"
+        assert len(traj[0]["steps"]) == 2
+
+    def test_user_prompt_noop_when_steps_begin_with_system(self):
+        traj = build_atif_trajectory(
+            [
+                {"source": "system", "message": "You are a helpful assistant."},
+                {"source": "agent", "message": "ok"},
+            ],
+            user_prompt="unused",
+        )
+        assert traj[0]["steps"][0]["source"] == "system"
+        assert len(traj[0]["steps"]) == 2
+
+    def test_user_prompt_with_system_prompt_creates_prelude(self):
+        traj = build_atif_trajectory(
+            [{"source": "agent", "message": "done"}],
+            user_prompt="do the thing",
+            system_prompt="Be helpful",
+        )
+        sources = [s["source"] for s in traj[0]["steps"]]
+        assert sources == ["system", "user", "agent"]
+        assert_atif_compliant(traj, strict=True)
+
+
+class TestBuildSingleTurnAtifCompliance:
+    def test_chat_like_single_turn_strict_compliant(self):
+        traj = build_single_turn_atif(
+            prompt="What is 2+2?",
+            response="4",
+            prompt_tokens=3,
+            completion_tokens=1,
+        )
+        assert_atif_compliant(traj, strict=True)
+        sources = [s["source"] for s in traj[0]["steps"]]
+        assert sources[:2] == ["user", "agent"]
+
+    def test_single_turn_with_system_prelude(self):
+        traj = build_single_turn_atif(
+            prompt="hi",
+            response="hello",
+            system="You are a concise assistant.",
+        )
+        assert [s["source"] for s in traj[0]["steps"]] == ["system", "user", "agent"]
+        assert_atif_compliant(traj, strict=True)
+
+    def test_empty_agent_response_still_strict_compliant(self):
+        traj = build_single_turn_atif(prompt="write answer.txt", response="")
+        assert_atif_compliant(traj, strict=True)
+
+
+class TestRegressionOpenClawStyleTrajectory:
+    AGENT_ONLY_STEPS = [
+        {"source": "agent", "message": "Let me check the transcript."},
+        {
+            "source": "agent",
+            "message": "",
+            "tool_calls": [{"tool_call_id": "c1", "function_name": "Read", "arguments": {"path": "t.md"}}],
+            "observation": {"results": [{"source_call_id": "c1", "content": "file contents"}]},
+        },
+        {"source": "agent", "message": "I've written the blog post."},
+    ]
+
+    def test_pre_fix_agent_only_trajectory_fails_strict(self):
+        traj = build_atif_trajectory(copy.deepcopy(self.AGENT_ONLY_STEPS), agent_name="openclaw")
+        assert validate_atif(traj, strict=False) == []
+        errors = validate_atif(traj, strict=True)
+        assert any("no user or system step" in e for e in errors), errors
+
+    def test_post_fix_passes_strict(self):
+        traj = build_atif_trajectory(
+            copy.deepcopy(self.AGENT_ONLY_STEPS),
+            agent_name="openclaw",
+            user_prompt="Summarize the meeting transcript into a blog post.",
+        )
+        assert_atif_compliant(traj, strict=True)
+
+        # The synthesized user step must preserve ATIF sequencing.
+        steps = traj[0]["steps"]
+        assert [s["step_id"] for s in steps] == list(range(1, len(steps) + 1))
+        assert steps[0]["source"] == "user"
+        assert steps[0]["message"].startswith("Summarize the meeting")

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -140,9 +140,9 @@ class TestClaudeCodeAgent:
     def test_ensure_claude_host_env_sets_anthropic_vars(self, monkeypatch):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
-        _ensure_claude_host_env("sk-abc", "https://integrate.api.nvidia.com")
+        _ensure_claude_host_env("sk-abc", "https://inference-api.nvidia.com")
         assert os.environ["ANTHROPIC_API_KEY"] == "sk-abc"
-        assert os.environ["ANTHROPIC_BASE_URL"] == "https://integrate.api.nvidia.com"
+        assert os.environ["ANTHROPIC_BASE_URL"] == "https://inference-api.nvidia.com"
 
     def test_ensure_claude_host_env_setdefault(self, monkeypatch):
         """Existing values must not be overwritten."""
@@ -191,7 +191,7 @@ class TestPatchOpenhandsSDK:
         sandbox = AsyncMock()
         sandbox.exec.return_value = MagicMock(stdout="stuck_detection disabled", stderr="", return_code=0)
         await _patch_openhands_sdk(sandbox)
-        assert sandbox.exec.call_count >= 4
+        assert sandbox.exec.call_count >= 3
 
     async def test_runner_patch_disables_visualizer(self):
         """Patch 0 must inject both stuck_detection=False AND visualizer=None.

--- a/tests/test_solvers/test_openclaw_transcript.py
+++ b/tests/test_solvers/test_openclaw_transcript.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for OpenClaw session transcript persistence.
+
+The PinchBench ``grade()`` contract (and other task-authored scorers)
+reads ``<workspace>/.nel_transcript.jsonl`` in the upstream OpenClaw
+envelope shape (``{"type": "message", "message": {...}}``).  The solver
+must write that file verbatim from the session JSONL it recovers from
+the container / local session store.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nemo_evaluator.solvers.openclaw import (
+    _TRANSCRIPT_FILENAME,
+    _parse_session_jsonl,
+    _persist_session_transcript,
+)
+
+
+class TestPersistSessionTranscript:
+    def test_writes_bytes_verbatim(self, tmp_path: Path) -> None:
+        """Raw JSONL is written unchanged so the envelope shape survives.
+
+        ``grade()`` functions iterate top-level records looking for
+        ``event["type"] == "message"`` and then descend into
+        ``event["message"]["content"]`` blocks.  Any transformation here
+        would invalidate that contract.
+        """
+        raw = "\n".join(
+            [
+                json.dumps(
+                    {"type": "message", "message": {"role": "user", "content": "hi"}},
+                ),
+                json.dumps(
+                    {
+                        "type": "message",
+                        "message": {
+                            "role": "assistant",
+                            "content": [
+                                {"type": "text", "text": "ok"},
+                                {
+                                    "type": "tool_use",
+                                    "id": "t1",
+                                    "name": "bash",
+                                    "input": {"command": "ls"},
+                                },
+                            ],
+                        },
+                    },
+                ),
+            ],
+        )
+
+        _persist_session_transcript(tmp_path, raw)
+
+        out = tmp_path / _TRANSCRIPT_FILENAME
+        assert out.exists()
+        assert out.read_text(encoding="utf-8") == raw
+
+    def test_filename_matches_scorer_contract(self) -> None:
+        """Scorer expects this exact filename; guard against drift."""
+        assert _TRANSCRIPT_FILENAME == ".nel_transcript.jsonl"
+
+    def test_missing_workspace_is_silent_noop(self, tmp_path: Path) -> None:
+        """A non-existent workspace must not raise — best-effort by design."""
+        missing = tmp_path / "does-not-exist"
+        _persist_session_transcript(missing, "anything")
+        assert not missing.exists()
+
+    def test_not_a_directory_is_silent_noop(self, tmp_path: Path) -> None:
+        """If the ``workspace`` path is a regular file, we must not crash."""
+        not_dir = tmp_path / "file.txt"
+        not_dir.write_text("x")
+        _persist_session_transcript(not_dir, "anything")
+        assert not_dir.read_text() == "x"
+
+    def test_overwrites_existing_transcript(self, tmp_path: Path) -> None:
+        """A previous stale transcript (resume, retry) is replaced cleanly."""
+        existing = tmp_path / _TRANSCRIPT_FILENAME
+        existing.write_text("stale content that must be replaced")
+
+        new = json.dumps(
+            {"type": "message", "message": {"role": "user", "content": "fresh"}},
+        )
+        _persist_session_transcript(tmp_path, new)
+        assert existing.read_text(encoding="utf-8") == new
+
+    def test_empty_transcript_produces_empty_file(self, tmp_path: Path) -> None:
+        """Empty string is still written — scorer treats missing vs empty alike."""
+        _persist_session_transcript(tmp_path, "")
+        assert (tmp_path / _TRANSCRIPT_FILENAME).read_text(encoding="utf-8") == ""
+
+    def test_unicode_and_control_chars_preserved(self, tmp_path: Path) -> None:
+        """Tool outputs often include UTF-8 text and embedded newlines; must round-trip."""
+        raw = json.dumps(
+            {
+                "type": "message",
+                "message": {
+                    "role": "tool",
+                    "content": "emoji 🦀, accent é, newline preserved line:\nline2",
+                },
+            },
+        )
+        _persist_session_transcript(tmp_path, raw)
+        out = (tmp_path / _TRANSCRIPT_FILENAME).read_text(encoding="utf-8")
+        assert json.loads(out)["message"]["content"].startswith("emoji 🦀")
+
+
+class TestParseSessionJsonl:
+    def test_captures_thinking_block(self) -> None:
+        raw = json.dumps(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "the chain of thought"},
+                    {"type": "text", "text": "answer"},
+                    {"type": "tool_use", "id": "t1", "name": "bash", "input": {"cmd": "ls"}},
+                ],
+            },
+        )
+        steps = _parse_session_jsonl(raw)
+        assert len(steps) == 1
+        assert steps[0]["reasoning_content"] == "the chain of thought"
+        assert steps[0]["message"] == "answer"
+        assert steps[0]["tool_calls"][0]["tool_call_id"] == "t1"
+
+    def test_redacted_thinking_is_marked(self) -> None:
+        raw = json.dumps(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "redacted_thinking", "data": "<opaque>"},
+                    {"type": "text", "text": "ok"},
+                ],
+            },
+        )
+        steps = _parse_session_jsonl(raw)
+        assert steps[0]["reasoning_content"] == "[redacted_thinking]"
+
+    def test_multiple_thinking_blocks_joined(self) -> None:
+        raw = json.dumps(
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "thinking", "thinking": "first"},
+                    {"type": "text", "text": "answer"},
+                    {"type": "thinking", "thinking": "second"},
+                ],
+            },
+        )
+        steps = _parse_session_jsonl(raw)
+        assert steps[0]["reasoning_content"] == "first\nsecond"
+
+    def test_thinking_only_message_is_kept(self) -> None:
+        raw = json.dumps(
+            {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "just a thought"}],
+            },
+        )
+        steps = _parse_session_jsonl(raw)
+        assert len(steps) == 1
+        assert steps[0]["reasoning_content"] == "just a thought"
+        assert steps[0]["message"] == ""
+
+    def test_no_reasoning_field_when_absent(self) -> None:
+        raw = json.dumps(
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "plain"}],
+            },
+        )
+        steps = _parse_session_jsonl(raw)
+        assert "reasoning_content" not in steps[0]

--- a/tests/test_solvers/test_oracle_solver.py
+++ b/tests/test_solvers/test_oracle_solver.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import pytest
+
+from nemo_evaluator.environments.base import SeedResult
+from nemo_evaluator.solvers.base import ErrorKind
+from nemo_evaluator.solvers.oracle import OracleSolver
+from tests.conftest import MockExecResult, MockSandbox
+
+
+def _seed(task_dir: str, **metadata) -> SeedResult:
+    md = {"source": "harbor", "task_id": "test-task", "task_dir": task_dir}
+    md.update(metadata)
+    return SeedResult(prompt="", expected_answer="", metadata=md)
+
+
+@pytest.mark.asyncio
+async def test_missing_sandbox_returns_infra_error(tmp_path):
+    (tmp_path / "solution").mkdir()
+    (tmp_path / "solution" / "solve.sh").write_text("#!/bin/bash\necho ok\n")
+    solver = OracleSolver(timeout=30)
+    result = await solver.solve(_seed(str(tmp_path)))
+    assert result.error_kind == ErrorKind.INFRA
+    assert "sandbox" in (result.error or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_missing_task_dir_returns_system_error(mock_sandbox):
+    solver = OracleSolver(timeout=30)
+    seed = SeedResult(prompt="", expected_answer="", metadata={"source": "harbor", "task_id": "x"})
+    result = await solver.solve(seed, sandbox=mock_sandbox)
+    assert result.error_kind == ErrorKind.SYSTEM
+
+
+@pytest.mark.asyncio
+async def test_missing_solve_sh_returns_system_error(tmp_path, mock_sandbox):
+    # task_dir exists but solution/solve.sh does not
+    solver = OracleSolver(timeout=30)
+    result = await solver.solve(_seed(str(tmp_path)), sandbox=mock_sandbox)
+    assert result.error_kind == ErrorKind.SYSTEM
+    assert "solve.sh" in (result.error or "")
+
+
+@pytest.mark.asyncio
+async def test_happy_path_uploads_and_execs(tmp_path, mock_sandbox):
+    (tmp_path / "solution").mkdir()
+    (tmp_path / "solution" / "solve.sh").write_text("#!/bin/bash\necho hello\n")
+
+    solver = OracleSolver(timeout=30)
+    result = await solver.solve(_seed(str(tmp_path)), sandbox=mock_sandbox)
+
+    assert result.error is None
+    assert result.error_kind == ErrorKind.NONE
+    assert len(result.trajectory) == 1
+    entry = result.trajectory[0]
+    assert entry["type"] == "oracle"
+    assert entry["return_code"] == 0
+    # upload happened (solve.sh bytes landed at /solution/solve.sh in mock FS)
+    assert mock_sandbox._files.get("/solution/solve.sh", b"").startswith(b"#!/bin/bash")
+    # mkdir + chmod + bash all dispatched
+    assert any("mkdir -p /solution" in c for c in mock_sandbox._exec_log)
+    assert any("chmod +x /solution/solve.sh" in c for c in mock_sandbox._exec_log)
+    assert any("bash /solution/solve.sh" in c for c in mock_sandbox._exec_log)
+
+
+@pytest.mark.asyncio
+async def test_uploads_sibling_files_to_solution_dir(tmp_path, mock_sandbox):
+    """Multi-file solution/ dirs (e.g. headless-terminal) need every file at /solution/."""
+    (tmp_path / "solution").mkdir()
+    (tmp_path / "solution" / "solve.sh").write_text("#!/bin/bash\ncp /solution/helper.py /app/\n")
+    (tmp_path / "solution" / "helper.py").write_text("print('hi')\n")
+
+    solver = OracleSolver(timeout=30)
+    result = await solver.solve(_seed(str(tmp_path)), sandbox=mock_sandbox)
+
+    assert result.error is None
+    # Both files ended up at /solution/ in the sandbox
+    assert mock_sandbox._files.get("/solution/solve.sh", b"").startswith(b"#!/bin/bash")
+    assert mock_sandbox._files.get("/solution/helper.py", b"").startswith(b"print")
+
+
+@pytest.mark.asyncio
+async def test_timeout_strategy_max_picks_larger(tmp_path, mock_sandbox):
+    (tmp_path / "solution").mkdir()
+    (tmp_path / "solution" / "solve.sh").write_text("#!/bin/bash\nexit 0\n")
+
+    solver = OracleSolver(timeout=900, run_timeout=600, timeout_strategy="max")
+    # task.toml says 7200s
+    seed = _seed(str(tmp_path), agent_timeout_sec=7200.0)
+    result = await solver.solve(seed, sandbox=mock_sandbox)
+    # Just confirm no error; logger will have printed the 7200s resolution.
+    assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_propagates_return_code(tmp_path, mock_sandbox_factory):
+    (tmp_path / "solution").mkdir()
+    (tmp_path / "solution" / "solve.sh").write_text("#!/bin/bash\nexit 42\n")
+
+    sb = mock_sandbox_factory({"bash /solution/solve.sh": MockExecResult(return_code=42, stderr="boom")})
+    solver = OracleSolver(timeout=30)
+    result = await solver.solve(_seed(str(tmp_path)), sandbox=sb)
+
+    assert result.error is None  # non-zero is not solver error; verify phase decides pass/fail
+    assert result.trajectory[0]["return_code"] == 42
+    assert result.trajectory[0]["stderr"] == "boom"
+
+
+@pytest.fixture
+def mock_sandbox_factory():
+    def _make(exec_results):
+        return MockSandbox(exec_results=exec_results)
+
+    return _make


### PR DESCRIPTION
## Summary

Adds a gold-trajectory replay solver and the Terminal-Bench-Hard subsets used to measure infrastructure ceiling — the fraction of tasks that pass when the agent already knows the answer. Used as the upper bound when diagnosing whether a model failure is reasoning vs. environment.

## What's added

### OracleSolver (NEW)

`src/nemo_evaluator/solvers/oracle.py` (167 LOC). Executes each Harbor task's gold `solution/solve.sh` inside the sandbox. Result measures sandbox / environment correctness, not model competence. **Note**: uploads the entire `solution/` directory; if you reuse the same sandbox config for a real eval after an oracle run, the gold trajectory is in the sandbox image. Only meant for infra-ceiling measurement.

### Terminal-Bench-Hard benchmark (NEW)

`src/nemo_evaluator/benchmarks/terminal_bench_hard.py` (180 LOC). Registers `terminal-bench-hard` (47 tasks) and `terminal-bench-hard-aa-split` (44 tasks) — curated leaderboard subsets of TB v1.

### Harbor environment hardening (MODIFIED)

`environments/harbor.py`:
- File-locked sparse-checkout — fixes a race where parallel Harbor downloads tore down each other's caches mid-copy.
- `DEFAULT_HARBOR_VERIFIER_TIMEOUT = 600` matching upstream Harbor.
- SWE-bench-multilingual hints-stripper marker so eval prompts no longer leak hint text.

### OpenClaw transcript persistence (MODIFIED)

`solvers/openclaw.py`:
- Persists session JSONL verbatim to `<workspace>/.nel_transcript.jsonl` — the scoring contract with PinchBench's `grade()`.
- Captures `thinking` / `redacted_thinking` blocks as `reasoning_content` in the trajectory.
- Removes hardcoded 131,072 default `contextWindow` (`None` opt-out for chat-template mismatch).
- New `idleTimeoutSeconds: 600` knob.

## Files (16 total, +2381 / -106)

NEW: `solvers/oracle.py`, `benchmarks/terminal_bench_hard.py`, `tests/test_solvers/test_oracle_solver.py`, `tests/test_solvers/test_openclaw_transcript.py`, `tests/test_solvers/atif_validator.py`, `tests/test_solvers/test_atif_compliance.py`, `tests/test_environments/test_harbor_dataset_lock.py`, `tests/test_environments/test_harbor_instruction.py`, `tests/test_environments/test_harbor_timeouts.py`, `tests/test_pinchbench_judge.py`.

MODIFIED: `benchmarks/terminal_bench_v1.py`, `environments/harbor.py`, `solvers/harbor.py`, `solvers/openclaw.py`, `tests/test_solvers/test_harbor_solver.py`, `tests/test_integration/test_terminal_bench_v1.py`.

## Sync source

`gitlab-master.nvidia.com:12051/.../nemo-evaluator-next` `main` @ `20830504`.

## Verification

- ✅ Leak grep on staged tree: zero hits (excluding NVIDIA-public `inference-api.nvidia.com`).
- ✅ One scrub applied: `tests/test_solvers/test_harbor_solver.py:256` — stripped `(EVAL-1116)` from docstring.
- ✅ SPDX header added to `test_harbor_solver.py` (was missing in gitlab/main).
- ✅ Pre-commit clean.

## Companion PRs

Part of a 5-PR sync from gitlab/main; see PR description for siblings.
