### PR TITLE
feat: Legacy container

### DIFF
--- a/docs/tutorials/walkthrough.md
+++ b/docs/tutorials/walkthrough.md
@@ -640,13 +640,20 @@ nel eval merge ./results
 ```yaml
 benchmarks:
   - name: "container://registry.example.com/nemo-skills:26.03#gsm8k"
+    params:                          # eval-factory harness params
+      temperature: 1.0
+      top_p: 0.95
+      parallelism: 128
+      extra:
+        num_repeats: 16
     solver:
       type: container
       service: nemotron
-      uri: "container://registry.example.com/nemo-skills:26.03#gsm8k"
-    sandbox:
-      type: docker
-      timeout: 3600.0
+      adapter_config:                # passed verbatim to harness's adapter pipeline
+        use_reasoning: true
+        params_to_remove: [max_tokens, max_completion_tokens]
+      env_vars: { HF_TOKEN: ${HF_TOKEN} }
+      mounts: {}
 ```
 
 The `container://` scheme runs an existing eval harness container as an opaque box. The container owns the full eval loop — NEL parses `results.yml` and `eval_factory_metrics.json` from the output.

--- a/src/nemo_evaluator/cli/eval.py
+++ b/src/nemo_evaluator/cli/eval.py
@@ -745,7 +745,7 @@ def eval_report(results_dir, run_id, fmt, output, all_formats, with_results):
     Accepts a local RESULTS_DIR or --run-id to fetch results from a remote
     SLURM cluster automatically.
     """
-    from nemo_evaluator.reports.eval import RENDERERS, build_table, load_bundles
+    from nemo_evaluator.reports.eval import RENDERERS, build_table, load_bundles, materialize_legacy_bundles
 
     if results_dir is None and run_id is None:
         raise click.ClickException("Specify a RESULTS_DIR or --run-id.")
@@ -757,6 +757,12 @@ def eval_report(results_dir, run_id, fmt, output, all_formats, with_results):
         results, cleanup_dir = _fetch_remote_results(run_id, include_results=with_results)
 
     try:
+        # Convert any raw legacy-harness results.yml into NEL bundles
+        # before scanning for eval-*.json.  No-op when no legacy results
+        # are present (native runs already emit bundles directly).
+        for bundle_path in materialize_legacy_bundles(results):
+            click.echo(f"  Materialized legacy bundle: {bundle_path}")
+
         bundle_files = sorted(results.rglob("eval-*.json"))
 
         if not bundle_files:

--- a/src/nemo_evaluator/cli/export.py
+++ b/src/nemo_evaluator/cli/export.py
@@ -88,9 +88,25 @@ def export_cmd(
     from nemo_evaluator.reports.eval import (
         discover_bundle_paths,
         load_bundles_for_export,
+        materialize_legacy_bundles,
     )
 
-    bundle_paths = discover_bundle_paths(list(paths))
+    materialized: list[Path] = []
+    discovery_roots: list[Path] = []
+    for path in paths:
+        if path.is_dir():
+            discovery_roots.append(path)
+            materialized.extend(materialize_legacy_bundles(path))
+        elif path.name in {"results.yml", "results.json"} and path.parent.name == "results":
+            bench_dir = path.parent.parent
+            discovery_roots.append(bench_dir)
+            materialized.extend(materialize_legacy_bundles(bench_dir))
+        else:
+            discovery_roots.append(path)
+    for bundle_path in materialized:
+        click.echo(f"Materialized legacy bundle: {bundle_path}")
+
+    bundle_paths = discover_bundle_paths(discovery_roots)
     if not bundle_paths:
         raise click.ClickException(
             "No eval-*.json bundle files found under the given PATHS. Pass a run directory or bundle file directly."

--- a/src/nemo_evaluator/cli/report.py
+++ b/src/nemo_evaluator/cli/report.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 import click
 
-from nemo_evaluator.reports.eval import RENDERERS, build_table, load_bundles
+from nemo_evaluator.reports.eval import RENDERERS, build_table, discover_bundle_paths, load_bundles
 
 
 @click.command("report")
@@ -30,16 +30,7 @@ from nemo_evaluator.reports.eval import RENDERERS, build_table, load_bundles
 def report_cmd(bundle_paths, fmt, output):
     """Generate a multi-benchmark evaluation report from bundle JSON files."""
     paths = [Path(p) for p in bundle_paths]
-    expanded: list[Path] = []
-    for p in paths:
-        if p.is_dir():
-            top = sorted(p.glob("eval-*.json"))
-            if top:
-                expanded.extend(top)
-            else:
-                expanded.extend(sorted(p.glob("*/eval-*.json")))
-        else:
-            expanded.append(p)
+    expanded = discover_bundle_paths(paths)
 
     if not expanded:
         raise click.ClickException(

--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -112,6 +112,7 @@ class _ModelServerBase(BaseModel):
     extra_args: list[str] = Field(default_factory=list)
     setup_commands: list[str] = Field(default_factory=list)
     container_mounts: list[str] = Field(default_factory=list)
+    pre_cmd: str | None = None
     ray_binary: str = "ray"
     reasoning_pattern: str | None = None
     max_input_tokens: int | None = None

--- a/src/nemo_evaluator/config/solvers.py
+++ b/src/nemo_evaluator/config/solvers.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Discriminator, Field, Tag, model_validator
 
 from .services import GenerationConfig
 
@@ -177,25 +177,29 @@ class OpenClawSolverConfig(BaseModel):
 class ContainerSolverConfig(BaseModel):
     """Container URI solver (NeMo Skills, etc.).
 
-    The container receives a **legacy Evaluator** ``run_config.yaml`` with
-    ``config.type``, ``target.api_endpoint``, and any extra ``params``
-    defined here merged into ``config.params``.
+    Marks a benchmark as legacy-container BC and binds it to a model
+    service.  The container receives a **legacy Evaluator**
+    ``run_config.yaml`` with ``config.type``, ``config.params`` populated
+    from the benchmark-level ``params:`` dict, and ``adapter_config``
+    written verbatim under ``target.api_endpoint.adapter_config`` for the
+    container's internal adapter pipeline.
+
+    ``adapter_config``, ``env_vars``, ``mounts`` mirror v1 launcher
+    vocabulary so v1 configs port across with minimal changes.  Use
+    ``${VAR}`` / ``${VAR:-default}`` for host-env interpolation in any
+    string value.  Harness params (``temperature``, ``parallelism``,
+    ``extra.*``) live at the benchmark level (``BenchmarkConfig.params``)
+    like every other env's constructor kwargs.
     """
 
     model_config = ConfigDict(extra="forbid")
 
     type: Literal["container"] = "container"
     service: str
-    uri: str
     endpoint_type: str | None = None
-    params: dict[str, Any] | None = None
-
-    @field_validator("uri")
-    @classmethod
-    def _validate_uri(cls, v: str) -> str:
-        if not v.startswith("container://"):
-            raise ValueError("container solver uri must start with 'container://'")
-        return v
+    adapter_config: dict[str, Any] | None = None
+    env_vars: dict[str, str] = Field(default_factory=dict)
+    mounts: dict[str, str] = Field(default_factory=dict)
 
 
 class OracleSolverConfig(BaseModel):

--- a/src/nemo_evaluator/engine/exporters/mlflow_export.py
+++ b/src/nemo_evaluator/engine/exporters/mlflow_export.py
@@ -416,7 +416,8 @@ class MLflowExporter:
 
         benchmark = bundle.get("benchmark", {}) or {}
         safe_name = re.sub(r"[^a-zA-Z0-9_.-]", "_", benchmark.get("name", "unknown"))
-        task_dir = output_dir / safe_name
+        output_path = bundle.get("_output_path")
+        task_dir = Path(output_path) if output_path else output_dir / safe_name
 
         if not task_dir.exists():
             # Fallback for in-process flows that export before materializing.

--- a/src/nemo_evaluator/environments/container.py
+++ b/src/nemo_evaluator/environments/container.py
@@ -41,8 +41,12 @@ Usage in NEL config:
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
+import os
+import re
+import shutil
 import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -66,6 +70,217 @@ _NEL_PROTOCOL_TO_LEGACY_TYPE = {
     "responses": "chat",
 }
 
+# Matches `-e KEY=VALUE` argv pairs (either joined or split) so values don't leak to logs.
+_REDACT_ENV_VALUE = re.compile(r"(-e\s+\w+=)\S+")
+
+
+def build_legacy_run_config(
+    task: str,
+    model_url: str,
+    model_id: str,
+    endpoint_type: str,
+    extra_params: dict[str, Any] | None = None,
+    adapter_config: dict[str, Any] | None = None,
+    api_key: str | None = None,
+) -> dict[str, Any]:
+    """Build a legacy Evaluator ``run_config.yaml`` dict.
+
+    Module-level so callers outside ``ContainerEnvironment`` (slurm_gen
+    pre-rendering at submit time) can produce the same yaml the
+    in-process docker dispatch path produces.
+
+    The container's ``nemo-evaluator run_eval --run_config <path>``
+    entrypoint consumes this and merges it with the baked-in
+    ``framework.yml`` defaults.
+
+    ``api_key_name`` is only emitted when *api_key* is truthy.  Mirrors
+    v1 launcher's behaviour for self-deployed vLLM services where the
+    hydra config sets ``target.api_endpoint.api_key_name: null`` — the
+    harness then skips the ``os.environ[NEMO_API_KEY]`` lookup, which
+    would otherwise raise ``ValueError`` when no real key exists.
+    """
+    api_endpoint: dict[str, Any] = {
+        "url": model_url,
+        "model_id": model_id,
+        "type": endpoint_type,
+    }
+    if api_key:
+        api_endpoint["api_key_name"] = _API_KEY_ENV
+    if adapter_config:
+        api_endpoint["adapter_config"] = adapter_config
+    run_config: dict[str, Any] = {
+        "config": {
+            "type": task,
+            "output_dir": _CONTAINER_RESULTS_DIR,
+        },
+        "target": {"api_endpoint": api_endpoint},
+    }
+    if extra_params:
+        run_config["config"]["params"] = extra_params
+    return run_config
+
+
+def parse_legacy_results(results_dir: Path) -> dict[str, Any]:
+    """Parse ``results.yml`` / ``results.json`` from a legacy harness.
+
+    Returns ``{"scores": {...}, "samples": <int>, "repeats": <int>}``.
+    Module-level so post-job report steps can call it without
+    instantiating ``ContainerEnvironment``.
+    """
+    results_file = results_dir / "results.yml"
+    results_json = results_dir / "results.json"
+
+    raw: dict[str, Any] = {}
+    if results_file.exists():
+        raw = yaml.safe_load(results_file.read_text()) or {}
+    elif results_json.exists():
+        raw = json.loads(results_json.read_text())
+
+    scores = ContainerEnvironment._extract_scores(raw)
+    samples = ContainerEnvironment._extract_sample_count(raw, scores)
+    repeats = _extract_repeats(raw)
+    return {"scores": scores, "samples": samples, "repeats": repeats}
+
+
+def _extract_repeats(raw: dict[str, Any]) -> int:
+    """Read ``config.params.extra.num_repeats`` from a legacy harness
+    output.  The eval-factory wrapper round-trips the run_config back
+    into ``results.yml`` so this field is the source of truth for how
+    many times each problem was actually evaluated.  Defaults to 1
+    matching :attr:`BenchmarkConfig.repeats` for native-env bundles.
+    """
+    cfg = raw.get("config") or {}
+    params = cfg.get("params") or {}
+    extra = params.get("extra") or {}
+    n = extra.get("num_repeats")
+    try:
+        return int(n) if n else 1
+    except (TypeError, ValueError):
+        return 1
+
+
+def build_legacy_bundle(image: str, task: str, results_dir: Path) -> dict[str, Any]:
+    """Build a NEL result bundle from a legacy harness ``results.yml``.
+
+    The bundle structure matches what
+    :meth:`ContainerEnvironment.run_batch` returns for the in-process
+    dispatch path, so post-job conversion produces artifacts identical
+    to the live-orchestrator path.
+    """
+    parsed = parse_legacy_results(results_dir)
+    rows = _parse_legacy_output_rows(results_dir)
+    name = f"container/{task or image.split('/')[-1].split(':')[0]}"
+    bundle: dict[str, Any] = {
+        "benchmark": {
+            "name": name,
+            "samples": parsed["samples"],
+            "repeats": parsed["repeats"],
+            "scores": parsed["scores"],
+        },
+        "config": {
+            "benchmark": name,
+            "image": image,
+            "task": task,
+            "framework": "container",
+        },
+    }
+    if rows:
+        bundle["_results"] = rows
+        bundle["n_results"] = len(rows)
+    return bundle
+
+
+def _parse_legacy_output_rows(results_dir: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in sorted(results_dir.glob("eval-results/**/output*.jsonl")):
+        with path.open(encoding="utf-8") as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    logger.warning("Skipping malformed legacy output row in %s: %s", path, exc)
+                    continue
+                if isinstance(record, dict):
+                    rows.append(record)
+
+    repeat_counts: dict[Any, int] = {}
+    normalized: list[dict[str, Any]] = []
+    for fallback_idx, row in enumerate(rows):
+        result = dict(row)
+        problem_idx = result.get("problem_idx", fallback_idx)
+        result["problem_idx"] = problem_idx
+        if result.get("repeat") is None:
+            result["repeat"] = repeat_counts.get(problem_idx, 0)
+        repeat_counts[problem_idx] = repeat_counts.get(problem_idx, 0) + 1
+
+        reward = _legacy_row_reward(result)
+        if reward is not None:
+            result.setdefault("reward", reward)
+
+        result.setdefault("prompt", result.get("problem") or result.get("question") or result.get("input", ""))
+        result.setdefault(
+            "model_response", result.get("generation") or result.get("response") or result.get("output", "")
+        )
+        if "expected_answer" not in result and "answer" in result:
+            result["expected_answer"] = result["answer"]
+        if "extracted_answer" not in result and "predicted_answer" in result:
+            result["extracted_answer"] = result["predicted_answer"]
+        result.setdefault("metadata", {})
+        result.setdefault("scoring_details", {})
+        normalized.append(result)
+
+    return normalized
+
+
+def _legacy_row_reward(row: dict[str, Any]) -> float | None:
+    for key in ("reward", "score"):
+        value = row.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+
+    for key in ("symbolic_correct", "correct", "is_correct", "passed", "success"):
+        value = row.get(key)
+        if isinstance(value, bool):
+            return 1.0 if value else 0.0
+        if isinstance(value, (int, float)):
+            return float(value)
+
+    return None
+
+
+def _redact_cmd_for_log(cmd: list[str]) -> str:
+    """Render an argv for log output with ``-e KEY=VALUE`` values redacted."""
+    joined = " ".join(cmd)
+    return _REDACT_ENV_VALUE.sub(r"\1<REDACTED>", joined)
+
+
+def _runs_on_slurm() -> bool:
+    """True when the current process is inside a SLURM allocation.
+
+    When set, ``ContainerEnvironment`` dispatches via ``srun
+    --container-image`` (Pyxis/Enroot) instead of ``docker run`` — HPC
+    compute nodes (e.g., HSG) typically don't have Docker.
+
+    To force the Docker path on a SLURM node, ``unset SLURM_JOB_ID``
+    before invoking nel.
+    """
+    return bool(os.environ.get("SLURM_JOB_ID"))
+
+
+def _resolve_pyxis_image(image: str) -> str:
+    """Format an image string for Pyxis ``--container-image=``.
+
+    File paths (``/srv/.../foo.sqsh``) pass through unchanged; registry
+    URIs (``nvcr.io/x:tag``, ``registry.example.com:5005/.../x:tag``)
+    get a ``docker://`` prefix so enroot imports them on first use.
+    """
+    if image.startswith(("/", "docker://")):
+        return image
+    return f"docker://{image}"
+
 
 class ContainerEnvironment(EvalEnvironment):
     """Runs a legacy eval-factory container and parses its results.
@@ -84,9 +299,9 @@ class ContainerEnvironment(EvalEnvironment):
         api_key: str | None = None,
         endpoint_type: str = "chat",
         legacy_params: dict[str, Any] | None = None,
+        adapter_config: dict[str, Any] | None = None,
         extra_env: dict[str, str] | None = None,
         extra_mounts: list[str] | None = None,
-        pre_cmd: str | None = None,
         timeout: float = 3600.0,
     ) -> None:
         super().__init__()
@@ -98,9 +313,9 @@ class ContainerEnvironment(EvalEnvironment):
         self._api_key = api_key
         self._endpoint_type = endpoint_type
         self._legacy_params = legacy_params or {}
+        self._adapter_config = adapter_config
         self._extra_env = extra_env or {}
         self._extra_mounts = extra_mounts or []
-        self._pre_cmd = pre_cmd
         self._timeout = timeout
 
     async def dataset_size(self) -> int:
@@ -126,8 +341,21 @@ class ContainerEnvironment(EvalEnvironment):
         api_key = self._api_key or config.get("api_key", "")
         endpoint_type = config.get("endpoint_type", self._endpoint_type)
         extra_params = {**self._legacy_params, **config.get("params", {})}
