### PR TITLE
feat(engine): collect model usage and token statistics per eval run

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -251,7 +251,7 @@
         "filename": "tests/test_adapters/test_interceptors_extended.py",
         "hashed_secret": "fb0123cbab73d8a58896fbe39b8b7b5b6df15c5e",
         "is_verified": false,
-        "line_number": 60
+        "line_number": 48
       }
     ],
     "tests/test_config/test_config_schema.py": [
@@ -399,5 +399,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-11T10:43:38Z"
+  "generated_at": "2026-05-14T11:13:44Z"
 }

--- a/src/nemo_evaluator/adapters/interceptors/endpoint.py
+++ b/src/nemo_evaluator/adapters/interceptors/endpoint.py
@@ -27,6 +27,7 @@ from nemo_evaluator.adapters.types import (
     AdapterResponse,
     RequestToResponseInterceptor,
 )
+from nemo_evaluator.observability.model_traffic import get_store
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +49,7 @@ class Interceptor(RequestToResponseInterceptor):
         max_retries: int = 0,
         retry_on_status: list[int] | None = None,
         max_concurrent: int = 64,
+        model_traffic_store_id: str | None = None,
     ) -> None:
         clean = upstream_url.rstrip("/")
         for suffix in ("/chat/completions", "/completions", "/embeddings"):
@@ -67,6 +69,7 @@ class Interceptor(RequestToResponseInterceptor):
         self._max_retries = max_retries
         self._retry_on_status = set(retry_on_status or [429, 502, 503, 504])
         self._max_concurrent = max_concurrent
