### PR TITLE
chore: keep directory with legacy configs

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -46,10 +46,6 @@
       "name": "JwtTokenDetector"
     },
     {
-      "name": "KeywordDetector",
-      "keyword_exclude": ""
-    },
-    {
       "name": "MailchimpDetector"
     },
     {
@@ -129,33 +125,6 @@
     }
   ],
   "results": {
-    "docs/api/index.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/api/index.md",
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_verified": false,
-        "line_number": 76
-      }
-    ],
-    "docs/get-started/quickstart.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/get-started/quickstart.md",
-        "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
-        "is_verified": false,
-        "line_number": 8
-      }
-    ],
-    "docs/tutorials/walkthrough.md": [
-      {
-        "type": "Secret Keyword",
-        "filename": "docs/tutorials/walkthrough.md",
-        "hashed_secret": "aecdccc1cf64595b34e0cc152d238daabb32183a",
-        "is_verified": false,
-        "line_number": 9
-      }
-    ],
     "examples/configs/conf/services/nemotron_fp8_vllm.yaml": [
       {
         "type": "Base64 High Entropy String",
@@ -165,22 +134,22 @@
         "line_number": 3
       }
     ],
-    "src/nemo_evaluator/environments/container.py": [
+    "packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml": [
       {
-        "type": "Secret Keyword",
-        "filename": "src/nemo_evaluator/environments/container.py",
-        "hashed_secret": "499224054c6bf4153347ae50fc73271227053cd7",
+        "type": "Base64 High Entropy String",
+        "filename": "packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml",
+        "hashed_secret": "a85b13313b8625a71cbee03550444030399f38a7",
         "is_verified": false,
-        "line_number": 61
+        "line_number": 102
       }
     ],
-    "src/nemo_evaluator/solvers/harbor.py": [
+    "packages/nemo-evaluator-launcher/examples/nemotron/nemotron/slurm_nvidia_nemotron_3_nano_30b_a3b_nvfp4.yaml": [
       {
-        "type": "Secret Keyword",
-        "filename": "src/nemo_evaluator/solvers/harbor.py",
-        "hashed_secret": "aba587d0ca054afc6656ee19c938be86b9bff6a4",
+        "type": "Base64 High Entropy String",
+        "filename": "packages/nemo-evaluator-launcher/examples/nemotron/nemotron/slurm_nvidia_nemotron_3_nano_30b_a3b_nvfp4.yaml",
+        "hashed_secret": "a85b13313b8625a71cbee03550444030399f38a7",
         "is_verified": false,
-        "line_number": 779
+        "line_number": 90
       }
     ],
     "tests/fixtures/pinchbench.json": [
@@ -220,15 +189,6 @@
         "line_number": 117
       }
     ],
-    "tests/generate_fixtures.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/generate_fixtures.py",
-        "hashed_secret": "ec3810e10fb78db55ce38b9c18d1c3eb1db739e0",
-        "is_verified": false,
-        "line_number": 19
-      }
-    ],
     "tests/test_adapters/test_cache_keys.py": [
       {
         "type": "Hex High Entropy String",
@@ -243,61 +203,6 @@
         "hashed_secret": "d4f68778b82c1e4853837d5b8ecdf2625256429f",
         "is_verified": false,
         "line_number": 37
-      }
-    ],
-    "tests/test_adapters/test_interceptors_extended.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_adapters/test_interceptors_extended.py",
-        "hashed_secret": "fb0123cbab73d8a58896fbe39b8b7b5b6df15c5e",
-        "is_verified": false,
-        "line_number": 48
-      }
-    ],
-    "tests/test_config/test_config_schema.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_config/test_config_schema.py",
-        "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
-        "is_verified": false,
-        "line_number": 700
-      }
-    ],
-    "tests/test_config/test_ssm_autodiscovery.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_config/test_ssm_autodiscovery.py",
-        "hashed_secret": "ba24b4dca3523679452cbe20dab9eaa9f50c6f16",
-        "is_verified": false,
-        "line_number": 42
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_config/test_ssm_autodiscovery.py",
-        "hashed_secret": "51268d9109e2b52a7c4b53775b1560c138b4d6b4",
-        "is_verified": false,
-        "line_number": 48
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_config/test_ssm_autodiscovery.py",
-        "hashed_secret": "92a8159fa2ade5dc0d3e3975d4ac26bcf1e4efdf",
-        "is_verified": false,
-        "line_number": 49
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_config/test_ssm_autodiscovery.py",
-        "hashed_secret": "7378bd4307a3e05617b530844ca33163fdcc49bb",
-        "is_verified": false,
-        "line_number": 328
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_config/test_ssm_autodiscovery.py",
-        "hashed_secret": "9e1c50f264cff2dcb7ce59c030babfe1a0b45c0a",
-        "is_verified": false,
-        "line_number": 329
       }
     ],
     "tests/test_engine/test_exporters.py": [
@@ -326,78 +231,7 @@
         "is_verified": false,
         "line_number": 49
       }
-    ],
-    "tests/test_orchestration/test_slurm_sharding.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_orchestration/test_slurm_sharding.py",
-        "hashed_secret": "e85b3f19ba65dae3aa220232f23dd669ca75b0a3",
-        "is_verified": false,
-        "line_number": 639
-      }
-    ],
-    "tests/test_sandbox/test_ecs_fargate.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_sandbox/test_ecs_fargate.py",
-        "hashed_secret": "4b72fe9b2ca9a73f7b9c92399fc0bc66a6a1ba46",
-        "is_verified": false,
-        "line_number": 36
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_sandbox/test_ecs_fargate.py",
-        "hashed_secret": "32b7fff7855ef49f519751298add56327b6fda80",
-        "is_verified": false,
-        "line_number": 37
-      }
-    ],
-    "tests/test_slurm_sidecar_services.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_slurm_sidecar_services.py",
-        "hashed_secret": "e9a5f12a8ecbb3eb46eca5096b5c52aa5e7c9fdd",
-        "is_verified": false,
-        "line_number": 297
-      }
-    ],
-    "tests/test_solvers/test_harbor_solver.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_solvers/test_harbor_solver.py",
-        "hashed_secret": "9e52503a0984e613e6ed5f6f9a3cf0b93b2d826b",
-        "is_verified": false,
-        "line_number": 94
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_solvers/test_harbor_solver.py",
-        "hashed_secret": "d53bc841bc79960df8f8bd2b261f11abb1157138",
-        "is_verified": false,
-        "line_number": 103
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_solvers/test_harbor_solver.py",
-        "hashed_secret": "aba587d0ca054afc6656ee19c938be86b9bff6a4",
-        "is_verified": false,
-        "line_number": 110
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_solvers/test_harbor_solver.py",
-        "hashed_secret": "d17f1ab3e20d30ec8e0ec98bc91e03091f0573e1",
-        "is_verified": false,
-        "line_number": 144
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "tests/test_solvers/test_harbor_solver.py",
-        "hashed_secret": "04d2297e558a68a20a32eaca04908e6d6b0b6300",
-        "is_verified": false,
-        "line_number": 151
-      }
     ]
   },