+        adapter_config = config.get("adapter_config") or self._adapter_config
+        cfg_env_vars: dict[str, str] = config.get("env_vars") or {}
+        cfg_mounts: dict[str, str] = config.get("mounts") or {}
 
-        with tempfile.TemporaryDirectory(prefix="nel_container_") as tmpdir:
+        # Manual mkdtemp + try/finally + shutil.rmtree(ignore_errors=True):
+        # legacy eval-factory images run as root and write artifacts
+        # (cache.db, response_stats_cache/) owned by root into the bind-mounted
+        # /results.  On Linux these can't be unlinked by the host's non-root
+        # user.  ``TemporaryDirectory(ignore_cleanup_errors=True)`` is not
+        # enough — its onexc handler still calls _resetperms which raises
+        # PermissionError before the ignore_errors guard, masking the
+        # successful bundle return.  ``shutil.rmtree(ignore_errors=True)`` is
+        # documented "never raises" and skips the chmod entirely.
+        tmpdir = tempfile.mkdtemp(prefix="nel_container_")
+        try:
             results_dir = Path(tmpdir) / "results"
             results_dir.mkdir()
 
@@ -136,47 +364,53 @@ class ContainerEnvironment(EvalEnvironment):
                 model_id,
                 endpoint_type,
                 extra_params,
+                adapter_config,
+                api_key=api_key,
             )
             config_path = Path(tmpdir) / "run_config.yaml"
             config_path.write_text(yaml.dump(run_config, sort_keys=False), encoding="utf-8")
 
-            cmd = self._build_docker_cmd(results_dir, config_path)
+            mounts = list(self._extra_mounts) + [f"{host}:{cont}" for host, cont in cfg_mounts.items()]
 
             env_vars: dict[str, str] = {}
             if api_key:
                 env_vars[_API_KEY_ENV] = api_key
             env_vars.update(self._extra_env)
+            env_vars.update(cfg_env_vars)
 
-            for k, v in env_vars.items():
-                cmd.extend(["-e", f"{k}={v}"])
+            eval_cmd = (
+                "cmd=$(command -v nemo-evaluator >/dev/null 2>&1"
+                " && echo nemo-evaluator || echo eval-factory)"
+                f" && $cmd run_eval --run_config {_CONTAINER_CONFIG_PATH}"
+            )
+            inner_command = ["bash", "-c", eval_cmd]
 
-            cmd.append(self._image)
-
-            if self._pre_cmd:
-                cmd.extend(["bash", "-c", self._pre_cmd])
-            else:
-                cmd.extend(
-                    [
-                        "run_eval",
-                        "--run_config",
-                        _CONTAINER_CONFIG_PATH,
-                        "--output_dir",
-                        _CONTAINER_RESULTS_DIR,
-                    ]
+            if _runs_on_slurm():
+                if shutil.which("srun") is None:
+                    raise RuntimeError(
+                        "SLURM_JOB_ID is set but `srun` is not in PATH. "
+                        "Either run inside an sbatch step on a SLURM cluster, "
+                        "or unset SLURM_JOB_ID to force the Docker dispatch."
+                    )
+                logger.info(
+                    "Detected SLURM_JOB_ID=%s — dispatching via Pyxis (srun --container-image)",
+                    os.environ.get("SLURM_JOB_ID"),
                 )
+                cmd, subprocess_env = self._build_srun_cmd(results_dir, config_path, mounts, env_vars, inner_command)
+            else:
+                cmd, subprocess_env = self._build_docker_cmd(results_dir, config_path, mounts, env_vars, inner_command)
 
-            logger.info("Running container: %s", " ".join(cmd[:12]) + " ...")
+            logger.info("Running container: %s ...", _redact_cmd_for_log(cmd[:12]))
 
-            import asyncio as _aio
-
-            proc = await _aio.create_subprocess_exec(
+            proc = await asyncio.create_subprocess_exec(
                 *cmd,
-                stdout=_aio.subprocess.PIPE,
-                stderr=_aio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=subprocess_env,
             )
             try:
-                stdout, stderr = await _aio.wait_for(proc.communicate(), timeout=self._timeout)
-            except _aio.TimeoutError:
+                _stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=self._timeout)
+            except asyncio.TimeoutError:
                 proc.kill()
                 await proc.wait()
                 stderr = b"timeout"
@@ -184,7 +418,9 @@ class ContainerEnvironment(EvalEnvironment):
             if proc.returncode != 0:
                 logger.error("Container failed (exit %d): %s", proc.returncode, (stderr or b"").decode()[:2000])
 
-            return self._parse_results(results_dir, proc.returncode or 0)
+            return self._parse_results(results_dir)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
     # ------------------------------------------------------------------
     # Legacy run_config generation
@@ -196,36 +432,41 @@ class ContainerEnvironment(EvalEnvironment):
         model_id: str,
         endpoint_type: str,
         extra_params: dict[str, Any],
+        adapter_config: dict[str, Any] | None = None,
+        api_key: str | None = None,
     ) -> dict[str, Any]:
-        """Build a legacy Evaluator ``run_config.yaml``.
-
-        The generated YAML is consumed by the container's
-        ``nemo-evaluator run_eval --run_config <path>`` entrypoint, which
-        merges it with the baked-in ``framework.yml`` defaults.
+        """Thin wrapper around :func:`build_legacy_run_config` that
+        forwards this environment's task name.  Kept on the class so
+        callers that already have a ``ContainerEnvironment`` instance
+        don't need to pass ``task`` again.
         """
-        run_config: dict[str, Any] = {
-            "config": {
-                "type": self._task,
-                "output_dir": _CONTAINER_RESULTS_DIR,
-            },
-            "target": {
-                "api_endpoint": {
-                    "url": model_url,
-                    "model_id": model_id,
-                    "api_key_name": _API_KEY_ENV,
-                    "type": endpoint_type,
-                },
-            },
-        }
-        if extra_params:
-            run_config["config"]["params"] = extra_params
-        return run_config
+        return build_legacy_run_config(
+            task=self._task,
+            model_url=model_url,
+            model_id=model_id,
+            endpoint_type=endpoint_type,
+            extra_params=extra_params,
+            adapter_config=adapter_config,
+            api_key=api_key,
+        )
 
     # ------------------------------------------------------------------
     # Docker plumbing
     # ------------------------------------------------------------------
 
-    def _build_docker_cmd(self, results_dir: Path, config_path: Path) -> list[str]:
+    def _build_docker_cmd(
+        self,
+        results_dir: Path,
+        config_path: Path,
+        mounts: list[str],
+        env_vars: dict[str, str],
+        inner_command: list[str],
+    ) -> tuple[list[str], dict[str, str] | None]:
+        """Build a complete ``docker run`` argv.
+
+        Returns ``(argv, env)`` where ``env`` is ``None`` so the subprocess
+        inherits the parent environment (env values travel inline via ``-e``).
+        """
         cmd = [
             "docker",
             "run",
@@ -235,49 +476,76 @@ class ContainerEnvironment(EvalEnvironment):
             "-v",
             f"{config_path}:{_CONTAINER_CONFIG_PATH}:ro",
         ]
-        for mount in self._extra_mounts:
+        for mount in mounts:
             cmd.extend(["-v", mount])
-        return cmd
+        for k, v in env_vars.items():
+            cmd.extend(["-e", f"{k}={v}"])
+        cmd.append(self._image)
+        cmd.extend(inner_command)
+        return cmd, None
+
+    def _build_srun_cmd(
+        self,
+        results_dir: Path,
+        config_path: Path,
+        mounts: list[str],
+        env_vars: dict[str, str],
+        inner_command: list[str],
+    ) -> tuple[list[str], dict[str, str]]:
+        """Build a ``srun --container-image`` argv for Pyxis/Enroot.
+
+        Pyxis differs from Docker in flag syntax:
+
+        - **Mounts**: a single comma-separated ``--container-mounts=H1:C1,H2:C2``
+          flag instead of repeated ``-v`` args.
+        - **Env vars**: ``--container-env=K1 --container-env=K2 ...`` lists
+          *names only*; Pyxis inherits the values from the caller's process
+          env.  We return the values as the subprocess ``env`` dict so
+          :func:`asyncio.create_subprocess_exec` propagates them.
+
+        Eval-factory containers are single-node by design (they iterate
+        problems and call out to the model server over HTTP), so we hardcode
+        ``--nodes=1 --ntasks=1`` and use ``--overlap`` to share the existing
+        sbatch allocation.  Het-jobs and master-IP pinning are out of scope
+        for this MR — see follow-up issue.
+
+        ``--no-container-mount-home`` prevents Pyxis from mounting the
+        caller's ``$HOME`` into the container; legacy eval-factory images
+        run as root and could otherwise pollute the user's home dir.
+        """
+        all_mounts = [
+            f"{results_dir}:{_CONTAINER_RESULTS_DIR}",
+            f"{config_path}:{_CONTAINER_CONFIG_PATH}:ro",
+            *mounts,
+        ]
+        cmd = [
+            "srun",
+            "--mpi=pmix",
+            "--overlap",
+            "--unbuffered",
+            "--nodes=1",
+            "--ntasks=1",
+            f"--container-image={_resolve_pyxis_image(self._image)}",
+            f"--container-mounts={','.join(all_mounts)}",
+            "--no-container-mount-home",
+        ]
+        cmd.extend(f"--container-env={name}" for name in env_vars)
+        cmd.extend(inner_command)
+        return cmd, {**os.environ, **env_vars}
 
     # ------------------------------------------------------------------
     # Results parsing (handles both legacy and simple formats)
     # ------------------------------------------------------------------
 
-    def _parse_results(self, results_dir: Path, exit_code: int) -> dict[str, Any]:
+    def _parse_results(self, results_dir: Path) -> dict[str, Any]:
         """Parse container output into NEL bundle format.
 
-        Supports two result layouts:
-
-        1. **Legacy Evaluator** — ``results.yml`` with nested
-           ``results.tasks.<task>.metrics.<group>.scores.<metric>.value``
-        2. **Simple** — flat ``metrics:`` or ``scores:`` dict at the top
-           level of ``results.yml`` / ``results.json``.
+        Thin wrapper around :func:`build_legacy_bundle` so the in-process
+        docker/srun path produces the same bundle shape that
+        ``nel eval report`` later materialises from ``results.yml`` for
+        ``--submit`` runs.
         """
-        results_file = results_dir / "results.yml"
-        results_json = results_dir / "results.json"
-
-        raw: dict[str, Any] = {}
-        if results_file.exists():
-            raw = yaml.safe_load(results_file.read_text()) or {}
-        elif results_json.exists():
-            raw = json.loads(results_json.read_text())
-
-        scores = self._extract_scores(raw)
-
-        return {
-            "benchmark": {
-                "name": self.name,
-                "samples": raw.get("samples", raw.get("n_samples", 0)),
-                "scores": scores,
-            },
-            "config": {
-                "benchmark": self.name,
-                "image": self._image,
-                "task": self._task,
-                "framework": "container",
-            },
-            "_container_exit_code": exit_code,
-        }
+        return build_legacy_bundle(self._image, self._task, results_dir)
 
     @staticmethod
     def _extract_scores(raw: dict[str, Any]) -> dict[str, Any]:
@@ -344,3 +612,27 @@ class ContainerEnvironment(EvalEnvironment):
             elif isinstance(value, dict) and "value" in value:
                 scores[key] = value
         return scores
+
+    @staticmethod
+    def _extract_sample_count(raw: dict[str, Any], scores: dict[str, Any]) -> int:
+        """Extract sample count from results.
+
+        Tries (in order): top-level ``samples`` / ``n_samples``,
+        ``stats.count`` from the first scored metric, and finally
+        ``config.params.limit_samples`` from the eval-factory run_config
+        — needed for harnesses like lm-eval-harness that don't emit a
+        per-metric count.
+        """
+        for key in ("samples", "n_samples"):
+            val = raw.get(key)
+            if val is not None:
+                return int(val)
+        for score_data in scores.values():
+            if isinstance(score_data, dict):
+                count = (score_data.get("stats") or {}).get("count")
+                if count is not None:
+                    return int(count)
+        limit = (raw.get("config") or {}).get("params", {}).get("limit_samples")
+        if isinstance(limit, int) and limit > 0:
+            return limit
+        return 0

--- a/src/nemo_evaluator/environments/registry.py
+++ b/src/nemo_evaluator/environments/registry.py
@@ -155,7 +155,8 @@ def _make_container(rest: str, **kwargs: Any) -> "EvalEnvironment":
         image, task = rest.rsplit("#", 1)
     else:
         image, task = rest, ""
-    return ContainerEnvironment(image=image, task=task)
+    user_params = kwargs.get("params") or {}
+    return ContainerEnvironment(image=image, task=task, legacy_params=user_params)
 
 
 def _make_harbor(rest: str, **kwargs: Any) -> "EvalEnvironment":

--- a/src/nemo_evaluator/executors/slurm_executor.py
+++ b/src/nemo_evaluator/executors/slurm_executor.py
@@ -429,7 +429,12 @@ class SlurmExecutor(Executor):
             submission_error: Exception | None = None
             try:
                 for script_path in script_paths:
-                    shard_extras = [p for p in extra_paths if p.parent == script_path.parent]
+                    # Include all extras under the script's staging dir, not
+                    # just direct siblings — legacy container:// benchmarks
+                    # write run_config.yaml under {staging}/{safe_name}/ which
+                    # the sbatch then bind-mounts.  Filter by ancestor.
+                    local_base = script_path.parent
+                    shard_extras = [p for p in extra_paths if local_base in p.parents]
                     shard_remote = f"{resolved_dir}/{script_path.parent.name}" if is_sharded else resolved_dir
                     meta = submit_eval(
                         script_path=script_path,
@@ -437,6 +442,7 @@ class SlurmExecutor(Executor):
                         remote_dir=shard_remote,
                         username=config.cluster.username,
                         extra_files=shard_extras,
+                        local_base=local_base,
                     )
                     meta["parent_dir"] = parent_dir
                     meta["submitted_at"] = datetime.now(timezone.utc).isoformat()

--- a/src/nemo_evaluator/executors/ssh.py
+++ b/src/nemo_evaluator/executors/ssh.py
@@ -161,8 +161,15 @@ def copy_to_remote(
     local_paths: list[Path],
     remote_dir: str,
     username: str | None = None,
+    local_base: Path | None = None,
 ) -> None:
-    """Copy files to the remote host via scp, preserving permissions."""
+    """Copy files to the remote host via scp, preserving permissions.
+
+    When ``local_base`` is provided, each path's position relative to
+    ``local_base`` is preserved on the remote (so a file at
+    ``{local_base}/sub/x.yaml`` lands at ``{remote_dir}/sub/x.yaml``).
+    Without ``local_base`` files are flattened under ``remote_dir``.
+    """
     target = _ssh_target(hostname, username)
 
     has_secrets = any(p.name == ".secrets.env" for p in local_paths)
@@ -176,9 +183,25 @@ def copy_to_remote(
     else:
         _ssh(target, f"mkdir -p {shlex.quote(remote_dir)}/logs", timeout=15.0)
 
+    if local_base is not None:
+        nested_dirs = sorted(
+            {
+                str(p.relative_to(local_base).parent)
+                for p in local_paths
+                if p.relative_to(local_base).parent != Path(".")
+            }
+        )
+        for d in nested_dirs:
+            _ssh(target, f"mkdir -p {shlex.quote(remote_dir + '/' + d)}", timeout=15.0)
+
     for p in local_paths:
-        _scp(str(p), f"{target}:{remote_dir}/", target)
-        logger.info("Copied %s -> %s:%s/", p.name, target, remote_dir)
+        if local_base is not None:
+            rel = p.relative_to(local_base)
+            dest = f"{target}:{remote_dir}/{rel}"
+        else:
+            dest = f"{target}:{remote_dir}/"
+        _scp(str(p), dest, target)
+        logger.info("Copied %s -> %s", p.name, dest)
 
 
 def submit_sbatch(
@@ -327,10 +350,11 @@ def submit_eval(
     remote_dir: str,
     username: str | None = None,
     extra_files: list[Path] | None = None,
+    local_base: Path | None = None,
 ) -> dict[str, str]:
     """Full submission flow: copy files, sbatch, return job metadata."""
     files = [script_path] + (extra_files or [])
-    copy_to_remote(hostname, files, remote_dir, username)
+    copy_to_remote(hostname, files, remote_dir, username, local_base=local_base)
 
     remote_script = f"{remote_dir}/{script_path.name}"
     job_id = submit_sbatch(hostname, remote_script, username)

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -871,6 +871,7 @@ def _build_batch_config(
     api_key: str | None,
     solver_cfg: Any,
     svc: Any,
+    cluster: Any = None,
 ) -> dict[str, Any]:
     """Build the config dict for ``env.run_batch()``."""
     cfg: dict[str, Any] = {"base_url": model_url, "model": model_id, "api_key": api_key}
@@ -881,8 +882,16 @@ def _build_batch_config(
 
     protocol = getattr(svc, "protocol", "chat_completions") if svc else "chat_completions"
     cfg["endpoint_type"] = solver_cfg.endpoint_type or _NEL_PROTOCOL_TO_LEGACY_TYPE.get(protocol, "chat")
-    if solver_cfg.params:
-        cfg["params"] = solver_cfg.params
+    if solver_cfg.adapter_config:
+        cfg["adapter_config"] = solver_cfg.adapter_config
+    # cluster.container_env is the global env-var bag (already honored by the
+    # docker/slurm dispatch paths); solver.env_vars overrides per-benchmark.
+    cluster_env = dict(getattr(cluster, "container_env", {}) or {})
+    merged_env = {**cluster_env, **solver_cfg.env_vars}
+    if merged_env:
+        cfg["env_vars"] = merged_env
+    if solver_cfg.mounts:
+        cfg["mounts"] = solver_cfg.mounts
     return cfg
 
 
@@ -955,7 +964,20 @@ async def _run_single_benchmark(
     service_name: str | None = getattr(solver_cfg, "service", None)
 
     model_url, model_id, api_key, svc = _resolve_service_connection(config, handles, service_name)
-    model_url, proxy_handle, model_traffic_store = _start_proxy(model_url, model_id, api_key, svc, service_name)
+    if isinstance(solver_cfg, ContainerSolverConfig):
+        proxy_cfg = getattr(svc, "proxy", None) if svc else None
+        if proxy_cfg is not None and proxy_cfg.needs_proxy:
+            raise ValueError(
+                f"Service {service_name!r} configures a nel-next adapter proxy "
+                f"(interceptors/extra_body/verbose), but benchmark {bench.name!r} "
+                f"uses ContainerEnvironment which runs the container's internal "
+                f"adapter. Configure interceptors via 'solver.adapter_config' "
+                f"instead — it is passed verbatim into the container's run_config."
+            )
+        proxy_handle = None
+        model_traffic_store = None
+    else:
+        model_url, proxy_handle, model_traffic_store = _start_proxy(model_url, model_id, api_key, svc, service_name)
 
     judge_client = None
     try:
@@ -973,7 +995,9 @@ async def _run_single_benchmark(
         )
 
         shard_info = shard_from_env()
-        batch_config = _build_batch_config(model_url, model_id, api_key, solver_cfg, svc)
+        batch_config = _build_batch_config(
+            model_url, model_id, api_key, solver_cfg, svc, cluster=getattr(config, "cluster", None)
+        )
         batch_result = await env.run_batch(solver=solver, config=batch_config)
         if batch_result is not None:
             return _finalize_batch_result(batch_result, shard_info, bench.name, env, output_dir)

--- a/src/nemo_evaluator/orchestration/slurm_gen.py
+++ b/src/nemo_evaluator/orchestration/slurm_gen.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 import os
 import re
 import shlex
-from pathlib import Path
+import uuid
+from pathlib import Path, PurePosixPath
 
 import yaml
 
@@ -34,6 +35,11 @@ from nemo_evaluator.config import (
     SlurmSandbox,
 )
 from nemo_evaluator.config.clusters import _parse_walltime
+from nemo_evaluator.config.solvers import ContainerSolverConfig
+from nemo_evaluator.environments.container import (
+    _NEL_PROTOCOL_TO_LEGACY_TYPE,
+    build_legacy_run_config,
+)
 from nemo_evaluator.orchestration.artifact_access import chmod_a_rx, warn_if_parent_chain_lacks_execute
 from nemo_evaluator.orchestration.image_resolver import (
     default_base_image,
@@ -67,6 +73,10 @@ _HEADER = """\
 set -uo pipefail
 export NEL_INNER_EXECUTION=1
 export PYTHONUNBUFFERED=1
