### PR TITLE
feat: Add new error type SOLVE_TIMEOUT

### DIFF
--- a/docs/evaluation/scoring.md
+++ b/docs/evaluation/scoring.md
@@ -172,6 +172,8 @@ The `ArtifactCollector` categorizes failures automatically:
 
 | Category | Detection |
 |----------|-----------|
+| `infra_error` | `scoring_details.error_category == "infra_error"` (set when the solver raises `InfraError` or returns `error_kind=ErrorKind.INFRA`) |
+| `solve_timeout` | `scoring_details.error_category == "solve_timeout"` (set when the solver returns `error_kind=ErrorKind.SOLVE_TIMEOUT` after `agent.run()` exceeded the wall-clock budget; verifier still runs on the partial workspace) |
 | `timeout` | Model error contains "timeout" |
 | `rate_limit` | Model error contains "429" or "rate" |
 | `refusal` | Response contains "I cannot", "I'm sorry" |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,10 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/nemo_evaluator"]
 
+# registry_overrides lives outside src/ (and is renamed), so it needs an explicit
+# force-include. Data files under src/nemo_evaluator/ (templates, playbooks, …) are
+# already bundled by the `packages` entry above — re-listing them here would add the
+# same archive path twice, which newer hatchling rejects.
 [tool.hatch.build.targets.wheel.force-include]
 "harbor_datasets/registry_overrides" = "nemo_evaluator/_registry_overrides"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,10 +100,6 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/nemo_evaluator"]
 
-# registry_overrides lives outside src/ (and is renamed), so it needs an explicit
-# force-include. Data files under src/nemo_evaluator/ (templates, playbooks, …) are
-# already bundled by the `packages` entry above — re-listing them here would add the
-# same archive path twice, which newer hatchling rejects.
 [tool.hatch.build.targets.wheel.force-include]
 "harbor_datasets/registry_overrides" = "nemo_evaluator/_registry_overrides"
 

