### PR TITLE
fix: revert premature v0.3.1 version bump

### DIFF
--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -26,7 +26,7 @@ to keep them in sync.
 # Below is the _next_ version that will be published, not the currently published one.
 MAJOR = 0
 MINOR = 3
-PATCH = 1
+PATCH = 0
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
<details><summary>Claude summary</summary>

### Background / motivation

- The `r0.3.0` release run bumped the "next version to publish" before publishing:
  - `1937ffb3` — *beep boop 🤖: Bumping Evaluator to v0.3.1* set `PATCH = 0` → `PATCH = 1` in `package_info.py`.
- But that release's publish step **failed** (PyPI `400 Bad Request`: `Can't have direct dependency: nemo-skills @ git+...`), so 0.3.0 was never actually published.
- Leaving `PATCH = 1` means the next release would skip straight to 0.3.1.

### What changed

- Revert `1937ffb3`, restoring `PATCH = 0` so the retried release publishes **0.3.0**.

### Details

- `src/nemo_evaluator/package_info.py`: `PATCH = 1` → `PATCH = 0` (single line).
- Base branch: `r0.3.0`.
- The publish fix itself lands separately in #1052 (move `nemo-skills` to `[tool.uv.sources]`).

</details>
