### PR TITLE
chore: align version to 0.3.0 (drop internal 0.13.0 counter)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.13.0 (unreleased)
+## 0.3.0 (unreleased)
 
 ### Adapter Proxy (Breaking — replaces LiteLLM)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nemo-evaluator"
-version = "0.13.0"
+version = "0.3.0"
 description = "NeMo Evaluator — benchmark environments, pluggable solvers, interceptor proxy, and decision-grade scoring for LLMs"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"

--- a/src/nemo_evaluator/__init__.py
+++ b/src/nemo_evaluator/__init__.py
@@ -18,7 +18,7 @@
 # can safely back-reference ``nemo_evaluator.__version__`` without triggering
 # a circular import while ``__init__.py`` is partially loaded. ``package_info``
 # remains the canonical source for the FW-CI-templates wheel patcher.
-__version__ = "0.13.0"
+__version__ = "0.3.0"
 __package_name__ = "nemo_evaluator"
 
 from nemo_evaluator.engine.eval_loop import run_evaluation

--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -25,7 +25,7 @@ to keep them in sync.
 
 # Below is the _next_ version that will be published, not the currently published one.
 MAJOR = 0
-MINOR = 13
+MINOR = 3
 PATCH = 0
 PRE_RELEASE = ""
 


### PR DESCRIPTION
## Summary

The bulk sync PR (#1002) imported the internal GitLab version counter (`0.13.0`) into this public repo. The canonical version for this branch is `0.3.0`, matching the branch name and the existing GitHub/PyPI release scheme.

## Changes (4 files, 4 lines)

| File | Change |
|---|---|
| `pyproject.toml` | `version = "0.13.0"` → `"0.3.0"` |
| `src/nemo_evaluator/__init__.py` | `__version__ = "0.13.0"` → `"0.3.0"` |
| `src/nemo_evaluator/package_info.py` | `MINOR = 13` → `MINOR = 3` |
| `CHANGELOG.md` | `## 0.13.0 (unreleased)` → `## 0.3.0 (unreleased)` |

The historical CHANGELOG entries (0.12.0, 0.11.0, …) are internal dev history from the GitLab side and can stay as context; only the `(unreleased)` header matters for the public release.