-  "generated_at": "2026-05-14T11:13:44Z"
+  "generated_at": "2026-06-01T09:07:06Z"
 }

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia-nemotron-3-nano-30b-a3b-base.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia-nemotron-3-nano-30b-a3b-base.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# How to use:
+#
+# 1. copy this file locally or clone the repository
+# 2. (optional) uncomment limit_samples in the config file to run with 10 samples for quick testing
+# 3. export your HF token in the terminal (some benchmark datasets might be gated)
+# 4. run `nemo-evaluator-launcher run --config path/to/local_nvidia-nemotron-nano-3-30b-a3b-base.yaml`
+#
+# ⚠️  WARNING:
+#     Always run full evaluations (without limit_samples) for actual benchmark results.
+#     Using a subset of samples is solely for testing configuration and setup.
+#     Results from such test runs should NEVER be used to compare models or
+#     report benchmark performance.
+defaults:
+  - execution: local
+  - deployment: vllm
+  - _self_
+
+execution:
+  output_dir: NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16
+  # mode: sequential  # enables sequential execution
+
+# specify deployment arguments
+deployment:
+  image: vllm/vllm-openai:v0.12.0
+  checkpoint_path: null
+  hf_model_handle: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16
+  served_model_name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16
+  tensor_parallel_size: 1
+  data_parallel_size: 1
+  extra_args: "--max-model-len 262144 --mamba_ssm_cache_dtype float32 --no-enable-prefix-caching"
+
+# specify the benchmarks to evaluate
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+  nemo_evaluator_config:  # global config settings that apply to all tasks
+    config:
+      params:
+        max_retries: 5  # number of retries for API requests
+        request_timeout: 360  # timeout for API requests in seconds
+        parallelism: 4  # number of parallel requests
+        # limit_samples: 10 # uncomment to limit number of samples for quick testing
+        extra:
+          tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16
+          tokenizer_backend: huggingface
+  tasks:
+    - name: adlr_mmlu_pro_5_shot_base
+    - name: adlr_mmlu
+    - name: adlr_agieval_en_cot
+    - name: adlr_humaneval_greedy
+    - name: adlr_mbpp_sanitized_3_shot_greedy
+    - name: adlr_gsm8k_cot_8_shot
+    - name: adlr_minerva_math_nemo_4_shot
+    - name: adlr_math_500_4_shot_sampled
+    - name: adlr_arc_challenge_llama_25_shot
+    - name: hellaswag
+    - name: openbookqa
+    - name: piqa
+    - name: adlr_race
+    - name: adlr_winogrande_5_shot
+    - name: adlr_global_mmlu_lite_5_shot
+    - name: adlr_mgsm_native_cot_8_shot

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia_nemotron_3_nano_30b_a3_tools.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia_nemotron_3_nano_30b_a3_tools.yaml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This config evaluates Nemotron 3 Nano 30B A3B with tool usage (Python code execution).
+# The model can use a Python interpreter tool to solve math and science problems.
+#
+# How to use:
+# 1. copy this file locally or clone the repository
+# 2. run `nemo-evaluator-launcher run --config path/to/local_nvidia_nemotron_3_nano_30b_a3_tools.yaml`
+
+defaults:
+  - execution: local
+  - deployment: none
+  - _self_
+
+execution:
+  output_dir: ./results_nvidia_nemotron_3_nano_30b_a3b_tools
+  mounts:
+    evaluation:
+      ./hf_cache: /root/.cache/huggingface
+target:
+  api_endpoint:
+    model_id: nvidia/nemotron-3-nano-30b-a3b
+    url: https://integrate.api.nvidia.com/v1/chat/completions
+    api_key_name: NGC_API_KEY
+
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    HF_HOME: host:HF_HOME
+  nemo_evaluator_config:
+    config:
+      params:
+        max_new_tokens: 131072
+        temperature: 0.99999
+        top_p: 0.99999
+        parallelism: 1
+        request_timeout: 3600
+        max_retries: 10
+        extra:
+          tokenizer: NVIDIA-Nemotron-Nano-3-30B-A3B-BF16
+          tokenizer_backend: huggingface
+    target:
+      api_endpoint:
+        adapter_config:
+          use_caching: true
+          tracking_requests_stats: true
+          log_failed_requests: true
+          use_request_logging: true
+          max_logged_requests: 10
+          use_response_logging: true
+          max_logged_responses: 10
+  tasks:
+  - name: ns_aime2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            use_sandbox: true
+            num_repeats: 64
+            args: "++inference.tokens_to_generate=null ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"
+  - name: ns_gpqa
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            use_sandbox: true
+            num_repeats: 8
+            args: "++inference.tokens_to_generate=null ++prompt_config=eval/aai/mcq-4choices ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - execution: local
+  - deployment: none
+  - _self_
+
+execution:
+  output_dir: ./results_nvidia_nemotron_3_nano_30b_a3b
+  mounts:
+    evaluation:
+      ./hf_cache: /root/.cache/huggingface
+target:
+  api_endpoint:
+    model_id: nvidia/nemotron-3-nano-30b-a3b
+    url: https://integrate.api.nvidia.com/v1/chat/completions
+    api_key_name: NGC_API_KEY # API Key with access to build.nvidia.com
+
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    JUDGE_API_KEY: host:JUDGE_API_KEY # API Key with access to gpt-4o for HLE
+    HF_HOME: host:HF_HOME
+  nemo_evaluator_config:
+    config:
+      params:
+        max_new_tokens: 131072
+        temperature: 0.99999
+        top_p: 0.99999
+        parallelism: 1
+        request_timeout: 3600
+        max_retries: 10
+        extra:
+          tokenizer: NVIDIA-Nemotron-Nano-3-30B-A3B-BF16
+          tokenizer_backend: huggingface
+    target:
+      api_endpoint:
+        adapter_config:
+          use_caching: true
+          tracking_requests_stats: true
+          log_failed_requests: true
+          use_request_logging: true
+          max_logged_requests: 10
+          use_response_logging: true
+          max_logged_responses: 10
+  tasks:
+  - name: ns_ifbench
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+  - name: ns_bfcl_v3
+    nemo_evaluator_config:
+      config:
+        params:
+          temperature: 0.6
+          top_p: 0.95
+          extra:
+            num_repeats: 1
+            args: ++use_client_parsing=False
+      target:
+        api_endpoint:
+          adapter_config:
+            use_caching: false
+  - name: ns_bfcl_v4
+    nemo_evaluator_config:
+      config:
+        params:
+          max_new_tokens: 8192
+          temperature: 0.6
+          top_p: 0.95
+          extra:
+            num_repeats: 1
+            args: ++use_client_parsing=False
+  - name: ns_livecodebench
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            dataset_split: test_v5_2407_2412
+  - name: ns_mmlu_pro
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+            args: "++prompt_config=eval/aai/mcq-10choices-boxed"
+  - name: ns_gpqa
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            args: "++prompt_config=eval/aai/mcq-4choices"
+  - name: ns_scicode
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+  - name: ns_hle
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+            judge_support: true
+            judge:
+              parallelism: 16
+              model_id: openai/gpt-4o
+              url: ??? # Set your OpenAI-compatible API URL for the judge model
+              api_key: JUDGE_API_KEY
+  - name: ns_aime2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 64
+            args: '++prompt_config="/nemo_run/code/eval_factory_prompts/math-oai.yaml"'
+  - name: ns_mmlu_prox
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+  - name: ns_wmt24pp
+  - name: tau2_bench_telecom
+    env_vars:
+      JUDGE_API_KEY: host:NGC_API_KEY
+      USER_API_KEY: host:NGC_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          temperature: 0.6
+          top_p: 0.95
+          extra:
+            n_samples: 8
+            skip_failed_samples: true
+            cache:
+              enabled: true
+              cache_dir: /results/native_cache
+  - name: ruler-128k-chat
+    nemo_evaluator_config:
+      config:
+        params:
+          limit_samples: 100
+          parallelism: 1
+          temperature: 0.00001
+          top_p: 0.99
+          extra:
+            tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+            tokenizer_backend: hf
+      target:
+        api_endpoint:
+          adapter_config:
+            use_reasoning: false
+            params_to_add: {"chat_template_kwargs": {"enable_thinking": false}, "skip_special_tokens": false}
+  - name: ruler-64k-chat
+    nemo_evaluator_config:
+      config:
+        params:
+          limit_samples: 100
+          parallelism: 1
+          temperature: 0.00001
+          top_p: 0.99
+          extra:
+            tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+            tokenizer_backend: hf
+      target:
+        api_endpoint:
+          adapter_config:
+            use_reasoning: false
+            params_to_add: {"chat_template_kwargs": {"enable_thinking": false}, "skip_special_tokens": false}
+  - name: aa_lcr
+    env_vars:
+      JUDGE_API_KEY: host:NGC_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          temperature: 0.99999
+          top_p: 0.99999
+          extra:
+            n_samples: 8

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_qwen3-30b-a3b-base.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/local_qwen3-30b-a3b-base.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# How to use:
+#
+# 1. copy this file locally
+# 2. (optional) uncomment limit_samples in the config file to run with 10 samples for quick testing
+# 3. export your HF token in the terminal (some benchmark datasets might be gated)
+# 4. run `nemo-evaluator-launcher run --config path/to/local_qwen3-30b-a3b-base.yaml`
+#
+# ⚠️  WARNING:
+#     Always run full evaluations (without limit_samples) for actual benchmark results.
+#     Using a subset of samples is solely for testing configuration and setup.
+#     Results from such test runs should NEVER be used to compare models or
+#     report benchmark performance.
+defaults:
+  - execution: local
+  - deployment: vllm
+  - _self_
+
+execution:
+  output_dir: Qwen3-30B-A3B-Base
+  # mode: sequential  # enables sequential execution
+
+# specify deployment arguments
+deployment:
+  image: vllm/vllm-openai:v0.11.0
+  checkpoint_path: null
+  hf_model_handle: Qwen/Qwen3-30B-A3B-Base
+  served_model_name: Qwen/Qwen3-30B-A3B-Base
+  tensor_parallel_size: 1
+  data_parallel_size: 1
+
+# specify the benchmarks to evaluate
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+  nemo_evaluator_config:  # global config settings that apply to all tasks
+    config:
+      params:
+        max_retries: 5  # number of retries for API requests
+        request_timeout: 360  # timeout for API requests in seconds
+        parallelism: 4  # number of parallel requests
+        # limit_samples: 10 # uncomment to limit number of samples for quick testing
+        extra:
+          tokenizer: Qwen/Qwen3-30B-A3B-Base
+          tokenizer_backend: huggingface
+  tasks:
+    - name: adlr_mmlu_pro_5_shot_base
+    - name: adlr_mmlu
+    - name: adlr_agieval_en_cot
+    - name: adlr_humaneval_greedy
+    - name: adlr_mbpp_sanitized_3_shot_greedy
+    - name: adlr_gsm8k_cot_8_shot
+    - name: adlr_minerva_math_nemo_4_shot
+    - name: adlr_math_500_4_shot_sampled
+    - name: adlr_arc_challenge_llama_25_shot
+    - name: hellaswag
+    - name: openbookqa
+    - name: piqa
+    - name: adlr_race
+    - name: adlr_winogrande_5_shot
+    - name: adlr_global_mmlu_lite_5_shot
+    - name: adlr_mgsm_native_cot_8_shot

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nano-v3-reproducibility.md
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nano-v3-reproducibility.md
@@ -1,0 +1,488 @@
+# NVIDIA Nemotron 3 Nano 30B A3B — Reproducing Model Card Evaluation Results
+
+This tutorial demonstrates how to reproduce the evaluation results for the [**NVIDIA Nemotron 3 Nano 30B A3B**](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b) model using the NeMo Evaluator Launcher.
+
+## Overview
+
+The Nemotron 3 Nano 30B A3B is a compact yet powerful reasoning model from NVIDIA. This configuration runs a comprehensive evaluation suite covering:
+
+| Benchmark | Category | Description |
+|-----------|----------|-------------|
+| **BFCL v3** | Function Calling | Berkeley Function Calling Leaderboard v3 |
+| **BFCL v4** | Function Calling | Berkeley Function Calling Leaderboard v4 |
+| **LiveCodeBench** | Coding | Real-world coding problems evaluation |
+| **MMLU-Pro** | Knowledge | Multi-task language understanding (10-choice) |
+| **GPQA** | Science | Graduate-level science questions |
+| **AIME 2025** | Mathematics | American Invitational Mathematics Exam |
+| **SciCode** | Scientific Coding | Scientific programming challenges |
+| **IFBench** | Instruction Following | Instruction following benchmark |
+| **HLE** | Humanity's Last Exam | Expert-level questions across domains |
+| **AIME 2025 (tools)** | Mathematics + Tools | AIME with Python code execution |
+| **GPQA (tools)** | Science + Tools | GPQA with Python code execution |
+| **Tau2 Bench Telecom** | Telecom / Tool Use | Tau2 benchmark (telecom domain) with judge; uses NGC API for model and judge |
+| **MMLU-Pro X** | Knowledge | MMLU-Pro extended multilingual variant |
+| **WMT24++** | Translation | WMT24 translation benchmark |
+| **RULER 128k (chat)** | Long-context | RULER long-context evaluation (128k), chat template |
+| **RULER 64k (chat)** | Long-context | RULER long-context evaluation (64k), chat template |
+
+The open source container on NeMo Skills packaged via NVIDIA's NeMo Evaluator SDK used for evaluations can be found [here](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/nemo_skills?version=25.11).
+
+---
+
+## Prerequisites
+
+### 1. Install the NeMo Evaluator Launcher
+
+```bash
+pip install nemo-evaluator-launcher
+```
+
+Or install from source:
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Evaluator.git
+cd Evaluator/packages/nemo-evaluator-launcher
+pip install -e .
+```
+
+### 2. Required API Keys
+
+Set the following environment variables before running the evaluation:
+
+```bash
+# Required: NGC API key for accessing the model endpoint
+export NGC_API_KEY="your-ngc-api-key"
+
+# Required: HuggingFace token for accessing datasets
+export HF_TOKEN="your-huggingface-token"
+
+# Required for HLE benchmark: OpenAI/Azure API key for GPT-4o judge
+export JUDGE_API_KEY="your-judge-api-key"
+```
+
+> **Note:** The `JUDGE_API_KEY` is only required if you're running the HLE (Humanity's Last Exam) benchmark, which uses GPT-4o as a judge model.
+
+### 3. HuggingFace Cache (Optional)
+
+For faster subsequent runs, you can set a persistent cache directory:
+
+```bash
+export HF_HOME="/path/to/your/huggingface/cache"
+```
+
+---
+
+## Running the Full Evaluation Suite
+
+### 1. Get the Configuration
+
+Clone the repository or download the [example config file](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/packages/nemo-evaluator-launcher/examples/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml):
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Evaluator.git
+cd Evaluator  # or navigate to where you placed the config file
+```
+
+### 2. Run the Evaluation
+
+```bash
+nemo-evaluator-launcher run \
+  --config packages/nemo-evaluator-launcher/examples/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml
+# Or point to your path if you placed the file under a different location
+```
+
+### 3. Dry Run (Preview Configuration)
+
+To preview the configuration without running the evaluation:
+
+```bash
+nemo-evaluator-launcher run \
+  --config packages/nemo-evaluator-launcher/examples/nemotron/local_nvidia_nemotron_3_nano_30b_a3b.yaml \
+  --dry-run
+```
+
+---
+
+## Running Individual Benchmarks
+
+You can run specific benchmarks using the `-t` flag (from the `examples/nemotron` directory):
+
+```bash
+# Run only MMLU-Pro
+nemo-evaluator-launcher run --config local_nvidia_nemotron_3_nano_30b_a3b.yaml -t ns_mmlu_pro
+
+# Run only coding benchmarks
+nemo-evaluator-launcher run --config local_nvidia_nemotron_3_nano_30b_a3b.yaml -t ns_livecodebench
+
+# Run multiple specific benchmarks
+nemo-evaluator-launcher run --config local_nvidia_nemotron_3_nano_30b_a3b.yaml -t ns_gpqa -t ns_aime2025
+```
+
+### Available Task Names
+
+| Task Name | Benchmark |
+|-----------|-----------|
+| `ns_bfcl_v3` | Berkeley Function Calling Leaderboard v3 |
+| `ns_bfcl_v4` | Berkeley Function Calling Leaderboard v4 |
+| `ns_livecodebench` | LiveCodeBench |
+| `ns_mmlu_pro` | MMLU-Pro (10-choice format) |
+| `ns_gpqa` | GPQA Diamond |
+| `ns_aime2025` | AIME 2025 |
+| `ns_scicode` | SciCode |
+| `ns_ifbench` | IFBench |
+| `ns_hle` | Humanity's Last Exam |
+| `ns_mmlu_prox` | MMLU-Pro X |
+| `ns_wmt24pp` | WMT24++ |
+| `tau2_bench_telecom` | Tau2 Bench Telecom |
+| `ruler-128k-chat` | RULER 128k (chat) |
+| `ruler-64k-chat` | RULER 64k (chat) |
+
+---
+
+## Configuration Details
+
+### Model Endpoint
+
+The evaluation uses the NVIDIA API endpoint:
+
+```yaml
+target:
+  api_endpoint:
+    model_id: nvidia/nemotron-3-nano-30b-a3b
+    url: https://integrate.api.nvidia.com/v1/chat/completions
+    api_key_name: NGC_API_KEY
+```
+
+### Default Parameters
+
+The configuration uses the following default inference parameters:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `max_new_tokens` | 131072 | Maximum tokens to generate |
+| `temperature` | 0.99999 | Sampling temperature |
+| `top_p` | 0.99999 | Nucleus sampling threshold |
+| `parallelism` | 512 | Concurrent requests |
+| `request_timeout` | 3600 | Request timeout in seconds |
+| `max_retries` | 10 | Maximum retry attempts |
+
+### Benchmark-Specific Configurations
+
+Different benchmarks use tailored parameters:
+
+#### BFCL (Function Calling)
+- Temperature: 0.6
+- Top-p: 0.95
+- Client parsing disabled
+
+#### LiveCodeBench
+- 8 repeated samples (`num_repeats: 8`)
+- Test split: `test_v5_2407_2412`
+
+#### GPQA
+- 8 repeated samples for pass@1
+- 4-choice MCQ prompt format
+
+#### AIME 2025
+- 64 repeated samples (`num_repeats: 64`)
+- Math-specific prompt template
+
+#### HLE
+- GPT-4o judge via OpenAI API
+- Judge parallelism: 16
+- Requires `JUDGE_API_KEY` and configuring the judge URL
+
+#### Tau2 Bench Telecom
+- Temperature: 0.6, top_p: 0.95
+- 8 samples per item; optional caching and skip_failed_samples
+- Uses `JUDGE_API_KEY` and `USER_API_KEY` (mapped from `NGC_API_KEY` in the config)
+
+#### RULER (128k / 64k chat)
+- Long-context evaluation with chat template; thinking disabled
+- Default: 100 samples, parallelism 1, low temperature (0.00001)
+- Uses Nemotron tokenizer via HuggingFace
+
+---
+
+## Monitoring and Results
+
+### Check Job Status
+
+```bash
+nemo-evaluator-launcher status
+```
+
+### View Logs
+
+```bash
+# Stream logs for a specific job
+nemo-evaluator-launcher logs <job-id>
+```
+
+### Results Location
+
+Results are saved to the output directory specified in the config:
+
+```
+./results_nvidia_nemotron_3_nano_30b_a3b/
+├── artifacts/
+│   └── <task_name>/
+│       └── results.json
+└── logs/
+    └── stdout.log
+```
+
+---
+
+## Customization
+
+All examples below assume you are in the `examples/nemotron` directory.
+
+### Override Output Directory
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nvidia_nemotron_3_nano_30b_a3b.yaml \
+  -o execution.output_dir=/custom/output/path
+```
+
+### Limit Samples (for Testing)
+
+For quick testing, you can limit the number of samples:
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nvidia_nemotron_3_nano_30b_a3b.yaml \
+  -o evaluation.nemo_evaluator_config.config.params.limit_samples=10
+```
+
+### Use a Different API Endpoint
+
+If you're hosting the model locally or using a different endpoint:
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nvidia_nemotron_3_nano_30b_a3b.yaml \
+  -o target.api_endpoint.url=http://localhost:8000/v1/chat/completions
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+1. **API Key Not Found**
+   - Ensure environment variables are exported in the current shell
+   - Verify the key names match exactly: `NGC_API_KEY`, `HF_TOKEN`, `JUDGE_API_KEY`
+
+2. **Timeout Errors**
+   - The model generates long reasoning chains; timeouts are set to 3600s
+   - Reduce `parallelism` if hitting rate limits
+
+3. **HLE Judge Failures**
+   - Verify `JUDGE_API_KEY` has access to GPT-4o
+   - Check the judge endpoint URL is accessible
+
+4. **HuggingFace Dataset Access**
+   - Some datasets require accepting terms on HuggingFace Hub
+   - Ensure your `HF_TOKEN` has appropriate permissions
+
+### Getting Help
+
+```bash
+# View all available commands
+nemo-evaluator-launcher --help
+
+# View run command options
+nemo-evaluator-launcher run --help
+
+# List available evaluation tasks
+nemo-evaluator-launcher ls tasks
+```
+
+---
+
+## Expected Results
+
+After running the full evaluation suite, you should obtain results comparable to those reported in the NVIDIA Nemotron 3 Nano 30B A3B Model Card.
+
+> **Important:** Due to the stochastic nature of sampling (temperature > 0) and the use of `num_repeats` for consensus-based scoring, slight variations in results are expected between runs.
+
+---
+
+## Tool Usage Evaluation
+
+The Nemotron 3 Nano 30B A3B model supports tool usage, allowing it to call a Python interpreter to solve math and science problems step by step.
+
+### Tool Usage Config
+
+| Config File | Model |
+|-------------|-------|
+| `local_nvidia_nemotron_3_nano_30b_a3_tools.yaml` | nvidia/nemotron-3-nano-30b-a3b |
+
+### Tool Usage Benchmarks
+
+| Benchmark | Category | Description |
+|-----------|----------|-------------|
+| **AIME 2025** | Mathematics | American Invitational Mathematics Exam (with Python tool) |
+| **GPQA** | Science | Graduate-level science questions (with Python tool) |
+
+### Available Task Names (Tool Usage)
+
+| Task Name | Benchmark |
+|-----------|-----------|
+| `ns_aime2025` | AIME 2025 (with sandbox + Python tool) |
+| `ns_gpqa` | GPQA Diamond (with sandbox + Python tool) |
+
+### Running Tool Usage Evaluations
+
+```bash
+cd packages/nemo-evaluator-launcher/examples/nemotron
+
+nemo-evaluator-launcher run --config local_nvidia_nemotron_3_nano_30b_a3_tools.yaml
+
+# Run only AIME 2025 with tools
+nemo-evaluator-launcher run --config local_nvidia_nemotron_3_nano_30b_a3_tools.yaml -t ns_aime2025
+
+# Run only GPQA with tools
+nemo-evaluator-launcher run --config local_nvidia_nemotron_3_nano_30b_a3_tools.yaml -t ns_gpqa
+```
+
+### Tool Usage Configuration Details
+
+Tool usage is enabled per-task via these extra parameters:
+
+```yaml
+extra:
+  use_sandbox: true
+  args: "++inference.tokens_to_generate=null ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"
+```
+
+The model generates tool calls (Python code), which are executed in a sandboxed environment, and the results are fed back to the model for further reasoning.
+
+---
+
+## Base Model Evaluation
+
+In addition to the instruct model, you can reproduce evaluation results for the base (pre-trained) models using local vLLM deployment.
+
+### Available Base Model Configs
+
+| Config File | Model |
+|-------------|-------|
+| `local_nvidia-nemotron-3-nano-30b-a3b-base.yaml` | nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16 |
+| `local_qwen3-30b-a3b-base.yaml` | Qwen/Qwen3-30B-A3B-Base |
+
+### Base Model Benchmarks
+
+The base model evaluation suite includes traditional pre-training benchmarks:
+
+| Benchmark | Category | Description |
+|-----------|----------|-------------|
+| **MMLU (5-shot)** | General Knowledge | Massive Multitask Language Understanding |
+| **MMLU-Pro (5-shot, CoT)** | General Knowledge | Multi-task language understanding |
+| **AGIEval-En (CoT)** | General Knowledge | Human-centric benchmark with chain-of-thought |
+| **HumanEval (0-shot)** | Code | Code generation |
+| **MBPP Sanitized (3-shot)** | Code | Python programming problems |
+| **GSM8K (8-shot)** | Math | Grade school math word problems |
+| **MATH (4-shot)** | Math | Competition mathematics |
+| **MATH-500 (4-shot)** | Math | Subset of MATH benchmark |
+| **ARC-Challenge (25-shot)** | Commonsense Understanding | AI2 Reasoning Challenge |
+| **HellaSwag (10-shot)** | Commonsense Understanding | Sentence completion |
+| **OpenBookQA (0-shot)** | Commonsense Understanding | Open-book question answering |
+| **PIQA (0-shot)** | Commonsense Understanding | Physical intuition |
+| **WinoGrande (5-shot)** | Commonsense Understanding | Coreference resolution |
+| **RACE (0-shot)** | Reading Comprehension | Reading comprehension |
+| **Global MMLU Lite (5-shot)** | Multilingual | Multilingual understanding |
+| **MGSM (8-shot)** | Multilingual | Multilingual grade school math |
+
+### Available Task Names (Base Models)
+
+| Task Name | Benchmark |
+|-----------|-----------|
+| `adlr_mmlu` | MMLU (5-shot) |
+| `adlr_mmlu_pro_5_shot_base` | MMLU-Pro (5-shot, CoT) |
+| `adlr_agieval_en_cot` | AGIEval-En (CoT) |
+| `adlr_humaneval_greedy` | HumanEval (greedy) |
+| `adlr_mbpp_sanitized_3_shot_greedy` | MBPP Sanitized (3-shot, greedy) |
+| `adlr_gsm8k_cot_8_shot` | GSM8K (8-shot) |
+| `adlr_minerva_math_nemo_4_shot` | MATH (4-shot) |
+| `adlr_math_500_4_shot_sampled` | MATH-500 (4-shot) |
+| `adlr_arc_challenge_llama_25_shot` | ARC-Challenge (25-shot) |
+| `hellaswag` | HellaSwag (10-shot) |
+| `openbookqa` | OpenBookQA (0-shot) |
+| `piqa` | PIQA (0-shot) |
+| `adlr_race` | RACE (0-shot) |
+| `adlr_winogrande_5_shot` | WinoGrande (5-shot) |
+| `adlr_global_mmlu_lite_5_shot` | Global MMLU Lite (5-shot) |
+| `adlr_mgsm_native_cot_8_shot` | MGSM (8-shot) |
+
+### Running Base Model Evaluations
+
+Base model configs use local vLLM deployment instead of an API endpoint:
+
+```bash
+cd packages/nemo-evaluator-launcher/examples/nemotron
+
+# Run NVIDIA Nemotron base model evaluation
+nemo-evaluator-launcher run --config local_nvidia-nemotron-3-nano-30b-a3b-base.yaml
+
+# Run Qwen3 base model evaluation
+nemo-evaluator-launcher run --config local_qwen3-30b-a3b-base.yaml
+```
+
+### Base Model Configuration Details
+
+#### Deployment (vLLM)
+
+The base models are deployed locally using vLLM:
+
+```yaml
+deployment:
+  image: vllm/vllm-openai:v0.12.0
+  hf_model_handle: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-Base-BF16
+  tensor_parallel_size: 1
+  data_parallel_size: 1
+  extra_args: "--max-model-len 262144 --mamba_ssm_cache_dtype float32 --no-enable-prefix-caching"
+```
+
+#### Inference Parameters
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `max_retries` | 5 | Number of retries for API requests |
+| `request_timeout` | 360 | Request timeout in seconds |
+| `parallelism` | 4 | Concurrent requests |
+
+### Running Individual Base Model Benchmarks
+
+```bash
+# Run only MMLU
+nemo-evaluator-launcher run --config local_nvidia-nemotron-3-nano-30b-a3b-base.yaml -t adlr_mmlu
+
+# Run only coding benchmarks
+nemo-evaluator-launcher run --config local_nvidia-nemotron-3-nano-30b-a3b-base.yaml -t adlr_humaneval_greedy -t adlr_mbpp_sanitized_3_shot_greedy
+
+# Run math benchmarks
+nemo-evaluator-launcher run --config local_nvidia-nemotron-3-nano-30b-a3b-base.yaml -t adlr_gsm8k_cot_8_shot -t adlr_minerva_math_nemo_4_shot -t adlr_math_500_4_shot_sampled
+```
+
+### Quick Testing (Base Models)
+
+For quick configuration testing, uncomment `limit_samples` in the config file or override via CLI:
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nvidia-nemotron-3-nano-30b-a3b-base.yaml \
+  -o evaluation.nemo_evaluator_config.config.params.limit_samples=10
+```
+
+> **Warning:** Always run full evaluations (without `limit_samples`) for actual benchmark results. Results from test runs with limited samples should never be used to compare models.
+
+---
+
+## License
+
+This configuration and tutorial are provided under the Apache License 2.0. See the main repository LICENSE file for details.
+

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b-base.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b-base.yaml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+# How to use:
+#
+# 1. copy this file locally or clone the repository
+# 2. (optional) uncomment limit_samples in the config file to run with 10 samples for quick testing
+# 3. export your HF token in the terminal (some benchmark datasets might be gated)
+# 4. run `nemo-evaluator-launcher run --config path/to/local_nemotron-3-super-120b-a12b-base.yaml`
+#
+# ⚠️  WARNING:
+#     Always run full evaluations (without limit_samples) for actual benchmark results.
+#     Using a subset of samples is solely for testing configuration and setup.
+#     Results from such test runs should NEVER be used to compare models or
+#     report benchmark performance.
+defaults:
+  - execution: local
+  - deployment: vllm
+  - _self_
+
+execution:
+  output_dir: NVIDIA-Nemotron-3-Super-120B-A12B-Base
+  # mode: sequential  # enables sequential execution
+
+# specify deployment arguments
+deployment:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    VLLM_ATTENTION_BACKEND: lit:FLASH_ATTN
+  image: vllm/vllm-openai:v0.13.0
+  hf_model_handle: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base
+  served_model_name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base
+  tensor_parallel_size: 8
+  data_parallel_size: 1
+
+# specify the benchmarks to evaluate
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+  nemo_evaluator_config:  # global config settings that apply to all tasks
+    config:
+      params:
+        max_retries: 5  # number of retries for API requests
+        request_timeout: 360  # timeout for API requests in seconds
+        parallelism: 4  # number of parallel requests
+        # limit_samples: 10 # uncomment to limit number of samples for quick testing
+        extra:
+          tokenizer: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base #pragma: allowlist secret 
+          tokenizer_backend: huggingface
+  tasks:
+    # General Knowledge
+    - name: adlr_mmlu
+    - name: adlr_mmlu_pro_5_shot_base
+    - name: adlr_agieval_en_cot
+    - name: adlr_gpqa_diamond_cot_5_shot
+    # Math
+    - name: adlr_gsm8k_cot_8_shot
+    - name: adlr_minerva_math_nemo_4_shot
+    - name: adlr_math_500_4_shot_sampled
+    # Code
+    - name: adlr_humaneval_greedy
+    - name: adlr_mbpp_sanitized_3_shot_greedy
+    # Commonsense Understanding
+    - name: adlr_arc_challenge_llama_25_shot
+    - name: hellaswag
+    - name: openbookqa
+    - name: piqa
+    - name: adlr_winogrande_5_shot
+    # Reasing comprehension
+    - name: adlr_race
+    # Multilingual
+    - name: adlr_global_mmlu_lite_5_shot
+    - name: adlr_mgsm_native_cot_8_shot
+    # Long Context
+    - name: ruler-64k-completions
+      nemo_evaluator_config:
+        config:
+          params:
+            extra:
+              tokenizer_backend: hf
+    - name: ruler-128k-completions
+      nemo_evaluator_config:
+        config:
+          params:
+            extra:
+              tokenizer_backend: hf
+    - name: ruler-512k-completions
+      nemo_evaluator_config:
+        config:
+          params:
+            extra:
+              tokenizer_backend: hf
+    - name: ruler-1m-completions
+      nemo_evaluator_config:
+        config:
+          params:
+            extra:
+              tokenizer_backend: hf

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b.yaml
@@ -1,0 +1,308 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This configuration file is for the NVIDIA Nemotron 3 Super 120B A12B model, deployed on https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b.
+# If you prefer to deploy the model on your own infrastructure, use the following deployment setup:
+
+### 1. NVIDIA-Nemotron-3-Super-120B-A12B-BF16 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 --tensor-parallel-size=8
+#     --pipeline-parallel-size=1 --data-parallel-size=1 --port 8000 --trust-remote-code
+#     --served-model-name nvidia/nemotron-3-super-120b-a12b --gpu-memory-utilization 0.8
+#     --enable-log-requests --mamba_ssm_cache_dtype float32 --enable-auto-tool-choice
+#     --tool-call-parser qwen3_coder --attention-backend FLASH_ATTN --reasoning-parser
+#     super_v3 --no-enable-chunked-prefill --no-enable-prefix-caching --model-loader-extra-config
+#     ''{"enable_multithread_load": true, "num_threads": 96}''
+
+
+### 2. NVIDIA-Nemotron-3-Super-120B-A12B-FP8 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - Environment Variables:
+#       - VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP8: 1
+#       - VLLM_FLASHINFER_MOE_BACKEND: throughput
+#       - MAMBA_CACHE_PHILOX_ROUNDS: 5
+#       - MAMBA_CACHE_RS_ROUNDING: 1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8 --tensor-parallel-size=4 --pipeline-parallel-size=1
+#     --data-parallel-size=1 --port 8000 --trust-remote-code --served-model-name nvidia/nemotron-3-super-120b-a12b
+#     --gpu-memory-utilization 0.8 --trust-remote-code --no-enable-prefix-caching --no-enable-chunked-prefill
+#     --mamba_ssm_cache_dtype float16 --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser super_v3 
+#     --model-loader-extra-config ''{"enable_multithread_load": true, "num_threads": 96}'' --kv-cache-dtype fp8
+
+
+### 3. NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - Environment Variables:
+#       - VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP4: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP8: 1
+#       - VLLM_FLASHINFER_MOE_BACKEND: throughput
+#       - MAMBA_CACHE_PHILOX_ROUNDS: 5
+#       - MAMBA_CACHE_RS_ROUNDING: 1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 --tensor-parallel-size=4 --pipeline-parallel-size=1
+#    --data-parallel-size=1 --port 8000 --trust-remote-code --served-model-name nvidia/nemotron-3-super-120b-a12b
+#    --gpu-memory-utilization 0.8 --trust-remote-code --no-enable-prefix-caching --no-enable-chunked-prefill
+#    --mamba_ssm_cache_dtype float16 --enable-auto-tool-choice --tool-call-parser qwen3_coder
+#    --reasoning-parser super_v3 --model-loader-extra-config ''{"enable_multithread_load": true, "num_threads":
+#    96}'' --kv-cache-dtype fp8 
+
+
+defaults:
+  - execution: local
+  - deployment: none
+  - _self_
+
+execution:
+  output_dir: ./results_nvidia_nemotron_3_super_120b_a12b
+  mounts:
+    evaluation:
+      ./hf_cache: /root/.cache/huggingface
+target:
+  api_endpoint:
+    model_id: nvidia/nemotron-3-super-120b-a12b
+    url: https://integrate.api.nvidia.com/v1/chat/completions  # or your served model URL
+    api_key_name: NGC_API_KEY # API Key with access to build.nvidia.com
+
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    JUDGE_API_KEY: host:JUDGE_API_KEY # API Key with access to gpt-4o
+    GEMINI_API_KEY: host:GEMINI_API_KEY # API Key with access to Gemini-3-Flash-Preview for AA-Omniscience
+    QWEN_API_KEY: host:QWEN_API_KEY # API Key with access to qwen/qwen3-235b-a22b for AA-LCR and tau2-bench
+    HF_HOME: host:HF_HOME
+  nemo_evaluator_config:
+    config:
+      params:
+        parallelism: 1
+        max_new_tokens: 131072
+        temperature: 1.0 
+        top_p: 0.95       
+        request_timeout: 3600
+        max_retries: 10
+        extra:
+          tokenizer_backend: huggingface
+          # TODO: is the tokenizer correct?
+          tokenizer: NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+    target:
+      api_endpoint:
+        adapter_config:
+          params_to_add: {"chat_template_kwargs": {"enable_thinking": true}, "skip_special_tokens": false}
+          use_caching: true
+          tracking_requests_stats: true
+          log_failed_requests: true
+          use_request_logging: true
+          max_logged_requests: 10
+          use_response_logging: true
+          max_logged_responses: 10
+
+  tasks:
+  - name: nemo_skills.ns_gpqa
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            args: "++prompt_config=eval/aai/mcq-4choices"
+  - name: ns_hle
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+            judge_support: true
+            judge:
+              parallelism: 16
+              model_id: openai/gpt-4o
+              url: ... # Set your OpenAI-compatible API URL for the judge model
+              api_key: JUDGE_API_KEY
+  - name: nemo_skills.ns_mmlu_pro
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+            args: "++prompt_config=eval/aai/mcq-10choices-boxed" #pragma: allowlist secret
+  - name: nemo_skills.ns_aime2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 64
+            args: '++prompt_config="/nemo_run/code/eval_factory_prompts/math-oai.yaml"'
+  - name: nemo_skills.ns_aime2026
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 64
+            args: ++prompt_config=/nemo_run/code/eval_factory_prompts/math-oai.yaml ++inference.tokens_to_generate=null
+  - name: ns_hmmt_feb2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 64
+  - name: AA_math_test_500
+    env_vars:
+      JUDGE_API_KEY: host:NGC_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            n_samples: 5
+  - name: nemo_skills.ns_critpt
+    env_vars:
+      ARTIFICIAL_ANALYSIS_API_KEY: host:ARTIFICIAL_ANALYSIS_API_KEY
+    config:
+      config:
+        params:
+          extra:
+            num_repeats: 3
+  - name: ns_scicode
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+  - name: ns_livecodebench_v5
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            dataset_split: test_v5_2407_2412
+  - name: ns_livecodebench
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            dataset_split: test_v6_2408_2505
+  - name: ns_ifbench
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+  - name: nemo_skills.ns_bfcl_v4
+    nemo_evaluator_config:
+      config:
+        params:
+          max_new_tokens: 8192
+          parallelism: 128
+          extra:
+            num_repeats: 1
+            args: ++use_client_parsing=False
+  - name: tau2_bench_telecom
+    env_vars:
+      USER_API_KEY: host:QWEN_API_KEY
+    config:
+      config:
+        params:
+          extra:
+            n_samples: 8
+            skip_failed_samples: true
+            cache:
+              enabled: true
+              cache_dir: /results/native_cache
+            user:
+              model_id: ... # Set your model_id for the user model (non-reasoning qwen/qwen3-235b-a22b)
+              url: ... # Set your API URL for the user model (non-reasoning qwen/qwen3-235b-a22b)
+              api_key: USER_API_KEY
+      target:
+        api_endpoint:
+          adapter_config:
+            use_reasoning: true
+  - name: tau2_bench_retail
+    env_vars:
+      USER_API_KEY: host:QWEN_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            skip_failed_samples: true
+            n_samples: 8
+            cache:
+              enabled: true
+              cache_dir: /results/native_cache
+            user:
+              model_id: ... # Set your model_id for the user model (non-reasoning qwen/qwen3-235b-a22b)
+              url: ... # Set your API URL for the user model (non-reasoning qwen/qwen3-235b-a22b)
+              api_key: USER_API_KEY
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: true
+  - name: tau2_bench_airline
+    env_vars:
+      USER_API_KEY: host:QWEN_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            skip_failed_samples: true
+            n_samples: 8
+            cache:
+              enabled: true
+              cache_dir: /results/native_cache
+            user:
+              model_id: ... # Set your model_id for the user model (non-reasoning qwen/qwen3-235b-a22b)
+              url: ... # Set your API URL for the user model (non-reasoning qwen/qwen3-235b-a22b)
+              api_key: USER_API_KEY
+    target:
+      api_endpoint:
+        adapter_config:
+          use_reasoning: true
+  - name: ns_arena_hard_v2
+  - name: ns_aa_lcr
+    env_vars:
+      JUDGE_API_KEY: host:QWEN_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            judge:
+              url: ... # Set your API URL for the judge model (non-reasoning qwen/qwen3-235b-a22b)
+              model_id: ... # Set your model_id for the judge model (non-reasoning qwen/qwen3-235b-a22b)
+              api_key: JUDGE_API_KEY
+            num_repeats: 16
+  - name: ns_mmlu_prox
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+  - name: ns_omniscience
+    env_vars:
+      JUDGE_API_KEY: host:GEMINI_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            args: "++parse_reasoning=False"
+            judge:
+              api_key: JUDGE_API_KEY
+              model_id: google/gemini-3-flash-preview
+              url: ... # Set your API URL for the judge model
+  - name: ns_wmt24pp_comet
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            comet:
+              # download the model from https://huggingface.co/Unbabel/XCOMET-XXL 
+              # and replace the path below with your path to COMET-XXL checkpoint
+              model_path: /path/to/XCOMET-XXL/checkpoints/model.ckpt

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b_low_budget.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b_low_budget.yaml
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This configuration file is for the NVIDIA Nemotron 3 Super 120B A12B model, deployed on https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b.
+# If you prefer to deploy the model on your own infrastructure, use the following deployment setup:
+
+### 1. NVIDIA-Nemotron-3-Super-120B-A12B-BF16 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 --tensor-parallel-size=8
+#     --pipeline-parallel-size=1 --data-parallel-size=1 --port 8000 --trust-remote-code
+#     --served-model-name nvidia/nemotron-3-super-120b-a12b --gpu-memory-utilization 0.8
+#     --enable-log-requests --mamba_ssm_cache_dtype float32 --enable-auto-tool-choice
+#     --tool-call-parser qwen3_coder --attention-backend FLASH_ATTN --reasoning-parser
+#     super_v3 --no-enable-chunked-prefill --no-enable-prefix-caching --model-loader-extra-config
+#     ''{"enable_multithread_load": true, "num_threads": 96}''
+
+
+### 2. NVIDIA-Nemotron-3-Super-120B-A12B-FP8 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - Environment Variables:
+#       - VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP8: 1
+#       - VLLM_FLASHINFER_MOE_BACKEND: throughput
+#       - MAMBA_CACHE_PHILOX_ROUNDS: 5
+#       - MAMBA_CACHE_RS_ROUNDING: 1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8 --tensor-parallel-size=4 --pipeline-parallel-size=1
+#     --data-parallel-size=1 --port 8000 --trust-remote-code --served-model-name nvidia/nemotron-3-super-120b-a12b
+#     --gpu-memory-utilization 0.8 --trust-remote-code --no-enable-prefix-caching --no-enable-chunked-prefill
+#     --mamba_ssm_cache_dtype float16 --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser super_v3 
+#     --model-loader-extra-config ''{"enable_multithread_load": true, "num_threads": 96}'' --kv-cache-dtype fp8
+
+
+### 3. NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - Environment Variables:
+#       - VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP4: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP8: 1
+#       - VLLM_FLASHINFER_MOE_BACKEND: throughput
+#       - MAMBA_CACHE_PHILOX_ROUNDS: 5
+#       - MAMBA_CACHE_RS_ROUNDING: 1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 --tensor-parallel-size=4 --pipeline-parallel-size=1
+#    --data-parallel-size=1 --port 8000 --trust-remote-code --served-model-name nvidia/nemotron-3-super-120b-a12b
+#    --gpu-memory-utilization 0.8 --trust-remote-code --no-enable-prefix-caching --no-enable-chunked-prefill
+#    --mamba_ssm_cache_dtype float16 --enable-auto-tool-choice --tool-call-parser qwen3_coder
+#    --reasoning-parser super_v3 --model-loader-extra-config ''{"enable_multithread_load": true, "num_threads":
+#    96}'' --kv-cache-dtype fp8 
+
+
+defaults:
+  - execution: local
+  - deployment: none
+  - _self_
+
+execution:
+  output_dir: ./results_nvidia_nemotron_3_super_120b_a12b
+  mounts:
+    evaluation:
+      ./hf_cache: /root/.cache/huggingface
+target:
+  api_endpoint:
+    model_id: nvidia/nemotron-3-super-120b-a12b
+    url: https://integrate.api.nvidia.com/v1/chat/completions  # or your served model URL
+    api_key_name: NGC_API_KEY # API Key with access to build.nvidia.com
+
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    JUDGE_API_KEY: host:JUDGE_API_KEY
+  nemo_evaluator_config:
+    config:
+      params:
+        parallelism: 1
+        max_new_tokens: 131072
+        temperature: 1.0 
+        top_p: 0.95       
+        request_timeout: 3600
+        max_retries: 10
+        extra:
+          tokenizer_backend: huggingface
+          tokenizer: NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+    target:
+      api_endpoint:
+        adapter_config:
+          params_to_add: {"chat_template_kwargs": {"enable_thinking": true}, "skip_special_tokens": false}
+          use_caching: true
+          tracking_requests_stats: true
+          log_failed_requests: true
+          use_request_logging: true
+          max_logged_requests: 10
+          use_response_logging: true
+          max_logged_responses: 10
+
+  tasks:
+  - name: nemo_skills.ns_aime2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 64
+            args: ++prompt_config=/prompt_templates/math-oai.yaml
+      target:
+        api_endpoint:
+          adapter_config:
+            params_to_add: {"chat_template_kwargs": {"enable_thinking": true, "low_effort": true}}
+  - name: tau2_bench_telecom
+    env_vars:
+      USER_API_KEY: host:NGC_API_KEY
+    config:
+      config:
+        params:
+          extra:
+            n_samples: 8
+            skip_failed_samples: true
+            cache:
+              enabled: true
+              cache_dir: /results/native_cache
+      target:
+        api_endpoint:
+          adapter_config:
+            params_to_add: {"chat_template_kwargs": {"enable_thinking": true, "low_effort": true}}
+  - name: ns_livecodebench
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            dataset_split: test_v6_2408_2505
+      target:
+        api_endpoint:
+          adapter_config:
+            params_to_add: {"chat_template_kwargs": {"enable_thinking": true, "low_effort": true}}

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b_tools.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/local_nemotron-3-super-120b-a12b_tools.yaml
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This configuration file is for the NVIDIA Nemotron 3 Super 120B A12B model, deployed on https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b.
+# If you prefer to deploy the model on your own infrastructure, use the following deployment setup:
+
+### 1. NVIDIA-Nemotron-3-Super-120B-A12B-BF16 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 --tensor-parallel-size=8
+#     --pipeline-parallel-size=1 --data-parallel-size=1 --port 8000 --trust-remote-code
+#     --served-model-name nvidia/nemotron-3-super-120b-a12b --gpu-memory-utilization 0.8
+#     --enable-log-requests --mamba_ssm_cache_dtype float32 --enable-auto-tool-choice
+#     --tool-call-parser qwen3_coder --attention-backend FLASH_ATTN --reasoning-parser
+#     super_v3 --no-enable-chunked-prefill --no-enable-prefix-caching --model-loader-extra-config
+#     ''{"enable_multithread_load": true, "num_threads": 96}''
+
+
+### 2. NVIDIA-Nemotron-3-Super-120B-A12B-FP8 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - Environment Variables:
+#       - VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP8: 1
+#       - VLLM_FLASHINFER_MOE_BACKEND: throughput
+#       - MAMBA_CACHE_PHILOX_ROUNDS: 5
+#       - MAMBA_CACHE_RS_ROUNDING: 1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-FP8 --tensor-parallel-size=4 --pipeline-parallel-size=1
+#     --data-parallel-size=1 --port 8000 --trust-remote-code --served-model-name nvidia/nemotron-3-super-120b-a12b
+#     --gpu-memory-utilization 0.8 --trust-remote-code --no-enable-prefix-caching --no-enable-chunked-prefill
+#     --mamba_ssm_cache_dtype float16 --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser super_v3 
+#     --model-loader-extra-config ''{"enable_multithread_load": true, "num_threads": 96}'' --kv-cache-dtype fp8
+
+
+### 3. NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 ###
+# - Container: vllm/vllm-openai:v0.15.1
+# - Environment Variables:
+#       - VLLM_ALLOW_LONG_MAX_MODEL_LEN: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP4: 1
+#       - VLLM_USE_FLASHINFER_MOE_FP8: 1
+#       - VLLM_FLASHINFER_MOE_BACKEND: throughput
+#       - MAMBA_CACHE_PHILOX_ROUNDS: 5
+#       - MAMBA_CACHE_RS_ROUNDING: 1
+# - vLLM command: vllm serve nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 --tensor-parallel-size=4 --pipeline-parallel-size=1
+#    --data-parallel-size=1 --port 8000 --trust-remote-code --served-model-name nvidia/nemotron-3-super-120b-a12b
+#    --gpu-memory-utilization 0.8 --trust-remote-code --no-enable-prefix-caching --no-enable-chunked-prefill
+#    --mamba_ssm_cache_dtype float16 --enable-auto-tool-choice --tool-call-parser qwen3_coder
+#    --reasoning-parser super_v3 --model-loader-extra-config ''{"enable_multithread_load": true, "num_threads":
+#    96}'' --kv-cache-dtype fp8 
+
+
+defaults:
+  - execution: local
+  - deployment: none
+  - _self_
+
+execution:
+  output_dir: ./results_nvidia_nemotron_3_super_120b_a12b
+  mounts:
+    evaluation:
+      ./hf_cache: /root/.cache/huggingface
+target:
+  api_endpoint:
+    model_id: nvidia/nemotron-3-super-120b-a12b
+    url: https://integrate.api.nvidia.com/v1/chat/completions  # or your served model URL
+    api_key_name: NGC_API_KEY # API Key with access to build.nvidia.com
+
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    JUDGE_API_KEY: host:JUDGE_API_KEY # API Key with access to gpt-4o for HLE
+  nemo_evaluator_config:
+    config:
+      params:
+        parallelism: 1
+        max_new_tokens: 131072
+        temperature: 1.0 
+        top_p: 0.95       
+        request_timeout: 3600
+        max_retries: 10
+        extra:
+          tokenizer_backend: huggingface
+          tokenizer: NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+    target:
+      api_endpoint:
+        adapter_config:
+          params_to_add: {"chat_template_kwargs": {"enable_thinking": true}, "skip_special_tokens": false}
+          use_caching: true
+          tracking_requests_stats: true
+          log_failed_requests: true
+          use_request_logging: true
+          max_logged_requests: 10
+          use_response_logging: true
+          max_logged_responses: 10
+
+  tasks:
+  - name: nemo_skills.ns_gpqa
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            use_sandbox: true
+            num_repeats: 8
+            args: "++inference.tokens_to_generate=null ++prompt_config=eval/aai/mcq-4choices ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"
+  - name: ns_hle
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+            judge_support: true
+            judge:
+              parallelism: 16
+              model_id: openai/gpt-4o
+              url: ... # Set your API URL for the judge model
+              api_key: JUDGE_API_KEY
+            use_sandbox: true
+            args: "++inference.tokens_to_generate=null ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"
+  - name: nemo_skills.ns_aime2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            use_sandbox: true
+            num_repeats: 64
+            args: "++inference.tokens_to_generate=null ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"
+  - name: nemo_skills.ns_aime2026
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            use_sandbox: true
+            num_repeats: 64
+            args: "++prompt_config=/nemo_run/code/eval_factory_prompts/math-oai.yaml ++inference.tokens_to_generate=null ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"
+  - name: ns_hmmt_feb2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            use_sandbox: true
+            num_repeats: 64
+            args: "++inference.tokens_to_generate=null ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/reproducibility.md
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/nemotron-3-super/reproducibility.md
@@ -1,0 +1,618 @@
+# NVIDIA Nemotron 3 Super 120B A12B — Reproducing Model Card Evaluation Results
+
+This tutorial demonstrates how to reproduce the evaluation results for the [**NVIDIA Nemotron 3 Super 120B A12B**](https://build.nvidia.com/nvidia/nemotron-3-super-120b-a12b) model using the NeMo Evaluator Launcher.
+
+## Overview
+
+The Nemotron 3 Super 120B A12B is a powerful reasoning model from NVIDIA. This configuration runs a comprehensive evaluation suite covering:
+
+| Benchmark | Category | Description |
+|-----------|----------|-------------|
+| **GPQA** | Science | Graduate-level science questions |
+| **HLE** | Humanity's Last Exam | Expert-level questions across domains |
+| **MMLU-Pro** | Knowledge | Multi-task language understanding (10-choice) |
+| **AIME 2025** | Mathematics | American Invitational Mathematics Exam 2025 |
+| **AIME 2026** | Mathematics | American Invitational Mathematics Exam 2026 |
+| **HMMT Feb 2025** | Mathematics | Harvard-MIT Mathematics Tournament |
+| **Math 500** | Mathematics | MATH benchmark (500 problems) |
+| **CritPt** | Physics | Critical Point evaluation |
+| **SciCode** | Scientific Coding | Scientific programming challenges |
+| **LiveCodeBench** | Coding | Real-world coding problems evaluation |
+| **IFBench** | Instruction Following | Instruction following benchmark |
+| **BFCL v4** | Function Calling | Berkeley Function Calling Leaderboard v4 |
+| **Tau2 Bench Telecom** | Telecom / Tool Use | Tau2 benchmark (telecom domain) |
+| **Tau2 Bench Retail** | Retail / Tool Use | Tau2 benchmark (retail domain) |
+| **Tau2 Bench Airline** | Airline / Tool Use | Tau2 benchmark (airline domain) |
+| **Arena Hard v2** | Chat Preference | Arena Hard v2 benchmark |
+| **AA LCR** | Long-context | Artificial Analysis Long-Context-Reasoning benchmark |
+| **MMLU-Pro X** | Knowledge | MMLU-Pro extended multilingual variant |
+| **AA-Omniscience** | Knowledge / hallucination| AA Omniscience benchmark with Gemini-3-Flash-Preview judge |
+| **WMT24++** | Translation | WMT24 translation benchmark scored with XCOMET-XXL |
+
+The open source container on NeMo Skills packaged via NVIDIA's NeMo Evaluator SDK used for evaluations can be found [here](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/eval-factory/containers/nemo-skills/tags?version=latest).
+
+---
+
+## Prerequisites
+
+### 1. Install the NeMo Evaluator Launcher
+
+```bash
+pip install nemo-evaluator-launcher
+```
+
+Or install from source:
+
+```bash
+git clone https://github.com/NVIDIA-NeMo/Evaluator.git
+cd Evaluator/packages/nemo-evaluator-launcher
+pip install -e .
+```
+
+### 2. Required API Keys
+
+Set the following environment variables before running the evaluation:
+
+```bash
+# Required: NGC API key for accessing the model endpoint
+export NGC_API_KEY="your-ngc-api-key"
+
+# Required: HuggingFace token for accessing datasets
+export HF_TOKEN="your-huggingface-token"
+
+# Required for HLE and Multi-Challenge benchmarks: OpenAI/Azure API key for GPT-4o judge
+export JUDGE_API_KEY="your-judge-api-key"
+
+# Required for Omniscience benchmark: Gemini API key for Gemini-3-Flash-Preview judge
+export GEMINI_API_KEY="your-gemini-api-key"
+
+# Required for AA LCR benchmark: API key with access to non-reasoning Qwen3-235B-A22B judge
+export QWEN_API_KEY="your-qwen-api-key"
+
+# Required for CritPt benchmark
+export ARTIFICIAL_ANALYSIS_API_KEY="your-artificial-analysis-api-key"
+```
+
+> **Note:** Not all API keys are required for every benchmark. `JUDGE_API_KEY` is needed for HLE; `GEMINI_API_KEY` for AA-Omniscience; `QWEN_API_KEY` for AA LCR and tau2-bench; and `ARTIFICIAL_ANALYSIS_API_KEY` for CritPt. The `NGC_API_KEY` is also reused as the `JUDGE_API_KEY` for AA Math Test 500.
+
+### 3. HuggingFace Cache (Optional)
+
+For faster subsequent runs, you can set a persistent cache directory:
+
+```bash
+export HF_HOME="/path/to/your/huggingface/cache"
+```
+
+---
+
+## Running the Full Evaluation Suite
+
+### 1. Get the Configuration
+
+The config files are located in this directory:
+
+| Config File | Purpose |
+|-------------|---------|
+| [`local_nemotron-3-super-120b-a12b.yaml`](./local_nemotron-3-super-120b-a12b.yaml) | Main evaluation suite |
+| [`local_nemotron-3-super-120b-a12b_tools.yaml`](./local_nemotron-3-super-120b-a12b_tools.yaml) | Tool usage evaluation |
+| [`local_nemotron-3-super-120b-a12b_low_budget.yaml`](./local_nemotron-3-super-120b-a12b_low_budget.yaml) | Low-budget / low-effort thinking evaluation |
+
+### 2. Run the Evaluation
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nemotron-3-super-120b-a12b.yaml
+```
+
+### 3. Dry Run (Preview Configuration)
+
+To preview the configuration without running the evaluation:
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nemotron-3-super-120b-a12b.yaml \
+  --dry-run
+```
+
+---
+
+## Running Individual Benchmarks
+
+You can run specific benchmarks using the `-t` flag:
+
+```bash
+# Run only MMLU-Pro
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b.yaml -t nemo_skills.ns_mmlu_pro
+
+# Run only coding benchmarks
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b.yaml -t ns_livecodebench
+
+# Run multiple specific benchmarks
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b.yaml -t nemo_skills.ns_gpqa -t nemo_skills.ns_aime2025
+```
+
+### Available Task Names
+
+| Task Name | Benchmark |
+|-----------|-----------|
+| `nemo_skills.ns_gpqa` | GPQA Diamond (4-choice MCQ) |
+| `ns_hle` | Humanity's Last Exam |
+| `nemo_skills.ns_mmlu_pro` | MMLU-Pro (10-choice format) |
+| `nemo_skills.ns_aime2025` | AIME 2025 |
+| `nemo_skills.ns_aime2026` | AIME 2026 |
+| `ns_hmmt_feb2025` | HMMT Feb 2025 |
+| `AA_math_test_500` | Math 500 |
+| `nemo_skills.ns_critpt` | CritPt |
+| `ns_scicode` | SciCode |
+| `ns_livecodebench_v5` | LiveCodeBench v5 (Jul–Dec 2024) |
+| `ns_livecodebench` | LiveCodeBench v6 (Aug 2024–May 2025) |
+| `ns_ifbench` | IFBench |
+| `nemo_skills.ns_bfcl_v4` | BFCL v4 |
+| `tau2_bench_telecom` | Tau2 Bench Telecom |
+| `tau2_bench_retail` | Tau2 Bench Retail |
+| `tau2_bench_airline` | Tau2 Bench Airline |
+| `ns_arena_hard_v2` | Arena Hard v2 |
+| `ns_aa_lcr` | AA LCR |
+| `ns_omniscience` | AA-Omniscience |
+| `ns_mmlu_prox` | MMLU-Pro X |
+| `ns_wmt24pp_comet` | WMT24++ (COMET score) |
+
+---
+
+## Configuration Details
+
+### Model Endpoint
+
+The evaluation uses the NVIDIA API endpoint:
+
+```yaml
+target:
+  api_endpoint:
+    model_id: nvidia/nemotron-super-120b-a12b
+    url: https://integrate.api.nvidia.com/v1/chat/completions
+    api_key_name: NGC_API_KEY
+```
+
+### Default Parameters
+
+The configuration uses the following default inference parameters:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `max_new_tokens` | 131072 | Maximum tokens to generate |
+| `temperature` | 1.0 | Sampling temperature |
+| `top_p` | 0.95 | Nucleus sampling threshold |
+| `parallelism` | 1 | Concurrent requests |
+| `request_timeout` | 3600 | Request timeout in seconds |
+| `max_retries` | 10 | Maximum retry attempts |
+
+The adapter config enables thinking mode and response logging:
+
+```yaml
+adapter_config:
+  params_to_add: {"chat_template_kwargs": {"enable_thinking": true}, "skip_special_tokens": false}
+  use_caching: true
+  tracking_requests_stats: true
+  log_failed_requests: true
+  use_request_logging: true
+  max_logged_requests: 10
+  use_response_logging: true
+  max_logged_responses: 10
+```
+
+### Benchmark-Specific Configurations
+
+Different benchmarks use tailored parameters:
+
+#### GPQA
+- 8 repeated samples for pass@1
+- 4-choice MCQ prompt format (`eval/aai/mcq-4choices`)
+
+#### HLE
+- GPT-4o judge via OpenAI API
+- Judge parallelism: 16
+- Requires `JUDGE_API_KEY` and configuring the judge URL
+
+#### MMLU-Pro
+- 1 repeat
+- 10-choice boxed prompt format (`eval/aai/mcq-10choices-boxed`)
+
+#### AIME
+- 64 repeated samples (`num_repeats: 64`)
+- Math-specific prompt template (`math-oai.yaml`)
+
+#### HMMT Feb 2025
+- 64 repeated samples
+
+#### Math 500
+- 5 samples per item (`n_samples: 5`)
+- Uses `NGC_API_KEY` as `JUDGE_API_KEY`
+
+#### CritPt
+- 3 repeated samples
+- Requires `ARTIFICIAL_ANALYSIS_API_KEY`
+
+#### SciCode
+- 8 repeated samples
+
+#### LiveCodeBench v5 / v6
+- 8 repeated samples
+- v5 split: `test_v5_2407_2412`; v6 split: `test_v6_2408_2505`
+
+#### IFBench
+- 8 repeated samples
+
+#### BFCL v4 (Function Calling)
+- `max_new_tokens`: 8192
+- `parallelism`: 128
+- Client parsing disabled
+
+#### Tau2 Bench (Telecom / Retail / Airline)
+- 8 samples per item
+- Caching enabled; `skip_failed_samples: true`
+- `use_reasoning: true` in adapter config
+- Requires `QWEN_API_KEY` and configuring the user URL/model_id
+
+#### Arena Hard v2
+- Default parameters (no task-specific overrides)
+
+#### AA LCR
+- 16 repeated samples
+- Judge: non-reasoning Qwen3-235B-A22B
+- Requires `QWEN_API_KEY` and configuring the judge URL/model_id
+
+#### Omniscience
+- Reasoning parsing disabled (`++parse_reasoning=False`)
+- Judge: Gemini-3-Flash-Preview
+- Requires `GEMINI_API_KEY` and configuring the judge URL
+
+#### MMLU-Pro X
+- 1 repeat
+
+#### WMT24++ (COMET)
+- Scored using XCOMET-XXL
+- Requires downloading the [XCOMET-XXL model](https://huggingface.co/Unbabel/XCOMET-XXL) and setting the `model_path` in the config
+
+---
+
+## Monitoring and Results
+
+### Check Job Status
+
+```bash
+nemo-evaluator-launcher status
+```
+
+### View Logs
+
+```bash
+# Stream logs for a specific job
+nemo-evaluator-launcher logs <job-id>
+```
+
+### Results Location
+
+Results are saved to the output directory specified in the config:
+
+```
+./results_nvidia_nemotron_3_super_120b_a12b/
+├── artifacts/
+│   └── <task_name>/
+│       └── results.json
+└── logs/
+    └── stdout.log
+```
+
+---
+
+## Customization
+
+### Override Output Directory
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nemotron-3-super-120b-a12b.yaml \
+  -o execution.output_dir=/custom/output/path
+```
+
+### Limit Samples (for Testing)
+
+For quick testing, you can limit the number of samples:
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nemotron-3-super-120b-a12b.yaml \
+  -o evaluation.nemo_evaluator_config.config.params.limit_samples=10
+```
+
+### Use a Different API Endpoint
+
+If you're hosting the model locally or using a different endpoint:
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nemotron-3-super-120b-a12b.yaml \
+  -o target.api_endpoint.url=http://localhost:8000/v1/chat/completions
+```
+
+---
+
+## Troubleshooting
+
+### Common Issues
+
+1. **API Key Not Found**
+   - Ensure environment variables are exported in the current shell
+   - Verify the key names match exactly: `NGC_API_KEY`, `HF_TOKEN`, `JUDGE_API_KEY`, `GEMINI_API_KEY`, `QWEN_API_KEY`, `ARTIFICIAL_ANALYSIS_API_KEY`
+
+2. **Timeout Errors**
+   - The model generates long reasoning chains; timeouts are set to 3600s
+   - Reduce `parallelism` if hitting rate limits
+
+3. **HLE Judge Failures**
+   - Verify `JUDGE_API_KEY` has access to GPT-4o
+   - Check the judge endpoint URL is accessible
+
+4. **WMT24++ COMET Scoring**
+   - Download the XCOMET-XXL checkpoint from HuggingFace and update `model_path` in the config
+
+5. **HuggingFace Dataset Access**
+   - Some datasets require accepting terms on HuggingFace Hub
+   - Ensure your `HF_TOKEN` has appropriate permissions
+
+### Getting Help
+
+```bash
+# View all available commands
+nemo-evaluator-launcher --help
+
+# View run command options
+nemo-evaluator-launcher run --help
+
+# List available evaluation tasks
+nemo-evaluator-launcher ls tasks
+```
+
+---
+
+## Expected Results
+
+After running the full evaluation suite, you should obtain results comparable to those reported in the NVIDIA Nemotron 3 Super 120B A12B Model Card.
+
+> **Important:** Due to the stochastic nature of sampling (temperature > 0) and the use of `num_repeats` for consensus-based scoring, slight variations in results are expected between runs.
+
+---
+
+## Tool Usage Evaluation
+
+The Nemotron 3 Super 120B A12B model supports tool usage, allowing it to call a Python interpreter to solve math and science problems step by step.
+
+### Tool Usage Config
+
+| Config File | Model |
+|-------------|-------|
+| [`local_nemotron-3-super-120b-a12b_tools.yaml`](./local_nemotron-3-super-120b-a12b_tools.yaml) | nvidia/nemotron-3-super-120b-a12b |
+
+### Tool Usage Benchmarks
+
+| Benchmark | Category | Description |
+|-----------|----------|-------------|
+| **GPQA (tools)** | Science + Tools | GPQA with Python code execution |
+| **HLE (tools)** | Humanity's Last Exam + Tools | HLE with Python code execution and GPT-4o judge |
+| **AIME 2025 (tools)** | Mathematics + Tools | AIME with Python code execution |
+| **AIME 2026 (tools)** | Mathematics + Tools | AIME 2026 with Python code execution |
+| **HMMT Feb 2025 (tools)** | Mathematics + Tools | HMMT with Python code execution |
+
+### Available Task Names (Tool Usage)
+
+| Task Name | Benchmark |
+|-----------|-----------|
+| `nemo_skills.ns_gpqa` | GPQA Diamond (with sandbox + Python tool) |
+| `ns_hle` | HLE (with sandbox + Python tool + GPT-4o judge) |
+| `nemo_skills.ns_aime2025` | AIME 2025 (with sandbox + Python tool) |
+| `nemo_skills.ns_aime2026` | AIME 2026 (with sandbox + Python tool) |
+| `ns_hmmt_feb2025` | HMMT Feb 2025 (with sandbox + Python tool) |
+
+### Additional API Keys for Tool Usage
+
+```bash
+# Required for HLE (tools): OpenAI/Azure API key for GPT-4o judge
+export JUDGE_API_KEY="your-judge-api-key"
+```
+
+### Running Tool Usage Evaluations
+
+```bash
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b_tools.yaml
+
+# Run only AIME 2025 with tools
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b_tools.yaml -t nemo_skills.ns_aime2025
+
+# Run only GPQA with tools
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b_tools.yaml -t nemo_skills.ns_gpqa
+
+```
+
+### Tool Usage Configuration Details
+
+Tool usage is enabled per-task via these extra parameters:
+
+```yaml
+extra:
+  use_sandbox: true
+  args: "++inference.tokens_to_generate=null ++tool_modules=[nemo_skills.mcp.servers.python_tool::PythonTool]"
+```
+
+The model generates tool calls (Python code), which are executed in a sandboxed environment, and the results are fed back to the model for further reasoning.
+
+---
+
+## Low-Budget / Low-Effort Thinking Evaluation
+
+A separate configuration runs a subset of benchmarks with low-effort thinking mode enabled, useful for evaluating the model's performance under constrained compute budgets.
+
+### Low-Budget Config
+
+| Config File | Model |
+|-------------|-------|
+| [`local_nemotron-3-super-120b-a12b_low_budget.yaml`](./local_nemotron-3-super-120b-a12b_low_budget.yaml) | nvidia/nemotron-3-super-120b-a12b |
+
+### Low-Budget Benchmarks
+
+| Benchmark | Category | Description |
+|-----------|----------|-------------|
+| **AIME 2025** | Mathematics | AIME 2025 with low-effort thinking |
+| **Tau2 Bench Telecom** | Telecom / Tool Use | Tau2 telecom with low-effort thinking |
+| **LiveCodeBench v6** | Coding | LiveCodeBench with low-effort thinking |
+
+### Running Low-Budget Evaluations
+
+```bash
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b_low_budget.yaml
+
+# Run only AIME 2025 (low effort)
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b_low_budget.yaml -t nemo_skills.ns_aime2025
+```
+
+### Low-Budget Configuration Details
+
+The low-budget config overrides the adapter to enable low-effort thinking:
+
+```yaml
+adapter_config:
+  params_to_add: {"chat_template_kwargs": {"enable_thinking": true, "low_effort": true}}
+```
+
+---
+
+--
+
+## Base Model Evaluation
+
+In addition to the instruct model, you can reproduce evaluation results for the base (pre-trained) models using local vLLM deployment.
+
+### Available Base Model Configs
+
+| Config File | Model |
+|-------------|-------|
+| [`local_nemotron-3-super-120b-a12b-base.yaml`](./local_nemotron-3-super-120b-a12b-base.yaml) | nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base |
+
+### Base Model Benchmarks
+
+The base model evaluation suite includes traditional pre-training benchmarks:
+
+| Benchmark | Category | Description |
+|-----------|----------|-------------|
+| **MMLU (5-shot)** | General Knowledge | Massive Multitask Language Understanding |
+| **MMLU-Pro (5-shot, CoT)** | General Knowledge | Multi-task language understanding |
+| **AGIEval-En (CoT)** | General Knowledge | Human-centric benchmark with chain-of-thought |
+| **GPQA-Diamond (CoT)** | General Knowledge | Graduate-Level Google-Proof Q&A |
+| **GSM8K (8-shot)** | Math | Grade school math word problems |
+| **MATH (4-shot)** | Math | Competition mathematics |
+| **MATH-500 (4-shot)** | Math | Subset of MATH benchmark |
+| **HumanEval (0-shot)** | Code | Code generation |
+| **MBPP Sanitized (3-shot)** | Code | Python programming problems |
+| **ARC-Challenge (25-shot)** | Commonsense Understanding | AI2 Reasoning Challenge |
+| **HellaSwag (10-shot)** | Commonsense Understanding | Sentence completion |
+| **OpenBookQA (0-shot)** | Commonsense Understanding | Open-book question answering |
+| **PIQA (0-shot)** | Commonsense Understanding | Physical intuition |
+| **WinoGrande (5-shot)** | Commonsense Understanding | Coreference resolution |
+| **RACE (0-shot)** | Reading Comprehension | Reading comprehension |
+| **Global MMLU Lite (5-shot)** | Multilingual | Multilingual understanding |
+| **MGSM (8-shot)** | Multilingual | Multilingual grade school math |
+| **RULER 64k** | Long Context | Long context benchmarking |
+| **RULER 128k** | Long Context | Long context benchmarking |
+| **RULER 256k** | Long Context | Long context benchmarking |
+| **RULER 512k** | Long Context | Long context benchmarking |
+| **RULER 1m** | Long Context | Long context benchmarking |
+
+
+### Available Task Names (Base Models)
+
+| Task Name | Benchmark |
+|-----------|-----------|
+| `adlr_mmlu` | MMLU (5-shot) |
+| `adlr_mmlu_pro_5_shot_base` | MMLU-Pro (5-shot, CoT) |
+| `adlr_agieval_en_cot` | AGIEval-En (3/5-shot, CoT) |
+| `adlr_gpqa_diamond_cot_5_shot` | GPQA-Diamond (5-shot, CoT) |
+| `adlr_gsm8k_cot_8_shot` | GSM8K (8-shot) |
+| `adlr_minerva_math_nemo_4_shot` | MATH (4-shot) |
+| `adlr_math_500_4_shot_sampled` | MATH-500 (4-shot) |
+| `adlr_humaneval_greedy` | HumanEval (0-shot, pass@1, n=32) |
+| `adlr_mbpp_sanitized_3_shot_greedy` | MBPP Sanitized (3-shot, pass@1, n=32) |
+| `adlr_arc_challenge_llama_25_shot` | ARC-Challenge (25-shot) |
+| `hellaswag` | HellaSwag (10-shot) |
+| `openbookqa` | OpenBookQA (0-shot) |
+| `piqa` | PIQA (0-shot) |
+| `adlr_winogrande_5_shot` | WinoGrande (5-shot) |
+| `adlr_race` | RACE (0-shot) |
+| `adlr_global_mmlu_lite_5_shot` | Global MMLU Lite (5-shot) |
+| `adlr_mgsm_native_cot_8_shot` | MGSM (8-shot) |
+| `ruler-64k-completions` | RULER 64k |
+| `ruler-128k-completions` | RULER 128k |
+| `ruler-256k-completions` | RULER 256k |
+| `ruler-512k-completions` | RULER 512k |
+| `ruler-1m-completions` | RULER 1m |
+### Running Base Model Evaluations
+
+Base model configs use local vLLM deployment instead of an API endpoint:
+
+```bash
+cd packages/nemo-evaluator-launcher/examples/nemotron
+
+# Run NVIDIA Nemotron base model evaluation
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b-base.yaml
+
+
+### Base Model Configuration Details
+
+#### Deployment (vLLM)
+
+The base models are deployed locally using vLLM:
+
+```yaml
+deployment:
+  image: vllm/vllm-openai:v0.13.0
+  hf_model_handle: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-Base
+  tensor_parallel_size: 8
+  data_parallel_size: 1
+```
+
+#### Inference Parameters
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `max_retries` | 5 | Number of retries for API requests |
+| `request_timeout` | 360 | Request timeout in seconds |
+| `parallelism` | 4 | Concurrent requests |
+
+### Running Individual Base Model Benchmarks
+
+```bash
+# Run only MMLU
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b-base.yaml -t adlr_mmlu
+
+# Run only coding benchmarks
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b-base.yaml -t adlr_humaneval_greedy -t adlr_mbpp_sanitized_3_shot_greedy
+
+# Run math benchmarks
+nemo-evaluator-launcher run --config local_nemotron-3-super-120b-a12b-base.yaml -t adlr_gsm8k_cot_8_shot -t adlr_minerva_math_nemo_4_shot -t adlr_math_500_4_shot_sampled
+```
+
+### Quick Testing (Base Models)
+
+For quick configuration testing, uncomment `limit_samples` in the config file or override via CLI:
+
+```bash
+nemo-evaluator-launcher run \
+  --config local_nemotron-3-super-120b-a12b-base.yaml \
+  -o evaluation.nemo_evaluator_config.config.params.limit_samples=10
+```
+
+> **Warning:** Always run full evaluations (without `limit_samples`) for actual benchmark results. Results from test runs with limited samples should never be used to compare models.
+
+---
+
+## License
+
+This configuration and tutorial are provided under the Apache License 2.0. See the main repository LICENSE file for details.

--- a/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/slurm_nvidia_nemotron_3_nano_30b_a3b_nvfp4.yaml
+++ b/packages/nemo-evaluator-launcher/examples/nemotron/nemotron/slurm_nvidia_nemotron_3_nano_30b_a3b_nvfp4.yaml
@@ -1,0 +1,186 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+defaults:
+  - execution: slurm/default
+  - deployment: vllm
+  - _self_
+
+execution:
+  mounts:
+    evaluation:
+      ./hf_cache: /root/.cache/huggingface
+  hostname: ??? # SLURM headnode (login) hostname (required)
+  username: ${oc.env:USER} # Cluster username; defaults to $USER.
+  account: ??? # SLURM account allocation (required)
+  output_dir: ??? # ABSOLUTE path accessible to SLURM compute nodes (required)
+
+deployment:
+  image: vllm/vllm-openai:v0.13.0
+  checkpoint_path: null
+  hf_model_handle: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+  served_model_name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+  tensor_parallel_size: 2
+  data_parallel_size: 1
+  extra_args: "--max-model-len 262144 --gpu-memory-utilization 0.90 --enable-log-requests --no-enable-prefix-caching --trust-remote-code --mamba_ssm_cache_dtype float32 --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser deepseek_r1"
+
+
+target:
+  api_endpoint:
+    api_key_name: API_KEY # FIXME: needed for NeMo Skills container as it requires some api key to be set
+
+evaluation:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN
+    JUDGE_API_KEY: host:JUDGE_API_KEY # API Key with access to gpt-4o for HLE
+  nemo_evaluator_config:
+    config:
+      params:
+        max_new_tokens: 131072
+        temperature: 0.99999
+        top_p: 0.99999
+        parallelism: 32
+        request_timeout: 3600
+        max_retries: 10
+        extra:
+          tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+          tokenizer_backend: huggingface
+    target:
+      api_endpoint:
+        adapter_config:
+          use_caching: true
+          tracking_requests_stats: true
+          log_failed_requests: true
+          use_request_logging: true
+          max_logged_requests: 10
+          use_response_logging: true
+          max_logged_responses: 10
+  tasks:
+  - name: ns_ifbench
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+  - name: ns_livecodebench
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            dataset_split: test_v5_2407_2412
+  - name: ns_mmlu_pro
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+            args: "++prompt_config=eval/aai/mcq-10choices-boxed"
+  - name: ns_gpqa
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+            args: "++prompt_config=eval/aai/mcq-4choices"
+  - name: ns_scicode
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 8
+  - name: ns_hle
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+            judge_support: true
+            judge:
+              parallelism: 16
+              model_id: openai/gpt-4o
+              url: ??? # Set your OpenAI-compatible API URL for the judge model
+              api_key: JUDGE_API_KEY
+  - name: ns_aime2025
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 64
+            args: '++prompt_config="/nemo_run/code/eval_factory_prompts/math-oai.yaml"'
+  - name: ns_mmlu_prox
+    nemo_evaluator_config:
+      config:
+        params:
+          extra:
+            num_repeats: 1
+  - name: ns_wmt24pp
+  - name: tau2_bench_telecom
+    env_vars:
+      JUDGE_API_KEY: host:NGC_API_KEY
+      USER_API_KEY: host:NGC_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          temperature: 0.6
+          top_p: 0.95
+          extra:
+            n_samples: 8
+            skip_failed_samples: true
+            cache:
+              enabled: true
+              cache_dir: /results/native_cache
+  - name: ruler-128k-chat
+    nemo_evaluator_config:
+      config:
+        params:
+          limit_samples: 100
+          parallelism: 1
+          temperature: 0.00001
+          top_p: 0.99
+          extra:
+            tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+            tokenizer_backend: hf
+      target:
+        api_endpoint:
+          adapter_config:
+            use_reasoning: false
+            params_to_add: {"chat_template_kwargs": {"enable_thinking": false}, "skip_special_tokens": false}
+  - name: ruler-64k-chat
+    nemo_evaluator_config:
+      config:
+        params:
+          limit_samples: 100
+          parallelism: 1
+          temperature: 0.00001
+          top_p: 0.99
+          extra:
+            tokenizer: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4
+            tokenizer_backend: hf
+      target:
+        api_endpoint:
+          adapter_config:
+            use_reasoning: false
+            params_to_add: {"chat_template_kwargs": {"enable_thinking": false}, "skip_special_tokens": false}
+  - name: aa_lcr
+    env_vars:
+      JUDGE_API_KEY: host:NGC_API_KEY
+    nemo_evaluator_config:
+      config:
+        params:
+          temperature: 0.99999
+          top_p: 0.99999
+          extra:
+            n_samples: 8


### PR DESCRIPTION
We link to those configs in HF model cards and we need to make sure users can access them during the transition period.