### PR TITLE
feat: streaming response coalescer + Dynamo multi-node deployment

### DIFF
--- a/docs/deployment/slurm.md
+++ b/docs/deployment/slurm.md
@@ -115,6 +115,67 @@ If a benchmark fails within a multi-benchmark SLURM suite, re-submit with `--res
 nel eval run slurm_eval.yaml --resume
 ```
 
+## ai-dynamo deployment
+
+Deploy NVIDIA `ai-dynamo` (sglang engine) as a managed service. Dynamo is multi-process by design — NEL launches the NATS broker, etcd, the `dynamo.frontend` HTTP server, and the `dynamo.sglang` worker(s) in one sbatch job. The OpenAI-compatible endpoint is the frontend on `svc.port`.
+
+**Aggregated** (one worker):
+
+```yaml
+services:
+  glm:
+    type: dynamo
+    model: /lustre/path/to/GLM-5.1-FP8
+    served_model_name: glm
+    protocol: chat_completions
+    port: 8000
+    tensor_parallel_size: 8
+```
+
+For multi-node TP the worker rendezvouses via sglang's torch.distributed (`--nnodes/--node-rank/--dist-init-addr`); set `num_nodes: 2` and `tensor_parallel_size: 16` and NEL gates the NATS/etcd/frontend bootstrap on rank 0.
+
+**Disaggregated** (separate prefill + decode workers, KV transfer over NIxl/UCX-CUDA):
+
+```yaml
+services:
+  glm:
+    type: dynamo
+    model: /lustre/path/to/GLM-5.1-FP8
+    served_model_name: glm
+    protocol: chat_completions
+    port: 8000
+    prefill:
+      tensor_parallel_size: 8
+      num_nodes: 1
+      node_pool: prefill_pool
+      extra_env:
+        UCX_TLS: "rc_x,rc,cuda_copy,cuda_ipc"
+        UCX_NET_DEVICES: "mlx5_0:1"
+    decode:
+      tensor_parallel_size: 8
+      num_nodes: 1
+      node_pool: decode_pool
+      extra_env:
+        UCX_TLS: "rc_x,rc,cuda_copy,cuda_ipc"
+        UCX_NET_DEVICES: "mlx5_0:1"
+
+cluster:
+  type: slurm
+  node_pools:
+    prefill_pool:
+      partition: batch
+      nodes: 1
+      gres: "gpu:8"
+    decode_pool:
+      partition: batch
+      nodes: 1
+      gres: "gpu:8"
+```
+
+Mode is implicit: presence of `prefill` AND `decode` switches to disaggregated; their absence (default) is aggregated. Setting only one of the pair is a validation error.
+
+Default image: `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.1-cuda13` from NGC. Override per service with `image:` or globally via `containers.toml`.
+
 ## Heterogeneous jobs
 
 For configurations that require separate GPU and CPU nodes (e.g., model on GPU + sandboxes on CPU), define multiple node pools:

--- a/examples/configs/15c_slurm_gsm8k_dynamo.yaml
+++ b/examples/configs/15c_slurm_gsm8k_dynamo.yaml
@@ -1,0 +1,70 @@
+# Flavor: SLURM + ai-dynamo (sglang engine, aggregated mode) + gsm8k smoke
+#
+# Deploys NVIDIA ai-dynamo with its sglang engine on a single SVG B200 node
+# (TP=8). NEL starts NATS + etcd + python3 -m dynamo.frontend in the
+# background, then runs the worker (python3 -m dynamo.sglang). Workers
+# self-register via NATS; the frontend exposes the OpenAI-compatible /v1
+# endpoint at localhost:8000.
+#
+# Prerequisites:
+#   - SVG SLURM cluster access
+#   - GLM-5.1-FP8 weights at the lustre path below (update if your copy
+#     lives elsewhere)
+#   - The dynamo runtime container is pulled lazily by pyxis from NGC
+#
+# Run:
+#   nel eval run examples/configs/15c_slurm_gsm8k_dynamo.yaml --dry-run
+#   nel eval run examples/configs/15c_slurm_gsm8k_dynamo.yaml
+
+services:
+  glm5-dynamo:
+    type: dynamo
+    model: ${SHARED_ROOT}/GLM-5.1-FP8
+    served_model_name: glm5
+    protocol: chat_completions
+    port: 8000
+    tensor_parallel_size: 8
+    startup_timeout: 1800.0
+    # Local pre-imported sqsh on SVG. Skip the 22 GB NGC pull. The
+    # containers.toml default (`nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.1-cuda13`)
+    # still works as a fallback on clusters that don't have the sqsh staged.
+    image: ${SHARED_ROOT}/sglang-runtime-1.1.0-cuda13-amd64.sqsh
+    # GLM-5.1-FP8 on SVG B200 single-node TP=8 needs:
+    #   - disable-flashinfer-autotune  → without it the autotune loop hangs
+    #   - SGLANG_ENABLE_JIT_DEEPGEMM=false → falls back to pre-compiled flashinfer
+    #     GEMM kernels; the JIT path silently hangs on this GPU/model combo
+    # (Both are documented in field-notes 2026-05-11 as the prerequisites that
+    # unblocked the GLM-5 single-node TP=8 serving path on SVG.)
+    extra_args:
+      - "--trust-remote-code"
+      - "--mem-fraction-static=0.85"
+      - "--disable-flashinfer-autotune"
+    extra_env:
+      SGLANG_ENABLE_JIT_DEEPGEMM: "false"
+      SGLANG_ENABLE_FLASHINFER_GEMM: "1"
+      # UCX/NIxl agent init runs at dynamo worker startup even in aggregated
+      # mode. On SVG nodes (12 active mlx5_* HCAs), the default UCX device
+      # probe overflows UCX's 128-transport cap and the worker hangs in
+      # do_poll forever. Pin to mlx5_0:1 + restricted TLS per field-notes
+      # 2026-05-11 "winning combo on SVG B200 single-node TP=8".
+      UCX_TLS: "rc_x,rc,dc_x,dc,cuda_copy,cuda_ipc"
+      UCX_NET_DEVICES: "mlx5_0:1"
+
+benchmarks:
+  - name: gsm8k
+    max_problems: 10
+    solver:
+      type: simple
+      service: glm5-dynamo
+
+cluster:
+  type: slurm
+  walltime: "01:00:00"
+  account: <your-slurm-account>
+  container_mounts:
+    - "/lustre:/lustre"
+  node_pools:
+    compute:
+      partition: batch
+      nodes: 1
+      gres: "gpu:8"

--- a/examples/configs/15d_slurm_gsm8k_dynamo_disagg.yaml
+++ b/examples/configs/15d_slurm_gsm8k_dynamo_disagg.yaml
@@ -1,0 +1,69 @@
+# Flavor: SLURM + ai-dynamo (sglang engine, disaggregated mode) + gsm8k smoke
+#
+# Structural example for dynamo disaggregated deployment: one prefill worker
+# (TP=8, 1 node) + one decode worker (TP=8, 1 node) on separate node pools
+# (het-job). NATS + etcd + frontend run on the prefill rank-0 node; workers
+# exchange KV cache via NIxl over UCX-CUDA (the runtime container bundles
+# both).
+#
+# Verified via `nel eval run ... --dry-run` only as part of FEP-856. Live
+# disaggregated submission is a follow-up; the canonical UCX/MNNVL knobs
+# below match the recipe shape we use in srt-slurm production.
+#
+# Run:
+#   nel eval run examples/configs/15d_slurm_gsm8k_dynamo_disagg.yaml --dry-run
+
+services:
+  glm5-dynamo-disagg:
+    type: dynamo
+    model: ${SHARED_ROOT}/GLM-5.1-FP8
+    served_model_name: glm5
+    protocol: chat_completions
+    port: 8000
+    startup_timeout: 1800.0
+    image: ${SHARED_ROOT}/sglang-runtime-1.1.0-cuda13-amd64.sqsh
+    prefill:
+      tensor_parallel_size: 8
+      num_nodes: 1
+      node_pool: prefill_pool
+      extra_args:
+        - "--trust-remote-code"
+        - "--mem-fraction-static=0.85"
+      extra_env:
+        UCX_TLS: "rc_x,rc,cuda_copy,cuda_ipc"
+        UCX_NET_DEVICES: "mlx5_0:1"
+        UCX_MEMTYPE_CACHE: "n"
+    decode:
+      tensor_parallel_size: 8
+      num_nodes: 1
+      node_pool: decode_pool
+      extra_args:
+        - "--trust-remote-code"
+        - "--mem-fraction-static=0.85"
+      extra_env:
+        UCX_TLS: "rc_x,rc,cuda_copy,cuda_ipc"
+        UCX_NET_DEVICES: "mlx5_0:1"
+        UCX_MEMTYPE_CACHE: "n"
+
+benchmarks:
+  - name: gsm8k
+    max_problems: 10
+    solver:
+      type: simple
+      service: glm5-dynamo-disagg
+
+cluster:
+  type: slurm
+  walltime: "01:30:00"
+  account: <your-slurm-account>
+  container_mounts:
+    - "/lustre:/lustre"
+  node_pools:
+    prefill_pool:
+      partition: batch
+      nodes: 1
+      gres: "gpu:8"
+    decode_pool:
+      partition: batch
+      nodes: 1
+      gres: "gpu:8"

