### PR TITLE
fix: declare nemo-skills as a uv source dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,7 +80,7 @@ jobs:
     secrets: inherit  # pragma: allowlist secret
 
   release:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.4.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_release_library.yml@v1.4.2
     needs: [pre-flight]
     if: |
       !cancelled() && !failure()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
 scoring = ["sympy>=1.12"]
 stats = ["scipy>=1.10"]
 ray = ["ray[default]>=2.9"]
-skills = ["nemo-skills @ git+https://github.com/NVIDIA-NeMo/Skills.git"]
+skills = ["nemo-skills"]
 lm-eval = ["lm_eval>=0.4"]
 harbor = ["harbor>=0.3.0,<0.4.0"]
 inspect = ["inspect_ai"]
@@ -93,9 +93,6 @@ Issues = "https://github.com/NVIDIA-NeMo/Evaluator/issues"
 
 [project.scripts]
 nel = "nemo_evaluator.cli.main:cli"
-
-[tool.hatch.metadata]
-allow-direct-references = true
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nemo_evaluator"]
@@ -145,6 +142,13 @@ conflicts = [
     [{ extra = "skills" }, { extra = "all" }],
     [{ extra = "skills" }, { extra = "dev" }],
 ]
+
+[tool.uv.sources]
+# Resolve nemo-skills from git for local/dev installs (uv sync, uv pip).
+# Declaring the URL here instead of as a PEP 508 direct reference in
+# project.optional-dependencies keeps it out of the published wheel METADATA,
+# which PyPI/twine reject ("Can't have direct dependency ...").
+nemo-skills = { git = "https://github.com/NVIDIA-NeMo/Skills.git" }
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### Background / motivation

- Publishing `nemo-evaluator` fails at the `twine upload` step with a PyPI `400 Bad Request`:
  > Can't have direct dependency: `nemo-skills @ git+https://github.com/NVIDIA-NeMo/Skills.git ; extra == "skills"`
- PEP 508 **direct references** (`name @ url`) are forbidden in published core metadata. The `skills` extra declared one, so the wheel was unpublishable. (Confirmed on run `26895132713`, step *Release wheel*.)

### What changed

- Move the `nemo-skills` git URL out of `[project.optional-dependencies]` and into `[tool.uv.sources]`.
- Drop the now-unused `[tool.hatch.metadata] allow-direct-references = true` flag.
- Bump the `_release_library.yml` pin `v1.4.0` → `v1.4.2` (the other FW-CI-templates refs in this repo are already on `v1.4.2`).

### Details

- `pyproject.toml`
  - `skills = ["nemo-skills @ git+…/Skills.git"]` → `skills = ["nemo-skills"]`
  - New `[tool.uv.sources]` entry: `nemo-skills = { git = "https://github.com/NVIDIA-NeMo/Skills.git" }`
  - `tool.uv.sources` is uv-only config — it drives resolution for `uv sync` / `uv pip` but is **not** emitted into the built distribution's `METADATA`, so the published wheel carries a plain `Requires-Dist: nemo-skills; extra == 'skills'`.
  - Removed `allow-direct-references = true` (it only existed to permit that one direct URL); without it, the build now hard-fails if a direct reference is reintroduced.
- `.github/workflows/release.yaml`
  - `_release_library.yml@v1.4.0` → `@v1.4.2`. The nested `_build_test_publish_wheel.yml` is called via a local `./` path, so it inherits whichever tag this entry point pins.

### Tested

Built and validated locally exactly as the release pipeline does:

```console
$ uv build
Successfully built nemo_evaluator-0.3.0.tar.gz
Successfully built nemo_evaluator-0.3.0-py3-none-any.whl

$ unzip -p dist/*.whl '*/METADATA' | grep nemo-skills
Requires-Dist: nemo-skills; extra == 'skills'      # no git URL

$ twine check dist/*
Checking nemo_evaluator-0.3.0-py3-none-any.whl: PASSED
Checking nemo_evaluator-0.3.0.tar.gz: PASSED
```

Dev installs are unaffected — `uv sync --extra skills` still pulls `nemo-skills` from git via `[tool.uv.sources]`.

</details>