+# Stable namespace for shared filesystem coordination between sibling
+# Pyxis containers (e.g. legacy gym deployment companion + eval container).
+# Pinned at submit time so auto-resume chain links share the same path.
+export NEL_INVOCATION_ID={nel_invocation_id}
 
 export OUTPUT_DIR="{output_dir}"
 NEL_EXIT_CODE=0
@@ -160,6 +170,10 @@ _HEADER_HETJOB_FOOTER = """\
 set -uo pipefail
 export NEL_INNER_EXECUTION=1
 export PYTHONUNBUFFERED=1
+# Stable namespace for shared filesystem coordination between sibling
+# Pyxis containers (e.g. legacy gym deployment companion + eval container).
+# Pinned at submit time so auto-resume chain links share the same path.
+export NEL_INVOCATION_ID={nel_invocation_id}
 
 export OUTPUT_DIR="{output_dir}"
 NEL_EXIT_CODE=0
@@ -531,6 +545,31 @@ fi
 if [ $_EVAL_RC -ne 0 ]; then echo "  FAILED: {bench_name}"; NEL_EXIT_CODE=1; fi
 """
 
+
+_TASK_LEGACY_CONTAINER = """\
+# Benchmark {idx}/{total}: {bench_name} (legacy container, direct dispatch)
+echo ""
+echo "============================================================"
+echo "  Benchmark {idx}/{total}: {bench_name} (legacy, repeats={repeats})"
+echo "============================================================"
+echo "  Logs: $OUTPUT_DIR/logs/eval-{safe_name}-$SLURM_JOB_ID.log"
+mkdir -p "{results_dir}"
+{reexport}\
+if [ -f "{results_dir}/results.yml" ] || [ -f "{results_dir}/results.json" ]; then
+    echo "  Already complete (results.yml present), skipping."
+else
+    srun --mpi=pmix --overlap --unbuffered --nodes 1 --ntasks 1{node_flag} \\
+        --container-image {harness_image} \\
+        --container-mounts={mounts} \\
+        {home_flag}{env_flags} \\
+        bash -c '$(command -v nemo-evaluator >/dev/null 2>&1 && echo nemo-evaluator || echo eval-factory) run_eval --run_config {run_config_in_container}' \\
+        2>&1 | stdbuf -oL tee -a "$OUTPUT_DIR/logs/eval-{safe_name}-$SLURM_JOB_ID.log"
+    _EVAL_RC=${{PIPESTATUS[0]}}
+    ln -sf "eval-{safe_name}-$SLURM_JOB_ID.log" "$OUTPUT_DIR/logs/eval-{safe_name}.log"
+    if [ $_EVAL_RC -ne 0 ]; then echo "  FAILED: {bench_name}"; NEL_EXIT_CODE=1; fi
+fi
+"""
+
 _REPORT = """\
 # Generate reports
 echo ""
@@ -538,6 +577,24 @@ echo "=== Generating reports ==="
 {report_commands}
 chmod a+rx "$OUTPUT_DIR"/report.* 2>/dev/null || true
 """
+
+_EXPORT = """\
+# Export results
+echo ""
+echo "=== Exporting results ==="
+{export_commands}
+"""
+
+_EXPORT_CONFIG_FILE = "export_config.yaml"
+_LEGACY_SHARDING_ERROR = (
+    "cluster.shards is not supported for legacy container:// benchmarks. "
+    "Legacy harness run_config.yaml has no NEL shard range, so each shard would run the same work."
+)
+
+
+def _has_multiple_shards(shards: int | None) -> bool:
+    return shards is not None and shards > 1
+
 
 _PREFLIGHT_IMAGE_CHECK = """\
 # Pre-flight: verify container images are pullable
@@ -1374,6 +1431,7 @@ def _service_block(
     reexport_cmds: str = "",
     mount_home: bool = True,
     pool_to_het: dict[str, int] | None = None,
+    extra_mounts: list[str] | None = None,
 ) -> str:
     upper = _safe(name).upper()
     pool = getattr(svc, "node_pool", None)
@@ -1420,7 +1478,7 @@ def _service_block(
                 cluster_mounts=cluster_mounts or [],
                 env_keys=env_keys or [],
                 mount_home=mount_home,
-                extra_mounts=model_mount + ["$OUTPUT_DIR:$OUTPUT_DIR"],
+                extra_mounts=model_mount + ["$OUTPUT_DIR:$OUTPUT_DIR"] + list(extra_mounts or []),
             )
         tp_flag = f"{tp_flag_name} {svc.tensor_parallel_size} " if svc.tensor_parallel_size else ""
         pp_flag = (
@@ -1455,11 +1513,20 @@ def _service_block(
         else:
             full_cmd = main_cmd
 
-        script_lines = ["set -euo pipefail"] + list(setup_list)
-        if num_nodes > 1 and svc.type == "sglang":
-            script_lines.append('NEL_NODE_RANK="${1:-0}"')
-            script_lines.append("export NEL_NODE_RANK")
-        script_lines.append(full_cmd)
+        if getattr(svc, "pre_cmd", None):
+            # User-supplied pre_cmd replaces the default service command
+            # (e.g. ``vllm serve``).  Used to port v1 launcher
+            # ``deployment.pre_cmd`` blocks for legacy gym etc., where the
+            # user owns the entire service-side script (vLLM startup,
+            # fake-health, gym poll-execute).  ``set -euo pipefail`` stays
+            # off — the user controls error semantics.
+            script_lines = [svc.pre_cmd]
+        else:
+            script_lines = ["set -euo pipefail"] + list(setup_list)
+            if num_nodes > 1 and svc.type == "sglang":
+                script_lines.append('NEL_NODE_RANK="${1:-0}"')
+                script_lines.append("export NEL_NODE_RANK")
+            script_lines.append(full_cmd)
         script_file = f"_svc_{safe_name}_cmd_$SLURM_JOB_ID.sh"
         script_heredoc = (
             f"cat > \"$OUTPUT_DIR/logs/{script_file}\" <<'_NEMO_SVC_CMD_EOF_'\n"
@@ -1819,6 +1886,91 @@ def _get_probe_url(
     return f"http://localhost:{port}{health}"
 
 
+def _is_legacy_container_bench(bench) -> bool:
+    """True iff a benchmark uses the v1 BC container bridge."""
+    return isinstance(bench.solver, ContainerSolverConfig)
+
+
+def _runs_legacy_container_bench(config: EvalConfig) -> bool:
+    return any(_is_legacy_container_bench(bench) for bench in config.benchmarks)
+
+
+# Where the pre-rendered run_config.yaml is mounted inside the harness.
+_LEGACY_RUN_CONFIG_PATH = "/config/run_config.yaml"
+# Where /results is mounted inside the harness; matches container.py.
+_LEGACY_RESULTS_PATH = "/results"
+
+
+def _parse_container_uri(name: str) -> tuple[str, str]:
+    """Split ``container://image#task`` into (image, task)."""
+    rest = name[len("container://") :] if name.startswith("container://") else name
+    if "#" in rest:
+        image, task = rest.rsplit("#", 1)
+        return image, task
+    return rest, ""
+
+
+def _resolve_legacy_url(svc, service_name: str, protocol_to_legacy: dict[str, str]) -> tuple[str, str, str]:
+    """Resolve (model_url, model_id, endpoint_type) for a legacy harness.
+
+    Mirrors the runtime path in ``orchestrator._resolve_service_connection``
+    + ``_build_batch_config`` so submit-time rendering produces the same
+    ``run_config.yaml`` the live dispatch path would generate.
+    """
+    if isinstance(svc, ExternalApiService):
+        url = svc.url
+        model_id = svc.model or service_name
+    else:
+        # Managed model server (vllm/sglang/nim/docker_model): URL is
+        # ``http://localhost:<port>/v1/<protocol-suffix>``.  We append the
+        # protocol-specific suffix so the harness sees the full endpoint.
+        suffix = {
+            "chat_completions": "/chat/completions",
+            "completions": "/completions",
+            "responses": "/responses",
+        }.get(getattr(svc, "protocol", "chat_completions"), "/chat/completions")
+        url = f"{svc.base_url}{suffix}"
+        model_id = getattr(svc, "served_model_name", None) or getattr(svc, "model", "")
+    proto = getattr(svc, "protocol", "chat_completions")
+    endpoint_type = protocol_to_legacy.get(proto, "chat")
+    return url, model_id, endpoint_type
+
+
+def _render_legacy_run_config(bench, services) -> dict:
+    """Render the legacy ``run_config.yaml`` dict for a v1 BC bench.
+
+    Pure function — no filesystem side effects.  The caller
+    (:func:`_write_single_script`) writes the result to disk so that
+    ``generate_sbatch`` stays a pure script-generator.
+    """
+    solver: ContainerSolverConfig = bench.solver  # type: ignore[assignment]
+    svc = services.get(solver.service)
+    if svc is None:
+        raise ValueError(f"Benchmark {bench.name!r} references service {solver.service!r} which is not defined")
+    proxy_cfg = getattr(svc, "proxy", None)
+    if proxy_cfg is not None and proxy_cfg.needs_proxy:
+        raise ValueError(
+            f"Service {solver.service!r} configures a nel-next adapter proxy "
+            f"(interceptors/extra_body/extra_headers/verbose), but benchmark {bench.name!r} "
+            "uses legacy container:// SLURM dispatch. Configure legacy adapter behavior via "
+            "'solver.adapter_config' instead."
+        )
+
+    _image, task = _parse_container_uri(bench.name)
+    model_url, model_id, default_endpoint = _resolve_legacy_url(svc, solver.service, _NEL_PROTOCOL_TO_LEGACY_TYPE)
+    endpoint_type = solver.endpoint_type or default_endpoint
+
+    return build_legacy_run_config(
+        task=task,
+        model_url=model_url,
+        model_id=model_id,
+        endpoint_type=endpoint_type,
+        extra_params=bench.params or None,
+        adapter_config=solver.adapter_config,
+        api_key=getattr(svc, "api_key", None),
+    )
+
+
 def _find_sandbox_bench(config: EvalConfig):
     """Return the first benchmark with a SLURM/Apptainer sandbox that has a node_pool."""
     for b in config.benchmarks:
@@ -1986,6 +2138,12 @@ def generate_sbatch(
     standalone per-shard job (no ``--array``).  Each shard gets its own
     output sub-directory (``shard_N/``) and auto-resume chain.
 
+    Pure script-generator: never touches the filesystem.  For
+    ``container://`` benchmarks the script references a pre-rendered
+    ``run_config.yaml`` at ``{output_dir}/{safe_name}/run_config.yaml`` —
+    :func:`write_sbatch` is responsible for materializing that file (via
+    :func:`_render_legacy_run_config` + ``yaml.dump``).
+
     Returns:
         (script_text, sidecar_configs, secrets_result)
     """
@@ -1996,6 +2154,12 @@ def generate_sbatch(
     parent_output_dir = config.output.dir
     output_dir = f"{parent_output_dir}/shard_{shard_idx}" if shard_idx is not None else parent_output_dir
     job_name = _safe(config.benchmarks[0].name) if len(config.benchmarks) == 1 else "multi"
+    # NEL_INVOCATION_ID: a hex token unique to this submission, exported in
+    # the sbatch header and propagated into every Pyxis container via
+    # --container-env=NEL_INVOCATION_ID.  Used by legacy gym deployments
+    # to namespace their shared-filesystem coordination dir
+    # (/cache/huggingface/$NEL_INVOCATION_ID/).
+    nel_invocation_id = uuid.uuid4().hex
     account_line = f"#SBATCH --account={cluster.account}" if cluster.account else ""
     sbatch_comment_line = f"#SBATCH --comment={shlex.quote(cluster.sbatch_comment)}" if cluster.sbatch_comment else ""
     sbatch_extra_lines = _format_sbatch_extra_flags(cluster.sbatch_extra_flags)
@@ -2008,19 +2172,53 @@ def generate_sbatch(
     # --- Build env groups for disambiguated .secrets.env ---
     env_groups: dict[str, dict[str, str]] = {}
 
+    # v1 BC: solver.env_vars on a container:// benchmark mirrors v1
+    # launcher's container-agnostic ``env_vars:`` block — values reach
+    # both deployment and evaluation containers.  Pre-aggregate per-svc
+    # so a multi-bench config sharing a service unions correctly.
+    legacy_svc_env_vars: dict[str, dict[str, str]] = {}
+    for bench in config.benchmarks:
+        if not _is_legacy_container_bench(bench):
+            continue
+        solver: ContainerSolverConfig = bench.solver  # type: ignore[assignment]
+        if not solver.env_vars:
+            continue
+        legacy_svc_env_vars.setdefault(solver.service, {}).update({k: str(v) for k, v in solver.env_vars.items()})
+
     for name, svc in config.services.items():
-        svc_env = {**cluster.container_env, **getattr(svc, "extra_env", {})}
+        svc_env = {**cluster.container_env, **getattr(svc, "extra_env", {}), **legacy_svc_env_vars.get(name, {})}
         if svc_env:
             env_groups[f"svc_{name}"] = svc_env
 
     for bench in config.benchmarks:
         eval_env = dict(cluster.container_env)
+        # Legacy v1 BC bridge: also fold in the harness's bearer token
+        # (NEMO_API_KEY, drawn from the linked service's resolved api_key)
+        # and the solver's user-declared env_vars (HF_TOKEN,
+        # OPENAI_API_KEY, …).  Going through the secrets mechanism keeps
+        # values out of the sbatch script and out of git.
+        if _is_legacy_container_bench(bench):
+            solver: ContainerSolverConfig = bench.solver  # type: ignore[assignment]
+            svc = config.services.get(solver.service)
+            api_key = getattr(svc, "api_key", None) if svc else None
+            if api_key:
+                eval_env["NEMO_API_KEY"] = str(api_key)
+            for k, v in (solver.env_vars or {}).items():
+                eval_env[k] = str(v)
         if eval_env:
             env_groups[f"eval_{_safe(bench.name)}"] = eval_env
 
     secrets_result = generate_secrets_env(env_groups)
 
-    _IMPLICIT_KEYS = ["PYTHONUNBUFFERED", "NEL_INNER_EXECUTION", "NEL_SHARD_IDX", "NEL_TOTAL_SHARDS"]
+    _IMPLICIT_KEYS = [
+        "PYTHONUNBUFFERED",
+        "NEL_INNER_EXECUTION",
+        "NEL_SHARD_IDX",
+        "NEL_TOTAL_SHARDS",
+        # Forwarded into every Pyxis container so user pre_cmd scripts and
+        # gym's eval-factory wrapper can use it as a shared-mount namespace.
+        "NEL_INVOCATION_ID",
+    ]
 
     parts: list[str] = []
 
@@ -2063,6 +2261,7 @@ def generate_sbatch(
                 sbatch_comment_line=sbatch_comment_line,
                 sbatch_extra_lines=sbatch_extra_lines,
                 het_echo_lines=het_echo_lines,
+                nel_invocation_id=nel_invocation_id,
             )
         )
     else:
@@ -2084,12 +2283,16 @@ def generate_sbatch(
                 account_line=account_line,
                 sbatch_comment_line=sbatch_comment_line,
                 sbatch_extra_lines=sbatch_extra_lines,
+                nel_invocation_id=nel_invocation_id,
             )
         )
 
     is_shard_script = shard_idx is not None
 
-    if cluster.shards is not None and not is_shard_script:
+    if is_shard_script and _runs_legacy_container_bench(config) and _has_multiple_shards(total_shards):
+        raise ValueError(_LEGACY_SHARDING_ERROR)
+
+    if _has_multiple_shards(cluster.shards) and not is_shard_script:
         raise ValueError(
             "generate_sbatch must not be called directly with cluster.shards set. "
             "Use write_sbatch which generates per-shard scripts."
@@ -2137,11 +2340,48 @@ def generate_sbatch(
     if cluster.conda_env:
         parts.append(_CONDA_ACTIVATE.format(conda_env=cluster.conda_env))
 
+    # When a legacy ``container://`` benchmark depends on a service, the
+    # gym CLI (or whatever harness runs in that container) writes results
+    # to ``/results``.  In nel-next, ``_TASK_LEGACY_CONTAINER`` mounts
+    # ``<run_dir>/<safe>/results`` at ``/results`` *only* in the eval
+    # container.  When the harness's actual writes happen on the
+    # deployment side via ``pre_cmd`` (gym Pattern A), the deployment
+    # container needs the same ``/results`` bind so those writes persist
+    # — otherwise gym writes into ephemeral container storage and the
+    # eval-factory output parser finds an empty results dir.  v1 launcher
+    # auto-adds ``<task_artifacts>:/results`` as the first deployment
+    # mount unconditionally (slurm/executor.py:826-828); we mirror that.
+    #
+    # Restriction: ``/results`` is a single bind point per container, so
+    # if multiple legacy benchmarks reference the same service we use the
+    # first one's results dir.  In Pattern A topologies this is 1:1.
+    legacy_results_mount_by_svc: dict[str, str] = {}
+    legacy_results_dirs: list[str] = []
+    for bench in config.benchmarks:
+        if not _is_legacy_container_bench(bench):
+            continue
+        bench_svc = _get_solver_service(bench)
+        if not bench_svc or bench_svc in legacy_results_mount_by_svc:
+            continue
+        bench_safe = _safe(bench.name)
+        bench_results_dir = f"{output_dir}/{bench_safe}/results"
+        legacy_results_mount_by_svc[bench_svc] = f"{bench_results_dir}:{_LEGACY_RESULTS_PATH}"
+        legacy_results_dirs.append(bench_results_dir)
+
+    # Pyxis requires the host-side bind source to exist BEFORE the service
+    # srun starts.  ``_TASK_LEGACY_CONTAINER`` mkdir's its own ``results/``
+    # later in the script, but that's too late for the service block we're
+    # about to emit — so create those dirs up front.
+    if legacy_results_dirs:
+        mkdir_lines = "\n".join(f'mkdir -p "{d}"' for d in legacy_results_dirs)
+        parts.append(mkdir_lines + "\n")
+
     for name, svc in config.services.items():
         group_name = f"svc_{name}"
         svc_env_keys = reexport_keys(group_name, secrets_result) + _IMPLICIT_KEYS
         svc_env_keys = list(dict.fromkeys(svc_env_keys))
         svc_reexport = build_reexport_commands(group_name, secrets_result)
+        legacy_mount = legacy_results_mount_by_svc.get(name)
         parts.append(
             _service_block(
                 name,
@@ -2152,6 +2392,7 @@ def generate_sbatch(
                 reexport_cmds=svc_reexport,
                 mount_home=cluster.mount_home,
                 pool_to_het=pool_to_het if use_het else None,
+                extra_mounts=[legacy_mount] if legacy_mount else None,
             )
         )
 
@@ -2297,6 +2538,85 @@ def generate_sbatch(
         model_id_var = f"{upper}_MODEL"
         safe_name = _safe(bench.name)
 
+        # ----- Legacy v1 BC bridge: direct sibling-srun for the harness.
+        # The harness is self-contained (eval-factory owns the loop), so
+        # nel-next has nothing to do mid-eval.  We pre-render run_config.yaml
+        # at submit time and emit a single ``srun --container-image=<harness>``
+        # alongside (not nested inside) any eval_image wrap — the same
+        # sibling pattern slurm_gen already uses for managed services.
+        # See `_TASK_LEGACY_CONTAINER` for the rendered shape.
+        if _is_legacy_container_bench(bench):
+            harness_image, _task = _parse_container_uri(bench.name)
+            # Validate render works at submit time (raises early on
+            # missing/misconfigured service); the actual file is written by
+            # write_sbatch via the same helper.
+            _render_legacy_run_config(bench, config.services)
+            rc_path = f"{output_dir}/{safe_name}/run_config.yaml"
+            results_dir = f"{output_dir}/{safe_name}/results"
+
+            solver: ContainerSolverConfig = bench.solver  # type: ignore[assignment]
+            user_mounts = [f"{h}:{c}" for h, c in (solver.mounts or {}).items()]
+            mounts = list(
+                dict.fromkeys(
+                    [
+                        f"{rc_path}:{_LEGACY_RUN_CONFIG_PATH}:ro",
+                        f"{results_dir}:{_LEGACY_RESULTS_PATH}",
+                        *list(cluster.container_mounts),
+                        *user_mounts,
+                    ]
+                )
+            )
+
+            # Env keys come from the secrets group built above (NEMO_API_KEY
+            # + solver.env_vars + cluster.container_env), so values stay in
+            # the sourced .secrets.env and never appear in the script itself.
+            group_name = f"eval_{safe_name}"
+            env_keys = reexport_keys(group_name, secrets_result) + _IMPLICIT_KEYS
+            env_keys = list(dict.fromkeys(env_keys))
+            env_flags = " ".join(f"--container-env={k}" for k in env_keys)
+            reexport_lines = build_reexport_commands(group_name, secrets_result)
+            reexport_block = (reexport_lines + "\n") if reexport_lines else ""
+            home_flag = "" if cluster.mount_home else "--no-container-mount-home "
+
+            # Co-locate the legacy harness srun with the head node of the
+            # service it depends on.  Pyxis on the same node shares the host
+            # network namespace, so the eval-factory adapter proxy on
+            # 127.0.0.1:<port> in this container is reachable from the
+            # service's container (e.g. gym CLI) only when both run on the
+            # same node.  Mirror the existing ``_eval_srun_prefix`` rule:
+            # het-mode → pin to the service's het-group; single-pool
+            # multi-node → pin to ``$MASTER_IP`` (the service head).  Single-
+            # node services need no flag — sbatch already runs there.
+            _legacy_node_flag = ""
+            solver_svc = config.services.get(svc_name) if svc_name else None
+            if solver_svc is not None:
+                if use_het:
+                    svc_pool = getattr(solver_svc, "node_pool", None)
+                    if svc_pool and svc_pool in pool_to_het:
+                        _legacy_node_flag = f" --het-group={pool_to_het[svc_pool]}"
+                elif getattr(solver_svc, "num_nodes", 1) > 1:
+                    _legacy_node_flag = " -w $MASTER_IP"
+
+            parts.append(
+                _TASK_LEGACY_CONTAINER.format(
+                    idx=i,
+                    total=total,
+                    bench_name=bench.name,
+                    repeats=bench.repeats,
+                    safe_name=safe_name,
+                    results_dir=results_dir,
+                    reexport=reexport_block,
+                    harness_image=harness_image,
+                    mounts=",".join(mounts),
+                    home_flag=home_flag,
+                    env_flags=env_flags,
+                    node_flag=_legacy_node_flag,
+                    run_config_in_container=_LEGACY_RUN_CONFIG_PATH,
+                )
+            )
+            continue
+
+        # ----- Native env path (unchanged).
         eval_image = ""
         if use_containers:
             eval_image = resolve_eval_image(bench.name, base_override=base_override) or default_base_image(
@@ -2374,6 +2694,16 @@ def generate_sbatch(
             report_cmds.append(f'{eval_run_prefix}nel eval report "$OUTPUT_DIR" -f {fmt} -o "$OUTPUT_DIR/report.{ext}"')
         if report_cmds:
             parts.append(_REPORT.format(report_commands="\n".join(report_cmds)))
+        export_cmds = []
+        export_config_arg = f' --config "$OUTPUT_DIR/{_EXPORT_CONFIG_FILE}"' if config.output.export_config else ""
+        if _runs_legacy_container_bench(config):
+            for exporter_name in config.output.export:
+                export_cmds.append(
+                    f'{eval_run_prefix}nel export "$OUTPUT_DIR" --dest {shlex.quote(exporter_name)}'
+                    f'{export_config_arg} --output-dir "$OUTPUT_DIR"'
+                )
+        if export_cmds:
+            parts.append(_EXPORT.format(export_commands="\n".join(export_cmds)))
 
     if sb_bench and isinstance(sb_bench.sandbox, ApptainerSandbox):
         het_group_flag = (
@@ -2460,6 +2790,15 @@ def _sidecar_contains_secret(cfg_dict: dict) -> bool:
     return False
 
 
+def _write_export_config(out: Path, export_config: dict) -> Path | None:
+    if not export_config:
+        return None
+    path = out / _EXPORT_CONFIG_FILE
+    path.write_text(yaml.dump(export_config, default_flow_style=False, sort_keys=False), encoding="utf-8")
+    path.chmod(0o600)
+    return path
+
+
 def _write_single_script(
     out: Path,
     script: str,
@@ -2467,8 +2806,15 @@ def _write_single_script(
     secrets_result: SecretsEnvResult,
     *,
     dry_run: bool = False,
+    legacy_run_configs: dict[str, dict] | None = None,
 ) -> tuple[Path, list[Path]]:
-    """Write one sbatch script + its sidecar/secrets into *out*."""
+    """Write one sbatch script + its sidecar/secrets into *out*.
+
+    For ``container://`` benchmarks (passed in *legacy_run_configs*), the
+    pre-rendered legacy ``run_config.yaml`` is written under
+    ``{out}/{safe_name}/run_config.yaml`` so the harness srun can
+    bind-mount it.
+    """
     out.mkdir(parents=True, exist_ok=True)
     logs_dir = out / "logs"
     logs_dir.mkdir(exist_ok=True)
@@ -2502,6 +2848,13 @@ def _write_single_script(
             chmod_a_rx(cfg_path)
         extra_paths.append(cfg_path)
 
+    for safe_name, run_config in (legacy_run_configs or {}).items():
+        bench_dir = out / safe_name
+        bench_dir.mkdir(parents=True, exist_ok=True)
+        rc_path = bench_dir / "run_config.yaml"
+        rc_path.write_text(yaml.dump(run_config, default_flow_style=False, sort_keys=False), encoding="utf-8")
+        extra_paths.append(rc_path)
+
     return path, extra_paths
 
 
@@ -2524,6 +2877,27 @@ def write_sbatch(
     artifact_root = Path(config.output.dir)
     cluster = config.cluster
     n_shards = getattr(cluster, "shards", None) if isinstance(cluster, SlurmCluster) else None
+    if _has_multiple_shards(n_shards) and _runs_legacy_container_bench(config):
+        raise ValueError(_LEGACY_SHARDING_ERROR)
+    if n_shards == 1 and _runs_legacy_container_bench(config):
+        n_shards = None
+
+    common_extras: list[Path] = []
+    if config.output.export and _runs_legacy_container_bench(config):
+        out.mkdir(parents=True, exist_ok=True)
+        export_config_path = _write_export_config(out, config.output.export_config)
+        if export_config_path is not None:
+            common_extras.append(export_config_path)
+
+    # Pre-render legacy run_config.yaml content for any container:// benchmark.
+    # generate_sbatch references {output_dir}/{safe_name}/run_config.yaml; we
+    # materialize that file alongside the sbatch script so the harness srun
+    # can bind-mount it.
+    legacy_run_configs: dict[str, dict] = {
+        _safe(b.name): _render_legacy_run_config(b, config.services)
+        for b in config.benchmarks
+        if _is_legacy_container_bench(b)
+    }
 
     out.mkdir(parents=True, exist_ok=True)
     chmod_a_rx(out)
@@ -2546,6 +2920,7 @@ def write_sbatch(
                 sidecars,
                 secrets,
                 dry_run=dry_run,
+                legacy_run_configs=legacy_run_configs,
             )
             script_paths.append(path)
             all_extras.extend(extras)
@@ -2558,5 +2933,6 @@ def write_sbatch(
         sidecar_configs,
         secrets_result,
         dry_run=dry_run,
+        legacy_run_configs=legacy_run_configs,
     )
-    return [path], extras
+    return [path], [*common_extras, *extras]

--- a/src/nemo_evaluator/reports/eval.py
+++ b/src/nemo_evaluator/reports/eval.py
@@ -133,6 +133,56 @@ def discover_bundle_paths(paths: list[Path]) -> list[Path]:
     return expanded
 
 
+def materialize_legacy_bundles(results: Path) -> list[Path]:
+    """Convert legacy ``results/results.yml`` outputs under *results* into NEL bundles.
+
+    Legacy ``container://`` SLURM dispatch runs the eval-factory harness
+    directly, so the first durable artifact is ``<bench>/results/results.yml``
+    or ``results.json``. Report/export commands consume ``eval-*.json``
+    bundles, so this conversion is the shared bridge between those worlds.
+    """
+    import json as _json
+
+    from nemo_evaluator.engine.artifacts import write_all
+    from nemo_evaluator.environments.container import build_legacy_bundle
+
+    created: list[Path] = []
+    result_files = list(results.rglob("results/results.yml")) + list(results.rglob("results/results.json"))
+    for result_file in result_files:
+        bench_dir = result_file.parent.parent
+
+        rc_path = bench_dir / "run_config.yaml"
+        image, task = bench_dir.name, ""
+        if rc_path.exists():
+            try:
+                import yaml as _yaml
+
+                rc = _yaml.safe_load(rc_path.read_text(encoding="utf-8")) or {}
+                task = (rc.get("config") or {}).get("type") or ""
+            except Exception as exc:
+                logger.warning("Could not read legacy run config %s: %s", rc_path, exc)
+
+        try:
+            bundle = build_legacy_bundle(image, task, result_file.parent)
+        except Exception as exc:
+            logger.warning("Skipping legacy results in %s: %s", bench_dir, exc)
+            continue
+
+        existing_bundles = list(bench_dir.glob("eval-*.json"))
+        if existing_bundles:
+            rows = bundle.get("_results") or []
+            results_jsonl = bench_dir / "results.jsonl"
+            if rows and (not results_jsonl.exists() or not results_jsonl.read_text(encoding="utf-8").strip()):
+                with results_jsonl.open("w", encoding="utf-8") as f:
+                    for row in rows:
+                        f.write(_json.dumps(row, default=str) + "\n")
+            continue
+
+        paths = write_all(bundle, bench_dir)
+        created.append(paths["bundle"])
+    return created
+
+
 def build_table(bundles: list[dict[str, Any]]) -> dict[str, Any]:
     benchmarks: dict[str, dict[str, Any]] = {}
     model_name = ""
@@ -163,14 +213,42 @@ def build_table(bundles: list[dict[str, Any]]) -> dict[str, Any]:
     return {"model": model_name, "benchmarks": benchmarks, "n_benchmarks": len(benchmarks)}
 
 
+_NON_METRIC_ROW_KEYS = {"samples", "repeats", "categories", "total_tokens", "latency_p50_ms"}
+
+# Substrings that mark a metric leaf as auxiliary timing/cost data, not the
+# benchmark's headline score.  Real-world example: nemo-skills math harnesses
+# emit BOTH ``pass@1/symbolic_correct`` (the score) AND ``pass@1/gen_seconds``
+# (latency) under the same group — without this filter the fallback below
+# surfaces "score=140" when the model actually got 100%.
+_TIMING_LEAF_PATTERNS = ("gen_seconds", "latency", "duration", "tokens", "time_ms", "_time", "_ms")
+
+
+def _is_timing_leaf(key: str) -> bool:
+    leaf = key.rsplit("/", 1)[-1].lower()
+    return any(p in leaf for p in _TIMING_LEAF_PATTERNS)
+
+
 def _primary_metric(row: dict[str, Any]) -> tuple[str, dict[str, Any]]:
-    """Pick the best headline metric: mean_reward if available, else pass@1."""
+    """Pick the best headline metric: mean_reward if available, else pass@1.
+
+    Falls back to the first quality-flavored row entry with a numeric
+    ``value`` so legacy container bundles (whose harness-specific scores
+    don't conform to ``mean_reward``/``pass@1``) surface a real number
+    in the report table instead of rendering ``-``.  Timing/cost leaves
+    (``gen_seconds``, ``latency_ms``, ``duration``, etc.) are never used
+    as headlines.
+    """
     mr = row.get("mean_reward", {})
     if isinstance(mr, dict) and "value" in mr:
         return "mean_reward", mr
     p1 = row.get("pass@1", {})
     if isinstance(p1, dict) and "value" in p1:
         return "pass@1", p1
+    for k, v in row.items():
+        if k in _NON_METRIC_ROW_KEYS or k.startswith("scorer:"):
+            continue
+        if isinstance(v, dict) and "value" in v and not _is_timing_leaf(k):
+            return k, v
     return "", {}
 
 

--- a/tests/test_engine/test_mlflow_exporter.py
+++ b/tests/test_engine/test_mlflow_exporter.py
@@ -730,13 +730,44 @@ class TestArtifactPolicy:
         assert "results.jsonl" not in names
         assert "eval-mmlu-000.json" in names
 
+    def test_exporter_uses_bundle_output_path_for_artifacts(self, mlflow_fake, tmp_path, monkeypatch):
+        from nemo_evaluator.engine.exporters import mlflow_export
 
-mlflow_real = pytest.importorskip("mlflow", reason="mlflow not installed")
+        out_root = tmp_path / "out"
+        task_dir = out_root / "container___legacy_task"
+        task_dir.mkdir(parents=True)
+        (task_dir / "eval-container-001.json").write_text('{"run_id":"eval-container-001"}')
+        (task_dir / "results.jsonl").write_text('{"problem_idx":0}\n')
+
+        logged: list[tuple[str, str | None, Path]] = []
+
+        def fake_log_artifact(path, artifact_path=None):
+            p = Path(path)
+            logged.append((p.name, artifact_path, p.parent))
+
+        monkeypatch.setattr(
+            mlflow_export.mlflow,
+            "log_artifact",
+            staticmethod(fake_log_artifact),
+            raising=False,
+        )
+
+        bundle = _make_bundle("container/ifeval", run_id="eval-container-001")
+        bundle["_output_path"] = str(task_dir)
+        mlflow_export.MLflowExporter(
+            tracking_uri="http://mlflow",
+            only_required=True,
+            copy_artifacts=True,
+        ).export([bundle], config={"output_dir": str(out_root)})
+
+        assert ("eval-container-001.json", "container_ifeval", task_dir) in logged
+        assert ("results.jsonl", "container_ifeval", task_dir) in logged
 
 
 @pytest.fixture
 def mlflow_file_tracking(tmp_path, monkeypatch):
     """Point the exporter at a file:// tracking store under tmp_path."""
+    mlflow_real = pytest.importorskip("mlflow", reason="mlflow not installed")
     store = tmp_path / "mlruns"
     store.mkdir()
     uri = f"file://{store}"

--- a/tests/test_environments/test_environments_extended.py
+++ b/tests/test_environments/test_environments_extended.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -68,23 +69,410 @@ class TestCompositeEnvironment:
 
 
 class TestContainerEnvironment:
-    def test_seed_raises(self):
+    @pytest.mark.parametrize("method,args", [("seed", (0,)), ("verify", ("a", "b"))], ids=["seed", "verify"])
+    def test_seed_and_verify_raise_not_implemented(self, method, args):
+        """ContainerEnvironment uses ``run_batch()``; the seed/verify cycle isn't supported."""
+        import asyncio
+
         from nemo_evaluator.environments.container import ContainerEnvironment
 
         env = ContainerEnvironment(image="test:latest")
         with pytest.raises(NotImplementedError):
-            import asyncio
+            asyncio.run(getattr(env, method)(*args))
 
-            asyncio.run(env.seed(0))
+    async def test_run_batch_end_to_end(self):
+        """Full run_batch flow: config -> docker command -> results parsing."""
+        import yaml as _yaml
 
-    def test_verify_raises(self):
         from nemo_evaluator.environments.container import ContainerEnvironment
 
-        env = ContainerEnvironment(image="test:latest")
-        with pytest.raises(NotImplementedError):
-            import asyncio
+        # Realistic v1 results.yml (matches EvaluationResult schema)
+        v1_results = {
+            "results": {
+                "groups": {
+                    "mmlu": {
+                        "metrics": {
+                            "pass@1": {
+                                "scores": {
+                                    "symbolic_correct": {"value": 80.0, "stats": {"count": 50}},
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-            asyncio.run(env.verify("a", "b"))
+        captured_cmd = []
+        captured_run_config = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured_cmd.extend(args)
+            for arg in args:
+                if not isinstance(arg, str):
+                    continue
+                if arg.endswith(":/results"):
+                    Path(arg.split(":")[0]).joinpath("results.yml").write_text(_yaml.dump(v1_results))
+                if arg.endswith(":/config/run_config.yaml:ro"):
+                    captured_run_config.update(_yaml.safe_load(Path(arg.split(":")[0]).read_text()))
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            proc.kill = AsyncMock()
+            proc.wait = AsyncMock()
+            return proc
+
+        env = ContainerEnvironment(image="test:latest", task="ns_mmlu")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            result = await env.run_batch(
+                config={
+                    "base_url": "https://api.example.com/v1/chat/completions",
+                    "model": "test-model",
+                    "api_key": "test-key",
+                    "endpoint_type": "chat",
+                    "params": {"limit_samples": 50},
+                }
+            )
+
+        # Verify docker command structure
+        cmd_str = " ".join(str(c) for c in captured_cmd)
+        assert "docker run --rm" in cmd_str
+        assert "test:latest" in cmd_str
+        assert "NEMO_API_KEY=test-key" in cmd_str
+        # Entrypoint: nemo-evaluator with eval-factory fallback
+        assert "command -v nemo-evaluator" in cmd_str
+        assert "eval-factory" in cmd_str
+        assert "run_eval --run_config" in cmd_str
+
+        # Verify generated run_config.yaml matches v1 schema
+        assert captured_run_config["config"]["type"] == "ns_mmlu"
+        assert captured_run_config["config"]["output_dir"] == "/results"
+        assert captured_run_config["config"]["params"]["limit_samples"] == 50
+        assert captured_run_config["target"]["api_endpoint"]["url"] == "https://api.example.com/v1/chat/completions"
+        assert captured_run_config["target"]["api_endpoint"]["model_id"] == "test-model"
+        assert captured_run_config["target"]["api_endpoint"]["api_key_name"] == "NEMO_API_KEY"
+        assert captured_run_config["target"]["api_endpoint"]["type"] == "chat"
+
+        # Verify results parsed correctly from v1 format
+        assert result["benchmark"]["name"] == "container/ns_mmlu"
+        assert result["benchmark"]["samples"] == 50
+        assert result["benchmark"]["scores"]["mmlu/pass@1/symbolic_correct"]["value"] == 80.0
+
+    def test_adapter_config_written_verbatim(self):
+        """adapter_config lands at target.api_endpoint.adapter_config verbatim."""
+        from nemo_evaluator.environments.container import ContainerEnvironment
+
+        adapter_cfg = {
+            "use_reasoning": True,
+            "params_to_add": {"chat_template_kwargs": {"enable_thinking": True}},
+            "params_to_remove": ["max_tokens", "max_completion_tokens"],
+        }
+        env = ContainerEnvironment(image="test:latest", task="ns_mmlu")
+        rc = env._build_legacy_run_config("http://m/v1", "m", "chat", {"temperature": 1.0}, adapter_cfg)
+        assert rc["target"]["api_endpoint"]["adapter_config"] == adapter_cfg
+        assert "adapter_config" not in rc["config"].get("params", {})
+
+    async def test_run_batch_pyxis_dispatch_on_slurm(self, monkeypatch):
+        """When SLURM_JOB_ID is set, dispatch via `srun --container-image`."""
+        from nemo_evaluator.environments.container import ContainerEnvironment
+
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+        # ``shutil.which`` should find srun for the dispatch to proceed.
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/srun" if name == "srun" else None)
+
+        captured_cmd: list[str] = []
+        captured_env: dict = {}
+
+        async def fake_exec(*args, **kwargs):
+            captured_cmd.extend(a for a in args if isinstance(a, str))
+            if kwargs.get("env") is not None:
+                captured_env.update(kwargs["env"])
+            from pathlib import Path
+
+            # mounts flag holds all mounts; results dir is in there
+            for a in args:
+                if isinstance(a, str) and a.startswith("--container-mounts="):
+                    for entry in a.split("=", 1)[1].split(","):
+                        if entry.endswith(":/results"):
+                            Path(entry.split(":")[0]).joinpath("results.yml").write_text("results: {tasks: {}}\n")
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            proc.kill = AsyncMock()
+            proc.wait = AsyncMock()
+            return proc
+
+        # Use a sqsh-style file path to exercise the file-vs-registry detection.
+        env = ContainerEnvironment(image="/srv/nemo-skills.sqsh", task="ns_mmlu")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await env.run_batch(
+                config={
+                    "base_url": "http://m/v1",
+                    "model": "m",
+                    "api_key": "k",
+                    "endpoint_type": "chat",
+                    "env_vars": {"JUDGE_API_KEY": "judge-secret"},
+                    "mounts": {"/host/data": "/data"},
+                }
+            )
+
+        # Pyxis-shaped argv, not docker
+        assert "srun" in captured_cmd
+        assert "docker" not in captured_cmd
+        # Single-node, overlap, unbuffered
+        assert "--mpi=pmix" in captured_cmd
+        assert "--overlap" in captured_cmd
+        assert "--unbuffered" in captured_cmd
+        assert "--nodes=1" in captured_cmd
+        assert "--ntasks=1" in captured_cmd
+        assert "--no-container-mount-home" in captured_cmd
+        # File-path image passes through (no docker:// prefix)
+        assert "--container-image=/srv/nemo-skills.sqsh" in captured_cmd
+        # Mounts joined into one comma-separated flag
+        mount_flag = next(c for c in captured_cmd if c.startswith("--container-mounts="))
+        assert "/host/data:/data" in mount_flag
+        assert ":/results" in mount_flag
+        assert ":/config/run_config.yaml:ro" in mount_flag
+        # Env *names* on argv; *values* in subprocess env (Pyxis inherits)
+        assert "--container-env=JUDGE_API_KEY" in captured_cmd
+        assert "--container-env=NEMO_API_KEY" in captured_cmd
+        assert "JUDGE_API_KEY=judge-secret" not in " ".join(captured_cmd)  # value not in argv
+        assert captured_env.get("JUDGE_API_KEY") == "judge-secret"
+        assert captured_env.get("NEMO_API_KEY") == "k"
+
+    async def test_run_batch_pyxis_registry_uri_gets_docker_prefix(self, monkeypatch):
+        """Registry URIs (no leading slash) get the ``docker://`` prefix for Pyxis."""
+        from nemo_evaluator.environments.container import ContainerEnvironment
+
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/srun" if name == "srun" else None)
+
+        captured_cmd: list[str] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured_cmd.extend(a for a in args if isinstance(a, str))
+            from pathlib import Path
+
+            for a in args:
+                if isinstance(a, str) and a.startswith("--container-mounts="):
+                    for entry in a.split("=", 1)[1].split(","):
+                        if entry.endswith(":/results"):
+                            Path(entry.split(":")[0]).joinpath("results.yml").write_text("results: {tasks: {}}\n")
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            proc.kill = AsyncMock()
+            proc.wait = AsyncMock()
+            return proc
+
+        env = ContainerEnvironment(image="registry.example.com:5005/x:tag", task="ns_mmlu")
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await env.run_batch(config={"base_url": "http://m", "model": "m"})
+
+        assert "--container-image=docker://registry.example.com:5005/x:tag" in captured_cmd
+
+    async def test_run_batch_slurm_without_srun_raises_clear_error(self, monkeypatch):
+        """If SLURM_JOB_ID is set but srun isn't installed, surface a helpful error."""
+        from nemo_evaluator.environments.container import ContainerEnvironment
+
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+        monkeypatch.setattr("shutil.which", lambda name: None)
+
+        env = ContainerEnvironment(image="test:latest", task="ns_mmlu")
+        with pytest.raises(RuntimeError, match=r"srun.*not in PATH|unset SLURM_JOB_ID"):
+            await env.run_batch(config={"base_url": "http://m", "model": "m"})
+
+    def test_redact_cmd_for_log_hides_env_values(self):
+        """Secrets in -e K=V must not leak into INFO logs."""
+        from nemo_evaluator.environments.container import _redact_cmd_for_log
+
+        cmd = [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            "/tmp/x:/results",
+            "-e",
+            "NEMO_API_KEY=nvapi-SECRETSECRET",
+            "-e",
+            "JUDGE_API_KEY=another-secret",
+            "image:tag",
+        ]
+        out = _redact_cmd_for_log(cmd)
+        assert "nvapi-SECRETSECRET" not in out
+        assert "another-secret" not in out
+        assert "NEMO_API_KEY=<REDACTED>" in out
+        assert "JUDGE_API_KEY=<REDACTED>" in out
+        # Non-env argv survives intact
+        assert "/tmp/x:/results" in out
+        assert "image:tag" in out
+
+    async def test_env_vars_and_mounts_forwarded_to_docker(self):
+        """solver-level env_vars/mounts land in docker run -e/-v flags."""
+        from nemo_evaluator.environments.container import ContainerEnvironment
+
+        captured_cmd: list[str] = []
+
+        async def fake_exec(*args, **kwargs):
+            captured_cmd.extend(a for a in args if isinstance(a, str))
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b""))
+            proc.returncode = 0
+            proc.kill = AsyncMock()
+            proc.wait = AsyncMock()
+            return proc
+
+        env = ContainerEnvironment(image="test:latest", task="ns_mmlu")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            await env.run_batch(
+                config={
+                    "base_url": "http://m/v1",
+                    "model": "m",
+                    "api_key": "k",
+                    "endpoint_type": "chat",
+                    "env_vars": {"JUDGE_API_KEY": "judge-secret", "HF_TOKEN": "hf-secret"},
+                    "mounts": {"/host/ruler_data": "/ruler_data", "/host/hf": "/checkpoint"},
+                }
+            )
+
+        cmd_str = " ".join(captured_cmd)
+        assert "JUDGE_API_KEY=judge-secret" in cmd_str
+        assert "HF_TOKEN=hf-secret" in cmd_str
+        assert "/host/ruler_data:/ruler_data" in cmd_str
+        assert "/host/hf:/checkpoint" in cmd_str
+
+    async def test_run_batch_container_failure(self):
+        """Container exits non-zero with no results — should return empty scores, not crash."""
+        from nemo_evaluator.environments.container import ContainerEnvironment
+
+        async def fake_exec(*args, **kwargs):
+            proc = AsyncMock()
+            proc.communicate = AsyncMock(return_value=(b"", b"task not found"))
+            proc.returncode = 1
+            proc.kill = AsyncMock()
+            proc.wait = AsyncMock()
+            return proc
+
+        env = ContainerEnvironment(image="test:latest", task="bad_task")
+
+        with patch("asyncio.create_subprocess_exec", side_effect=fake_exec):
+            result = await env.run_batch(
+                config={
+                    "base_url": "https://api.example.com/v1",
+                    "model": "test-model",
+                    "endpoint_type": "chat",
+                }
+            )
+
+        assert result["benchmark"]["scores"] == {}
+        assert result["benchmark"]["samples"] == 0
+
+    @pytest.mark.parametrize(
+        "raw,scores,expected,case_id",
+        [
+            # No per-metric count → fall back to ``limit_samples`` (cap).
+            (
+                {
+                    "config": {"params": {"limit_samples": 3, "task": "ifeval"}},
+                    "results": {
+                        "groups": {
+                            "ifeval": {
+                                "metrics": {
+                                    "inst_level_loose_acc": {
+                                        "scores": {
+                                            "inst_level_loose_acc": {
+                                                "value": 0.6,
+                                                "stats": {"stderr": 0.2828},
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                },
+                None,  # use _extract_scores below
+                3,
+                "limit_samples_fallback",
+            ),
+            # Top-level ``samples`` reflects actual evaluated count, beats cap.
+            ({"samples": 7, "config": {"params": {"limit_samples": 100}}}, {}, 7, "top_level_samples_wins"),
+            # ``stats.count`` is the legacy Evaluator per-metric counter, beats cap.
+            (
+                {"config": {"params": {"limit_samples": 999}}},
+                {"acc": {"value": 0.5, "stats": {"count": 50}}},
+                50,
+                "stats_count_wins",
+            ),
+        ],
+        ids=lambda x: x if isinstance(x, str) else None,
+    )
+    def test_extract_sample_count_priority_chain(self, raw, scores, expected, case_id):
+        """``_extract_sample_count`` prefers (in order): top-level
+        ``samples``/``n_samples`` → per-metric ``stats.count`` → fallback
+        ``raw.config.params.limit_samples`` (the cap)."""
+        from nemo_evaluator.environments.container import ContainerEnvironment
+
+        if scores is None:
+            scores = ContainerEnvironment._extract_scores(raw)
+        assert ContainerEnvironment._extract_sample_count(raw, scores) == expected
+
+    def test_build_legacy_bundle_populates_repeats_from_results_yml(self, tmp_path):
+        """v1 launcher writes back the eval-factory config under
+        ``results.yml::config``.  Real production configs include
+        ``config.params.extra.num_repeats`` (e.g. Ultra HMMT uses 16,
+        AIME uses 64).  The bundle MUST surface this so downstream
+        statistics (pass@1[avg-of-N], CIs) compute correctly — without
+        it, native-env bundles get ``repeats=1`` from the schema default
+        while container bundles silently drop the value."""
+        import yaml as _yaml
+
+        from nemo_evaluator.environments.container import build_legacy_bundle
+
+        results_yml = {
+            "config": {
+                "type": "nemo_skills.ns_hmmt_feb2025",
+                "params": {"extra": {"num_repeats": 16}},
+            },
+            "results": {
+                "groups": {
+                    "hmmt_feb25": {
+                        "metrics": {
+                            "pass@1": {
+                                "scores": {
+                                    "symbolic_correct": {"value": 100.0, "stats": {"count": 3}},
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+        }
+        (tmp_path / "results.yml").write_text(_yaml.dump(results_yml))
+        bundle = build_legacy_bundle("nemo-skills:dev", "nemo_skills.ns_hmmt_feb2025", tmp_path)
+        assert bundle["benchmark"]["repeats"] == 16, (
+            f"build_legacy_bundle must read config.params.extra.num_repeats from results.yml; "
+            f"got bundle['benchmark']={bundle['benchmark']!r}"
+        )
+
+    def test_build_legacy_bundle_repeats_defaults_to_1_when_missing(self, tmp_path):
+        """Harnesses without ``num_repeats`` (BBQ, terminal-bench, etc.)
+        get ``repeats=1`` — matching the schema default for native-env
+        bundles."""
+        import yaml as _yaml
+
+        from nemo_evaluator.environments.container import build_legacy_bundle
+
+        results_yml = {
+            "config": {"type": "bbq_small", "params": {}},
+            "results": {"groups": {"bbq": {"metrics": {"acc": {"scores": {"acc": {"value": 0.5}}}}}}},
+        }
+        (tmp_path / "results.yml").write_text(_yaml.dump(results_yml))
+        bundle = build_legacy_bundle("safety-harness:dev", "bbq_small", tmp_path)
+        assert bundle["benchmark"]["repeats"] == 1
 
 
 # ── SkillsEnvironment ───────────────────────────────────────────────────

--- a/tests/test_orchestration/test_orchestrator.py
+++ b/tests/test_orchestration/test_orchestrator.py
@@ -263,3 +263,36 @@ class TestInstallDefaultExecutor:
             assert executor._max_workers == 50
 
         asyncio.run(_runner())
+
+
+class TestBuildBatchConfigEnvVars:
+    """``_build_batch_config`` merges ``cluster.container_env`` (global) under
+    ``solver.env_vars`` (per-benchmark) so users can declare shared env vars
+    once at cluster scope and override per-benchmark when needed."""
+
+    def _container_solver(self, env_vars=None):
+        from nemo_evaluator.config.solvers import ContainerSolverConfig
+
+        return ContainerSolverConfig(service="endpoint", env_vars=env_vars or {})
+
+    def test_cluster_container_env_propagates_for_container_solver(self):
+        from nemo_evaluator.config.clusters import LocalCluster
+        from nemo_evaluator.orchestration.orchestrator import _build_batch_config
+
+        cluster = LocalCluster(container_env={"HF_TOKEN": "tok", "HF_HOME": "/cache"})
+        solver_cfg = self._container_solver()
+        svc = MagicMock(protocol="chat_completions")
+
+        cfg = _build_batch_config("u", "m", None, solver_cfg, svc, cluster=cluster)
+        assert cfg["env_vars"] == {"HF_TOKEN": "tok", "HF_HOME": "/cache"}
+
+    def test_solver_env_vars_override_cluster(self):
+        from nemo_evaluator.config.clusters import LocalCluster
+        from nemo_evaluator.orchestration.orchestrator import _build_batch_config
+
+        cluster = LocalCluster(container_env={"HF_TOKEN": "global", "HF_HOME": "/cache"})
+        solver_cfg = self._container_solver(env_vars={"HF_TOKEN": "per-bench"})
+        svc = MagicMock(protocol="chat_completions")
+
+        cfg = _build_batch_config("u", "m", None, solver_cfg, svc, cluster=cluster)
+        assert cfg["env_vars"] == {"HF_TOKEN": "per-bench", "HF_HOME": "/cache"}

--- a/tests/test_orchestration/test_slurm_legacy_container.py
+++ b/tests/test_orchestration/test_slurm_legacy_container.py
@@ -1,0 +1,806 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for slurm_gen's legacy `container://` direct-dispatch path.
+
+These tests cover the v1 BC bridge generation: when a benchmark uses
+``ContainerSolverConfig`` (``container://image#task``), slurm_gen pre-renders
+``run_config.yaml`` at submit time and emits a single ``srun
+--container-image=<harness>`` step — no nested Pyxis, no ``eval_image`` wrap.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from nemo_evaluator.config import EvalConfig
+from nemo_evaluator.orchestration.slurm_gen import (
+    _render_legacy_run_config,
+    generate_sbatch,
+    write_sbatch,
+)
+
+
+def _legacy_config(
+    output_dir: str,
+    *,
+    with_eval_image: bool = False,
+    with_native_too: bool = False,
+    shards: int | None = None,
+) -> EvalConfig:
+    """Minimal valid config with one container:// benchmark."""
+    cluster: dict = {
+        "type": "slurm",
+        "account": "test-account",
+        "walltime": "00:30:00",
+        "node_pools": {"cpu": {"partition": "cpu", "nodes": 1}},
+    }
+    if with_eval_image:
+        cluster["eval_image"] = "nvcr.io/nemo-evaluator:test"
+    if shards is not None:
+        cluster["shards"] = shards
+
+    benchmarks: list[dict] = [
+        {
+            "name": "container://gitlab.example.com/ns/lm-evaluation-harness:25.11#ifeval",
+            "params": {"limit_samples": 3, "parallelism": 1, "request_timeout": 300},
+            "solver": {
+                "type": "container",
+                "service": "nemotron",
+                "env_vars": {"HF_TOKEN": "hf_xxx", "OPENAI_API_KEY": "sk-xxx"},
+            },
+        }
+    ]
+    if with_native_too:
+        benchmarks.append(
+            {
+                "name": "skills://gsm8k",
+                "solver": {"type": "simple", "service": "nemotron"},
+            }
+        )
+
+    return EvalConfig.model_validate(
+        {
+            "services": {
+                "nemotron": {
+                    "type": "api",
+                    "url": "https://api.example.com/v1/chat/completions",
+                    "protocol": "chat_completions",
+                    "model": "nemotron",
+                    "api_key": "secret-token",
+                }
+            },
+            "benchmarks": benchmarks,
+            "cluster": cluster,
+            "output": {"dir": output_dir},
+        }
+    )
+
+
+def test_legacy_emits_direct_harness_srun_no_nested_wrap(tmp_path: Path):
+    """Container:// benchmark renders one direct srun for the harness, no eval_image wrap."""
+    cfg = _legacy_config(str(tmp_path), with_eval_image=True)
+    script, _sidecars, _secrets = generate_sbatch(cfg)
+
+    # The harness image appears in a srun --container-image step.
+    assert "gitlab.example.com/ns/lm-evaluation-harness:25.11" in script
+    assert "--container-image gitlab.example.com/ns/lm-evaluation-harness:25.11" in script
+    # The eval-factory entrypoint (with nemo-evaluator fallback) is invoked
+    # directly inside that srun, not via `nel eval run`.
+    assert "eval-factory" in script
+    assert "nemo-evaluator" in script
+    # No `nel eval run` command targets the legacy benchmark — that's the
+    # whole point of removing the nested-Pyxis wrap.
+    assert "nel eval run" not in [
+        line.strip()[: len("nel eval run")] for line in script.splitlines() if "container___gitlab" in line
+    ]
+
+
+def test_legacy_pre_renders_run_config_yaml(tmp_path: Path):
+    """write_sbatch materializes run_config.yaml under {out}/{safe_name}/."""
+    cfg = _legacy_config(str(tmp_path))
+    write_sbatch(cfg)
+
+    rc_paths = list(tmp_path.glob("**/run_config.yaml"))
+    assert len(rc_paths) == 1, f"expected one run_config.yaml, got {rc_paths}"
+    rc = yaml.safe_load(rc_paths[0].read_text())
+
+    # Schema sanity: legacy v1 layout, with our solver fields written through.
+    assert rc["config"]["type"] == "ifeval"
+    assert rc["config"]["output_dir"] == "/results"
+    assert rc["config"]["params"]["limit_samples"] == 3
+    assert rc["target"]["api_endpoint"]["url"] == "https://api.example.com/v1/chat/completions"
+    assert rc["target"]["api_endpoint"]["model_id"] == "nemotron"
+    # api_key stays as the env var NAME; the value is injected via
+    # --container-env=NEMO_API_KEY at runtime, never written to disk.
+    assert rc["target"]["api_endpoint"]["api_key_name"] == "NEMO_API_KEY"
+    assert "api_key" not in rc["target"]["api_endpoint"]
+
+
+def test_legacy_rejects_cluster_shards(tmp_path: Path):
+    cfg = _legacy_config(str(tmp_path), shards=2)
+
+    with pytest.raises(ValueError, match=r"cluster\.shards.*container://"):
+        write_sbatch(cfg)
+    with pytest.raises(ValueError, match=r"cluster\.shards.*container://"):
+        generate_sbatch(cfg, shard_idx=0, total_shards=2)
+
+
+def test_legacy_allows_single_shard_noop(tmp_path: Path):
+    cfg = _legacy_config(str(tmp_path), shards=1)
+
+    script_paths, _extras = write_sbatch(cfg)
+
+    assert len(script_paths) == 1
+    assert "shard_0" not in str(script_paths[0])
+
+
+def test_legacy_skips_when_results_already_exist(tmp_path: Path):
+    """Generated sbatch is auto-resume safe: skips harness srun if results.yml exists."""
+    cfg = _legacy_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+    assert 'if [ -f "' in script, "missing auto-resume sentinel check"
+    assert "results.yml" in script, "auto-resume sentinel does not check results.yml"
+    assert "Already complete" in script, "missing 'Already complete' short-circuit message"
+
+
+def test_legacy_omits_api_key_name_when_service_has_no_api_key(tmp_path: Path):
+    """A self-deployed vLLM service has no ``api_key`` field — emitting
+    ``api_key_name: NEMO_API_KEY`` then forces the harness inside the
+    container to ``os.environ["NEMO_API_KEY"]`` (which is unset), and it
+    raises ValueError("the value is not set").  v1 launcher's equivalent
+    is ``api_key_name: null`` → harness skips the env-var lookup.  We
+    mirror that: when the linked service has no resolved api_key, omit
+    ``api_key_name`` from the run_config entirely."""
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "vllm": {
+                    "type": "vllm",
+                    "image": "/srv/vllm.sqsh",
+                    "model": "/srv/model",
+                    "served_model_name": "test",
+                    "protocol": "chat_completions",
+                    "tensor_parallel_size": 1,
+                    "node_pool": "gpu",
+                },
+            },
+            "benchmarks": [
+                {
+                    "name": "container://x/y:1#ifeval",
+                    "params": {"limit_samples": 3},
+                    "solver": {"type": "container", "service": "vllm"},
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "account": "test",
+                "walltime": "00:30:00",
+                "eval_image": "nvcr.io/nel:test",
+                "node_pools": {"gpu": {"partition": "batch", "nodes": 1, "gpus_per_node": 4}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+    write_sbatch(cfg)
+
+    rc_paths = list(tmp_path.glob("**/run_config.yaml"))
+    assert len(rc_paths) == 1
+    rc = yaml.safe_load(rc_paths[0].read_text())
+    assert "api_key_name" not in rc["target"]["api_endpoint"], (
+        f"vLLM service has no api_key → api_key_name must be omitted; got: {rc['target']['api_endpoint']}"
+    )
+
+
+def test_legacy_api_service_without_model_uses_service_name(tmp_path: Path):
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "nemotron": {
+                    "type": "api",
+                    "url": "https://api.example.com/v1/chat/completions",
+                    "protocol": "chat_completions",
+                },
+            },
+            "benchmarks": [
+                {
+                    "name": "container://x/y:1#task",
+                    "solver": {"type": "container", "service": "nemotron"},
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "node_pools": {"cpu": {"partition": "cpu", "nodes": 1}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+
+    rc = _render_legacy_run_config(cfg.benchmarks[0], cfg.services)
+    assert rc["target"]["api_endpoint"]["model_id"] == "nemotron"
+
+
+def test_legacy_secrets_via_container_env_no_inline_values(tmp_path: Path):
+    """Solver env_vars + service api_key flow through .secrets.env, never inline.
+
+    Generated sbatch references env names via --container-env=NAME and
+    re-exports values from secrets via mangled placeholder names; the raw
+    values never appear as `export FOO=value` lines in the script.
+    """
+    cfg = _legacy_config(str(tmp_path))
+    script, _, secrets = generate_sbatch(cfg)
+
+    # Names appear via --container-env flags.
+    assert "--container-env=NEMO_API_KEY" in script
+    assert "--container-env=HF_TOKEN" in script
+    assert "--container-env=OPENAI_API_KEY" in script
+
+    # Raw values are NOT in the script — they live in secrets_content (which
+    # is later written to .secrets.env at 0600 by _write_single_script).
+    assert "secret-token" not in script
+    assert "hf_xxx" not in script
+    assert "sk-xxx" not in script
+    # ... but they ARE in the secrets payload.
+    assert "secret-token" in secrets.secrets_content
+    assert "hf_xxx" in secrets.secrets_content
+    assert "sk-xxx" in secrets.secrets_content
+
+
+def test_legacy_mounts_run_config_and_results_dir(tmp_path: Path):
+    """Generated srun bind-mounts the pre-rendered run_config.yaml and results dir."""
+    cfg = _legacy_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+
+    # run_config.yaml is mounted read-only at /config/run_config.yaml
+    assert ":/config/run_config.yaml:ro" in script
+    # The output bench dir houses both the run_config and results subdir
+    assert "/run_config.yaml:/config/run_config.yaml:ro" in script
+    assert "/results:/results" in script
+
+
+def test_mixed_legacy_and_native_routes_each_correctly(tmp_path: Path):
+    """A config with both container:// and native benches emits two distinct shapes."""
+    cfg = _legacy_config(str(tmp_path), with_eval_image=True, with_native_too=True)
+    script, sidecars, _ = generate_sbatch(cfg)
+
+    # Native bench gets a sidecar (nel runs on compute for it).
+    assert "skills___gsm8k" in sidecars
+    # Legacy bench does not.
+    assert not any("ifeval" in k for k in sidecars)
+    # Both images are referenced.
+    assert "lm-evaluation-harness:25.11" in script
+    # The native bench routes through nel-next inside eval_image.
+    assert "nvcr.io/nemo-evaluator:test" in script
+    assert "nel eval run" in script
+
+
+def test_legacy_export_runs_without_report_generation(tmp_path: Path):
+    cfg = _legacy_config(str(tmp_path))
+    cfg.output.report = []
+    cfg.output.export = ["mlflow"]
+    cfg.output.export_config = {"mlflow": {"tracking_uri": "file:///tmp/mlflow"}}
+
+    scripts, extras = write_sbatch(cfg)
+    script = scripts[0].read_text(encoding="utf-8")
+
+    assert "nel eval report" not in script
+    assert (
+        'nel export "$OUTPUT_DIR" --dest mlflow --config "$OUTPUT_DIR/export_config.yaml" --output-dir "$OUTPUT_DIR"'
+        in script
+    )
+    export_config_path = tmp_path / "export_config.yaml"
+    assert export_config_path in extras
+    assert export_config_path.exists()
+    assert export_config_path.stat().st_mode & 0o777 == 0o600
+    assert yaml.safe_load(export_config_path.read_text()) == cfg.output.export_config
+
+
+def test_native_slurm_export_is_not_emitted_by_legacy_bridge(tmp_path: Path):
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "nemotron": {
+                    "type": "api",
+                    "url": "https://api.example.com/v1/chat/completions",
+                    "protocol": "chat_completions",
+                    "model": "nemotron",
+                }
+            },
+            "benchmarks": [
+                {
+                    "name": "gsm8k",
+                    "solver": {"type": "simple", "service": "nemotron"},
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "account": "test-account",
+                "walltime": "00:30:00",
+                "node_pools": {"cpu": {"partition": "cpu", "nodes": 1}},
+            },
+            "output": {
+                "dir": str(tmp_path),
+                "export": ["mlflow"],
+                "export_config": {"mlflow": {"tracking_uri": "file:///tmp/mlflow"}},
+            },
+        }
+    )
+
+    scripts, extras = write_sbatch(cfg)
+    script = scripts[0].read_text(encoding="utf-8")
+
+    assert "nel export" not in script
+    export_config_path = tmp_path / "export_config.yaml"
+    assert export_config_path not in extras
+    assert not export_config_path.exists()
+
+
+def _service_pre_cmd_config(output_dir: str) -> EvalConfig:
+    """Multi-node vllm service with a user-supplied ``pre_cmd``.
+
+    Stand-in for a v1 launcher gym deployment ports — the user owns the
+    full service-side script (vLLM startup, fake health, gym poll-execute).
+    """
+    return EvalConfig.model_validate(
+        {
+            "services": {
+                "vllm_ray": {
+                    "type": "vllm",
+                    "image": "/srv/vllm.sqsh",
+                    "model": "/srv/model",
+                    "served_model_name": "test-model",
+                    "protocol": "chat_completions",
+                    "tensor_parallel_size": 4,
+                    "data_parallel_size": 8,
+                    "num_nodes": 8,
+                    "pre_cmd": "#!/bin/bash\nFAKE_HEALTH_PLACEHOLDER\nVLLM_PLACEHOLDER\nGYM_DANCE_PLACEHOLDER",
+                    "node_pool": "gpu",
+                },
+            },
+            "benchmarks": [
+                {
+                    "name": "container:///srv/nemo-gym.sqsh#nemo_gym",
+                    "solver": {
+                        "type": "container",
+                        "service": "vllm_ray",
+                    },
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "account": "test",
+                "walltime": "01:00:00",
+                "eval_image": "nvcr.io/nel:test",
+                "mount_home": False,
+                "node_pools": {"gpu": {"partition": "batch", "nodes": 8, "gpus_per_node": 4}},
+            },
+            "output": {"dir": output_dir},
+        }
+    )
+
+
+def test_pre_cmd_replaces_default_service_command(tmp_path: Path):
+    """When ``pre_cmd`` is set, the script file the service execs contains
+    only the user's script — no implicit ``vllm serve …`` line, no
+    ``set -euo pipefail`` prefix."""
+    cfg = _service_pre_cmd_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+
+    # User markers present.
+    assert "FAKE_HEALTH_PLACEHOLDER" in script
+    assert "VLLM_PLACEHOLDER" in script
+    assert "GYM_DANCE_PLACEHOLDER" in script
+    # Default vllm command absent — `vllm serve <model> --port …`.
+    # (The echo line "...Ray vllm server..." contains the substring "vllm s",
+    # so we look for the actual command form.)
+    assert "vllm serve /model --port 8000" not in script
+    # set -euo pipefail prefix not added (user controls error semantics).
+    # (We allow `set -uo pipefail` in the sbatch header — that's nel-next's,
+    # not the per-service script.)
+    svc_block_start = script.index("FAKE_HEALTH_PLACEHOLDER")
+    # Walk back to the start of the heredoc and verify no `set -euo` line.
+    heredoc_window = script[max(0, svc_block_start - 200) : svc_block_start]
+    assert "set -euo pipefail" not in heredoc_window
+
+
+def test_pre_cmd_keeps_default_health_check(tmp_path: Path):
+    """``pre_cmd`` is the user's escape hatch for service startup, but
+    nel-next still polls ``/health`` to gate the eval container.  That
+    curl is the coordination signal v1 launcher's fake-health pattern
+    relies on — one shot to unblock fake-health, then vLLM takes over
+    port 8000.  Skipping it would leave fake-health on the port and
+    crash vLLM."""
+    cfg = _service_pre_cmd_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+    assert "Skipping health check for vllm_ray (pre_cmd controls readiness)" not in script
+    assert 'curl -sf "http://localhost:8000/health"' in script
+
+
+def test_pre_cmd_propagates_nel_invocation_id(tmp_path: Path):
+    """``NEL_INVOCATION_ID`` is exported in the sbatch header (so siblings
+    in the auto-resume chain share the value) and forwarded into every
+    Pyxis container via ``--container-env``."""
+    cfg = _service_pre_cmd_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+
+    # Exported once in the header with a hex token (not the literal placeholder).
+    matches = re.findall(r"^export NEL_INVOCATION_ID=([0-9a-f]+)$", script, re.MULTILINE)
+    assert len(matches) == 1, f"expected exactly one NEL_INVOCATION_ID export, found {matches}"
+    assert len(matches[0]) == 32, f"expected uuid hex (32 chars), got {matches[0]!r}"
+    # Forwarded into containers (we don't assert exact count — at least one
+    # service-block srun and one eval-container srun should reference it).
+    assert script.count("--container-env=NEL_INVOCATION_ID") >= 2
+
+
+def test_solver_env_vars_broadcast_to_service_container_for_legacy_bench(tmp_path: Path):
+    """v1 launcher's ``env_vars:`` block is container-agnostic — values reach
+    both deployment and evaluation containers.  Our nel-next mirror is
+    ``solver.env_vars`` on a container:// benchmark.  When that benchmark's
+    linked service has its own container (vllm/sglang/gym Pattern A),
+    ``solver.env_vars`` MUST reach the service container too, otherwise a
+    user's gym deployment script that expands ``$INFERENCE_API_KEY`` etc.
+    silently sees an empty string.
+    """
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "vllm_ray": {
+                    "type": "vllm",
+                    "image": "/srv/vllm.sqsh",
+                    "model": "/srv/model",
+                    "served_model_name": "test",
+                    "protocol": "chat_completions",
+                    "tensor_parallel_size": 4,
+                    "num_nodes": 2,
+                    "pre_cmd": "#!/bin/bash\necho $INFERENCE_API_KEY\n",
+                    "node_pool": "gpu",
+                },
+            },
+            "benchmarks": [
+                {
+                    "name": "container:///srv/nemo-gym.sqsh#nemo_gym",
+                    "solver": {
+                        "type": "container",
+                        "service": "vllm_ray",
+                        "env_vars": {"INFERENCE_API_KEY": "v1-style-key"},
+                    },
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "account": "test",
+                "walltime": "01:00:00",
+                "eval_image": "nvcr.io/nel:test",
+                "node_pools": {"gpu": {"partition": "batch", "nodes": 2, "gpus_per_node": 4}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+    script, _, _ = generate_sbatch(cfg)
+    # The service srun is the multi-node one; both that and the eval srun
+    # should advertise INFERENCE_API_KEY via --container-env.
+    svc_lines = [
+        line for line in script.splitlines() if "srun --mpi=pmix --overlap --mem=0" in line and "vllm.sqsh" in line
+    ]
+    assert svc_lines, "expected vllm_ray service srun line"
+    assert any("--container-env=INFERENCE_API_KEY" in line for line in svc_lines), (
+        "solver.env_vars must broadcast to the service container srun (v1 env_vars semantics); "
+        f"got service srun heads: {svc_lines!r}"
+    )
+
+
+def test_pre_cmd_does_not_affect_default_service(tmp_path: Path):
+    """Sanity: services without ``pre_cmd`` still get the default vllm/sglang
+    template + health wait."""
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "vllm": {
+                    "type": "vllm",
+                    "image": "/srv/vllm.sqsh",
+                    "model": "/srv/model",
+                    "served_model_name": "test",
+                    "protocol": "chat_completions",
+                    "tensor_parallel_size": 1,
+                    "node_pool": "gpu",
+                },
+            },
+            "benchmarks": [
+                {
+                    "name": "skills://gsm8k",
+                    "solver": {"type": "simple", "service": "vllm"},
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "account": "test",
+                "walltime": "01:00:00",
+                "eval_image": "nvcr.io/nel:test",
+                "node_pools": {"gpu": {"partition": "batch", "nodes": 1, "gpus_per_node": 4}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+    script, _, _ = generate_sbatch(cfg)
+    assert "vllm serve" in script
+    # Default health-wait is emitted (we look for the curl probe).
+    assert 'curl -sf "http://localhost:8000/health"' in script
+    assert "Skipping health check" not in script
+
+
+def test_legacy_pins_to_master_ip_when_dependent_service_is_multinode(tmp_path: Path):
+    """When a legacy ``container://`` benchmark depends on a multi-node
+    service (e.g. vLLM with num_nodes>1), the harness srun must include
+    ``-w $MASTER_IP`` so it lands on the same node as the service head.
+    Pyxis on the same node shares the host network, so the eval-factory
+    adapter proxy on 127.0.0.1:<port> in the harness container is then
+    reachable from the service container's loopback (where, e.g., the
+    gym CLI's HTTP client runs).  Without this, the harness drifts to a
+    worker node and the cross-container loopback connect fails."""
+    cfg = _service_pre_cmd_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+
+    # The legacy block contains exactly one harness srun per benchmark.
+    # We look for the srun line on its own (continuation backslashes split
+    # the rest across follow-up lines, so we only need to match the head).
+    srun_heads = [
+        line
+        for line in script.splitlines()
+        if "srun --mpi=pmix --overlap --unbuffered" in line and "--ntasks 1" in line
+    ]
+    assert srun_heads, "expected at least one srun head line in the script"
+    # At least one must carry ``-w $MASTER_IP`` (the legacy harness srun for
+    # the multi-node-service-dependent benchmark).
+    assert any("-w $MASTER_IP" in line for line in srun_heads), (
+        f"expected ``-w $MASTER_IP`` on a srun head when bench depends on multi-node service; got: {srun_heads!r}"
+    )
+
+
+def test_service_gets_legacy_results_dir_mount(tmp_path: Path):
+    """When a legacy ``container://`` benchmark depends on a service, the
+    service container's srun must mount the bench's results dir at
+    ``/results`` — otherwise harness writes from ``pre_cmd`` (gym
+    Pattern A) land in ephemeral container storage and the eval-factory
+    output parser sees an empty dir.  v1 launcher does this implicitly
+    (executors/slurm/executor.py:826-828)."""
+    cfg = _service_pre_cmd_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+
+    # Find the service-block srun (rl image is the marker in this fixture).
+    svc_lines = [
+        line for line in script.splitlines() if "srun --mpi=pmix --overlap --mem=0" in line and "vllm.sqsh" in line
+    ]
+    assert svc_lines, "expected vllm_ray service srun head line"
+    # Match the literal "<host_path_to_bench>/results:/results" tail.
+    expected_fragment = "/results:/results"
+    matched = any(expected_fragment in line for line in svc_lines)
+    assert matched, (
+        "service srun must include a legacy bench's <results_dir>:/results bind mount; got srun heads:\n  "
+        + "\n  ".join(svc_lines)
+    )
+
+
+def test_service_no_legacy_mount_when_no_legacy_bench(tmp_path: Path):
+    """Regression guard: services without any dependent legacy benchmark
+    must NOT get a spurious ``/results`` bind from this code path.  Native
+    benchmarks own their own mounts via the eval container."""
+    # Use a config that has only a native (non-container://) benchmark.
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "vllm": {
+                    "type": "vllm",
+                    "image": "/srv/vllm.sqsh",
+                    "model": "/srv/model",
+                    "served_model_name": "test",
+                    "protocol": "chat_completions",
+                    "tensor_parallel_size": 1,
+                    "node_pool": "gpu",
+                },
+            },
+            "benchmarks": [
+                {"name": "skills://gsm8k", "solver": {"type": "simple", "service": "vllm"}},
+            ],
+            "cluster": {
+                "type": "slurm",
+                "account": "test",
+                "walltime": "01:00:00",
+                "eval_image": "nvcr.io/nel:test",
+                "node_pools": {"gpu": {"partition": "batch", "nodes": 1, "gpus_per_node": 4}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+    script, _, _ = generate_sbatch(cfg)
+    svc_lines = [
+        line for line in script.splitlines() if "srun --mpi=pmix --overlap --mem=0" in line and "vllm.sqsh" in line
+    ]
+    assert svc_lines, "expected vllm service srun head line"
+    for line in svc_lines:
+        # No `<...>/results:/results` bind on the service srun for
+        # native-only configs.
+        assert "/results:/results" not in line, (
+            f"native-only config must not get a /results bind on the service srun; got: {line!r}"
+        )
+
+
+def test_legacy_no_master_ip_pin_when_service_is_single_node(tmp_path: Path):
+    """Regression guard: the ``-w $MASTER_IP`` flag must NOT appear on the
+    legacy srun for a single-node service.  Single-node services run on
+    the sbatch's only node anyway; pinning would be redundant and could
+    fail in pools with strict node selection."""
+    cfg = _legacy_config(str(tmp_path))
+    script, _, _ = generate_sbatch(cfg)
+
+    srun_heads = [
+        line
+        for line in script.splitlines()
+        if "srun --mpi=pmix --overlap --unbuffered" in line and "--ntasks 1" in line
+    ]
+    assert srun_heads, "expected at least one srun head line"
+    for line in srun_heads:
+        assert "-w $MASTER_IP" not in line, (
+            f"-w $MASTER_IP must not appear when service deps are single-node; got: {line!r}"
+        )
+
+
+def test_legacy_dedups_overlapping_mounts(tmp_path: Path):
+    """If a user declares the same ``host:container`` mount in both
+    ``cluster.container_mounts`` AND ``solver.mounts`` (easy to do when
+    porting a v1 hydra config that has overlapping deployment/evaluation
+    mount lists), Pyxis sees the same mount twice on the srun command and
+    behaviour is undefined.  Dedupe so the mount appears once."""
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "nemotron": {
+                    "type": "api",
+                    "url": "https://api.example.com/v1/chat/completions",
+                    "protocol": "chat_completions",
+                    "model": "nemotron",
+                    "api_key": "tok",
+                },
+            },
+            "benchmarks": [
+                {
+                    "name": "container://x/y:1#task",
+                    "solver": {
+                        "type": "container",
+                        "service": "nemotron",
+                        "mounts": {"/srv/shared": "/srv/shared"},
+                    },
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "account": "test",
+                "walltime": "00:30:00",
+                "container_mounts": ["/srv/shared:/srv/shared"],
+                "node_pools": {"cpu": {"partition": "cpu", "nodes": 1}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+    script, _, _ = generate_sbatch(cfg)
+    # Find the --container-mounts= line(s) for the legacy srun and verify
+    # the duplicated mount only appears once.
+    mount_lines = [line for line in script.splitlines() if "--container-mounts=" in line and "/srv/shared" in line]
+    assert mount_lines, "expected at least one --container-mounts= line carrying /srv/shared"
+    for line in mount_lines:
+        mounts_arg = line.split("--container-mounts=")[1].split(" ")[0].rstrip("\\,")
+        assert mounts_arg.count("/srv/shared:/srv/shared") == 1, (
+            f"mount appears multiple times — dedup missing; got mounts arg: {mounts_arg!r}"
+        )
+
+
+def test_legacy_rejects_incompatible_service_type_at_config_load(tmp_path: Path):
+    """A container:// benchmark needs a chat/completions endpoint.
+    Pointing it at a ``type: gym`` (resource server) raises a clear
+    ValueError at ``EvalConfig.model_validate`` time — before any sbatch
+    rendering — so users see the misconfiguration immediately rather
+    than after submit produces a broken ``run_config.yaml`` with empty
+    ``model_id``."""
+    with pytest.raises(ValueError, match="requires a model service"):
+        EvalConfig.model_validate(
+            {
+                "services": {
+                    "tool_server": {
+                        "type": "gym",
+                        "benchmark": "calendar",
+                        "port": 9090,
+                    },
+                },
+                "benchmarks": [
+                    {
+                        "name": "container://x/y:1#task",
+                        "solver": {"type": "container", "service": "tool_server"},
+                    }
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "node_pools": {"cpu": {"partition": "cpu", "nodes": 1}},
+                },
+                "output": {"dir": str(tmp_path)},
+            }
+        )
+
+
+def test_legacy_rejects_service_proxy_on_slurm_submit(tmp_path: Path):
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "nemotron": {
+                    "type": "api",
+                    "url": "https://api.example.com/v1/chat/completions",
+                    "protocol": "chat_completions",
+                    "model": "nemotron",
+                    "proxy": {"extra_body": {"thinking": True}},
+                },
+            },
+            "benchmarks": [
+                {
+                    "name": "container://x/y:1#task",
+                    "solver": {"type": "container", "service": "nemotron"},
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "node_pools": {"cpu": {"partition": "cpu", "nodes": 1}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+
+    with pytest.raises(ValueError, match=r"adapter proxy.*solver.adapter_config"):
+        generate_sbatch(cfg)
+
+
+def test_render_legacy_run_config_handles_managed_service(tmp_path: Path):
+    """Managed model server (vllm) resolves to localhost URL with protocol suffix."""
+    cfg = EvalConfig.model_validate(
+        {
+            "services": {
+                "vllm-svc": {
+                    "type": "vllm",
+                    "model": "/path/model.bin",
+                    "protocol": "completions",
+                    "tensor_parallel_size": 1,
+                    "port": 9000,
+                    "node_pool": "cpu",
+                }
+            },
+            "benchmarks": [
+                {
+                    "name": "container://x/y:1#task",
+                    "solver": {
+                        "type": "container",
+                        "service": "vllm-svc",
+                    },
+                }
+            ],
+            "cluster": {
+                "type": "slurm",
+                "node_pools": {"cpu": {"partition": "cpu", "nodes": 1}},
+            },
+            "output": {"dir": str(tmp_path)},
+        }
+    )
+    rc = _render_legacy_run_config(cfg.benchmarks[0], cfg.services)
+    assert rc["target"]["api_endpoint"]["url"].startswith("http://localhost:9000/v1")
+    assert rc["target"]["api_endpoint"]["url"].endswith("/completions")
+    assert rc["target"]["api_endpoint"]["type"] == "completions"
+
+
+def test_legacy_generated_script_is_bash_clean(tmp_path: Path):
+    """Run `bash -n` on the generated script to confirm syntactic correctness."""
+    cfg = _legacy_config(str(tmp_path), with_eval_image=True)
+    script, _, _ = generate_sbatch(cfg)
+    bash_path = shutil.which("bash")
+    assert bash_path is not None, "bash not found in PATH"
+    proc = subprocess.run([bash_path, "-n"], input=script.encode(), capture_output=True, check=False)
+    assert proc.returncode == 0, f"bash -n failed: {proc.stderr.decode()}"

--- a/tests/test_orchestration/test_ssh_executor.py
+++ b/tests/test_orchestration/test_ssh_executor.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the SSH-based remote SLURM submission helpers.
+
+The functions under test shell out to ``ssh`` / ``scp`` so we patch
+``_ssh`` and ``_scp`` and assert on the calls they would have made.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from nemo_evaluator.executors import ssh as ssh_mod
+
+
+def _record_calls():
+    ssh_calls: list[tuple] = []
+    scp_calls: list[tuple] = []
+
+    def fake_ssh(target, cmd, *args, **kwargs):
+        ssh_calls.append((target, cmd))
+        return ""
+
+    def fake_scp(local_path, remote_dest, target, *args, **kwargs):
+        scp_calls.append((local_path, remote_dest, target))
+        return ""
+
+    return ssh_calls, scp_calls, fake_ssh, fake_scp
+
+
+def test_copy_to_remote_local_base_preserves_subdir_structure(tmp_path: Path):
+    """When local_base is set, files in subdirs are copied to matching
+    remote subdirs (not flattened).  Critical for legacy container://
+    benchmarks that drop a ``run_config.yaml`` under ``{staging}/{safe_name}/``.
+    """
+    sbatch = tmp_path / "nel_eval.sbatch"
+    sbatch.write_text("#!/bin/bash\n")
+    secrets = tmp_path / ".secrets.env"
+    secrets.write_text("FOO=bar\n")
+    sub = tmp_path / "container_xyz"
+    sub.mkdir()
+    sidecar = sub / "run_config.yaml"
+    sidecar.write_text("config: {}\n")
+
+    ssh_calls, scp_calls, fake_ssh, fake_scp = _record_calls()
+    with patch.object(ssh_mod, "_ssh", side_effect=fake_ssh), patch.object(ssh_mod, "_scp", side_effect=fake_scp):
+        ssh_mod.copy_to_remote(
+            hostname="loginhost",
+            local_paths=[sbatch, secrets, sidecar],
+            remote_dir="/srv/run/abc",
+            local_base=tmp_path,
+        )
+
+    # subdir mkdir was issued before scp.
+    mkdir_cmds = [c[1] for c in ssh_calls if "mkdir -p" in c[1]]
+    assert any("/srv/run/abc/container_xyz" in c for c in mkdir_cmds), mkdir_cmds
+
+    scp_dests = [c[1] for c in scp_calls]
+    assert "loginhost:/srv/run/abc/nel_eval.sbatch" in scp_dests
+    assert "loginhost:/srv/run/abc/.secrets.env" in scp_dests
+    assert "loginhost:/srv/run/abc/container_xyz/run_config.yaml" in scp_dests
+
+
+def test_copy_to_remote_without_local_base_flattens(tmp_path: Path):
+    """Default behavior (no local_base): everything lands directly under
+    remote_dir.  Preserves backwards compat for callers that pass siblings
+    only and don't care about subdir structure."""
+    a = tmp_path / "a.txt"
+    a.write_text("a")
+    b = tmp_path / "b.txt"
+    b.write_text("b")
+
+    _, scp_calls, fake_ssh, fake_scp = _record_calls()
+    with patch.object(ssh_mod, "_ssh", side_effect=fake_ssh), patch.object(ssh_mod, "_scp", side_effect=fake_scp):
+        ssh_mod.copy_to_remote(
+            hostname="loginhost",
+            local_paths=[a, b],
+            remote_dir="/srv/run/abc",
+        )
+
+    scp_dests = [c[1] for c in scp_calls]
+    # No filename appended — old behavior puts files into the dir.
+    assert all(d == "loginhost:/srv/run/abc/" for d in scp_dests), scp_dests
+
+
+def test_submit_eval_propagates_local_base(tmp_path: Path):
+    """submit_eval forwards ``local_base`` to copy_to_remote so nested
+    sidecars don't get flattened on the way up."""
+    sbatch = tmp_path / "nel_eval.sbatch"
+    sbatch.write_text("#!/bin/bash\n")
+    sub = tmp_path / "bench_x"
+    sub.mkdir()
+    sidecar = sub / "run_config.yaml"
+    sidecar.write_text("k: v\n")
+
+    captured: dict = {}
+
+    def fake_copy(hostname, local_paths, remote_dir, username=None, local_base=None):
+        captured["hostname"] = hostname
+        captured["local_paths"] = list(local_paths)
+        captured["remote_dir"] = remote_dir
+        captured["local_base"] = local_base
+
+    def fake_submit(hostname, remote_script, username=None):
+        return "12345"
+
+    with (
+        patch.object(ssh_mod, "copy_to_remote", side_effect=fake_copy),
+        patch.object(ssh_mod, "submit_sbatch", side_effect=fake_submit),
+    ):
+        meta = ssh_mod.submit_eval(
+            script_path=sbatch,
+            hostname="loginhost",
+            remote_dir="/srv/run/abc",
+            extra_files=[sidecar],
+            local_base=tmp_path,
+        )
+
+    assert captured["local_base"] == tmp_path
+    assert sbatch in captured["local_paths"]
+    assert sidecar in captured["local_paths"]
+    assert meta["job_id"] == "12345"

--- a/tests/test_serving/test_export_cli.py
+++ b/tests/test_serving/test_export_cli.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 
 import pytest
+import yaml
 from click.testing import CliRunner
 
 from nemo_evaluator.cli.export import _parse_override, _parse_value, export_cmd
@@ -277,6 +278,81 @@ class TestCLI:
         assert result.exit_code == 0, result.output
         benchmark_names = {b["benchmark"]["name"] for b in captured["bundles"]}
         assert benchmark_names == {"gsm8k", "mmlu"}
+
+    def test_legacy_results_are_materialized_before_export(self, tmp_path, monkeypatch):
+        captured = {}
+
+        class _FakeExporter:
+            def __init__(self, **kwargs):
+                pass
+
+            def export(self, bundles, config=None):
+                captured["bundles"] = bundles
+
+        monkeypatch.setattr(
+            "nemo_evaluator.engine.exporters.get_exporter",
+            lambda name, **kw: _FakeExporter(**kw),
+        )
+
+        run = tmp_path / "legacy-run"
+        bench_dir = run / "container___legacy"
+        results_dir = bench_dir / "results"
+        results_dir.mkdir(parents=True)
+        (bench_dir / "run_config.yaml").write_text(
+            yaml.dump({"config": {"type": "ifeval", "output_dir": "/results"}}),
+            encoding="utf-8",
+        )
+        (results_dir / "results.yml").write_text(
+            yaml.dump(
+                {
+                    "results": {
+                        "tasks": {
+                            "ifeval": {
+                                "metrics": {
+                                    "prompt_level": {
+                                        "scores": {
+                                            "strict_acc": {
+                                                "value": 0.75,
+                                                "stats": {"count": 4},
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        output_dir = results_dir / "eval-results" / "ifeval"
+        output_dir.mkdir(parents=True)
+        (output_dir / "output.jsonl").write_text(
+            "\n".join(
+                json.dumps({"problem_idx": i, "problem": f"p{i}", "generation": f"g{i}", "symbolic_correct": i < 3})
+                for i in range(4)
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(export_cmd, [str(run), "--dest", "mlflow", "-o", "tracking_uri=http://x"])
+
+        assert result.exit_code == 0, result.output
+        assert list(bench_dir.glob("eval-*.json"))
+        assert (bench_dir / "results.jsonl").read_text(encoding="utf-8").count("\n") == 4
+        assert captured["bundles"][0]["benchmark"]["name"] == "container/ifeval"
+        assert captured["bundles"][0]["benchmark"]["samples"] == 4
+        assert [row["reward"] for row in captured["bundles"][0]["_results"]] == [1.0, 1.0, 1.0, 0.0]
+
+        (bench_dir / "results.jsonl").write_text("", encoding="utf-8")
+        captured.clear()
+        result = runner.invoke(export_cmd, [str(run), "--dest", "mlflow", "-o", "tracking_uri=http://x"])
+
+        assert result.exit_code == 0, result.output
+        assert (bench_dir / "results.jsonl").read_text(encoding="utf-8").count("\n") == 4
+        assert len(captured["bundles"][0]["_results"]) == 4
 
     def test_output_dir_is_run_dir_not_bench_dir(self, tmp_path, monkeypatch):
         """Regression: ``output_dir`` must be the run dir (parent of the bench

--- a/tests/test_serving/test_report.py
+++ b/tests/test_serving/test_report.py
@@ -20,6 +20,7 @@ import pytest
 from click.testing import CliRunner
 
 from nemo_evaluator.cli.report import report_cmd
+from nemo_evaluator.reports.eval import _primary_metric
 
 
 @pytest.fixture
@@ -72,6 +73,29 @@ class TestReportCommand:
         data = json.loads(result.output)
         assert data["n_benchmarks"] == 2
 
+    def test_run_directory_discovers_benchmark_subdirectories(self, tmp_path):
+        run_dir = tmp_path / "run"
+        bench_dir = run_dir / "gsm8k"
+        bench_dir.mkdir(parents=True)
+        bundle = {
+            "run_id": "eval-gsm8k",
+            "config": {"model": "test-model"},
+            "benchmark": {
+                "name": "gsm8k",
+                "samples": 100,
+                "repeats": 1,
+                "scores": {"pass@1": {"value": 0.85}},
+            },
+        }
+        (bench_dir / "eval-gsm8k.json").write_text(json.dumps(bundle))
+
+        runner = CliRunner()
+        result = runner.invoke(report_cmd, [str(run_dir)])
+
+        assert result.exit_code == 0
+        assert "gsm8k" in result.output
+        assert "0.8500" in result.output
+
     def test_write_to_file(self, bundle_dir, tmp_path):
         out = tmp_path / "report.md"
         runner = CliRunner()
@@ -79,3 +103,97 @@ class TestReportCommand:
         assert result.exit_code == 0
         assert out.exists()
         assert "gsm8k" in out.read_text()
+
+
+class TestPrimaryMetricFallback:
+    """``_primary_metric`` falls back to the first scored metric when no
+    canonical ``mean_reward``/``pass@1`` is present (legacy container
+    bundles surface harness-specific metric names)."""
+
+    # nemo-skills math containers emit BOTH a quality metric (symbolic_correct)
+    # and a timing metric (gen_seconds) under the same pass@1 group.  Insertion
+    # order puts gen_seconds first, so the naïve "first scored metric" fallback
+    # would surface latency as the headline — actively misleading.  Fallback
+    # must skip timing-flavored leaves.
+    @pytest.mark.parametrize(
+        "row, expected",
+        [
+            pytest.param(
+                {
+                    "samples": 3,
+                    "repeats": 1,
+                    "ifeval/inst_level_loose_acc": {"value": 0.6},
+                    "ifeval/prompt_level_strict_acc": {"value": 0.3333},
+                },
+                ("ifeval/inst_level_loose_acc", 0.6),
+                id="legacy_names",
+            ),
+            pytest.param(
+                {
+                    "samples": 3,
+                    "repeats": 1,
+                    "categories": {"x": "y"},
+                    "total_tokens": 100,
+                    "latency_p50_ms": 50,
+                    "scorer:foo": {"value": 0.5},
+                    "real_metric": {"value": 0.9},
+                },
+                ("real_metric", 0.9),
+                id="skip_non_metric_keys",
+            ),
+            pytest.param(
+                {
+                    "samples": 3,
+                    "repeats": 1,
+                    "hmmt_feb25/pass@1/gen_seconds": {"value": 140.0},
+                    "hmmt_feb25/pass@1/symbolic_correct": {"value": 100.0},
+                },
+                ("hmmt_feb25/pass@1/symbolic_correct", 100.0),
+                id="skip_timing_flavored",
+            ),
+            pytest.param(
+                {
+                    "samples": 3,
+                    "repeats": 1,
+                    "hmmt_feb25/pass@1/gen_seconds": {"value": 140.0},
+                    "hmmt_feb25/pass@1/latency_ms": {"value": 2500.0},
+                    "hmmt_feb25/pass@1/output_tokens": {"value": 512.0},
+                },
+                ("", None),
+                id="timing_only",
+            ),
+        ],
+    )
+    def test_primary_metric(self, row, expected):
+        expected_name, expected_value = expected
+        name, m = _primary_metric(row)
+        assert name == expected_name
+        if expected_value is None:
+            assert m == {}
+        else:
+            assert m["value"] == expected_value
+
+    def test_legacy_bundle_renders_score_in_markdown(self, tmp_path):
+        """End-to-end: a bundle whose only scores are ifeval-style
+        metric names renders a numeric headline in markdown output."""
+        bundle = {
+            "run_id": "eval-container-ifeval",
+            "config": {"model": "test"},
+            "benchmark": {
+                "name": "container/ifeval",
+                "samples": 3,
+                "repeats": 1,
+                "scores": {
+                    "ifeval/inst_level_loose_acc/inst_level_loose_acc": {"value": 0.6},
+                    "ifeval/prompt_level_strict_acc/prompt_level_strict_acc": {"value": 0.3333},
+                },
+            },
+        }
+        (tmp_path / "eval-container-ifeval.json").write_text(json.dumps(bundle))
+        runner = CliRunner()
+        result = runner.invoke(report_cmd, [str(tmp_path)])
+        assert result.exit_code == 0
+        assert "container/ifeval" in result.output
+        # The fallback should surface 0.6000 (the first metric); without
+        # the fallback this row would render "| ... | - | 3 | - | |".
+        assert "0.6000" in result.output


### PR DESCRIPTION
Add `ContainerEnvironment` to run legacy eval-factory containers as opaque boxes via the `container://image#task` URI scheme.  NEL pre-renders a v1-format `run_config.yaml`, mounts it at `/config/run_config.yaml`, and dispatches the container's `nemo-evaluator run_eval` entrypoint either via local `docker run` or in-job `srun --container-image` (under `--submit`).

Includes:
- `ContainerEnvironment` + module-level helpers (`build_legacy_run_config`, `parse_legacy_results`) so `slurm_gen` can pre-render at submit time
- SLURM dispatch path for `container://` benchmarks + `service.pre_cmd` field for user-supplied service-side scripts
- `cluster.container_env` propagation on local-cluster path (was a no-op before — only SLURM / docker dispatch paths honored it)
- `ContainerSolverConfig` schema aligned with codebase
- Guard against nel-next adapter proxies on ContainerSolverConfig
- SSH executor: ship nested sidecar dirs on `--submit`
- Tests: legacy container BC dispatch, SSH executor, env-var propagation, CLI
- Walkthrough Section 14: generic `container://` schema example