### PR TITLE
ci: restore .github/copy-pr-bot.yaml

### DIFF
--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -1,0 +1,3 @@
+enabled: true
+auto_sync_draft: false
+auto_sync_ready: true


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- `.github/copy-pr-bot.yaml` exists on `main-legacy` but was never carried over when the repo was re-initialized on the current `main` lineage.
- Without it, `copy-pr-bot` cannot mirror fork-PRs into `pull-request/<N>` branches → internal CI never runs on external PRs.

## What changed

- Restore `.github/copy-pr-bot.yaml` with the same contents as on `main-legacy`.

## Details

- `.github/copy-pr-bot.yaml`:
  ```yaml
  enabled: true
  auto_sync_draft: false
  auto_sync_ready: true
  ```

## Tested

- N/A — config-only change. `copy-pr-bot` reads this from the merged base branch.
</details>
