### PR TITLE
ci: Ensure bump branch is created first for dependabot

### DIFF
--- a/.github/workflows/_update_dependencies.yml
+++ b/.github/workflows/_update_dependencies.yml
@@ -25,10 +25,26 @@ jobs:
         id: ref
         run: echo "date=$(date +%F)" | tee -a "$GITHUB_OUTPUT"
 
+  create-bump-branch:
+    needs: [pre-flight]
+    runs-on: ubuntu-latest
+    env:
+      SOURCE_BRANCH: ${{ needs.pre-flight.outputs.bump-branch }}
+      TARGET_BRANCH: ${{ inputs.target-branch }}
+    steps:
+      - name: Create bump branch if not exists
+        run: |
+          if ! git ls-remote --exit-code origin $SOURCE_BRANCH; then
+            git checkout -b $SOURCE_BRANCH $TARGET_BRANCH
+            git push origin $SOURCE_BRANCH
+          fi
+
   update-lockfile:
     environment: nemo-ci
     runs-on: ubuntu-latest
-    needs: [pre-flight]
+    needs:
+      - pre-flight
+      - create-bump-branch
     strategy:
       fail-fast: false
       matrix:
@@ -49,13 +65,6 @@ jobs:
           GH_TOKEN: ${{ secrets.PAT }}
         run: |
           docker build -f docker/Dockerfile.ci --build-arg PACKAGE=${{ matrix.package }} -t eval .
-
-      - name: Create bump branch if not exists
-        run: |
-          if ! git ls-remote --exit-code origin $SOURCE_BRANCH; then
-            git checkout -b $SOURCE_BRANCH $TARGET_BRANCH
-            git push origin $SOURCE_BRANCH
-          fi
 
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -135,10 +144,10 @@ jobs:
           title: ${{ env.title }}
           token: ${{ secrets.PAT }}
           body: |
-            🚀 PR to bump `uv.lock` in `${{ inputs.target-branch }}`.  
+            🚀 PR to bump `uv.lock` in `${{ inputs.target-branch }}`.
 
-            📝 Please remember the following to-do's before merge: 
-            - [ ] Verify the presubmit CI  
+            📝 Please remember the following to-do's before merge:
+            - [ ] Verify the presubmit CI
 
             🙏 Please merge this PR only if the CI workflow completed successfully.
           commit-message: ${{ env.title }}


### PR DESCRIPTION
ci: Ensure bump branch is created first for dependabot

This job updates uv dependencies given a range in the pyproject.toml.

This job would fail intermittently because there are multiple packages in this repo with multiple uv.lock files and some times the jobs would attempt to create a branch at the same time with the same name. This moves the branch creation to a separate step to avoid the collision.