### PR TITLE
fix(dev-wheel): stamp pyproject.toml so wheel is named 0.3.0.devN

### DIFF
--- a/.github/workflows/dev-wheel.yml
+++ b/.github/workflows/dev-wheel.yml
@@ -56,8 +56,10 @@ jobs:
         id: version
         run: |
           N=$(git rev-list --count HEAD)
+          # pyproject.toml is what uv build reads for the wheel filename
+          sed -i "s/^version = \"0\.3\.0\"/version = \"0.3.0.dev${N}\"/" pyproject.toml
+          # Keep package_info.py and __init__.py in sync for runtime
           sed -i "s/^PRE_RELEASE = .*/PRE_RELEASE = \".dev${N}\"/" src/nemo_evaluator/package_info.py
-          # Also keep __init__.py in sync at runtime
           sed -i "s/^__version__ = .*/__version__ = \"0.3.0.dev${N}\"/" src/nemo_evaluator/__init__.py
           VERSION="0.3.0.dev${N}"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Problem

PR #1010 introduced the dev-wheel workflow but the wheel built as `nemo_evaluator-0.3.0-...` instead of `nemo_evaluator-0.3.0.devN-...`.

Root cause: `uv build` reads the version from `pyproject.toml`, not from `package_info.py` or `__init__.py`. The stamp step was patching the latter two but not `pyproject.toml`.

## Fix

Add one `sed` line to the stamp step:
```diff
+ sed -i "s/^version = \"0\.3\.0\"/version = \"0.3.0.dev${N}\"" pyproject.toml
  sed -i "s/^PRE_RELEASE = .*/PRE_RELEASE = \".dev${N}\"" src/nemo_evaluator/package_info.py
  sed -i "s/^__version__ = .*/__version__ = \"0.3.0.dev${N}\"" src/nemo_evaluator/__init__.py
```

After this, the wheel will be correctly named `nemo_evaluator-0.3.0.dev24-py3-none-any.whl` and installable as:
```bash
pip install https://github.com/NVIDIA-NeMo/Evaluator/releases/download/v0.3.0-dev/nemo_evaluator-0.3.0.dev24-py3-none-any.whl
```