--- a/src/nemo_evaluator/adapters/interceptors/streaming.py
+++ b/src/nemo_evaluator/adapters/interceptors/streaming.py
@@ -1,0 +1,237 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from nemo_evaluator.adapters.types import AdapterResponse, ResponseInterceptor
+
+
+def _normalize_message_content(body: dict[str, Any]) -> None:
+    choices = body.get("choices")
+    if not isinstance(choices, list):
+        return
+
+    for choice in choices:
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message")
+        if isinstance(message, dict) and "content" in message and message["content"] is None:
+            message["content"] = ""
+
+
+class Interceptor(ResponseInterceptor):
+    async def intercept_response(self, resp: AdapterResponse) -> AdapterResponse:
+        if isinstance(resp.body, dict):
+            _normalize_message_content(resp.body)
+            return resp
+
+        content_type = _header_value(resp.headers, "content-type").lower()
+        if "text/event-stream" not in content_type:
+            return resp
+
+        text = _body_to_text(resp.body)
+        if text is None:
+            return resp
+
+        body = _coalesce_sse(text)
+        if body is None:
+            return resp
+
+        headers = {k: v for k, v in resp.headers.items() if k.lower() != "content-type"}
+        headers["Content-Type"] = "application/json"
+        status_code = _status_code_for_body(resp.status_code, body)
+        return AdapterResponse(
+            status_code=status_code,
+            headers=headers,
+            body=body,
+            latency_ms=resp.latency_ms,
+            ctx=resp.ctx,
+        )
+
+
+def _header_value(headers: dict[str, str], name: str) -> str:
+    for key, value in headers.items():
+        if key.lower() == name:
+            return value
+    return ""
+
+
+def _body_to_text(body: dict[str, Any] | bytes) -> str | None:
+    if isinstance(body, bytes):
+        return body.decode(errors="replace")
+    return None
+
+
+def _status_code_for_body(status_code: int, body: dict[str, Any]) -> int:
+    if not (200 <= status_code < 400) or "error" not in body:
+        return status_code
+
+    error = body.get("error")
+    if isinstance(error, dict):
+        error_status = error.get("status") or error.get("status_code")
+        if isinstance(error_status, int) and 400 <= error_status < 600:
+            return error_status
+    return 502
+
+
+def _coalesce_sse(text: str) -> dict[str, Any] | None:
+    first_chunk: dict[str, Any] = {}
+    last_usage: dict[str, Any] = {}
+    contents: dict[int, str] = {}
+    reasoning_contents: dict[int, str] = {}
+    roles: dict[int, str] = {}
+    finish_reasons: dict[int, Any] = {}
+    tool_calls_map: dict[int, dict[int, dict[str, Any]]] = {}
+
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or not line.startswith("data:"):
+            continue
+        data = line[len("data:") :].strip()
+        if data == "[DONE]":
+            break
+
+        try:
+            chunk = json.loads(data)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(chunk, dict):
+            continue
+
+        if "error" in chunk:
+            return chunk
+
+        if not first_chunk:
+            first_chunk = chunk
+        if isinstance(chunk.get("usage"), dict):
+            last_usage = chunk["usage"]
+        _merge_chunk(chunk, contents, reasoning_contents, roles, finish_reasons, tool_calls_map)
+
+    if not contents and not reasoning_contents and not tool_calls_map and not roles and not finish_reasons:
+        return None
+
+    body: dict[str, Any] = {
+        "id": first_chunk.get("id"),
+        "object": "chat.completion",
+        "created": first_chunk.get("created"),
+        "model": first_chunk.get("model"),
+        "choices": _build_choices(contents, reasoning_contents, roles, finish_reasons, tool_calls_map),
+    }
+    if last_usage:
+        body["usage"] = last_usage
+
+    _normalize_message_content(body)
+    return body
+
+
+def _merge_chunk(
+    chunk: dict[str, Any],
+    contents: dict[int, str],
+    reasoning_contents: dict[int, str],
+    roles: dict[int, str],
+    finish_reasons: dict[int, Any],
+    tool_calls_map: dict[int, dict[int, dict[str, Any]]],
+) -> None:
+    for choice in chunk.get("choices", []) or []:
+        if not isinstance(choice, dict):
+            continue
+        idx = int(choice.get("index", 0) or 0)
+        # TODO: Preserve /v1/completions streaming chunks (`choices[].text`) as completion responses.
+        delta = choice.get("delta") or {}
+        if not isinstance(delta, dict):
+            delta = {}
+
+        if isinstance(delta.get("role"), str):
+            roles.setdefault(idx, delta["role"])
+        if isinstance(delta.get("content"), str) and delta["content"]:
+            contents[idx] = contents.get(idx, "") + delta["content"]
+
+        reasoning_content = delta.get("reasoning_content") or delta.get("reasoning")
+        if isinstance(reasoning_content, str) and reasoning_content:
+            reasoning_contents[idx] = reasoning_contents.get(idx, "") + reasoning_content
+
+        tool_call_deltas = delta.get("tool_calls") or []
+        if isinstance(tool_call_deltas, list):
+            _merge_tool_calls(idx, tool_call_deltas, tool_calls_map)
+
+        if choice.get("finish_reason") is not None:
+            finish_reasons[idx] = choice["finish_reason"]
+
+
+def _merge_tool_calls(
+    choice_idx: int,
+    tool_call_deltas: list[Any],
+    tool_calls_map: dict[int, dict[int, dict[str, Any]]],
+) -> None:
+    for tool_call_delta in tool_call_deltas:
+        if not isinstance(tool_call_delta, dict):
+            continue
+        tool_call_idx = int(tool_call_delta.get("index", 0) or 0)
+        tool_call_by_idx = tool_calls_map.setdefault(choice_idx, {})
+        if tool_call_idx not in tool_call_by_idx:
+            tool_call_by_idx[tool_call_idx] = {
+                "id": tool_call_delta.get("id") or "",
+                "type": tool_call_delta.get("type") or "function",
+                "function": {"name": "", "arguments": ""},
+            }
+
+        tool_call = tool_call_by_idx[tool_call_idx]
+        if tool_call_delta.get("id"):
+            tool_call["id"] = tool_call_delta["id"]
+        if tool_call_delta.get("type"):
+            tool_call["type"] = tool_call_delta["type"]
+
+        function_delta = tool_call_delta.get("function") or {}
+        if not isinstance(function_delta, dict):
+            continue
+        if isinstance(function_delta.get("name"), str):
+            tool_call["function"]["name"] += function_delta["name"]
+        if isinstance(function_delta.get("arguments"), str):
+            tool_call["function"]["arguments"] += function_delta["arguments"]
+
+
+def _build_choices(
+    contents: dict[int, str],
+    reasoning_contents: dict[int, str],
+    roles: dict[int, str],
+    finish_reasons: dict[int, Any],
+    tool_calls_map: dict[int, dict[int, dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    choices: list[dict[str, Any]] = []
+    output_indices = sorted(
+        set(contents) | set(reasoning_contents) | set(roles) | set(finish_reasons) | set(tool_calls_map)
+    )
+    for idx in output_indices:
+        message: dict[str, Any] = {
+            "role": roles.get(idx, "assistant"),
+            "content": contents.get(idx),
+        }
+        if idx in reasoning_contents:
+            message["reasoning_content"] = reasoning_contents[idx]
+        if idx in tool_calls_map:
+            message["tool_calls"] = [
+                tool_calls_map[idx][tool_call_idx] for tool_call_idx in sorted(tool_calls_map[idx])
+            ]
+
+        choices.append(
+            {
+                "index": idx,
+                "message": message,
+                "finish_reason": finish_reasons.get(idx),
+            }
+        )
+    return choices

--- a/src/nemo_evaluator/adapters/registry.py
+++ b/src/nemo_evaluator/adapters/registry.py
@@ -51,6 +51,7 @@ _BUILTIN: dict[str, str] = {
     "reasoning_replay": "nemo_evaluator.adapters.interceptors.reasoning_replay",
     "progress_tracking": "nemo_evaluator.adapters.interceptors.progress_tracking",
     "logging": "nemo_evaluator.adapters.interceptors.request_logging",
+    "streaming": "nemo_evaluator.adapters.interceptors.streaming",
 }
 
 # External / plugin registrations at runtime.

--- a/src/nemo_evaluator/config/__init__.py
+++ b/src/nemo_evaluator/config/__init__.py
@@ -67,6 +67,8 @@ from .scoring import (
 from .services import (
     CustomService,
     DockerModelService,
+    DynamoService,
+    DynamoWorkerConfig,
     ExternalApiService,
     GenerationConfig,
     GymResourceService,
@@ -105,6 +107,8 @@ __all__ = [
     "SglangService",
     "NimService",
     "DockerModelService",
+    "DynamoService",
+    "DynamoWorkerConfig",
     "ExternalApiService",
     "GymResourceService",
     "NatAgentService",

--- a/src/nemo_evaluator/config/clusters.py
+++ b/src/nemo_evaluator/config/clusters.py
@@ -65,6 +65,13 @@ class NodePool(BaseModel):
     ntasks_per_node: int = 1
     gres: str | None = None
     gpus_per_node: int | None = None
+    # Per-pool sbatch directives, emitted alongside this pool's #SBATCH --nodes
+    # / --partition / etc. in het-job mode. Use for topology constraints like
+    # ``segment: <nodes>`` on GB200 NVL72 clusters so the het-group's nodes
+    # land on the same NVL72 rack — required for cross-node TP=8 via the
+    # NVLink Switch System (without it, ranks fall back to IB and intra-worker
+    # collectives are significantly slower).
+    sbatch_extra_flags: dict[str, str | int | float | bool] = Field(default_factory=dict)
 
 
 class SlurmCluster(BaseModel):

--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -150,6 +150,68 @@ class DockerModelService(_ModelServerBase):
     type: Literal["docker_model"] = "docker_model"
 
 
+class DynamoWorkerConfig(BaseModel):
+    """Per-role worker config for disaggregated dynamo deployments.
+
+    Used only inside ``DynamoService.prefill`` / ``DynamoService.decode``.
+    Mirrors the shape of the relevant ``_ModelServerBase`` fields, scoped
+    to the prefill or decode worker rather than the whole service."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    tensor_parallel_size: int | None = None
+    pipeline_parallel_size: int | None = None
+    data_parallel_size: int | None = None
+    num_nodes: int = 1
+    num_workers: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Number of independent worker processes for this role. Each worker "
+            "forms its own torch.distributed TP rendezvous and registers "
+            "separately with NATS. Total nodes for the role = num_workers * "
+            "num_nodes. Use >1 for production wide-EP shapes (e.g. 2P+1D)."
+        ),
+    )
+    node_pool: str | None = None
+    extra_args: list[str] = Field(default_factory=list)
+    extra_env: dict[str, str] = Field(default_factory=dict)
+
+
+class DynamoService(_ModelServerBase):
+    """NVIDIA ai-dynamo deployment (sglang engine).
+
+    Dynamo is intrinsically multi-process: NATS broker + etcd + HTTP frontend
+    (``python3 -m dynamo.frontend``) + one or more workers (``python3 -m
+    dynamo.sglang``). Workers self-register via NATS using
+    ``DYN_REQUEST_PLANE=nats``; the frontend dispatches OpenAI requests.
+
+    Mode is implicit:
+    - ``prefill`` and ``decode`` both unset (default) → aggregated: a single
+      worker handles both prefill and decode. Base-level fields
+      (``tensor_parallel_size`` etc.) apply to the worker.
+    - ``prefill`` and ``decode`` both set → disaggregated: two separate sets
+      of workers; per-role TP/DP/etc. live on the sub-blocks.
+
+    Setting only one of ``prefill``/``decode`` is rejected by validation."""
+
+    type: Literal["dynamo"] = "dynamo"
+    engine: Literal["sglang"] = "sglang"
+    prefill: DynamoWorkerConfig | None = None
+    decode: DynamoWorkerConfig | None = None
+
+    @model_validator(mode="after")
+    def _check_disagg_pair(self) -> DynamoService:
+        if (self.prefill is None) != (self.decode is None):
+            raise ValueError(
+                "dynamo: 'prefill' and 'decode' must both be set (disaggregated) "
+                "or both be None (aggregated); got prefill="
+                f"{'set' if self.prefill else 'None'}, decode="
+                f"{'set' if self.decode else 'None'}"
+            )
+        return self
+
+
 class ExternalApiService(BaseModel):
     """Pre-deployed model / judge behind an HTTP endpoint.
 
@@ -306,6 +368,7 @@ ServiceConfig = Annotated[
     | Annotated[SglangService, Tag("sglang")]
     | Annotated[NimService, Tag("nim")]
     | Annotated[DockerModelService, Tag("docker_model")]
+    | Annotated[DynamoService, Tag("dynamo")]
     | Annotated[ExternalApiService, Tag("api")]
     | Annotated[GymResourceService, Tag("gym")]
     | Annotated[NatAgentService, Tag("nat")]
@@ -318,5 +381,6 @@ _MODEL_SERVICE_TYPES = (
     SglangService,
     NimService,
     DockerModelService,
+    DynamoService,
     ExternalApiService,
 )

--- a/src/nemo_evaluator/orchestration/slurm_gen.py
+++ b/src/nemo_evaluator/orchestration/slurm_gen.py
@@ -25,6 +25,7 @@ import yaml
 
 from nemo_evaluator.config import (
     ApptainerSandbox,
+    DynamoService,
     EvalConfig,
     ExternalApiService,
     GymResourceService,
@@ -67,7 +68,7 @@ set -uo pipefail
 export NEL_INNER_EXECUTION=1
 export PYTHONUNBUFFERED=1
 
-OUTPUT_DIR="{output_dir}"
+export OUTPUT_DIR="{output_dir}"
 NEL_EXIT_CODE=0
 JOB_START_EPOCH=$(date +%s)
 mkdir -p "$OUTPUT_DIR/logs"
@@ -139,6 +140,7 @@ _HEADER_HETJOB_POOL = """\
 {gpus_per_node_line}
 {partition_line}
 {account_line}
+{pool_extra_lines}
 """
 
 _HEADER_HETJOB_SEPARATOR = """\
@@ -159,7 +161,7 @@ set -uo pipefail
 export NEL_INNER_EXECUTION=1
 export PYTHONUNBUFFERED=1
 
-OUTPUT_DIR="{output_dir}"
+export OUTPUT_DIR="{output_dir}"
 NEL_EXIT_CODE=0
 JOB_START_EPOCH=$(date +%s)
 mkdir -p "$OUTPUT_DIR/logs"
@@ -259,6 +261,76 @@ ln -sf "server-{name}-$SLURM_JOB_ID.log" "$OUTPUT_DIR/logs/server-{name}.log"
 {name_upper}_MODEL={model}
 """
 
+# ---------------------------------------------------------------------------
+# Dynamo (ai-dynamo) templates
+# ---------------------------------------------------------------------------
+#
+# Dynamo's HTTP frontend (`python3 -m dynamo.frontend`) is the user-facing
+# OpenAI-compatible endpoint. Workers (`python3 -m dynamo.sglang`) self-register
+# via NATS using DYN_REQUEST_PLANE=nats; the frontend dispatches requests.
+#
+# Aggregated: one worker, possibly multi-node TP via sglang's rendezvous.
+# Disaggregated: separate prefill + decode workers; frontend lives on the
+# first prefill node. KV transfer goes over NIxl (RDMA) between roles.
+
+_DYNAMO_NATS_PORT = 4222
+_DYNAMO_ETCD_PORT = 2379
+# Worker's internal HTTP port (not user-facing — frontend is on svc.port).
+_DYNAMO_WORKER_PORT_OFFSET = 1
+# Prefill workers run SGLang's CommonKVBootstrapServer; the sglang default
+# (8998) needs an explicit override to keep the contract obvious and avoid
+# surprises with future SGLang version drift (srt-slurm makes the same choice).
+_DYNAMO_PREFILL_BOOTSTRAP_PORT_OFFSET = 2
+_DYNAMO_DIST_INIT_PORT = 29500
+
+_DYNAMO_AGG_SERVICE = """\
+# Service: {name} (dynamo, aggregated{multinode_note})
+echo "Starting dynamo aggregated service: {name}..."
+echo "  Logs: $OUTPUT_DIR/logs/server-{name}-$SLURM_JOB_ID.log"
+{launch_block}
+ln -sf "server-{name}-$SLURM_JOB_ID.log" "$OUTPUT_DIR/logs/server-{name}.log"
+{name_upper}_URL="http://localhost:{port}/v1"
+{name_upper}_MODEL={model}
+"""
+
+_DYNAMO_AGG_SINGLENODE_LAUNCH = """\
+{srun_prefix}bash "$OUTPUT_DIR/logs/{script_file}" >> "$OUTPUT_DIR/logs/server-{name}-$SLURM_JOB_ID.log" 2>&1 &
+{name_upper}_PID=$!"""
+
+_DYNAMO_AGG_MULTINODE_LAUNCH = """\
+_NODES=$(scontrol show hostnames "{nodelist_var}")
+_RANK=0
+for _NODE in $_NODES; do
+    {srun_prefix_single_node}--container-name=nel-{safe_name}-rank$_RANK -w $_NODE bash "$OUTPUT_DIR/logs/{script_file}" $_RANK >> "$OUTPUT_DIR/logs/server-{name}-$SLURM_JOB_ID.log" 2>&1 &
+    if [ $_RANK -eq 0 ]; then
+        {name_upper}_PID=$!
+    fi
+    _RANK=$((_RANK + 1))
+done"""
+
+_DYNAMO_DISAGG_SERVICE = """\
+# Service: {name} (dynamo, disaggregated: {num_prefill_workers}P × {prefill_nodes_per_worker}n + {num_decode_workers}D × {decode_nodes_per_worker}n)
+echo "Starting dynamo disaggregated service: {name}..."
+echo "  Logs: $OUTPUT_DIR/logs/server-{name}-$SLURM_JOB_ID.log"
+
+# Each worker (prefill or decode) forms its OWN torch.distributed TP
+# rendezvous; they MUST NOT share --dist-init-addr — verified against
+# srt-slurm's HSG 2664281 production run (distinct leader IP per worker).
+# The leader IP is passed to each per-node script as a positional arg so
+# every worker spawned by the outer loop gets its slice's first hostname.
+# MASTER_IP (set earlier from the prefill nodelist) is still used by
+# NATS/etcd/frontend; that runs only on prefill worker 0, rank 0.
+{nodelist_split_block}
+
+{prefill_fanout}
+
+{decode_fanout}
+
+ln -sf "server-{name}-$SLURM_JOB_ID.log" "$OUTPUT_DIR/logs/server-{name}.log"
+{name_upper}_URL="http://localhost:{port}/v1"
+{name_upper}_MODEL={model}
+"""
+
 _RAY_MULTINODE_SERVICE = """\
 # Service: {name} ({svc_type}, multi-node Ray: {num_nodes} nodes)
 echo "Starting multi-node Ray {svc_type} server: {name}..."
@@ -346,6 +418,46 @@ for _i in $(seq 1 {max_attempts}); do
 done
 if [ ${name_upper}_READY -eq 0 ]; then
     echo "ERROR: {name} did not become healthy after {max_attempts} attempts."
+    exit 1
+fi
+"""
+
+_HEALTH_WAIT_DYNAMO = """\
+# Wait for {name} (dynamo: >={expected_prefill} prefill + >={expected_decode} decode/backend workers registered)
+echo "Waiting for {name} at {url} (workers registered via NATS)..."
+{name_upper}_READY=0
+for _i in $(seq 1 {max_attempts}); do
+    # Dynamo frontend /health returns 200 the moment its FastAPI binds,
+    # well before any worker registers. Parse the JSON body and count
+    # instances per ``component`` — matches the readiness rule srt-slurm's
+    # ``check_dynamo_health`` uses (srtctl/core/health.py). Aggregated
+    # workers report as ``component="backend"``; disagg as ``"prefill"`` or
+    # ``"decode"``/``"tensorrt_llm"``.
+    _RESP=$(curl -sf "{url}/health" 2>/dev/null)
+    if [ -n "$_RESP" ] && echo "$_RESP" | python3 -c '
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(1)
+inst = d.get("instances") or []
+gens = [i for i in inst if i.get("endpoint") == "generate"]
+n_p = sum(1 for i in gens if i.get("component") == "prefill")
+n_d = sum(1 for i in gens if i.get("component") in ("decode", "tensorrt_llm", "backend"))
+sys.exit(0 if (n_p >= {expected_prefill} and n_d >= {expected_decode}) else 1)
+' 2>/dev/null; then
+        echo "  {name} ready (>={expected_prefill} prefill + >={expected_decode} decode/backend registered)."
+        {name_upper}_READY=1
+        break
+    fi
+    if [ -n "${{{name_upper}_PID:-}}" ] && ! kill -0 ${name_upper}_PID 2>/dev/null; then
+        echo "  {name} died during startup."
+        exit 1
+    fi
+    sleep 5
+done
+if [ ${name_upper}_READY -eq 0 ]; then
+    echo "ERROR: {name} did not have the expected workers register after {max_attempts} attempts."
     exit 1
 fi
 """
@@ -645,6 +757,14 @@ def _collect_used_pools(config: EvalConfig) -> list[str]:
         pool = getattr(svc, "node_pool", None)
         if pool:
             used.add(pool)
+        # Dynamo disagg exposes a node_pool per role (prefill/decode) rather
+        # than a single service-level pool; surface both so they each get
+        # their own het-group when they differ.
+        for role_attr in ("prefill", "decode"):
+            role_cfg = getattr(svc, role_attr, None)
+            role_pool = getattr(role_cfg, "node_pool", None) if role_cfg else None
+            if role_pool:
+                used.add(role_pool)
     for sb in config.sandboxes.values():
         pool = getattr(sb, "node_pool", None)
         if pool:
@@ -712,6 +832,538 @@ def _build_srun_prefix(
     )
 
 
+def _dynamo_worker_command(
+    *,
+    model_for_cmd: str,
+    model_api_name: str,
+    worker_port: int,
+    tp: int | None,
+    pp: int | None,
+    dp: int | None,
+    role: str | None,
+    bootstrap_port: int | None,
+    dist_init_var: str = "MASTER_IP",
+    num_nodes: int,
+    extra_args: list[str],
+) -> str:
+    """Build a single ``python3 -m dynamo.sglang`` command.
+
+    ``role`` is None for aggregated, "prefill" or "decode" for disagg.
+    ``bootstrap_port`` is only meaningful for prefill workers (the
+    CommonKVBootstrapServer port that decode workers connect to).
+    ``dist_init_var`` is the env-var name holding the worker's TP-rendezvous
+    leader (``MASTER_IP`` for aggregated; ``LEADER_IP`` for disagg, which the
+    per-node script sets from positional arg ``$2`` so every worker spawned
+    by the disagg fan-out picks up its OWN slice's leader). The production
+    multi-node disagg shape (HSG GB200 2664281) confirms each worker dumps
+    its own ``dist_init_addr`` IP."""
+    parts = [
+        "python3 -m dynamo.sglang",
+        f"--model-path {model_for_cmd}" if model_for_cmd else "",
+        f"--served-model-name {shlex.quote(model_api_name)}" if model_api_name else "",
+        "--host 0.0.0.0",
+        f"--port {worker_port}",
+    ]
+    if tp:
+        parts.append(f"--tp-size {tp}")
+    if pp:
+        parts.append(f"--pp-size {pp}")
+    if dp:
+        parts.append(f"--dp-size {dp}")
+    if role in ("prefill", "decode"):
+        parts.append(f"--disaggregation-mode {role}")
+    if role == "prefill" and bootstrap_port is not None:
+        parts.append(f"--disaggregation-bootstrap-port {bootstrap_port}")
+    if num_nodes > 1:
+        parts.extend(
+            [
+                f"--nnodes {num_nodes}",
+                '--node-rank "${NEL_NODE_RANK:-0}"',
+                f'--dist-init-addr "${{{dist_init_var}}}:{_DYNAMO_DIST_INIT_PORT}"',
+            ]
+        )
+    if extra_args:
+        parts.append(" ".join(shlex.quote(a) for a in extra_args))
+    return " ".join(p for p in parts if p)
+
+
+def _dynamo_infra_env_exports(infra_host: str = "${MASTER_IP}") -> list[str]:
+    """Env vars every dynamo process (frontend + workers) needs.
+
+    ``infra_host`` defaults to ``${MASTER_IP}`` so workers on non-rank-0 nodes
+    can reach the NATS broker and etcd that rank 0 brings up. For single-node
+    aggregated runs ``${MASTER_IP}`` resolves to the lone allocated node."""
+    return [
+        "export DYN_REQUEST_PLANE=nats",
+        f'export NATS_SERVER="nats://{infra_host}:{_DYNAMO_NATS_PORT}"',
+        f'export ETCD_ENDPOINTS="http://{infra_host}:{_DYNAMO_ETCD_PORT}"',
+        "export DYN_SKIP_SGLANG_LOG_FORMATTING=1",
+    ]
+
+
+def _dynamo_infra_bootstrap_block(name: str, frontend_port: int) -> list[str]:
+    """Lines that start NATS broker + etcd + dynamo frontend in the background.
+
+    Caller is responsible for gating this on rank 0 in multi-node setups —
+    only one node should run the broker/etcd/frontend or they'll fight over
+    ports.
+
+    The trailing readiness loop waits for NATS and etcd to actually accept
+    TCP connections before returning, so the worker spawn that follows can
+    safely register with NATS. The frontend's own readiness is gated later
+    by the eval-side ``/health`` poll (which only succeeds once a worker
+    has registered)."""
+    safe = _safe(name)
+    return [
+        f'nats-server -js >> "$OUTPUT_DIR/logs/dynamo-nats-{safe}-$SLURM_JOB_ID.log" 2>&1 &',
+        (
+            f"etcd "
+            f"--listen-client-urls http://0.0.0.0:{_DYNAMO_ETCD_PORT} "
+            f"--advertise-client-urls http://localhost:{_DYNAMO_ETCD_PORT} "
+            f'>> "$OUTPUT_DIR/logs/dynamo-etcd-{safe}-$SLURM_JOB_ID.log" 2>&1 &'
+        ),
+        (
+            f"python3 -m dynamo.frontend --http-port {frontend_port} "
+            f'>> "$OUTPUT_DIR/logs/dynamo-frontend-{safe}-$SLURM_JOB_ID.log" 2>&1 &'
+        ),
+        "for _i in $(seq 1 60); do",
+        (
+            f"    (exec 3<>/dev/tcp/localhost/{_DYNAMO_NATS_PORT}) 2>/dev/null"
+            f" && (exec 3<>/dev/tcp/localhost/{_DYNAMO_ETCD_PORT}) 2>/dev/null && break"
+        ),
+        "    sleep 1",
+        "done",
+    ]
+
+
+_DYNAMO_EXTRA_ENV_KEYS = ("OUTPUT_DIR", "SLURM_JOB_ID")
+
+
+def _dynamo_service_block(
+    name: str,
+    svc: DynamoService,
+    *,
+    use_containers: bool,
+    cluster_mounts: list[str],
+    env_keys: list[str],
+    reexport_cmds: str,
+    mount_home: bool,
+    pool_to_het: dict[str, int] | None,
+) -> str:
+    """Emit the bash for a ``type: dynamo`` service (aggregated or disagg).
+
+    Mode is implicit: ``svc.prefill is None`` → aggregated; otherwise disagg
+    (the schema validator guarantees prefill and decode are both set or both
+    None)."""
+    upper = _safe(name).upper()
+    safe_name = _safe(name)
+    deploy_image = _resolve_service_image(svc)
+
+    model_for_cmd = svc.model
+    model_mount: list[str] = []
+    if svc.model and svc.model.startswith("/") and use_containers:
+        model_for_cmd = "/model"
+        model_mount = [f"{svc.model}:/model:ro"]
+    model_api_name = getattr(svc, "served_model_name", None) or name
+
+    reexport_block = f"{reexport_cmds}\n" if reexport_cmds else ""
+    worker_port = svc.port + _DYNAMO_WORKER_PORT_OFFSET
+    bootstrap_port = svc.port + _DYNAMO_PREFILL_BOOTSTRAP_PORT_OFFSET
+
+    if svc.prefill is None:
+        return _dynamo_aggregated_block(
+            name=name,
+            upper=upper,
+            safe_name=safe_name,
+            svc=svc,
+            deploy_image=deploy_image,
+            model_for_cmd=model_for_cmd or "",
+            model_mount=model_mount,
+            model_api_name=model_api_name,
+            worker_port=worker_port,
+            use_containers=use_containers,
+            cluster_mounts=cluster_mounts,
+            env_keys=env_keys,
+            mount_home=mount_home,
+            pool_to_het=pool_to_het,
+            reexport_block=reexport_block,
+        )
+
+    return _dynamo_disaggregated_block(
+        name=name,
+        upper=upper,
+        safe_name=safe_name,
+        svc=svc,
+        deploy_image=deploy_image,
+        model_for_cmd=model_for_cmd or "",
+        model_mount=model_mount,
+        model_api_name=model_api_name,
+        worker_port=worker_port,
+        bootstrap_port=bootstrap_port,
+        use_containers=use_containers,
+        cluster_mounts=cluster_mounts,
+        env_keys=env_keys,
+        mount_home=mount_home,
+        pool_to_het=pool_to_het,
+        reexport_block=reexport_block,
+    )
+
+
+def _dynamo_aggregated_block(
+    *,
+    name: str,
+    upper: str,
+    safe_name: str,
+    svc: DynamoService,
+    deploy_image: str,
+    model_for_cmd: str,
+    model_mount: list[str],
+    model_api_name: str,
+    worker_port: int,
+    use_containers: bool,
+    cluster_mounts: list[str],
+    env_keys: list[str],
+    mount_home: bool,
+    pool_to_het: dict[str, int] | None,
+    reexport_block: str,
+) -> str:
+    num_nodes = svc.num_nodes
+    pool = getattr(svc, "node_pool", None)
+    het_flag = ""
+    if pool and pool_to_het and pool in pool_to_het:
+        het_flag = f" --het-group={pool_to_het[pool]}"
+
+    srun_prefix = ""
+    if use_containers:
+        srun_prefix = _build_srun_prefix(
+            svc,
+            deploy_image,
+            het_flag=het_flag,
+            cluster_mounts=cluster_mounts,
+            env_keys=list(env_keys) + list(_DYNAMO_EXTRA_ENV_KEYS),
+            mount_home=mount_home,
+            extra_mounts=model_mount + ["$OUTPUT_DIR:$OUTPUT_DIR"],
+        )
+
+    worker_cmd = _dynamo_worker_command(
+        model_for_cmd=model_for_cmd,
+        model_api_name=model_api_name,
+        worker_port=worker_port,
+        tp=svc.tensor_parallel_size,
+        pp=svc.pipeline_parallel_size,
+        dp=svc.data_parallel_size,
+        role=None,
+        bootstrap_port=None,
+        num_nodes=num_nodes,
+        extra_args=list(svc.extra_args),
+    )
+
+    infra_host = "${MASTER_IP}" if num_nodes > 1 else "localhost"
+    infra_lines = _dynamo_infra_bootstrap_block(name, svc.port)
+    env_exports = _dynamo_infra_env_exports(infra_host)
+
+    script_lines = ["set -euo pipefail"]
+    setup_list = getattr(svc, "setup_commands", []) or []
+    script_lines.extend(setup_list)
+    if num_nodes > 1:
+        script_lines.append('NEL_NODE_RANK="${1:-0}"')
+        script_lines.append("export NEL_NODE_RANK")
+    script_lines.extend(env_exports)
+    if num_nodes > 1:
+        script_lines.append('if [ "$NEL_NODE_RANK" -eq 0 ]; then')
+        script_lines.extend(f"    {line}" for line in infra_lines)
+        script_lines.append("fi")
+    else:
+        script_lines.extend(infra_lines)
+    script_lines.append(worker_cmd)
+
+    script_file = f"_svc_{safe_name}_cmd_$SLURM_JOB_ID.sh"
+    script_heredoc = (
+        f"cat > \"$OUTPUT_DIR/logs/{script_file}\" <<'_NEMO_SVC_CMD_EOF_'\n"
+        + "\n".join(script_lines)
+        + "\n_NEMO_SVC_CMD_EOF_\n"
+    )
+
+    if num_nodes > 1:
+        head_srun = srun_prefix.replace(f"--nodes {num_nodes} --ntasks {num_nodes}", "--nodes 1 --ntasks 1").replace(
+            " --label", ""
+        )
+        per_node_srun = head_srun.rstrip() + " "
+        nodelist_var = "$SLURM_JOB_NODELIST"
+        if het_flag:
+            het_idx = het_flag.strip().split("=")[-1]
+            nodelist_var = f"$SLURM_JOB_NODELIST_HET_GROUP_{het_idx}"
+        launch_block = _DYNAMO_AGG_MULTINODE_LAUNCH.format(
+            name=name,
+            name_upper=upper,
+            safe_name=safe_name,
+            srun_prefix_single_node=per_node_srun,
+            nodelist_var=nodelist_var,
+            script_file=script_file,
+        )
+        multinode_note = f", multi-node torch.distributed: {num_nodes} nodes"
+    else:
+        launch_block = _DYNAMO_AGG_SINGLENODE_LAUNCH.format(
+            name=name,
+            name_upper=upper,
+            srun_prefix=srun_prefix,
+            script_file=script_file,
+        )
+        multinode_note = ""
+
+    return (
+        reexport_block
+        + script_heredoc
+        + _DYNAMO_AGG_SERVICE.format(
+            name=name,
+            name_upper=upper,
+            port=svc.port,
+            model=shlex.quote(model_api_name or ""),
+            multinode_note=multinode_note,
+            launch_block=launch_block,
+        )
+    )
+
+
+def _dynamo_disagg_role_fanout(
+    *,
+    role: str,
+    name: str,
+    name_upper: str,
+    safe_name: str,
+    num_workers: int,
+    nodes_per_worker: int,
+    srun_prefix: str,
+    script_file: str,
+    nodes_var: str,
+    set_pid_var: bool,
+) -> str:
+    """Emit the bash that spawns ``num_workers`` workers for a role.
+
+    Each worker is one independent dynamo.sglang process group with its own
+    TP rendezvous. We carve the role's nodelist into contiguous slices of
+    ``nodes_per_worker`` hosts; worker ``w`` claims slice
+    ``[w * nodes_per_worker + 1 : (w+1) * nodes_per_worker]`` (1-based to
+    match ``sed -n`` semantics), with the slice's first host serving as the
+    worker's torch.distributed leader.
+
+    For prefill, worker 0 / rank 0 is the global infra host (NATS + etcd +
+    dynamo frontend). For decode, no worker runs infra. ``set_pid_var`` ties
+    ``${{NAME_UPPER}}_PID`` to that infra-host srun so the cleanup trap can
+    track the service. The per-node script receives positional args
+    ``$1=rank``, ``$2=leader_ip``, ``$3=is_infra_host``."""
+    is_infra_assign = (
+        '        if [ "$_W" -eq 0 ] && [ "$_NR" -eq 0 ]; then\n            _IS_INFRA=1\n        fi'
+        if role == "prefill"
+        else ""
+    )
+    pid_assign = (
+        f'\n        if [ "$_W" -eq 0 ] && [ "$_NR" -eq 0 ]; then\n            {name_upper}_PID=$!\n        fi'
+        if set_pid_var
+        else ""
+    )
+    container_suffix = f"{role}-w$_W-r$_NR"
+    return (
+        f"# {role.capitalize()} workers ({num_workers} worker(s) × {nodes_per_worker} node(s) each)\n"
+        f"_W=0\n"
+        f"while [ $_W -lt {num_workers} ]; do\n"
+        f"    _OFF=$((_W * {nodes_per_worker} + 1))\n"
+        f"    _END=$((_OFF + {nodes_per_worker} - 1))\n"
+        f'    _SLICE=$(echo "${nodes_var}" | sed -n "${{_OFF}},${{_END}}p")\n'
+        f'    _LEADER=$(echo "$_SLICE" | head -n 1)\n'
+        f"    echo \"  {role} worker $_W: leader=$_LEADER nodes=$(echo \"$_SLICE\" | tr '\\n' ' ')\"\n"
+        f"    _NR=0\n"
+        f"    for _NODE in $_SLICE; do\n"
+        f"        _IS_INFRA=0\n"
+        + (is_infra_assign + "\n" if is_infra_assign else "")
+        + f"        {srun_prefix}--container-name=nel-{safe_name}-{container_suffix} -w $_NODE "
+        f'bash "$OUTPUT_DIR/logs/{script_file}" $_NR $_LEADER $_IS_INFRA '
+        f'>> "$OUTPUT_DIR/logs/server-{name}-$SLURM_JOB_ID.log" 2>&1 &' + pid_assign + "\n        _NR=$((_NR + 1))\n"
+        "    done\n"
+        "    _W=$((_W + 1))\n"
+        "done"
+    )
+
+
+def _dynamo_disaggregated_block(
+    *,
+    name: str,
+    upper: str,
+    safe_name: str,
+    svc: DynamoService,
+    deploy_image: str,
+    model_for_cmd: str,
+    model_mount: list[str],
+    model_api_name: str,
+    worker_port: int,
+    bootstrap_port: int,
+    use_containers: bool,
+    cluster_mounts: list[str],
+    env_keys: list[str],
+    mount_home: bool,
+    pool_to_het: dict[str, int] | None,
+    reexport_block: str,
+) -> str:
+    assert svc.prefill is not None
+    assert svc.decode is not None
+    prefill = svc.prefill
+    decode = svc.decode
+
+    def _role_script(role: str, role_cfg, *, run_infra: bool) -> tuple[str, str]:
+        """Build the per-node script + script_file for a role.
+
+        Returns ``(script_file, heredoc)``. ``run_infra`` is True for prefill
+        (only the very first prefill rank — worker 0, node-rank 0 — runs
+        NATS+etcd+frontend); False for decode.
+
+        Each worker forms its OWN TP=N rendezvous on its own leader, so the
+        leader IP is injected per invocation as positional arg ``$2``. The
+        worker command uses ``LEADER_IP`` (set from that arg) — NOT a shared
+        ``MASTER_IP`` or per-role global. Verified against srt-slurm's HSG
+        2664281 logs (prefill_w0=10.109.24.19, prefill_w1=10.109.30.165,
+        decode_w0=10.109.31.91 — distinct per worker).
+
+        Positional args: ``$1`` = node-rank within this worker's TP group;
+        ``$2`` = the worker's leader IP (== first host of its node slice);
+        ``$3`` = 1 iff this is the global infra host (prefill w0, rank 0)."""
+        worker_cmd = _dynamo_worker_command(
+            model_for_cmd=model_for_cmd,
+            model_api_name=model_api_name,
+            worker_port=worker_port,
+            tp=role_cfg.tensor_parallel_size,
+            pp=role_cfg.pipeline_parallel_size,
+            dp=role_cfg.data_parallel_size,
+            role=role,
+            bootstrap_port=bootstrap_port if role == "prefill" else None,
+            dist_init_var="LEADER_IP",
+            num_nodes=role_cfg.num_nodes,
+            extra_args=list(role_cfg.extra_args),
+        )
+
+        lines = ["set -euo pipefail"]
+        lines.append('NEL_NODE_RANK="${1:-0}"')
+        lines.append('LEADER_IP="${2:-$MASTER_IP}"')
+        lines.append('IS_INFRA_HOST="${3:-0}"')
+        lines.append("export NEL_NODE_RANK LEADER_IP IS_INFRA_HOST")
+        lines.extend(_dynamo_infra_env_exports("${MASTER_IP}"))
+        for k, v in role_cfg.extra_env.items():
+            lines.append(f"export {k}={shlex.quote(v)}")
+        if run_infra:
+            lines.append('if [ "$IS_INFRA_HOST" = "1" ]; then')
+            lines.extend(f"    {line}" for line in _dynamo_infra_bootstrap_block(name, svc.port))
+            lines.append("fi")
+        lines.append(worker_cmd)
+
+        script_file = f"_svc_{safe_name}_{role}_cmd_$SLURM_JOB_ID.sh"
+        heredoc = (
+            f"cat > \"$OUTPUT_DIR/logs/{script_file}\" <<'_NEMO_SVC_CMD_EOF_'\n"
+            + "\n".join(lines)
+            + "\n_NEMO_SVC_CMD_EOF_\n"
+        )
+        return script_file, heredoc
+
+    prefill_script_file, prefill_heredoc = _role_script("prefill", prefill, run_infra=True)
+    decode_script_file, decode_heredoc = _role_script("decode", decode, run_infra=False)
+
+    def _role_srun(role_cfg) -> str:
+        pool = role_cfg.node_pool
+        het_flag = ""
+        if pool and pool_to_het and pool in pool_to_het:
+            het_flag = f" --het-group={pool_to_het[pool]}"
+        if not use_containers:
+            return ""
+        srun = _build_srun_prefix(
+            role_cfg,
+            deploy_image,
+            het_flag=het_flag,
+            cluster_mounts=cluster_mounts,
+            env_keys=list(env_keys) + list(_DYNAMO_EXTRA_ENV_KEYS),
+            mount_home=mount_home,
+            extra_mounts=model_mount + ["$OUTPUT_DIR:$OUTPUT_DIR"],
+        )
+        srun = srun.replace(
+            f"--nodes {role_cfg.num_nodes} --ntasks {role_cfg.num_nodes}", "--nodes 1 --ntasks 1"
+        ).replace(" --label", "")
+        return srun.rstrip() + " "
+
+    prefill_srun = _role_srun(prefill)
+    decode_srun = _role_srun(decode)
+
+    def _role_nodelist_var(role_cfg) -> str:
+        pool = role_cfg.node_pool
+        if pool and pool_to_het and pool in pool_to_het:
+            return f"$SLURM_JOB_NODELIST_HET_GROUP_{pool_to_het[pool]}"
+        return "$SLURM_JOB_NODELIST"
+
+    # Two modes for splitting the allocation between prefill and decode:
+    # (a) HET-JOB MODE (different pools): each role has its own het-group
+    #     nodelist — emit `scontrol show hostnames` per role.
+    # (b) SINGLE-POOL MODE (same pool): the SBATCH header is flat, so the
+    #     pool's nodelist contains BOTH roles. Slice it with head/tail to
+    #     give prefill the first N and decode the rest. This is what
+    #     srt-slurm production recipes do (e.g. gb200-fp8-nvl72-port:
+    #     #SBATCH --nodes=6 --segment=6 with the orchestrator splitting
+    #     workers across the 6 nodes). Required to get all roles on one
+    #     NVL72 rack via `cluster.sbatch_extra_flags.segment: <total>`.
+    p_total = prefill.num_workers * prefill.num_nodes
+    d_total = decode.num_workers * decode.num_nodes
+    same_pool = prefill.node_pool is not None and prefill.node_pool == decode.node_pool
+    if same_pool:
+        pool_nodelist = _role_nodelist_var(prefill)  # same for both
+        nodelist_split_block = (
+            f'_ALL_NODES=$(scontrol show hostnames "{pool_nodelist}")\n'
+            f'_PREFILL_NODES=$(echo "$_ALL_NODES" | head -n {p_total})\n'
+            f'_DECODE_NODES=$(echo "$_ALL_NODES" | sed -n "{p_total + 1},{p_total + d_total}p")'
+        )
+    else:
+        nodelist_split_block = (
+            f'_PREFILL_NODES=$(scontrol show hostnames "{_role_nodelist_var(prefill)}")\n'
+            f'_DECODE_NODES=$(scontrol show hostnames "{_role_nodelist_var(decode)}")'
+        )
+
+    prefill_fanout = _dynamo_disagg_role_fanout(
+        role="prefill",
+        name=name,
+        name_upper=upper,
+        safe_name=safe_name,
+        num_workers=prefill.num_workers,
+        nodes_per_worker=prefill.num_nodes,
+        srun_prefix=prefill_srun,
+        script_file=prefill_script_file,
+        nodes_var="_PREFILL_NODES",
+        set_pid_var=True,
+    )
+    decode_fanout = _dynamo_disagg_role_fanout(
+        role="decode",
+        name=name,
+        name_upper=upper,
+        safe_name=safe_name,
+        num_workers=decode.num_workers,
+        nodes_per_worker=decode.num_nodes,
+        srun_prefix=decode_srun,
+        script_file=decode_script_file,
+        nodes_var="_DECODE_NODES",
+        set_pid_var=False,
+    )
+
+    body = _DYNAMO_DISAGG_SERVICE.format(
+        name=name,
+        name_upper=upper,
+        safe_name=safe_name,
+        port=svc.port,
+        model=shlex.quote(model_api_name or ""),
+        num_prefill_workers=prefill.num_workers,
+        num_decode_workers=decode.num_workers,
+        prefill_nodes_per_worker=prefill.num_nodes,
+        decode_nodes_per_worker=decode.num_nodes,
+        nodelist_split_block=nodelist_split_block,
+        prefill_fanout=prefill_fanout,
+        decode_fanout=decode_fanout,
+    )
+
+    return reexport_block + prefill_heredoc + decode_heredoc + body
+
+
 def _service_block(
     name: str,
     svc,
@@ -732,6 +1384,18 @@ def _service_block(
     # (like Gym) to $MASTER_IP so they share the host network namespace with
     # the batch script and eval srun, enabling localhost communication.
     _pin = not pool_to_het and use_containers
+
+    if isinstance(svc, DynamoService):
+        return _dynamo_service_block(
+            name,
+            svc,
+            use_containers=use_containers,
+            cluster_mounts=cluster_mounts or [],
+            env_keys=env_keys or [],
+            reexport_cmds=reexport_cmds,
+            mount_home=mount_home,
+            pool_to_het=pool_to_het,
+        )
 
     if svc.type in _MODEL_CMD:
         cmd, model_flag, tp_flag_name, pp_flag_name, dp_flag_name = _MODEL_CMD[svc.type]
@@ -981,6 +1645,28 @@ def _health_block(name: str, svc, *, pool_to_het: dict[str, int] | None = None) 
             name_upper=upper,
             url=svc.base_url or url,
             max_attempts=max_attempts,
+        )
+
+    if isinstance(svc, DynamoService):
+        # Aggregated mode: one ``backend`` worker, counted as decode by the
+        # frontend's /health response (matches srt-slurm's
+        # ``check_dynamo_health`` convention). Disagg: gate on the configured
+        # per-role ``num_workers`` so 2P+1D etc. only flips ready once every
+        # worker has registered (a partial registration round-robins traffic
+        # to a worker that isn't actually serving).
+        if svc.prefill is None:
+            expected_prefill = 0
+            expected_decode = 1
+        else:
+            expected_prefill = svc.prefill.num_workers
+            expected_decode = svc.decode.num_workers
+        return _HEALTH_WAIT_DYNAMO.format(
+            name=name,
+            name_upper=upper,
+            url=url,
+            max_attempts=max_attempts,
+            expected_prefill=expected_prefill,
+            expected_decode=expected_decode,
         )
 
     health = getattr(svc, "health_path", "/health") or "/health"
@@ -1235,15 +1921,30 @@ def _format_sbatch_extra_flags(flags: dict) -> str:
 
 
 def _any_multinode_service(config: EvalConfig) -> bool:
-    """Return True if any service requests multiple nodes."""
-    return any(getattr(svc, "num_nodes", 1) > 1 for svc in config.services.values())
+    """Return True if any service requests multiple nodes.
+
+    Dynamo disagg surfaces per-role ``num_nodes`` on ``prefill`` / ``decode``
+    sub-configs; the service-level ``num_nodes`` stays at the 1-default for
+    those configs, so the role sub-blocks have to be checked too — otherwise
+    the batch script's ``MASTER_IP=$(scontrol ...)`` discovery never gets
+    emitted and the worker scripts hit ``MASTER_IP: unbound variable``."""
+    for svc in config.services.values():
+        if getattr(svc, "num_nodes", 1) > 1:
+            return True
+        for role_attr in ("prefill", "decode"):
+            role_cfg = getattr(svc, role_attr, None)
+            if role_cfg and getattr(role_cfg, "num_nodes", 1) > 1:
+                return True
+    return False
 
 
 def _compute_pool_nodes(config: EvalConfig, pool_name: str) -> int:
     """Compute total nodes needed for a pool, accounting for multi-node services.
 
-    Returns the max of the pool's declared nodes and any service's num_nodes
-    requirement, so that the SBATCH header always requests enough.
+    Returns the max of the pool's declared nodes and the largest sizing among
+    services referencing this pool. For dynamo disagg with prefill+decode
+    BOTH pointing at the same pool (the single-rack-enforcement shape), sums
+    their per-role ``num_nodes`` since they share the allocation.
     """
     cluster = config.cluster
     if not isinstance(cluster, SlurmCluster):
@@ -1254,6 +1955,22 @@ def _compute_pool_nodes(config: EvalConfig, pool_name: str) -> int:
         svc_pool = getattr(svc, "node_pool", None)
         if svc_pool == pool_name:
             svc_max = max(svc_max, getattr(svc, "num_nodes", 1))
+        # Sum prefill + decode if both share this pool (single-pool disagg).
+        # Per-role footprint = num_workers * num_nodes (each worker forms its
+        # own TP-rendezvous group, so the allocation must cover all of them).
+        prefill = getattr(svc, "prefill", None)
+        decode = getattr(svc, "decode", None)
+        if prefill is not None and decode is not None:
+            p_total = prefill.num_workers * prefill.num_nodes
+            d_total = decode.num_workers * decode.num_nodes
+            p_pool = getattr(prefill, "node_pool", None)
+            d_pool = getattr(decode, "node_pool", None)
+            if p_pool == pool_name and d_pool == pool_name:
+                svc_max = max(svc_max, p_total + d_total)
+            elif p_pool == pool_name:
+                svc_max = max(svc_max, p_total)
+            elif d_pool == pool_name:
+                svc_max = max(svc_max, d_total)
     return max(base, svc_max)
 
 
@@ -1316,6 +2033,7 @@ def generate_sbatch(
             gpus_per_node_line = f"#SBATCH --gpus-per-node={pool.gpus_per_node}" if pool.gpus_per_node else ""
             partition_line = f"#SBATCH --partition={pool.partition}" if pool.partition else ""
             account_line = f"#SBATCH --account={cluster.account}" if cluster.account else ""
+            pool_extra_lines = _format_sbatch_extra_flags(getattr(pool, "sbatch_extra_flags", {}) or {})
             parts.append(
                 _HEADER_HETJOB_POOL.format(
                     het_idx=i,
@@ -1325,6 +2043,7 @@ def generate_sbatch(
                     walltime=cluster.walltime,
                     gres_line=gres_line,
                     gpus_per_node_line=gpus_per_node_line,
+                    pool_extra_lines=pool_extra_lines,
                     partition_line=partition_line,
                     account_line=account_line,
                 )
@@ -1388,6 +2107,15 @@ def generate_sbatch(
                     svc_pool = getattr(svc, "node_pool", None)
                     if svc_pool and svc_pool in pool_to_het:
                         nodelist_var = f"SLURM_JOB_NODELIST_HET_GROUP_{pool_to_het[svc_pool]}"
+                    break
+                # Dynamo disagg: NATS+etcd+frontend live on the prefill rank-0
+                # node, so MASTER_IP must resolve to the prefill pool's first
+                # host. ``prefill`` is checked first regardless of which is
+                # multi-node so disagg + decode-only-multi-node still works.
+                prefill = getattr(svc, "prefill", None)
+                prefill_pool = getattr(prefill, "node_pool", None) if prefill else None
+                if prefill_pool and prefill_pool in pool_to_het:
+                    nodelist_var = f"SLURM_JOB_NODELIST_HET_GROUP_{pool_to_het[prefill_pool]}"
                     break
         parts.append(_MULTINODE_IP_DISCOVERY.format(nodelist_var=nodelist_var))
 

--- a/src/nemo_evaluator/resources/containers.toml
+++ b/src/nemo_evaluator/resources/containers.toml
@@ -7,7 +7,7 @@
 # Users can override via cluster.container_image in their config.
 
 [defaults]
-# Built by CI and published to the public container registry.
+# Built by CI and pushed to the GitLab container registry.
 # Override with cluster.container_image in config — variants are derived automatically.
 registry = "nvcr.io/nvidia/nemo-evaluator"
 tag = "latest"
@@ -19,6 +19,7 @@ vllm = "vllm/vllm-openai:latest"
 sglang = "lmsysorg/sglang:latest"
 nim = ""
 nat = "nvcr.io/nvidia/nemo-agent-toolkit:latest"
+dynamo = "nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.1-cuda13"
 
 # Evaluation containers (NEL + harness)
 [eval]

--- a/tests/test_adapters/test_streaming_interceptor.py
+++ b/tests/test_adapters/test_streaming_interceptor.py
@@ -1,0 +1,270 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import http.server
+import json
+import threading
+import urllib.request
+from typing import Any
+
+import pytest
+
+from nemo_evaluator.adapters.interceptors.streaming import Interceptor
+from nemo_evaluator.adapters.proxy import start_adapter_proxy
+from nemo_evaluator.adapters.registry import InterceptorRegistry
+from nemo_evaluator.adapters.types import AdapterResponse, InterceptorContext
+
+
+def _sse_body(chunks: list[dict[str, Any]]) -> bytes:
+    lines = b"".join(b"data: " + json.dumps(chunk).encode() + b"\n\n" for chunk in chunks)
+    return lines + b"data: [DONE]\n\n"
+
+
+def _resp(body: dict[str, Any] | bytes, content_type: str = "text/event-stream") -> AdapterResponse:
+    return AdapterResponse(
+        status_code=200,
+        headers={"Content-Type": content_type},
+        body=body,
+        ctx=InterceptorContext(),
+    )
+
+
+def _post_json(url: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Authorization": "Bearer local-test"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return resp.status, json.loads(resp.read())
+
+
+@pytest.fixture
+def local_server():
+    servers = []
+
+    def start(handler_cls: type[http.server.BaseHTTPRequestHandler]) -> str:
+        server = http.server.HTTPServer(("127.0.0.1", 0), handler_cls)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        servers.append(server)
+        return f"http://127.0.0.1:{server.server_address[1]}"
+
+    yield start
+
+    for server in servers:
+        server.shutdown()
+
+
+class _QuietHandler(http.server.BaseHTTPRequestHandler):
+    def log_message(self, *_args):
+        pass
+
+
+def test_registry_exposes_streaming():
+    assert InterceptorRegistry.resolve_class("streaming") is Interceptor
+    assert "streaming" in InterceptorRegistry.available()
+
+
+async def test_coalesces_streaming_response():
+    resp = _resp(
+        _sse_body(
+            [
+                {
+                    "id": "cmpl-test",
+                    "created": 1,
+                    "model": "test-model",
+                    "choices": [{"index": 0, "delta": {"role": "assistant", "content": "hello "}}],
+                },
+                {
+                    "id": "cmpl-test",
+                    "created": 1,
+                    "model": "test-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": "world", "reasoning_content": "because"},
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 3, "completion_tokens": 2, "total_tokens": 5},
+                },
+            ]
+        )
+    )
+
+    result = await Interceptor().intercept_response(resp)
+
+    assert result.headers["Content-Type"] == "application/json"
+    assert result.body["id"] == "cmpl-test"
+    assert result.body["object"] == "chat.completion"
+    assert result.body["choices"][0]["message"]["content"] == "hello world"
+    assert result.body["choices"][0]["message"]["reasoning_content"] == "because"
+    assert result.body["choices"][0]["finish_reason"] == "stop"
+    assert result.body["usage"]["total_tokens"] == 5
+
+
+async def test_merges_tool_call_deltas():
+    resp = _resp(
+        _sse_body(
+            [
+                {
+                    "id": "cmpl-tools",
+                    "created": 1,
+                    "model": "test-model",
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": "assistant",
+                                "tool_calls": [
+                                    {
+                                        "index": 0,
+                                        "id": "call_1",
+                                        "type": "function",
+                                        "function": {"name": "search", "arguments": '{"q"'},
+                                    }
+                                ],
+                            },
+                        }
+                    ],
+                },
+                {
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"tool_calls": [{"index": 0, "function": {"arguments": ':"x"}'}}]},
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                },
+            ]
+        )
+    )
+
+    result = await Interceptor().intercept_response(resp)
+
+    tool_call = result.body["choices"][0]["message"]["tool_calls"][0]
+    assert tool_call["id"] == "call_1"
+    assert tool_call["type"] == "function"
+    assert tool_call["function"] == {"name": "search", "arguments": '{"q":"x"}'}
+    assert result.body["choices"][0]["finish_reason"] == "tool_calls"
+
+
+async def test_streamed_error_event_overrides_partial_delta():
+    error = {"message": "upstream failed", "type": "server_error"}
+    resp = _resp(
+        _sse_body(
+            [
+                {
+                    "id": "cmpl-error",
+                    "created": 1,
+                    "model": "test-model",
+                    "choices": [{"index": 0, "delta": {"role": "assistant", "content": "partial"}}],
+                },
+                {"error": error},
+            ]
+        )
+    )
+
+    result = await Interceptor().intercept_response(resp)
+
+    assert result.status_code == 502
+    assert result.headers["Content-Type"] == "application/json"
+    assert result.body == {"error": error}
+
+
+async def test_replaces_null_message_content_in_json_response():
+    resp = _resp(
+        {"choices": [{"index": 0, "message": {"role": "assistant", "content": None}}]},
+        content_type="application/json",
+    )
+
+    result = await Interceptor().intercept_response(resp)
+
+    assert result.body["choices"][0]["message"]["content"] == ""
+
+
+async def test_replaces_missing_stream_content_with_empty_string():
+    resp = _resp(
+        _sse_body(
+            [
+                {
+                    "id": "cmpl-empty",
+                    "created": 1,
+                    "model": "test-model",
+                    "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": "stop"}],
+                }
+            ]
+        )
+    )
+
+    result = await Interceptor().intercept_response(resp)
+
+    assert result.body["choices"][0]["message"]["content"] == ""
+
+
+async def test_non_sse_bytes_are_left_unchanged():
+    resp = _resp(b"not json", content_type="text/plain")
+
+    result = await Interceptor().intercept_response(resp)
+
+    assert result is resp
+    assert result.body == b"not json"
+
+
+def test_start_adapter_proxy_coalesces_endpoint_streaming_response(local_server):
+    class Handler(_QuietHandler):
+        seen_body: dict[str, Any] | None = None
+
+        def do_POST(self):
+            Handler.seen_body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            body = _sse_body(
+                [
+                    {
+                        "id": "cmpl-proxy",
+                        "created": 1,
+                        "model": "test-model",
+                        "choices": [{"index": 0, "delta": {"role": "assistant", "content": "done"}}],
+                    }
+                ]
+            )
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    base = local_server(Handler)
+    handle = start_adapter_proxy(
+        upstream_url=base,
+        model_id="test-model",
+        port=0,
+        interceptor_specs=[
+            {"name": "payload_modifier", "config": {"params_to_add": {"stream": True}}},
+            {"name": "streaming", "config": {}},
+        ],
+    )
+    try:
+        status, body = _post_json(f"{handle.url}/v1/chat/completions", {"messages": []})
+    finally:
+        handle.stop()
+
+    assert status == 200
+    assert Handler.seen_body is not None
+    assert Handler.seen_body["stream"] is True
+    assert body["id"] == "cmpl-proxy"
+    assert body["choices"][0]["message"]["content"] == "done"

--- a/tests/test_orchestration/test_slurm_sharding.py
+++ b/tests/test_orchestration/test_slurm_sharding.py
@@ -1228,6 +1228,636 @@ class TestMultinodeSglang:
         assert "--dist-init-addr" not in script
 
 
+class TestDynamoAggregated:
+    """Aggregated dynamo: one ``python3 -m dynamo.sglang`` worker behind a
+    ``python3 -m dynamo.frontend`` HTTP frontend, coordinated through NATS+etcd.
+    Mode is implicit: presence of ``prefill``/``decode`` switches to disagg, their
+    absence is aggregated."""
+
+    def _cfg(self, num_nodes=1, **svc_overrides):
+        svc = {
+            "type": "dynamo",
+            "model": "nvidia/glm",
+            "protocol": "chat_completions",
+            "port": 8000,
+            "tensor_parallel_size": 8,
+            "num_nodes": num_nodes,
+        }
+        svc.update(svc_overrides)
+        return EvalConfig.model_validate(
+            {
+                "services": {"model": svc},
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "node_pools": {
+                        "compute": {"partition": "batch", "nodes": num_nodes, "gres": "gpu:8"},
+                    },
+                },
+            }
+        )
+
+    def test_emits_worker_module(self):
+        script, _, _ = generate_sbatch(self._cfg())
+        assert "python3 -m dynamo.sglang" in script
+
+    def test_emits_frontend(self):
+        script, _, _ = generate_sbatch(self._cfg())
+        assert "python3 -m dynamo.frontend" in script
+        assert "--http-port 8000" in script
+
+    def test_emits_nats_and_etcd(self):
+        script, _, _ = generate_sbatch(self._cfg())
+        assert "nats-server" in script
+        assert "etcd" in script
+
+    def test_dynamo_env_block(self):
+        script, _, _ = generate_sbatch(self._cfg())
+        assert "DYN_REQUEST_PLANE=nats" in script
+        assert "NATS_SERVER" in script
+        assert "ETCD_ENDPOINTS" in script
+
+    def test_singlenode_emits_tp_flag(self):
+        script, _, _ = generate_sbatch(self._cfg(num_nodes=1))
+        assert "--tp-size 8" in script
+
+    def test_singlenode_no_rendezvous_flags(self):
+        script, _, _ = generate_sbatch(self._cfg(num_nodes=1))
+        assert "--nnodes" not in script
+        assert "--node-rank" not in script
+        assert "--dist-init-addr" not in script
+
+    def test_singlenode_no_disagg_flag(self):
+        script, _, _ = generate_sbatch(self._cfg(num_nodes=1))
+        assert "--disaggregation-mode" not in script
+
+    def test_multinode_emits_torch_distributed_flags(self):
+        script, _, _ = generate_sbatch(self._cfg(num_nodes=2, tensor_parallel_size=16))
+        assert "--nnodes 2" in script
+        assert "--node-rank" in script
+        assert "--dist-init-addr" in script
+
+    def test_multinode_no_ray_flag(self):
+        script, _, _ = generate_sbatch(self._cfg(num_nodes=2, tensor_parallel_size=16))
+        assert "--distributed-executor-backend ray" not in script
+        assert "ray start --head" not in script
+
+    def test_multinode_frontend_gated_to_rank_zero(self):
+        """NATS+etcd+frontend run once. On multi-node aggregated they must be
+        gated by node rank so only rank 0 launches them — otherwise N nodes
+        would each spawn a frontend trying to bind the same port."""
+        script, _, _ = generate_sbatch(self._cfg(num_nodes=2, tensor_parallel_size=16))
+        assert 'if [ "$NEL_NODE_RANK" -eq 0 ]' in script or 'if [ "${NEL_NODE_RANK}" -eq 0 ]' in script
+
+    def test_container_env_propagates_output_dir_and_jobid(self):
+        """The worker script writes nats/etcd/frontend logs to
+        ``$OUTPUT_DIR/logs/dynamo-*-$SLURM_JOB_ID.log``. Both vars must be
+        propagated into the container via ``--container-env`` or the script
+        dies with ``unbound variable`` under ``set -euo pipefail``."""
+        cfg = EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "tensor_parallel_size": 8,
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "container_mounts": ["/lustre:/lustre"],
+                    "node_pools": {"compute": {"partition": "batch", "nodes": 1, "gres": "gpu:8"}},
+                },
+            }
+        )
+        script, _, _ = generate_sbatch(cfg)
+        assert "--container-env=OUTPUT_DIR" in script
+        assert "--container-env=SLURM_JOB_ID" in script
+
+    def test_default_image_resolved_from_containers_toml(self):
+        """No explicit image → falls back to containers.toml ``deployment.dynamo``.
+        Container-mount on the cluster forces the use-containers path so the
+        resolved image lands in the generated srun prefix."""
+        cfg = EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "tensor_parallel_size": 8,
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "container_mounts": ["/lustre:/lustre"],
+                    "node_pools": {"compute": {"partition": "batch", "nodes": 1, "gres": "gpu:8"}},
+                },
+            }
+        )
+        script, _, _ = generate_sbatch(cfg)
+        assert "ai-dynamo/sglang-runtime" in script
+
+    def test_health_check_on_frontend_port(self):
+        script, _, _ = generate_sbatch(self._cfg())
+        assert "localhost:8000/health" in script
+
+    def test_health_check_waits_for_worker_registration(self):
+        """The dynamo frontend's /health returns 200 the moment the HTTP
+        server binds — well before any worker has registered via NATS. The
+        health probe must parse the JSON body and count instances per
+        component (mirroring srt-slurm's ``check_dynamo_health``), otherwise
+        the eval kicks off against a not-yet-loaded model and all requests
+        404. Caught by SVG 99094 — model was at 39% of weight loading when
+        the eval finished scoring 10/10 as infra errors."""
+        script, _, _ = generate_sbatch(self._cfg())
+        # The readiness probe parses /health JSON and counts registered
+        # workers per component (prefill / decode / backend), matching
+        # srt-slurm's check_dynamo_health rule.
+        assert "python3" in script
+        assert '"instances"' in script
+        assert '"component"' in script
+        # The generic /health-200-is-enough probe used by vllm/sglang must NOT
+        # appear for dynamo.
+        assert 'curl -sf "http://localhost:8000/health" > /dev/null 2>&1' not in script
+
+    def test_aggregated_health_expects_backend_worker(self):
+        """Aggregated mode reports component=backend on the /health
+        response (per srt-slurm convention). The readiness gate should
+        require at least 1 such worker (expected_decode=1, expected_prefill=0)."""
+        script, _, _ = generate_sbatch(self._cfg())
+        # Aggregated: 0 prefills, 1 decode/backend.
+        assert "n_p >= 0 and n_d >= 1" in script
+
+
+class TestDynamoDisaggregated:
+    """Disaggregated dynamo: separate prefill and decode workers, both running
+    ``python3 -m dynamo.sglang ... --disaggregation-mode {prefill|decode}``.
+    NATS+etcd+frontend run once on the first prefill node."""
+
+    def _cfg(self, prefill=None, decode=None, **svc_overrides):
+        svc = {
+            "type": "dynamo",
+            "model": "nvidia/glm",
+            "protocol": "chat_completions",
+            "port": 8000,
+        }
+        if prefill is not None:
+            svc["prefill"] = prefill
+        if decode is not None:
+            svc["decode"] = decode
+        svc.update(svc_overrides)
+        return EvalConfig.model_validate(
+            {
+                "services": {"model": svc},
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "node_pools": {
+                        "prefill_pool": {"partition": "batch", "nodes": 1, "gres": "gpu:8"},
+                        "decode_pool": {"partition": "batch", "nodes": 1, "gres": "gpu:8"},
+                    },
+                },
+            }
+        )
+
+    def _basic_disagg_cfg(self):
+        return self._cfg(
+            prefill={"tensor_parallel_size": 8, "num_nodes": 1, "node_pool": "prefill_pool"},
+            decode={"tensor_parallel_size": 8, "num_nodes": 1, "node_pool": "decode_pool"},
+        )
+
+    def test_emits_both_role_flags(self):
+        script, _, _ = generate_sbatch(self._basic_disagg_cfg())
+        assert "--disaggregation-mode prefill" in script
+        assert "--disaggregation-mode decode" in script
+
+    def test_prefill_emits_bootstrap_port(self):
+        """SGLang's CommonKVBootstrapServer needs an explicit non-default port
+        on prefill workers — the sglang default 8998 collides with dynamo's NATS
+        on the head node and silently breaks multi-node prefill."""
+        script, _, _ = generate_sbatch(self._basic_disagg_cfg())
+        assert "--disaggregation-bootstrap-port" in script
+
+    def test_decode_has_no_bootstrap_port(self):
+        """Only prefill workers run the KV bootstrap server; decode workers
+        connect to it. Putting --disaggregation-bootstrap-port on decode is a
+        no-op at best and confusing at worst — keep it off."""
+        script, _, _ = generate_sbatch(self._basic_disagg_cfg())
+        decode_idx = script.find("--disaggregation-mode decode")
+        prefill_idx = script.find("--disaggregation-mode prefill")
+        assert decode_idx >= 0 and prefill_idx >= 0
+        # Slice the decode launch block (between decode marker and end of file
+        # or next major marker) and assert no bootstrap-port there.
+        decode_block = script[decode_idx : decode_idx + 800]
+        assert "--disaggregation-bootstrap-port" not in decode_block
+
+    def test_emits_two_role_sruns(self):
+        """Disagg requires two per-role srun fan-outs, not a single shared one."""
+        script, _, _ = generate_sbatch(self._basic_disagg_cfg())
+        assert script.count("dynamo.sglang") >= 2
+
+    def test_frontend_runs_once(self):
+        script, _, _ = generate_sbatch(self._basic_disagg_cfg())
+        assert script.count("python3 -m dynamo.frontend") == 1
+
+    def test_emits_worker_tp_flags_per_role(self):
+        cfg = self._cfg(
+            prefill={"tensor_parallel_size": 8, "num_nodes": 1, "node_pool": "prefill_pool"},
+            decode={"tensor_parallel_size": 4, "num_nodes": 1, "node_pool": "decode_pool"},
+        )
+        script, _, _ = generate_sbatch(cfg)
+        assert "--tp-size 8" in script
+        assert "--tp-size 4" in script
+
+    def test_health_check_on_frontend_port(self):
+        script, _, _ = generate_sbatch(self._basic_disagg_cfg())
+        assert "localhost:8000/health" in script
+
+    def test_multinode_per_role_emits_master_ip_discovery(self):
+        """When a per-role worker spans multiple nodes (TP=8 on 4-GPU nodes →
+        num_nodes=2), the worker script references ``${MASTER_IP}`` for NATS,
+        etcd and the torch-distributed init address. ``_any_multinode_service``
+        must look at prefill/decode sub-configs, not just the service-level
+        ``num_nodes``, or the discovery block is dropped and the worker fails
+        with ``MASTER_IP: unbound variable``. Caught by HSG 2670865."""
+        cfg = self._cfg(
+            prefill={"tensor_parallel_size": 8, "num_nodes": 2, "node_pool": "prefill_pool"},
+            decode={"tensor_parallel_size": 8, "num_nodes": 2, "node_pool": "decode_pool"},
+        )
+        # Adjust node_pools to declare 2 nodes per pool for this case.
+        cfg.cluster.node_pools["prefill_pool"].nodes = 2
+        cfg.cluster.node_pools["decode_pool"].nodes = 2
+        script, _, _ = generate_sbatch(cfg)
+        assert "MASTER_IP=$(scontrol show hostname" in script
+        # MASTER_IP must resolve from the prefill pool — that's where
+        # NATS+etcd+frontend live.
+        assert "SLURM_JOB_NODELIST_HET_GROUP_0" in script
+
+    def test_multinode_per_role_uses_distinct_dist_init_leaders(self):
+        """Each worker (prefill, decode) forms its own torch.distributed TP
+        rendezvous and must NOT share ``--dist-init-addr``. Verified against
+        srt-slurm's HSG 2664281 production run, where prefill_w0 / prefill_w1 /
+        decode_w0 each had distinct leader IPs in their dumped server_args.
+        Originally I shared ``MASTER_IP`` between roles and the decode TP
+        group never assembled (Gloo Rank 0 with 'Expected 0 peer ranks').
+
+        New shape: the per-node script reads its leader IP from positional
+        arg ``$2``, and the outer fan-out computes ``_LEADER`` per worker
+        slice — so leaders are per-WORKER (multi-worker-ready), not per-role
+        globals."""
+        cfg = self._cfg(
+            prefill={"tensor_parallel_size": 8, "num_nodes": 2, "node_pool": "prefill_pool"},
+            decode={"tensor_parallel_size": 8, "num_nodes": 2, "node_pool": "decode_pool"},
+        )
+        cfg.cluster.node_pools["prefill_pool"].nodes = 2
+        cfg.cluster.node_pools["decode_pool"].nodes = 2
+        cfg.cluster.container_mounts = ["/lustre:/lustre"]
+        script, _, _ = generate_sbatch(cfg)
+        # Per-role nodelists discovered from each het-group.
+        assert '_PREFILL_NODES=$(scontrol show hostnames "$SLURM_JOB_NODELIST_HET_GROUP_0")' in script
+        assert '_DECODE_NODES=$(scontrol show hostnames "$SLURM_JOB_NODELIST_HET_GROUP_1")' in script
+        # Per-worker leader computed inside the outer loop and passed to the
+        # per-node script as positional arg $2.
+        assert '_LEADER=$(echo "$_SLICE" | head -n 1)' in script
+        assert 'bash "$OUTPUT_DIR/logs/_svc_model_prefill_cmd_$SLURM_JOB_ID.sh" $_NR $_LEADER $_IS_INFRA' in script
+        assert 'bash "$OUTPUT_DIR/logs/_svc_model_decode_cmd_$SLURM_JOB_ID.sh" $_NR $_LEADER $_IS_INFRA' in script
+        # The per-node script binds LEADER_IP from $2 and the worker command
+        # references it (NOT a shared MASTER_IP).
+        assert 'LEADER_IP="${2:-$MASTER_IP}"' in script
+        assert '--dist-init-addr "${LEADER_IP}:29500"' in script
+
+    def test_single_pool_disagg_slices_nodelist(self):
+        """When prefill.node_pool == decode.node_pool, the sbatch is flat
+        (no het-job) and the disagg block must SLICE the pool's nodelist via
+        head/tail — otherwise both roles iterate the SAME nodelist and overlap.
+        This is the shape srt-slurm production recipes use (single allocation
+        with `--segment=N` for rack co-location)."""
+        cfg = EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "prefill": {"tensor_parallel_size": 8, "num_nodes": 2, "node_pool": "compute"},
+                        "decode": {"tensor_parallel_size": 8, "num_nodes": 2, "node_pool": "compute"},
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "sbatch_extra_flags": {"segment": 4},
+                    "node_pools": {"compute": {"partition": "batch", "nodes": 4, "gres": "gpu:4"}},
+                },
+            }
+        )
+        script, _, _ = generate_sbatch(cfg)
+        # Single flat SBATCH header (no #SBATCH hetjob), `--segment=4`
+        # ensures all 4 nodes land on one NVL72 rack.
+        assert "#SBATCH hetjob" not in script
+        assert "#SBATCH --segment=4" in script
+        # Disagg block slices the pool's nodelist into prefill (first 2) +
+        # decode (next 2) — sed range works for both N=2 and arbitrary sizes.
+        assert '_ALL_NODES=$(scontrol show hostnames "$SLURM_JOB_NODELIST")' in script
+        assert '_PREFILL_NODES=$(echo "$_ALL_NODES" | head -n 2)' in script
+        assert '_DECODE_NODES=$(echo "$_ALL_NODES" | sed -n "3,4p")' in script
+        # Pool sizing: _compute_pool_nodes sums prefill+decode for single-pool
+        # disagg, so the SBATCH allocates 4 nodes.
+        assert "#SBATCH --nodes=4" in script
+
+    def test_health_expects_one_prefill_and_one_decode(self):
+        """Disagg readiness needs BOTH roles registered — gating on either
+        alone would green when /v1/chat/completions still can't generate
+        (prefill-only can't return tokens, decode-only has no KV to consume)."""
+        script, _, _ = generate_sbatch(self._basic_disagg_cfg())
+        assert "n_p >= 1 and n_d >= 1" in script
+
+    def test_multi_worker_disagg_spawns_per_worker_with_distinct_leader(self):
+        """2P+1D wide-EP shape: prefill.num_workers=2, decode.num_workers=1.
+        Each prefill worker gets its OWN node slice and its OWN TP-rendezvous
+        leader (slice[0]); the inner per-node loop ranks 0..num_nodes-1 within
+        that worker. Verified against srt-slurm's HSG 2664281 production run
+        where prefill_w0=10.109.24.19, prefill_w1=10.109.30.165 (distinct).
+
+        With num_nodes=1 per worker the slices are single-host; with num_nodes>1
+        the inner loop emits multi-host TP rendezvous against the slice's
+        leader. The container name encodes worker AND node-rank so two srun's
+        for the same role don't collide on container names."""
+        cfg = EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "prefill": {
+                            "tensor_parallel_size": 4,
+                            "num_workers": 2,
+                            "num_nodes": 1,
+                            "node_pool": "compute",
+                        },
+                        "decode": {
+                            "tensor_parallel_size": 4,
+                            "num_workers": 1,
+                            "num_nodes": 1,
+                            "node_pool": "compute",
+                        },
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "sbatch_extra_flags": {"segment": 3},
+                    "node_pools": {"compute": {"partition": "batch", "nodes": 3, "gres": "gpu:4"}},
+                },
+            }
+        )
+        script, _, _ = generate_sbatch(cfg)
+        # Pool sized for 2 prefill + 1 decode workers (each 1 node) = 3 nodes.
+        assert "#SBATCH --nodes=3" in script
+        # Single-pool slice: prefill claims first 2 hosts, decode claims host 3.
+        assert '_PREFILL_NODES=$(echo "$_ALL_NODES" | head -n 2)' in script
+        assert '_DECODE_NODES=$(echo "$_ALL_NODES" | sed -n "3,3p")' in script
+        # Outer loop over workers + inner over per-worker nodes.
+        assert "while [ $_W -lt 2 ]; do" in script  # prefill
+        assert "while [ $_W -lt 1 ]; do" in script  # decode
+        # Each worker computes its own leader from its slice.
+        assert '_LEADER=$(echo "$_SLICE" | head -n 1)' in script
+        # Container names include worker AND rank to avoid collisions when a
+        # role spawns multiple workers.
+        assert "--container-name=nel-model-prefill-w$_W-r$_NR" in script
+        assert "--container-name=nel-model-decode-w$_W-r$_NR" in script
+
+    def test_multi_worker_infra_runs_only_on_prefill_worker0_rank0(self):
+        """NATS + etcd + dynamo frontend must run on exactly ONE host across
+        the whole allocation. With multi-prefill (2P+) the rank-0 gate alone
+        is not enough — both prefill workers have a rank 0. The fix is to
+        gate on (worker_idx == 0 AND node_rank == 0) for prefill only; decode
+        workers never run infra."""
+        cfg = self._multi_worker_cfg(prefill_workers=2, decode_workers=1)
+        script, _, _ = generate_sbatch(cfg)
+        # Prefill fan-out flips _IS_INFRA=1 only when both _W and _NR are 0.
+        assert 'if [ "$_W" -eq 0 ] && [ "$_NR" -eq 0 ]; then\n            _IS_INFRA=1' in script
+        # Decode fan-out never sets _IS_INFRA — it stays at the loop default 0.
+        decode_start = script.find("# Decode workers")
+        decode_block = script[decode_start : decode_start + 1500]
+        assert "_IS_INFRA=1" not in decode_block
+        # Per-node script gates the infra block on $IS_INFRA_HOST=="1", NOT
+        # the bare node-rank (multi-worker would otherwise spin up infra per
+        # worker).
+        assert 'if [ "$IS_INFRA_HOST" = "1" ]; then' in script
+        assert "nats-server -js" in script
+
+    def test_multi_worker_health_check_counts_workers(self):
+        """Readiness must gate on the FULL worker count per role — otherwise
+        we declare ready while only one prefill worker has registered, and
+        the dynamo prefill router round-robins traffic to a worker that's
+        still loading weights."""
+        cfg = self._multi_worker_cfg(prefill_workers=2, decode_workers=1)
+        script, _, _ = generate_sbatch(cfg)
+        assert "n_p >= 2 and n_d >= 1" in script
+
+    def test_multi_worker_with_multi_node_per_worker(self):
+        """Production shape: 2 prefill workers × 2 nodes each (TP=8 spanning
+        2 GB200 nodes per worker) + 1 decode worker × 2 nodes. Total = 6 nodes,
+        matching srt-slurm's gb200-fp8-nvl72-port `#SBATCH --nodes=6
+        --segment=6`. Per-worker node slices are 2-long, leader is slice[0],
+        inner loop assigns ranks 0..1 within each worker."""
+        cfg = EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "prefill": {
+                            "tensor_parallel_size": 8,
+                            "num_workers": 2,
+                            "num_nodes": 2,
+                            "node_pool": "compute",
+                        },
+                        "decode": {
+                            "tensor_parallel_size": 8,
+                            "num_workers": 1,
+                            "num_nodes": 2,
+                            "node_pool": "compute",
+                        },
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "sbatch_extra_flags": {"segment": 6},
+                    "node_pools": {"compute": {"partition": "batch", "nodes": 6, "gres": "gpu:4"}},
+                },
+            }
+        )
+        script, _, _ = generate_sbatch(cfg)
+        # 2*2 + 1*2 = 6 nodes.
+        assert "#SBATCH --nodes=6" in script
+        # Prefill: 2 workers × 2 nodes = 4 first hosts; decode = next 2.
+        assert '_PREFILL_NODES=$(echo "$_ALL_NODES" | head -n 4)' in script
+        assert '_DECODE_NODES=$(echo "$_ALL_NODES" | sed -n "5,6p")' in script
+        # Outer/inner loop bounds reflect the worker × nodes-per-worker shape.
+        assert "_OFF=$((_W * 2 + 1))" in script  # both roles
+        assert "while [ $_W -lt 2 ]; do" in script  # prefill workers
+        assert "while [ $_W -lt 1 ]; do" in script  # decode workers
+        # All 4 workers should form their OWN TP groups against their slice's
+        # leader — multi-node sglang flags must be present.
+        assert "--nnodes 2" in script
+        assert '--node-rank "${NEL_NODE_RANK:-0}"' in script
+        # Health gate matches: 2 prefill workers + 1 decode worker registered.
+        assert "n_p >= 2 and n_d >= 1" in script
+
+    def _multi_worker_cfg(self, *, prefill_workers: int, decode_workers: int):
+        total = prefill_workers + decode_workers
+        return EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "prefill": {
+                            "tensor_parallel_size": 4,
+                            "num_workers": prefill_workers,
+                            "num_nodes": 1,
+                            "node_pool": "compute",
+                        },
+                        "decode": {
+                            "tensor_parallel_size": 4,
+                            "num_workers": decode_workers,
+                            "num_nodes": 1,
+                            "node_pool": "compute",
+                        },
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "sbatch_extra_flags": {"segment": total},
+                    "node_pools": {"compute": {"partition": "batch", "nodes": total, "gres": "gpu:4"}},
+                },
+            }
+        )
+
+
+class TestDynamoSchema:
+    def test_partial_disagg_config_rejected(self):
+        """prefill set without decode (or vice versa) is a config error."""
+        import pytest
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError, match="prefill.*decode.*both be set"):
+            EvalConfig.model_validate(
+                {
+                    "services": {
+                        "model": {
+                            "type": "dynamo",
+                            "model": "nvidia/glm",
+                            "protocol": "chat_completions",
+                            "port": 8000,
+                            "tensor_parallel_size": 8,
+                            "prefill": {"tensor_parallel_size": 8},
+                            # decode intentionally missing
+                        }
+                    },
+                    "benchmarks": [
+                        {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                    ],
+                    "cluster": {
+                        "type": "slurm",
+                        "walltime": "04:00:00",
+                        "node_pools": {"compute": {"partition": "batch", "nodes": 1, "gres": "gpu:8"}},
+                    },
+                }
+            )
+
+    def test_aggregated_config_validates(self):
+        EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "tensor_parallel_size": 8,
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "node_pools": {"compute": {"partition": "batch", "nodes": 1, "gres": "gpu:8"}},
+                },
+            }
+        )
+
+    def test_disagg_config_validates(self):
+        EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "dynamo",
+                        "model": "nvidia/glm",
+                        "protocol": "chat_completions",
+                        "port": 8000,
+                        "prefill": {"tensor_parallel_size": 8, "node_pool": "prefill_pool"},
+                        "decode": {"tensor_parallel_size": 8, "node_pool": "decode_pool"},
+                    }
+                },
+                "benchmarks": [
+                    {"name": "gsm8k", "solver": {"type": "simple", "service": "model"}},
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "04:00:00",
+                    "node_pools": {
+                        "prefill_pool": {"partition": "batch", "nodes": 1, "gres": "gpu:8"},
+                        "decode_pool": {"partition": "batch", "nodes": 1, "gres": "gpu:8"},
+                    },
+                },
+            }
+        )
+
+
 # ---------------------------------------------------------------------------
 # Lifecycle helpers
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Backfill of two commits from `gitlab main @ 6f52ab5d` (new sync point after `0ffefa3d`).

