### PR TITLE
fix(cli): handle missing skills dependency in list command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.3.0 (unreleased)
 
+### CLI
+
+- Fixed `nel list` so missing optional NeMo Skills support is reported as an optional dependency notice instead of crashing benchmark discovery.
+
 ### Adapter Proxy (Breaking — replaces LiteLLM)
 
 - **LiteLLM removed**: The `litellm` dependency, `proxy` and `proxy-full` extras, and `litellm_settings` config field are all removed. The adapter proxy is now built-in with zero external proxy dependencies.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # NeMo Evaluator
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/LICENSE)
-[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-green)](https://www.python.org/downloads/)
+[![Python 3.12-3.13](https://img.shields.io/badge/python-3.12--3.13-green)](https://www.python.org/downloads/)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 
 [**Documentation**](https://docs.nvidia.com/nemo/evaluator/0.3.0/) | [**GitHub**](https://github.com/NVIDIA-NeMo/Evaluator) | [**Issues**](https://github.com/NVIDIA-NeMo/Evaluator/issues)
@@ -18,9 +18,8 @@ pip install -e ".[scoring]"        # + sympy for symbolic math
 pip install -e ".[stats]"          # + scipy (regression analysis)
 pip install -e ".[scoring,stats]"  # + sympy + scipy for confidence intervals
 pip install -e ".[harbor]"         # + Harbor agents (OpenHands, Terminus-2)
-pip install -e ".[proxy]"          # + LiteLLM proxy
 pip install -e ".[inspect]"        # + Inspect AI log export
-pip install -e ".[all]"            # everything
+pip install -e ".[all]"            # common runtime integrations
 ```
 
 ## Quick Start

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- Python 3.10+
+- Python 3.12 or 3.13
 - An OpenAI-compatible model endpoint (NVIDIA API Catalog, vLLM, NIM, etc.)
 
 ## Install from Source
@@ -27,25 +27,26 @@ pip install -e ".[scoring]"
 | `harnesses` | `pip install -e ".[harnesses]"` | lm-evaluation-harness tasks |
 | `export` | `pip install -e ".[export]"` | WandB and MLflow experiment tracker export |
 | `docs` | `pip install -e ".[docs]"` | Sphinx, NVIDIA theme, mermaid for building docs |
-| `all` | `pip install -e ".[all]"` | Everything above |
-| `dev` | `pip install -e ".[dev]"` | pytest, ruff, all extras |
+| `all` | `pip install -e ".[all]"` | Common runtime integrations: scoring, stats, ray, lm-eval, and Harbor |
+| `dev` | `pip install -e ".[dev]"` | pytest, ruff, and common development extras |
 
 ## Verify Installation
 
 ```bash
 nel --version
-nel list
+nel list --source builtin
 ```
 
 Expected output:
 
 ```
-nemo-evaluator 0.12.0
+nel, version 0.3.0
 
-Available environments:
-  drop, gpqa, gsm8k, healthbench, humaneval, math500,
-  mgsm, mmlu, mmlu_pro, pinchbench, simpleqa,
-  swebench-multilingual, swebench-verified, triviaqa, xstest
+Built-in benchmarks:
+  drop                           nel eval run --bench drop
+  gpqa                           nel eval run --bench gpqa
+  gsm8k                          nel eval run --bench gsm8k
+  ...
 ```
 
 ## Docker

--- a/docs/get-started/install.md
+++ b/docs/get-started/install.md
@@ -27,7 +27,7 @@ pip install -e ".[scoring]"
 | `harnesses` | `pip install -e ".[harnesses]"` | lm-evaluation-harness tasks |
 | `export` | `pip install -e ".[export]"` | WandB and MLflow experiment tracker export |
 | `docs` | `pip install -e ".[docs]"` | Sphinx, NVIDIA theme, mermaid for building docs |
-| `all` | `pip install -e ".[all]"` | Common runtime integrations: scoring, stats, ray, lm-eval, and Harbor |
+| `all` | `pip install -e ".[all]"` | Common runtime integrations |
 | `dev` | `pip install -e ".[dev]"` | pytest, ruff, and common development extras |
 
 ## Verify Installation
@@ -40,12 +40,12 @@ nel list --source builtin
 Expected output:
 
 ```
-nel, version 0.3.0
+nemo-evaluator 0.12.0
 
-Built-in benchmarks:
-  drop                           nel eval run --bench drop
-  gpqa                           nel eval run --bench gpqa
-  gsm8k                          nel eval run --bench gsm8k
+Available environments:
+  drop, gpqa, gsm8k, healthbench, humaneval, math500,
+  mgsm, mmlu, mmlu_pro, pinchbench, simpleqa,
+  swebench-multilingual, swebench-verified, triviaqa, xstest
   ...
 ```
 

--- a/src/nemo_evaluator/cli/list.py
+++ b/src/nemo_evaluator/cli/list.py
@@ -64,7 +64,10 @@ def _list_skills(data_dir: str | None) -> list[str]:
     except ImportError:
         return ["(nemo-skills not installed — pip install nemo-skills)"]
 
-    benchmarks = list_skills_benchmarks(data_dir)
+    try:
+        benchmarks = list_skills_benchmarks(data_dir)
+    except ImportError:
+        return ["(nemo-skills not installed — pip install nemo-skills)"]
     if not benchmarks:
         return ["(none — run: ns prepare_data <benchmark>)"]
 

--- a/tests/test_serving/test_cli_commands.py
+++ b/tests/test_serving/test_cli_commands.py
@@ -86,3 +86,10 @@ class TestListCommand:
     def test_list_benchmarks(self, runner):
         result = runner.invoke(cli, ["list", "--help"])
         assert result.exit_code == 0
+
+    @patch("nemo_evaluator.environments.skills.list_skills_benchmarks", side_effect=ImportError("missing skills"))
+    def test_list_skills_handles_missing_optional_dependency(self, _mock_list_skills, runner):
+        result = runner.invoke(cli, ["list", "--source", "skills"])
+
+        assert result.exit_code == 0
+        assert "nemo-skills not installed" in result.output


### PR DESCRIPTION
From VDRClaw -> with Codex (5.5)

## Summary

Fixes install/discovery friction.

- Updates install docs and README snippets for the `dev/0.3.0` branch reality: Python 3.12/3.13, no LiteLLM proxy extra, and `all` as common runtime integrations rather than literally everything.
- Changes the install verification command to `nel list --source builtin`, which works without optional benchmark integrations installed.
- Makes `nel list --source skills` handle a missing `nemo-skills` dependency gracefully when discovery reaches the optional dependency callsite.
- Adds a regression test for the missing NeMo Skills dependency path.
- Adds an unreleased changelog entry.

## Testing

- `pytest tests/test_serving/test_cli_commands.py -q`
- `ruff check src/nemo_evaluator/cli/list.py tests/test_serving/test_cli_commands.py`
- `ruff format --check src/nemo_evaluator/cli/list.py tests/test_serving/test_cli_commands.py`
- `git diff --check`
- Manual checks:
  - `nel list --source skills`
  - `nel list --source builtin`

## Notes

The broader offline gate still has an unrelated existing failure:

`tests/test_compare_cli.py::TestMultiBenchmarkCompare::test_worst_verdict_propagated`

It failed after `169 passed, 1 skipped, 14 deselected` and was not touched by this branch.