--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -330,6 +330,7 @@ async def run_evaluation(
                 model_stats: dict[str, Any] | None = None
                 step.model_error = None
                 vr = None
+                _is_solve_timeout = False
 
                 outside_eps: list[OutsideEndpoint] = []
                 step_session_id = uuid4().hex[:16] if model_url else None
@@ -383,6 +384,8 @@ async def run_evaluation(
                                 step.model_ms = solve_result.model_response.latency_ms
                             if solve_result.error_kind == ErrorKind.INFRA:
                                 _is_infra = True
+                            if solve_result.error_kind == ErrorKind.SOLVE_TIMEOUT:
+                                _is_solve_timeout = True
                             if solve_result.error:
                                 logger.warning("solve error p%d r%d: %s", idx, rep, solve_result.error)
                                 step.model_error = solve_result.error
@@ -582,6 +585,8 @@ async def run_evaluation(
                 step.extracted_answer = vr.extracted_answer
                 step.scoring_details = vr.scoring_details
                 step.scoring_method = vr.scoring_details.get("method", "")
+                if _is_solve_timeout:
+                    step.scoring_details["error_category"] = "solve_timeout"
 
                 extra_scorers = (config or {}).get("scorers", [])
                 if extra_scorers:

--- a/src/nemo_evaluator/observability/collector.py
+++ b/src/nemo_evaluator/observability/collector.py
@@ -60,6 +60,9 @@ class ArtifactCollector:
         if isinstance(sd, dict) and sd.get("error_category") == "infra_error":
             step.failure_category = "infra_error"
             return
+        if isinstance(sd, dict) and sd.get("error_category") == "solve_timeout":
+            step.failure_category = "solve_timeout"
+            return
         if step.model_error:
             err = step.model_error
             if any(code in err for code in ("408", "timeout", "Timeout", "timed out")):

--- a/src/nemo_evaluator/solvers/base.py
+++ b/src/nemo_evaluator/solvers/base.py
@@ -36,6 +36,7 @@ class ErrorKind(Enum):
     INFRA = "infra_error"
     TOOL_INFRA = "tool_infra"
     SYSTEM = "system"
+    SOLVE_TIMEOUT = "solve_timeout"
 
 
 @dataclass

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1217,9 +1217,19 @@ class HarborSolver:
                     "workspace changes — submitting for verification",
                     self._run_timeout,
                 )
+                error_kind = ErrorKind.SOLVE_TIMEOUT
             elif not response and prompt_tokens + completion_tokens == 0:
                 error = "Agent produced no output (0 tokens, empty response). Check agent logs for details."
                 logger.warning("HarborSolver: %s", error)
+            elif agent_timed_out:
+                logger.info(
+                    "HarborSolver: agent timed out after %.0fs without workspace changes "
+                    "(prompt_tokens=%d completion_tokens=%d) — submitting for verification",
+                    self._run_timeout,
+                    prompt_tokens,
+                    completion_tokens,
+                )
+                error_kind = ErrorKind.SOLVE_TIMEOUT
 
             return SolveResult(
                 response=response,

--- a/tests/test_engine/test_infra_error.py
+++ b/tests/test_engine/test_infra_error.py
@@ -54,6 +54,12 @@ class TestErrorKind:
         assert sr.error_kind == ErrorKind.INFRA
         assert sr.error_kind.value == "infra_error"
 
+    def test_solve_timeout_kind(self):
+        sr = SolveResult(response="", error_kind=ErrorKind.SOLVE_TIMEOUT)
+        assert sr.error_kind == ErrorKind.SOLVE_TIMEOUT
+        assert sr.error_kind.value == "solve_timeout"
+        assert sr.error is None
+
 
 # ── _get_error_category helper ───────────────────────────────────────
 
@@ -108,6 +114,59 @@ class TestCollectorInfraClassification:
         )
         collector._classify_failure(step)
         assert step.failure_category == "server_error"
+
+
+class TestCollectorSolveTimeoutClassification:
+    def test_solve_timeout_classified(self):
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
+        collector = ArtifactCollector()
+        step = StepRecord(
+            problem_idx=0,
+            repeat=0,
+            prompt="test",
+            scoring_details={"error_category": "solve_timeout", "method": "harbor"},
+        )
+        collector._classify_failure(step)
+        assert step.failure_category == "solve_timeout"
+
+    def test_solve_timeout_takes_precedence_over_substring_scan(self):
+        """`solve_timeout` must short-circuit before the substring scan, otherwise a
+        model_error string containing 'timed out' would mis-bucket as 'timeout'
+        (the HTTP-408/upstream-gateway-timeout label)."""
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
+        collector = ArtifactCollector()
+        step = StepRecord(
+            problem_idx=0,
+            repeat=0,
+            prompt="test",
+            model_error="agent timed out after 3600s",
+            scoring_details={"error_category": "solve_timeout"},
+        )
+        collector._classify_failure(step)
+        assert step.failure_category == "solve_timeout"
+
+    def test_solve_timeout_does_not_collide_with_infra_error(self):
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
+        collector = ArtifactCollector()
+        infra_step = StepRecord(
+            problem_idx=0,
+            repeat=0,
+            prompt="test",
+            scoring_details={"error_category": "infra_error"},
+        )
+        timeout_step = StepRecord(
+            problem_idx=1,
+            repeat=0,
+            prompt="test",
+            scoring_details={"error_category": "solve_timeout"},
+        )
+        collector._classify_failure(infra_step)
+        collector._classify_failure(timeout_step)
+        assert infra_step.failure_category == "infra_error"
+        assert timeout_step.failure_category == "solve_timeout"
 
 
 # ── ModelClient wraps errors as InfraError ───────────────────────────

--- a/tests/test_engine/test_infra_error.py
+++ b/tests/test_engine/test_infra_error.py
@@ -89,8 +89,6 @@ class TestGetErrorCategory:
 
 class TestCollectorInfraClassification:
     def test_infra_error_classified(self):
-        from nemo_evaluator.observability.collector import ArtifactCollector
-
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -102,8 +100,6 @@ class TestCollectorInfraClassification:
         assert step.failure_category == "infra_error"
 
     def test_graceful_falls_through_to_string_matching(self):
-        from nemo_evaluator.observability.collector import ArtifactCollector
-
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -118,8 +114,6 @@ class TestCollectorInfraClassification:
 
 class TestCollectorSolveTimeoutClassification:
     def test_solve_timeout_classified(self):
-        from nemo_evaluator.observability.collector import ArtifactCollector
-
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -134,8 +128,6 @@ class TestCollectorSolveTimeoutClassification:
         """`solve_timeout` must short-circuit before the substring scan, otherwise a
         model_error string containing 'timed out' would mis-bucket as 'timeout'
         (the HTTP-408/upstream-gateway-timeout label)."""
-        from nemo_evaluator.observability.collector import ArtifactCollector
-
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -148,8 +140,6 @@ class TestCollectorSolveTimeoutClassification:
         assert step.failure_category == "solve_timeout"
 
     def test_solve_timeout_does_not_collide_with_infra_error(self):
-        from nemo_evaluator.observability.collector import ArtifactCollector
-
         collector = ArtifactCollector()
         infra_step = StepRecord(
             problem_idx=0,

--- a/tests/test_engine/test_infra_error.py
+++ b/tests/test_engine/test_infra_error.py
@@ -89,6 +89,8 @@ class TestGetErrorCategory:
 
 class TestCollectorInfraClassification:
     def test_infra_error_classified(self):
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -100,6 +102,8 @@ class TestCollectorInfraClassification:
         assert step.failure_category == "infra_error"
 
     def test_graceful_falls_through_to_string_matching(self):
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -114,6 +118,8 @@ class TestCollectorInfraClassification:
 
 class TestCollectorSolveTimeoutClassification:
     def test_solve_timeout_classified(self):
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -128,6 +134,8 @@ class TestCollectorSolveTimeoutClassification:
         """`solve_timeout` must short-circuit before the substring scan, otherwise a
         model_error string containing 'timed out' would mis-bucket as 'timeout'
         (the HTTP-408/upstream-gateway-timeout label)."""
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
         collector = ArtifactCollector()
         step = StepRecord(
             problem_idx=0,
@@ -140,6 +148,8 @@ class TestCollectorSolveTimeoutClassification:
         assert step.failure_category == "solve_timeout"
 
     def test_solve_timeout_does_not_collide_with_infra_error(self):
+        from nemo_evaluator.observability.collector import ArtifactCollector
+
         collector = ArtifactCollector()
         infra_step = StepRecord(
             problem_idx=0,


### PR DESCRIPTION
Adds ErrorKind.SOLVE_TIMEOUT and a new "solve_timeout" failure_category
covering rollouts where the Harbor solver hit the configured run_timeout
but were previously emitted with error=None / failure_category=null.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced timeout detection and refined error classification for solver attempts, including clearer distinction between timeouts with and without workspace progress.
  * Improved diagnostics and reporting when solver timeouts occur.

* **Tests**
  * Added tests to verify timeout handling and ensure accurate failure categorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->