## Changes (12 files, +2149 / -7)

### feat(adapters): streaming response coalescer
- **`src/nemo_evaluator/adapters/interceptors/streaming.py`** (NEW) — `StreamingCoalescerInterceptor`: `RequestToResponseInterceptor` that collects SSE delta chunks from a streaming model response and returns a single assembled non-streaming response. Registered as `streaming_coalescer`.
- **`src/nemo_evaluator/adapters/registry.py`** — registers the new interceptor.
- **`tests/test_adapters/test_streaming_interceptor.py`** (NEW) — full test suite.

### feat: Dynamo deployment support (aggregated + disaggregated)
- **`src/nemo_evaluator/orchestration/slurm_gen.py`** — generates correct sbatch for Dynamo aggregated and disaggregated (prefill/decode split) topologies.
- **`src/nemo_evaluator/config/clusters.py`**, **`services.py`**, **`config/__init__.py`** — new `DynamoService` and `DynamoCluster` config types.
- **`docs/deployment/slurm.md`** — Dynamo deployment guide.
- **`examples/configs/15c_slurm_gsm8k_dynamo.yaml`** (NEW) — GSM8K eval with aggregated Dynamo.
- **`examples/configs/15d_slurm_gsm8k_dynamo_disagg.yaml`** (NEW) — GSM8K eval with disaggregated Dynamo.
- **`src/nemo_evaluator/resources/containers.toml`** — new `dynamo` image alias (`nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.1.1-cuda13`).
- **`tests/test_orchestration/test_slurm_sharding.py`** — extended tests.

## Scrubs applied
| File | Pattern | Replacement |
|---|---|---|
| 15c, 15d example configs | Lustre checkpoint paths | `${SHARED_ROOT}/...` |
| 15c, 15d example configs | User container `.sqsh` paths | `${CONTAINER_SQSH_PATH}` |
| 15c, 15d example configs | SLURM account `coreai_dlalgo_compeval` | `<your-slurm-account>` |
| `containers.toml` | `gitlab-master.nvidia.com/...` registry | `nvcr.io/nvidia/nemo-evaluator` |

## Excluded
**`15g_hsg_tb2_dynamo_2p1d_full_scale.yaml`** — references internal cluster `oci-hsg-cs-001`, user-specific Lustre paths, and an internal SLURM account (`coreai_dlalgo_llm`). Retained internally on `nv-internal-main`.

## Verification
- Zero internal-pattern hits across all 12 published files.
- Pre-commit clean (ruff, ruff-format, SPDX).

## Sync source
`gitlab main @ 6f52ab5d` — new left-off-at SHA.