+        self._model_traffic_store = get_store(model_traffic_store_id) if model_traffic_store_id else None
         self._session: aiohttp.ClientSession | None = None
         self._lock = asyncio.Lock()
         logger.info(
@@ -99,6 +102,28 @@ class Interceptor(RequestToResponseInterceptor):
             if "content" in msg and msg["content"] is None:
                 msg["content"] = ""
 
+    @staticmethod
+    def _request_stream_usage_chunks(path: str, body: dict[str, Any]) -> None:
+        if body.get("stream") is not True:
+            return
+        if not path.rstrip("/").endswith("/chat/completions"):
+            return
+
+        stream_options = body.get("stream_options")
+        if stream_options is None:
+            body["stream_options"] = {"include_usage": True}
+        elif isinstance(stream_options, dict) and "include_usage" not in stream_options:
+            body["stream_options"] = {**stream_options, "include_usage": True}
+
+    def _capture_response(self, resp: AdapterResponse) -> AdapterResponse:
+        if self._model_traffic_store is not None:
+            self._model_traffic_store.finish_response(resp)
+        return resp
+
+    def _capture_error(self, req: AdapterRequest, *, latency_ms: float, error_type: str) -> None:
+        if self._model_traffic_store is not None:
+            self._model_traffic_store.finish_error(req, latency_ms=latency_ms, error_type=error_type)
+
     async def intercept_request(
         self,
         req: AdapterRequest,
@@ -107,6 +132,12 @@ class Interceptor(RequestToResponseInterceptor):
         url = f"{self._upstream_url}{req.path}"
 
         body = {**req.body, **self._extra_body}
+        # Capture the effective upstream request, including endpoint-level
+        # body overrides, before sending it.
+        self._request_stream_usage_chunks(req.path, body)
+        req.ctx.extra["upstream_request_body"] = body
+        if self._model_traffic_store is not None:
+            self._model_traffic_store.start_request(req)
         headers = {k: v for k, v in req.headers.items() if k.lower() not in _HOP_BY_HOP_HEADERS}
         if self._api_key:
             headers["Authorization"] = f"Bearer {self._api_key}"
@@ -154,12 +185,14 @@ class Interceptor(RequestToResponseInterceptor):
                     if isinstance(parsed, dict):
                         self._normalize_content(parsed)
 
-                    return AdapterResponse(
-                        status_code=status,
-                        headers=resp_headers,
-                        body=parsed,
-                        latency_ms=latency,
-                        ctx=req.ctx,
+                    return self._capture_response(
+                        AdapterResponse(
+                            status_code=status,
+                            headers=resp_headers,
+                            body=parsed,
+                            latency_ms=latency,
+                            ctx=req.ctx,
+                        )
                     )
 
             except asyncio.TimeoutError as exc:
@@ -187,12 +220,16 @@ class Interceptor(RequestToResponseInterceptor):
                     exc,
                     latency / 1000,
                 )
-                return AdapterResponse(
-                    status_code=504,
-                    headers={},
-                    body={"error": {"message": f"Upstream timed out after {self._timeout.total}s", "type": "timeout"}},
-                    latency_ms=latency,
-                    ctx=req.ctx,
+                return self._capture_response(
+                    AdapterResponse(
+                        status_code=504,
+                        headers={},
+                        body={
+                            "error": {"message": f"Upstream timed out after {self._timeout.total}s", "type": "timeout"}
+                        },
+                        latency_ms=latency,
+                        ctx=req.ctx,
+                    )
                 )
 
             except aiohttp.ClientError as exc:
@@ -220,6 +257,7 @@ class Interceptor(RequestToResponseInterceptor):
                     exc,
                     latency / 1000,
                 )
+                self._capture_error(req, latency_ms=latency, error_type=type(exc).__name__)
                 raise
 
     async def close(self) -> None:

--- a/src/nemo_evaluator/adapters/pipeline.py
+++ b/src/nemo_evaluator/adapters/pipeline.py
@@ -23,7 +23,6 @@ from nemo_evaluator.adapters.registry import InterceptorRegistry
 from nemo_evaluator.adapters.types import (
     AdapterRequest,
     AdapterResponse,
-    InterceptorContext,
     RequestInterceptor,
     RequestToResponseInterceptor,
     ResponseInterceptor,
@@ -111,8 +110,7 @@ class AdapterPipeline:
            ``AdapterResponse`` short-circuits the chain.
         3. Response interceptors run in **reverse** order on success only.
         """
-        ctx = InterceptorContext(request_id=request.ctx.request_id)
-        set_context(ctx)
+        set_context(request.ctx)
 
         current: AdapterRequest | AdapterResponse = request
 

--- a/src/nemo_evaluator/adapters/proxy.py
+++ b/src/nemo_evaluator/adapters/proxy.py
@@ -223,6 +223,7 @@ def start_adapter_proxy(
     max_retries: int = 0,
     retry_on_status: list[int] | None = None,
     max_concurrent_upstream: int = 64,
+    model_traffic_store_id: str | None = None,
     verbose: bool = False,
 ) -> ProxyHandle:
     from nemo_evaluator.adapters.types import Stage
@@ -236,6 +237,7 @@ def start_adapter_proxy(
         "max_retries": max_retries,
         "retry_on_status": retry_on_status,
         "max_concurrent": max_concurrent_upstream,
+        "model_traffic_store_id": model_traffic_store_id,
     }
     endpoint_spec = {"name": "endpoint", "config": endpoint_config}
 

--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -25,8 +25,11 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from nemo_evaluator.engine.artifacts import build_artifact_bundle
+from nemo_evaluator.engine.model_call_context import AttemptContext, attempt_context
+from nemo_evaluator.engine.model_traffic_log import append_model_traffic_records, drain_model_traffic_session
 from nemo_evaluator.engine.step_log import (
     INFERENCE_LOG,
+    MODEL_TRAFFIC_LOG,
     VERIFIED_LOG,
     StepLog,
     config_hash,
@@ -37,6 +40,10 @@ from nemo_evaluator.metrics.aggregation import category_breakdown, scoring_detai
 from nemo_evaluator.metrics.confidence import bootstrap_ci
 from nemo_evaluator.metrics.headline import headline_score_metrics
 from nemo_evaluator.observability.collector import ArtifactCollector
+from nemo_evaluator.observability.model_traffic import (
+    ModelTrafficStore,
+    aggregate_model_traffic_stats,
+)
 from nemo_evaluator.observability.progress import NoOpProgress, ProgressTracker
 from nemo_evaluator.observability.types import ModelResponse, StepRecord
 from nemo_evaluator.sandbox.strategies import pick_lifecycle
@@ -79,6 +86,7 @@ async def run_evaluation(
     shard_info: tuple[int, int] | None = None,
     instruction_template: Path | None = None,
     shuffle_seed: int | None = None,
+    model_traffic_store: ModelTrafficStore | None = None,
 ) -> dict[str, Any]:
     config = config or {}
     max_system_retries = max(1, max_system_retries)
@@ -145,12 +153,14 @@ async def run_evaluation(
 
     inference_log: StepLog | None = None
     verified_log: StepLog | None = None
+    model_traffic_log: StepLog | None = None
     inferred_cache: dict[tuple[int, int], dict[str, Any]] = {}
     verified_cache: dict[tuple[int, int], dict[str, Any]] = {}
 
     if step_log_dir is not None:
         inference_log = StepLog(step_log_dir / INFERENCE_LOG)
         verified_log = StepLog(step_log_dir / VERIFIED_LOG)
+        model_traffic_log = StepLog(step_log_dir / MODEL_TRAFFIC_LOG)
 
         cfg_hash = config_hash(config)
 
@@ -172,6 +182,7 @@ async def run_evaluation(
                     verified_log.compact(verified_cache)
                 verified_log.open()
                 inference_log.open(truncate=True)
+                model_traffic_log.open(truncate=True)
                 inference_log.write_meta({"config_hash": cfg_hash})
             else:
                 inferred_cache_raw = inference_log.load()
@@ -188,6 +199,7 @@ async def run_evaluation(
                     verified_log.compact(verified_cache)
                 inference_log.open()
                 verified_log.open()
+                model_traffic_log.open()
 
             n_from_cache = len(verified_cache)
             n_verify_only = len(inferred_cache) - len(set(inferred_cache) & set(verified_cache))
@@ -197,6 +209,7 @@ async def run_evaluation(
             inference_log.open(truncate=True)
             inference_log.write_meta({"config_hash": cfg_hash})
             verified_log.open(truncate=True)
+            model_traffic_log.open(truncate=True)
 
     pg = progress or NoOpProgress()
     collector = ArtifactCollector()
@@ -314,14 +327,15 @@ async def run_evaluation(
                 response_text = ""
                 tokens = 0
                 latency_ms = 0.0
+                model_stats: dict[str, Any] | None = None
                 step.model_error = None
                 vr = None
 
                 outside_eps: list[OutsideEndpoint] = []
+                step_session_id = uuid4().hex[:16] if model_url else None
                 if model_url:
                     from nemo_evaluator.sandbox.base import OutsideEndpoint as OE
 
-                    step_session_id = uuid4().hex[:16]
                     step_url = f"{model_url.rstrip('/')}/s/{step_session_id}"
                     outside_eps.append(OE(url=step_url, env_var="MODEL_BASE_URL"))
 
@@ -352,10 +366,16 @@ async def run_evaluation(
                         try:
                             if _solver_accepts_sandbox(solver):
                                 sandbox = await lifecycle.get_agent_sandbox()
-                            if sandbox is not None:
-                                solve_result = await solver.solve(seed_result, sandbox=sandbox)
-                            else:
-                                solve_result = await solver.solve(seed_result)
+                            adapter_ctx = (
+                                AttemptContext(adapter_session_id=step_session_id)
+                                if step_session_id and model_traffic_store is not None
+                                else None
+                            )
+                            with attempt_context(adapter_ctx):
+                                if sandbox is not None:
+                                    solve_result = await solver.solve(seed_result, sandbox=sandbox)
+                                else:
+                                    solve_result = await solver.solve(seed_result)
                             if solve_result.model_response:
                                 step.model_response = solve_result.model_response
                                 step.model_ms = solve_result.model_response.latency_ms
@@ -373,6 +393,16 @@ async def run_evaluation(
                             raise  # system error — outer loop will retry
 
                         response_text = solve_result.response if solve_result else ""
+                        model_traffic = drain_model_traffic_session(model_traffic_store, step_session_id)
+                        if model_traffic:
+                            await append_model_traffic_records(
+                                model_traffic_log,
+                                model_traffic,
+                                benchmark=name,
+                                problem_idx=idx,
+                                repeat=rep,
+                            )
+                            model_stats = aggregate_model_traffic_stats(model_traffic)
                         tokens = (
                             solve_result.model_response.total_tokens
                             if solve_result and solve_result.model_response
@@ -402,6 +432,8 @@ async def run_evaluation(
                                 "seed_metadata": seed_result.metadata,
                                 "trajectory": solve_result.trajectory if solve_result else None,
                             }
+                            if model_stats is not None:
+                                inf_record["model_stats"] = model_stats
                             await inference_log.append(inf_record)
 
                     # ── Verify ───────────────────────────────────────
@@ -446,6 +478,7 @@ async def run_evaluation(
 
                 except InfraError as e:
                     await lifecycle.teardown()
+                    failed_model_traffic = drain_model_traffic_session(model_traffic_store, step_session_id)
                     if _attempt < max_system_retries:
                         delay = min(30, 5 * (2 ** (_attempt - 1)))
                         logger.warning(
@@ -459,6 +492,14 @@ async def run_evaluation(
                         )
                         await asyncio.sleep(delay)
                         continue
+                    if failed_model_traffic:
+                        await append_model_traffic_records(
+                            model_traffic_log,
+                            failed_model_traffic,
+                            benchmark=name,
+                            problem_idx=idx,
+                            repeat=rep,
+                        )
                     logger.warning(
                         "p%d r%d: infra error exhausted %d retries, scoring 0.0: %s",
                         idx,
@@ -479,6 +520,7 @@ async def run_evaluation(
 
                 except GracefulError as e:
                     await lifecycle.teardown()
+                    drain_model_traffic_session(model_traffic_store, step_session_id)
                     logger.warning(
                         "p%d r%d: graceful error, grading 0.0: %s",
                         idx,
@@ -497,6 +539,7 @@ async def run_evaluation(
 
                 except Exception as e:
                     await lifecycle.teardown()
+                    drain_model_traffic_session(model_traffic_store, step_session_id)
                     if _attempt < max_system_retries:
                         delay = min(30, 5 * (2 ** (_attempt - 1)))
                         logger.warning(
@@ -735,6 +778,8 @@ async def run_evaluation(
             inference_log.close()
         if verified_log is not None:
             verified_log.close()
+        if model_traffic_log is not None:
+            model_traffic_log.close()
         if sandbox_manager:
             await sandbox_manager.shutdown()
         if hasattr(solver, "close"):

--- a/src/nemo_evaluator/engine/model_call_context.py
+++ b/src/nemo_evaluator/engine/model_call_context.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Iterator
+from urllib.parse import urlsplit, urlunsplit
+
+
+@dataclass(frozen=True)
+class AttemptContext:
+    adapter_session_id: str | None = None
+
+
+_current_attempt: ContextVar[AttemptContext | None] = ContextVar("nel_attempt_context", default=None)
+
+
+@contextmanager
+def attempt_context(ctx: AttemptContext | None) -> Iterator[None]:
+    token = _current_attempt.set(ctx)
+    try:
+        yield
+    finally:
+        _current_attempt.reset(token)
+
+
+def url_for_current_adapter_session(url: str) -> str:
+    ctx = _current_attempt.get()
+    session_id = ctx.adapter_session_id if ctx else None
+    if not session_id:
+        return url
+    parts = urlsplit(url)
+    if not parts.scheme or not parts.netloc or parts.path.startswith("/s/"):
+        return url
+    path = parts.path or ""
+    return urlunsplit((parts.scheme, parts.netloc, f"/s/{session_id}{path}", parts.query, parts.fragment))

--- a/src/nemo_evaluator/engine/model_client.py
+++ b/src/nemo_evaluator/engine/model_client.py
@@ -24,6 +24,7 @@ from typing import Any
 
 import aiohttp
 
+from nemo_evaluator.engine.model_call_context import url_for_current_adapter_session
 from nemo_evaluator.errors import InfraError
 from nemo_evaluator.observability.types import ModelResponse
 from nemo_evaluator.schemas import RetryConfig
@@ -331,6 +332,7 @@ class ModelClient:
     async def _post_with_retry(self, url: str, payload: dict[str, Any]) -> dict:
         """Shared retry logic for all HTTP endpoints."""
         last_exc: Exception | None = None
+        url = url_for_current_adapter_session(url)
 
         for attempt in range(self.retry.max_retries + 1):
             async with self._sem:

--- a/src/nemo_evaluator/engine/model_traffic_log.py
+++ b/src/nemo_evaluator/engine/model_traffic_log.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+from nemo_evaluator.engine.step_log import StepLog
+from nemo_evaluator.observability.model_traffic import ModelTrafficStore
+
+_USAGE_KEYS = ("prompt_tokens", "completion_tokens", "total_tokens", "reasoning_tokens", "cached_tokens")
+_PROVIDER = "provider_reported"
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _traffic_id(record: dict[str, Any]) -> str:
+    rid = str(record.get("request_id") or "")
+    sid = record.get("session_id")
+    return f"{sid}:{rid}" if sid else rid
+
+
+def _timestamp(value: Any) -> str:
+    try:
+        ts = float(value)
+    except (TypeError, ValueError):
+        ts = time.time()
+    return datetime.fromtimestamp(ts, timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def drain_model_traffic_session(
+    model_traffic_store: ModelTrafficStore | None,
+    session_id: str | None,
+) -> list[dict[str, Any]]:
+    """Return and clear traffic records for one Adapter Session."""
+    if model_traffic_store is None or not session_id:
+        return []
+    return model_traffic_store.drain_session(session_id)
+
+
+async def append_model_traffic_records(
+    model_traffic_log: StepLog | None,
+    records: list[dict[str, Any]],
+    *,
+    benchmark: str,
+    problem_idx: int,
+    repeat: int,
+) -> None:
+    """Append captured model traffic as attempt-scoped step-log rows."""
+    if model_traffic_log is None or not records:
+        return
+    for traffic_record in format_model_traffic_log_records(
+        records,
+        benchmark=benchmark,
+        problem_idx=problem_idx,
+        repeat=repeat,
+    ):
+        await model_traffic_log.append(traffic_record)
+
+
+def format_model_traffic_log_records(
+    records: list[dict[str, Any]],
+    *,
+    benchmark: str,
+    problem_idx: int,
+    repeat: int,
+) -> list[dict[str, Any]]:
+    """Convert drained traffic records into model_traffic.jsonl rows."""
+    rows: list[dict[str, Any]] = []
+    for record in records:
+        usage = record.get("usage") or {}
+        row = {
+            "model_traffic_request_id": _traffic_id(record),
+            "timestamp": _timestamp(record.get("timestamp")),
+            "benchmark": benchmark,
+            "problem_idx": problem_idx,
+            "repeat": repeat,
+            "session_id": record.get("session_id"),
+            "adapter_request_id": record.get("request_id"),
+            "service": record.get("service"),
+            "method": record.get("method"),
+            "path": record.get("path"),
+            "status_code": record.get("status_code"),
+            "latency_ms": record.get("latency_ms"),
+            "model": record.get("model") or "",
+            "finish_reason": record.get("finish_reason") or "",
+            "usage": {key: _int(usage.get(key)) for key in _USAGE_KEYS if key in usage},
+            "tool_calls": record.get("tool_calls") or {"count": 0, "names": {}},
+        }
+        if row["usage"]:
+            row["token_provenance"] = _PROVIDER
+        if record.get("error_type"):
+            row["error_type"] = record["error_type"]
+        rows.append(row)
+    return rows

--- a/src/nemo_evaluator/engine/step_log.py
+++ b/src/nemo_evaluator/engine/step_log.py
@@ -35,6 +35,7 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 INFERENCE_LOG = "inference_log.jsonl"
+MODEL_TRAFFIC_LOG = "model_traffic.jsonl"
 VERIFIED_LOG = "verified_log.jsonl"
 META_TYPE = "meta"
 MAX_TRAJECTORY_BYTES = 5 * 1024 * 1024

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -1,0 +1,323 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+from collections import Counter
+from typing import TYPE_CHECKING, Any, Iterator
+
+if TYPE_CHECKING:
+    from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse
+
+_REGISTRY: dict[str, "ModelTrafficStore"] = {}
+_REGISTRY_LOCK = threading.Lock()
+_USAGE_KEYS = ("prompt_tokens", "completion_tokens", "total_tokens", "reasoning_tokens", "cached_tokens")
+_PROVIDER = "provider_reported"
+
+
+def register_store(store: "ModelTrafficStore") -> str:
+    with _REGISTRY_LOCK:
+        _REGISTRY[store.store_id] = store
+    return store.store_id
+
+
+def unregister_store(store_id: str) -> None:
+    with _REGISTRY_LOCK:
+        _REGISTRY.pop(store_id, None)
+
+
+def get_store(store_id: str) -> "ModelTrafficStore":
+    with _REGISTRY_LOCK:
+        store = _REGISTRY.get(store_id)
+    if store is None:
+        raise ValueError(f"Unknown model traffic store id: {store_id}")
+    return store
+
+
+def _int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _token_value(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_token(data: dict[str, Any], *keys: str) -> int | None:
+    for key in keys:
+        value = _token_value(data.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _usage(raw: Any) -> dict[str, int]:
+    if not isinstance(raw, dict):
+        return {}
+    prompt = _first_token(raw, "prompt_tokens", "input_tokens", "inputTokens")
+    completion = _first_token(raw, "completion_tokens", "output_tokens", "outputTokens", "content_tokens")
+    total = _first_token(raw, "total_tokens", "totalTokens")
+    reasoning = _first_token(raw, "reasoning_tokens")
+    cached = _first_token(raw, "cached_tokens")
+
+    for details_key in ("completion_tokens_details", "output_tokens_details"):
+        details = raw.get(details_key)
+        if reasoning is None and isinstance(details, dict):
+            reasoning = _first_token(details, "reasoning_tokens")
+    for details_key in ("prompt_tokens_details", "input_tokens_details"):
+        details = raw.get(details_key)
+        if cached is None and isinstance(details, dict):
+            cached = _first_token(details, "cached_tokens")
+    if total is None and prompt is not None and completion is not None:
+        total = prompt + completion
+
+    out: dict[str, int] = {}
+    for key, value in {
+        "prompt_tokens": prompt,
+        "completion_tokens": completion,
+        "total_tokens": total,
+        "reasoning_tokens": reasoning,
+        "cached_tokens": cached,
+    }.items():
+        if value is not None:
+            out[key] = value
+    return out
+
+
+def _tool_stats(names: list[str]) -> dict[str, Any]:
+    counts = Counter(name for name in names if name)
+    return {"count": len(names), "names": dict(sorted(counts.items()))}
+
+
+def _tool_names_from_message(message: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for raw in message.get("tool_calls") or []:
+        if not isinstance(raw, dict):
+            continue
+        function = raw.get("function") if isinstance(raw.get("function"), dict) else {}
+        names.append(str(function.get("name") or raw.get("name") or ""))
+    return names
+
+
+def _summary_from_json(body: dict[str, Any]) -> dict[str, Any]:
+    tool_names: list[str] = []
+    finish_reason = ""
+    for choice in body.get("choices") or []:
+        if not isinstance(choice, dict):
+            continue
+        finish_reason = str(choice.get("finish_reason") or finish_reason)
+        message = choice.get("message") or choice.get("delta") or {}
+        if isinstance(message, dict):
+            tool_names.extend(_tool_names_from_message(message))
+    return {
+        "model": str(body.get("model") or ""),
+        "finish_reason": finish_reason,
+        "usage": _usage(body.get("usage")),
+        "tool_calls": _tool_stats(tool_names),
+    }
+
+
+def _iter_sse(body: Any) -> Iterator[dict[str, Any]]:
+    text = body.decode("utf-8", errors="replace") if isinstance(body, bytes) else body
+    if not isinstance(text, str):
+        return
+
+    data_lines: list[str] = []
+
+    def load_payload(payload: str) -> dict[str, Any] | None:
+        payload = payload.strip()
+        if not payload or payload == "[DONE]":
+            return None
+        try:
+            chunk = json.loads(payload)
+        except json.JSONDecodeError:
+            return None
+        return chunk if isinstance(chunk, dict) else None
+
+    for raw_line in text.splitlines():
+        line = raw_line.rstrip("\r")
+        if not line:
+            chunk = load_payload("\n".join(data_lines))
+            data_lines = []
+            if chunk is not None:
+                yield chunk
+            continue
+        if not line.startswith("data:"):
+            continue
+        payload = line[5:]
+        if payload.startswith(" "):
+            payload = payload[1:]
+        data_lines.append(payload)
+
+    chunk = load_payload("\n".join(data_lines))
+    if chunk is not None:
+        yield chunk
+
+
+def _summary_from_sse(body: Any) -> dict[str, Any]:
+    model = ""
+    finish_reason = ""
+    usage: dict[str, int] = {}
+    stream_tools: dict[tuple[int, int], str] = {}
+    for chunk in _iter_sse(body):
+        model = str(chunk.get("model") or model)
+        if isinstance(chunk.get("usage"), dict):
+            usage = _usage(chunk["usage"])
+        for choice in chunk.get("choices") or []:
+            if not isinstance(choice, dict):
+                continue
+            finish_reason = str(choice.get("finish_reason") or finish_reason)
+            delta = choice.get("delta") or choice.get("message") or {}
+            if not isinstance(delta, dict):
+                continue
+            for raw in delta.get("tool_calls") or []:
+                if not isinstance(raw, dict):
+                    continue
+                idx = (_int(choice.get("index")), _int(raw.get("index")))
+                function = raw.get("function") if isinstance(raw.get("function"), dict) else {}
+                stream_tools[idx] = f"{stream_tools.get(idx, '')}{function.get('name') or raw.get('name') or ''}"
+    return {
+        "model": model,
+        "finish_reason": finish_reason,
+        "usage": usage,
+        "tool_calls": _tool_stats(list(stream_tools.values())),
+    }
+
+
+def _summary(body: Any) -> dict[str, Any]:
+    return _summary_from_json(body) if isinstance(body, dict) else _summary_from_sse(body)
+
+
+def _is_success(record: dict[str, Any]) -> bool:
+    return 200 <= _int(record.get("status_code")) < 400
+
+
+class ModelTrafficStore:
+    def __init__(self, *, service_name: str | None = None) -> None:
+        self.store_id = uuid.uuid4().hex
+        self.service_name = service_name
+        self._lock = threading.Lock()
+        self._pending: dict[str, dict[str, Any]] = {}
+        self._records_by_session: dict[str, list[dict[str, Any]]] = {}
+
+    def close(self) -> None:
+        unregister_store(self.store_id)
+
+    def start_request(self, req: AdapterRequest) -> None:
+        body = req.ctx.extra.get("upstream_request_body") or req.body
+        record = {
+            "request_id": req.ctx.request_id,
+            "session_id": req.ctx.extra.get("session_id"),
+            "timestamp": time.time(),
+            "method": req.method,
+            "path": req.path,
+            "service": self.service_name,
+            "model": body.get("model") if isinstance(body, dict) else "",
+        }
+        with self._lock:
+            self._pending[req.ctx.request_id] = record
+
+    def finish_response(self, resp: AdapterResponse) -> None:
+        with self._lock:
+            record = self._pending.pop(resp.ctx.request_id, None)
+        if record is None:
+            record = {
+                "request_id": resp.ctx.request_id,
+                "session_id": resp.ctx.extra.get("session_id"),
+                "timestamp": time.time(),
+            }
+
+        summary = _summary(resp.body)
+        success = 200 <= resp.status_code < 400
+        record.update(
+            {
+                "status_code": resp.status_code,
+                "latency_ms": resp.latency_ms,
+                "model": summary["model"] or record.get("model") or "",
+                "finish_reason": summary["finish_reason"] if success else "",
+                "usage": summary["usage"] if success else {},
+                "tool_calls": summary["tool_calls"] if success else {"count": 0, "names": {}},
+            }
+        )
+        session_id = record.get("session_id")
+        if session_id:
+            with self._lock:
+                self._records_by_session.setdefault(str(session_id), []).append(record)
+
+    def finish_error(self, req: AdapterRequest, *, latency_ms: float, error_type: str) -> None:
+        with self._lock:
+            record = self._pending.pop(req.ctx.request_id, None)
+        if record is None:
+            record = {
+                "request_id": req.ctx.request_id,
+                "session_id": req.ctx.extra.get("session_id"),
+                "timestamp": time.time(),
+                "method": req.method,
+                "path": req.path,
+                "service": self.service_name,
+                "model": "",
+            }
+
+        record.update(
+            {
+                "status_code": None,
+                "latency_ms": latency_ms,
+                "finish_reason": "",
+                "usage": {},
+                "tool_calls": {"count": 0, "names": {}},
+                "error_type": error_type,
+            }
+        )
+        session_id = record.get("session_id")
+        if session_id:
+            with self._lock:
+                self._records_by_session.setdefault(str(session_id), []).append(record)
+
+    def drain_session(self, session_id: str | None) -> list[dict[str, Any]]:
+        if not session_id:
+            return []
+        with self._lock:
+            return self._records_by_session.pop(session_id, [])
+
+
+def _successful(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [record for record in records if _is_success(record)]
+
+
+def _aggregate_usage(records: list[dict[str, Any]]) -> dict[str, Any]:
+    usage: dict[str, int] = {}
+    for record in _successful(records):
+        for key, value in (record.get("usage") or {}).items():
+            if key in _USAGE_KEYS:
+                usage[key] = usage.get(key, 0) + _int(value)
+    return {**usage, "token_provenance": _PROVIDER} if usage else {}
+
+
+def _aggregate_tool_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
+    total = 0
+    names: Counter[str] = Counter()
+    for record in _successful(records):
+        stats = record.get("tool_calls") or {}
+        total += _int(stats.get("count"))
+        names.update(stats.get("names") or {})
+    return {"count": total, "names": dict(sorted(names.items()))}
+
+
+def aggregate_model_traffic_stats(records: list[dict[str, Any]]) -> dict[str, Any] | None:
+    if not records:
+        return None
+    return {
+        "usage": _aggregate_usage(records),
+        "tool_calls": _aggregate_tool_stats(records),
+        "model_calls": len(records),
+    }

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -23,7 +23,7 @@ import re
 import subprocess
 import threading
 from pathlib import Path
-from typing import IO, Any
+from typing import IO, TYPE_CHECKING, Any
 
 from nemo_evaluator.config import (
     DEFAULT_EXEC_SERVER_PORT,
@@ -49,9 +49,14 @@ from nemo_evaluator.config import (
     ToolCallingSolverConfig,
 )
 from nemo_evaluator.config.services import _MODEL_SERVICE_TYPES
+from nemo_evaluator.engine.step_log import INFERENCE_LOG, MODEL_TRAFFIC_LOG, VERIFIED_LOG
 from nemo_evaluator.orchestration.artifact_access import apply_artifact_access
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from nemo_evaluator.adapters.proxy import ProxyHandle
+    from nemo_evaluator.observability.model_traffic import ModelTrafficStore
 
 
 def _snapshot_files(paths: set[Path]) -> dict[Path, tuple[int, int]]:
@@ -74,8 +79,9 @@ def _changed_files_since(paths: set[Path], before: dict[Path, tuple[int, int]]) 
 
 def _known_benchmark_artifact_files(task_dir: Path, bundle: dict[str, Any] | None = None) -> set[Path]:
     paths = {
-        task_dir / "inference_log.jsonl",
-        task_dir / "verified_log.jsonl",
+        task_dir / INFERENCE_LOG,
+        task_dir / MODEL_TRAFFIC_LOG,
+        task_dir / VERIFIED_LOG,
         task_dir / "results.jsonl",
         task_dir / "trajectories.jsonl",
         task_dir / "runtime_stats.json",
@@ -725,19 +731,25 @@ def _start_proxy(
     model_id: str,
     api_key: str | None,
     svc: Any,
-) -> tuple[str, Any]:
+    service_name: str | None = None,
+) -> tuple[str, "ProxyHandle | None", "ModelTrafficStore | None"]:
     """Start the adapter proxy when *model_url* is set.
 
-    Returns ``(effective_url, proxy_handle | None)``.
+    Returns ``(effective_url, proxy_handle | None, model_traffic_store | None)``.
     """
     if not model_url:
-        return model_url, None
+        return model_url, None, None
 
     from nemo_evaluator.adapters.proxy import start_adapter_proxy
 
-    proxy_kwargs: dict[str, Any] = dict(upstream_url=model_url, model_id=model_id, api_key=api_key)
+    proxy_kwargs: dict[str, Any] = {
+        "upstream_url": model_url,
+        "model_id": model_id,
+        "api_key": api_key,
+    }
     proxy_cfg = getattr(svc, "proxy", None) if svc else None
     interceptor_specs: list[dict[str, Any]] = []
+    traffic_store = None
 
     if proxy_cfg is not None and proxy_cfg.needs_proxy:
         interceptor_specs = _interceptor_specs(proxy_cfg.interceptors)
@@ -751,6 +763,12 @@ def _start_proxy(
             max_concurrent_upstream=proxy_cfg.max_concurrent_upstream,
         )
 
+    from nemo_evaluator.observability.model_traffic import ModelTrafficStore, register_store
+
+    traffic_store = ModelTrafficStore(service_name=service_name)
+    register_store(traffic_store)
+    proxy_kwargs["model_traffic_store_id"] = traffic_store.store_id
+
     gen = getattr(svc, "generation", None)
     if gen is not None:
         overrides = {k: v for k, v in gen.model_dump().items() if v is not None}
@@ -760,8 +778,12 @@ def _start_proxy(
     if interceptor_specs:
         proxy_kwargs["interceptor_specs"] = interceptor_specs
 
-    handle = start_adapter_proxy(**proxy_kwargs)
-    return handle.url, handle
+    try:
+        handle = start_adapter_proxy(**proxy_kwargs)
+    except Exception:
+        traffic_store.close()
+        raise
+    return handle.url, handle, traffic_store
 
 
 def _build_environment(
@@ -910,7 +932,6 @@ async def _run_single_benchmark(
     from nemo_evaluator.engine.artifacts import write_all
     from nemo_evaluator.engine.eval_loop import run_evaluation
     from nemo_evaluator.engine.sharding import shard_from_env
-    from nemo_evaluator.engine.step_log import INFERENCE_LOG, VERIFIED_LOG
     from nemo_evaluator.observability.progress import ConsoleProgress
     from nemo_evaluator.templates import resolve_template_path
 
@@ -918,7 +939,7 @@ async def _run_single_benchmark(
     service_name: str | None = getattr(solver_cfg, "service", None)
 
     model_url, model_id, api_key, svc = _resolve_service_connection(config, handles, service_name)
-    model_url, proxy_handle = _start_proxy(model_url, model_id, api_key, svc)
+    model_url, proxy_handle, model_traffic_store = _start_proxy(model_url, model_id, api_key, svc, service_name)
 
     judge_client = None
     try:
@@ -975,6 +996,7 @@ async def _run_single_benchmark(
             shard_info=shard_info,
             instruction_template=resolve_template_path(bench.instruction_template),
             shuffle_seed=bench.shuffle_seed,
+            model_traffic_store=model_traffic_store,
         )
 
         paths = write_all(bundle, task_dir)
@@ -985,6 +1007,7 @@ async def _run_single_benchmark(
                 *paths.values(),
                 task_dir / INFERENCE_LOG,
                 task_dir / VERIFIED_LOG,
+                *([task_dir / MODEL_TRAFFIC_LOG] if (task_dir / MODEL_TRAFFIC_LOG).exists() else []),
             )
         ]
         return bundle
@@ -993,6 +1016,8 @@ async def _run_single_benchmark(
             await judge_client.close()
         if proxy_handle is not None:
             await proxy_handle.async_stop()
+        if model_traffic_store is not None:
+            model_traffic_store.close()
 
 
 def _load_prior_bundle(task_dir: str) -> dict[str, Any]:

--- a/src/nemo_evaluator/solvers/gym.py
+++ b/src/nemo_evaluator/solvers/gym.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any
 
 import aiohttp
 
+from nemo_evaluator.engine.model_call_context import url_for_current_adapter_session
 from nemo_evaluator.environments.base import SeedResult
 from nemo_evaluator.environments.gym_protocol import (
     extract_assistant_text,
@@ -106,7 +107,7 @@ class GymSolver:
         if self._api_key:
             rcp["metadata"]["api_key"] = self._api_key
         if self._model_url:
-            rcp["metadata"]["model_url"] = self._model_url
+            rcp["metadata"]["model_url"] = url_for_current_adapter_session(self._model_url)
         return {"responses_create_params": rcp}
 
     def _build_miniswe_request(self, task: SeedResult, meta: dict) -> dict[str, Any]:

--- a/tests/test_adapters/test_interceptors_extended.py
+++ b/tests/test_adapters/test_interceptors_extended.py
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """Tests for interceptors not covered by test_interceptors.py."""
 
 from __future__ import annotations

--- a/tests/test_adapters/test_interceptors_extended.py
+++ b/tests/test_adapters/test_interceptors_extended.py
@@ -1,17 +1,3 @@
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Tests for interceptors not covered by test_interceptors.py."""
 
 from __future__ import annotations
@@ -170,6 +156,45 @@ class TestEndpointInterceptorExceptionLogging:
         assert "ServerDisconnectedError" in msg, f"exc class missing from log; got: {msg!r}"
         assert "upstream closed" in msg, f"exc message missing from log; got: {msg!r}"
         assert "t_in_flight_s=" in msg, f"t_in_flight_s missing from ClientError log; got: {msg!r}"
+
+    async def test_client_error_final_failure_records_model_traffic(self):
+        import aiohttp
+        import pytest
+
+        from nemo_evaluator.observability.model_traffic import ModelTrafficStore, register_store
+
+        store = ModelTrafficStore(service_name="solver")
+        register_store(store)
+        try:
+            ic = self._make(max_retries=0, model_traffic_store_id=store.store_id)
+
+            async def _stubbed_get_session():
+                return self._RaisingSession([aiohttp.ServerDisconnectedError("upstream closed")])
+
+            ctx = InterceptorContext()
+            ctx.extra["session_id"] = "abc123"
+            req = AdapterRequest(
+                method="POST",
+                path="/chat/completions",
+                headers={},
+                body={"model": "solver-model", "messages": [{"role": "user", "content": "hi"}]},
+                ctx=ctx,
+            )
+            ic._get_session = _stubbed_get_session  # type: ignore[assignment]
+
+            with pytest.raises(aiohttp.ServerDisconnectedError):
+                await ic.intercept_request(req)
+
+            records = store.drain_session("abc123")
+            assert len(records) == 1
+            assert records[0]["request_id"] == req.ctx.request_id
+            assert records[0]["status_code"] is None
+            assert records[0]["error_type"] == "ServerDisconnectedError"
+            assert records[0]["usage"] == {}
+            assert records[0]["tool_calls"] == {"count": 0, "names": {}}
+            assert store._pending == {}
+        finally:
+            store.close()
 
     async def test_init_log_includes_request_timeout(self, caplog):
         """The init log must record the configured request_timeout so we can

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import http.server
+import json
+import threading
+from pathlib import Path
+
+from nemo_evaluator.adapters.proxy import start_adapter_proxy
+from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
+from nemo_evaluator.engine.eval_loop import run_evaluation
+from nemo_evaluator.engine.model_client import ModelClient
+from nemo_evaluator.engine.model_traffic_log import format_model_traffic_log_records
+from nemo_evaluator.engine.step_log import INFERENCE_LOG, MODEL_TRAFFIC_LOG
+from nemo_evaluator.environments.base import EvalEnvironment, SeedResult, VerifyResult
+from nemo_evaluator.observability.model_traffic import (
+    ModelTrafficStore,
+    register_store,
+)
+from nemo_evaluator.solvers.base import SolveResult
+
+
+class _OneProblemEnv(EvalEnvironment):
+    name = "model_traffic_env"
+
+    async def dataset_size(self) -> int:
+        return 1
+
+    async def seed(self, idx: int) -> SeedResult:
+        return SeedResult(prompt="solve with a tool", expected_answer="answer", metadata={})
+
+    async def verify(self, response: str, expected: str, sandbox=None, **meta) -> VerifyResult:
+        return VerifyResult(reward=1.0 if response == expected else 0.0)
+
+
+class _ModelClientSolver:
+    def __init__(self, base_url: str) -> None:
+        self._client = ModelClient(base_url=base_url, model="solver-model")
+
+    async def solve(self, task: SeedResult) -> SolveResult:
+        response = await self._client.chat(task.prompt)
+        return SolveResult(response=response.content, model_response=response, trajectory=[])
+
+    async def close(self) -> None:
+        await self._client.close()
+
+
+def _start_upstream() -> tuple[http.server.HTTPServer, str]:
+    class _Handler(http.server.BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            self.rfile.read(length)
+            payload = json.dumps(
+                {
+                    "id": "chatcmpl-model-traffic",
+                    "object": "chat.completion",
+                    "model": "solver-model",
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "answer",
+                                "reasoning_content": "I need to inspect the workspace.",
+                                "tool_calls": [
+                                    {
+                                        "id": "call_1",
+                                        "type": "function",
+                                        "function": {
+                                            "name": "bash",
+                                            "arguments": '{"command":"ls"}',
+                                        },
+                                    }
+                                ],
+                            },
+                            "finish_reason": "tool_calls",
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 4,
+                        "total_tokens": 9,
+                        "prompt_tokens_details": {"cached_tokens": 3},
+                        "completion_tokens_details": {"reasoning_tokens": 2},
+                    },
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *_args):
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, f"http://127.0.0.1:{server.server_address[1]}"
+
+
+def _start_traffic_proxy(upstream_url: str):
+    store = ModelTrafficStore(service_name="solver")
+    register_store(store)
+    handle = start_adapter_proxy(
+        upstream_url=upstream_url,
+        model_id="solver-model",
+        port=0,
+        model_traffic_store_id=store.store_id,
+    )
+    return handle, store
+
+
+def _jsonl(path: Path):
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def test_model_traffic_parses_streaming_sse_usage_and_tool_calls() -> None:
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = "stream-session"
+    store = ModelTrafficStore(service_name="solver")
+    store.start_request(
+        AdapterRequest(
+            method="POST",
+            path="/chat/completions",
+            headers={},
+            body={"model": "stream-model", "stream": True},
+            ctx=ctx,
+        )
+    )
+
+    body = b"""
+data: {"model":"stream-model",
+data: "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"ba"}}]}}]}
+
+data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"sh"}}]}},{"index":1,"delta":{"tool_calls":[{"index":0,"function":{"name":"python"}}]}}]}
+
+data: {"choices":[{"index":0,"finish_reason":"tool_calls"}],
+data: "usage":{"prompt_tokens":7,"completion_tokens":5,"total_tokens":12,
+data: "completion_tokens_details":{"reasoning_tokens":3}}}
+
+data: [DONE]
+"""
+    store.finish_response(
+        AdapterResponse(
+            status_code=200,
+            headers={"content-type": "text/event-stream"},
+            body=body,
+            latency_ms=12.5,
+            ctx=ctx,
+        )
+    )
+
+    rows = format_model_traffic_log_records(
+        store.drain_session("stream-session"),
+        benchmark="model_traffic_env",
+        problem_idx=0,
+        repeat=0,
+    )
+
+    assert len(rows) == 1
+    assert rows[0]["model"] == "stream-model"
+    assert rows[0]["finish_reason"] == "tool_calls"
+    assert rows[0]["usage"] == {
+        "prompt_tokens": 7,
+        "completion_tokens": 5,
+        "total_tokens": 12,
+        "reasoning_tokens": 3,
+    }
+    assert rows[0]["tool_calls"] == {"count": 2, "names": {"bash": 1, "python": 1}}
+    assert rows[0]["token_provenance"] == "provider_reported"
+
+
+async def test_model_traffic_writes_compact_log_and_inference_stats(tmp_path: Path) -> None:
+    upstream, upstream_url = _start_upstream()
+    handle, store = _start_traffic_proxy(upstream_url)
+    try:
+        await run_evaluation(
+            _OneProblemEnv(),
+            _ModelClientSolver(handle.url),
+            max_concurrent=1,
+            config={"benchmark": "model_traffic_env", "model": "solver-model"},
+            model_url=handle.url,
+            model_traffic_store=store,
+            step_log_dir=tmp_path,
+        )
+
+        traffic_rows = _jsonl(tmp_path / MODEL_TRAFFIC_LOG)
+        assert len(traffic_rows) == 1
+        traffic = traffic_rows[0]
+        assert traffic["timestamp"].endswith("Z")
+        assert traffic["benchmark"] == "model_traffic_env"
+        assert traffic["problem_idx"] == 0
+        assert traffic["repeat"] == 0
+        assert traffic["session_id"]
+        assert traffic["adapter_request_id"]
+        assert traffic["model_traffic_request_id"] == f"{traffic['session_id']}:{traffic['adapter_request_id']}"
+        assert traffic["service"] == "solver"
+        assert traffic["status_code"] == 200
+        assert traffic["path"] == "/chat/completions"
+        assert traffic["usage"] == {
+            "prompt_tokens": 5,
+            "completion_tokens": 4,
+            "total_tokens": 9,
+            "reasoning_tokens": 2,
+            "cached_tokens": 3,
+        }
+        assert traffic["tool_calls"] == {"count": 1, "names": {"bash": 1}}
+        assert traffic["token_provenance"] == "provider_reported"
+        assert "request" not in traffic
+        assert "response" not in traffic
+
+        inference_rows = [row for row in _jsonl(tmp_path / INFERENCE_LOG) if row.get("_type") != "meta"]
+        assert len(inference_rows) == 1
+        assert inference_rows[0]["reasoning_tokens"] == 2
+        assert inference_rows[0]["model_stats"] == {
+            "usage": {
+                "prompt_tokens": 5,
+                "completion_tokens": 4,
+                "total_tokens": 9,
+                "reasoning_tokens": 2,
+                "cached_tokens": 3,
+                "token_provenance": "provider_reported",
+            },
+            "tool_calls": {"count": 1, "names": {"bash": 1}},
+            "model_calls": 1,
+        }
+
+    finally:
+        await handle.async_stop()
+        store.close()
+        upstream.shutdown()


### PR DESCRIPTION
Sync from `gitlab main @ a0813f1e` (new left-off-at SHA).

## Changes (13 files, +889 / -46)

Adds infrastructure to capture and aggregate model traffic (tokens, latency, call counts) across the proxy pipeline and export it alongside the eval bundle.

**New files:**
- `src/nemo_evaluator/engine/model_traffic_log.py` — accumulates per-step model traffic records (prompt_tokens, completion_tokens, latency_ms, model id)
- `src/nemo_evaluator/engine/model_call_context.py` — lightweight context passed through the eval loop to wire traffic capture into solvers and the proxy
- `src/nemo_evaluator/observability/model_traffic.py` (323 LOC) — Prometheus-style metrics aggregation + structured export
- `tests/test_engine/test_model_traffic_capture.py` — tests

**Modified:**
- `adapters/interceptors/endpoint.py` — emits a traffic record after each upstream call
- `adapters/pipeline.py`, `adapters/proxy.py` — thread model-call context through the interceptor chain
- `engine/eval_loop.py`, `engine/model_client.py`, `engine/step_log.py` — wire context + emit traffic into bundles
- `orchestration/orchestrator.py`, `solvers/gym.py` — propagate context
- `tests/test_adapters/test_interceptors_extended.py` — extended tests + SPDX header added

## Verification
- Zero internal-pattern hits across all 13 files
- Pre-commit clean (ruff, ruff-format, SPDX)