### PR TITLE
docs: improve Nemotron 3 Ultra v0.2 / v0.3 recipe READMEs

### DIFF
--- a/examples/nemotron/nemotron-3-ultra/reproducibility.md
+++ b/examples/nemotron/nemotron-3-ultra/reproducibility.md
@@ -17,18 +17,18 @@ The **Recipe** column links to each benchmark's recipe — the v0.2 README secti
 
 | Benchmark | Category | Description | Recipe |
 |---|---|---|---|
-| GPQA (Diamond) | Science | Graduate-level science questions | Instruct ([v0.2](./v0.2/README.md#running)) |
-| HLE | Humanity's Last Exam | Expert-level questions across domains | Instruct ([v0.2](./v0.2/README.md#running)) |
-| MMLU-Pro | Knowledge | Multi-task language understanding (10-choice) | Instruct ([v0.2](./v0.2/README.md#running)) |
-| MMLU-Pro X | Knowledge | MMLU-Pro extended multilingual variant | Instruct ([v0.2](./v0.2/README.md#running)) |
-| SciCode | Scientific Coding | Scientific programming challenges | Instruct ([v0.2](./v0.2/README.md#running)) |
-| CritPt | Physics | Critical Point evaluation | Instruct ([v0.2](./v0.2/README.md#running)) |
-| IFBench | Instruction Following | Instruction following benchmark | Instruct ([v0.2](./v0.2/README.md#running)) |
-| AA-Omniscience | Knowledge / hallucination | AA Omniscience benchmark (Gemini judge) | Instruct ([v0.2](./v0.2/README.md#running)) |
-| IMO-AnswerBench | Mathematics | International Math Olympiad answer benchmark | Instruct ([v0.2](./v0.2/README.md#running)) |
-| AA-LCR | Long-context | Artificial Analysis long-context benchmark | Instruct ([v0.2](./v0.2/README.md#running)) |
-| Multi-Challenge | Multi-turn | Multi-turn instruction-following benchmark | Instruct ([v0.2](./v0.2/README.md#running)) |
-| WMT24++ | Translation | WMT24 translation, scored with XCOMET-XXL | Instruct ([v0.2](./v0.2/README.md#running)) |
+| GPQA (Diamond) | Science | Graduate-level science questions | Instruct ([v0.2](./v0.2/README.md#gpqa-diamond)) |
+| HLE | Humanity's Last Exam | Expert-level questions across domains | Instruct ([v0.2](./v0.2/README.md#hle)) |
+| MMLU-Pro | Knowledge | Multi-task language understanding (10-choice) | Instruct ([v0.2](./v0.2/README.md#mmlu-pro)) |
+| MMLU-Pro X | Knowledge | MMLU-Pro extended multilingual variant | Instruct ([v0.2](./v0.2/README.md#mmlu-pro-x)) |
+| SciCode | Scientific Coding | Scientific programming challenges | Instruct ([v0.2](./v0.2/README.md#scicode)) |
+| CritPt | Physics | Critical Point evaluation | Instruct ([v0.2](./v0.2/README.md#critpt)) |
+| IFBench | Instruction Following | Instruction following benchmark | Instruct ([v0.2](./v0.2/README.md#ifbench)) |
+| AA-Omniscience | Knowledge / hallucination | AA Omniscience benchmark (Gemini judge) | Instruct ([v0.2](./v0.2/README.md#aa-omniscience)) |
+| IMO-AnswerBench | Mathematics | International Math Olympiad answer benchmark | Instruct ([v0.2](./v0.2/README.md#imo-answerbench)) |
+| AA-LCR | Long-context | Artificial Analysis long-context benchmark | Instruct ([v0.2](./v0.2/README.md#aa-lcr)) |
+| Multi-Challenge | Multi-turn | Multi-turn instruction-following benchmark | Instruct ([v0.2](./v0.2/README.md#multi-challenge)) |
+| WMT24++ | Translation | WMT24 translation, scored with XCOMET-XXL | Instruct ([v0.2](./v0.2/README.md#wmt24)) |
 | LiveCodeBench v6 | Coding | Real-world coding problems | Agentic — [v0.2 (Gym)](./v0.2/README.md#livecodebench-v6-cascade) |
 | Tau2 | Tool Use | Tool use across telecom / airline / retail | Agentic — [v0.2 (Gym)](./v0.2/README.md#tau2-taubench-v3) |
 | GDPVal | Office-deliverable agent | Office/PDF deliverables, judged pairwise/rubric | Agentic — [v0.2 (Gym)](./v0.2/README.md#gdpval-stirrup-agent) |

--- a/examples/nemotron/nemotron-3-ultra/v0.2/.env.example
+++ b/examples/nemotron/nemotron-3-ultra/v0.2/.env.example
@@ -1,22 +1,47 @@
 # Common env file for these recipes. Copy to `.env` and pass via `--env-file`.
+#
+# Each var notes which config / benchmark reads it. You only need the vars used by
+# the configs you actually run — leave the rest as `???`. Judge `url`/`model_id`
+# values are NOT set here; fill those in the relevant config block (see README).
 
-# === Required for all configs ===
+# === Required by every config ===
+# HuggingFace token — dataset access (accept terms on the Hub for gated datasets).
 HF_TOKEN=???
 
-# === Policy model endpoint (the model under test) ===
+# Optional: HuggingFace cache dir on the host (the instruct config reads `host:HF_HOME`).
+# HF_HOME=/home/you/.cache/huggingface
+
+# === Policy model endpoint — the model under test ===
+# Read via `_endpoints.yaml` -> `target.api_endpoint.api_key_name`. Used by the
+# instruct suite and all Gym agentic configs (livecodebench, tau2, gdpval).
+# The base suite does NOT use this — it deploys its own local vLLM.
 INFERENCE_API_KEY=???
 
-# === Per-benchmark judge / simulator keys ===
-# Each has its own var so you can use different credentials per role.
-# For simplicity, multiple vars can point at the same key value.
+# === Instruct-suite judges (local_nemotron-3-ultra-550b-a55b.yaml) ===
+# Set only the keys for the instruct benchmarks you run, and fill the matching judge
+# `url`/`model_id` in that task's `extra.judge` block in the config.
 
-# Tau2 customer simulator (configured in _endpoints.yaml: tau2_simulator)
+# HLE (gpt-4o), IMO-AnswerBench (gpt-4o), and Multi-Challenge. Multi-Challenge's
+# OPENAI_API_KEY is sourced from this var by the config — no separate var needed.
+JUDGE_API_KEY=???
+
+# AA-Omniscience judge (gemini-3-flash-preview).
+GEMINI_API_KEY=???
+
+# AA-LCR judge (non-reasoning qwen/qwen3-235b-a22b).
+QWEN_API_KEY=???
+
+# CritPt — Artificial Analysis grading API.
+ARTIFICIAL_ANALYSIS_API_KEY=???
+
+# === Gym agentic judges / simulators ===
+# Tau2 customer simulator (local_..._tau2.yaml; _endpoints.yaml: tau2_simulator). Used: GPT-5.2.
 TAU2_SIMULATOR_API_KEY=???
 
-# GDPVal pairwise judge (configured in _endpoints.yaml: gdpval_judge)
+# GDPVal pairwise judge (local_..._gdpval.yaml; _endpoints.yaml: gdpval_judge). Used: Gemini 3.1 Pro.
 GDPVAL_JUDGE_API_KEY=???
 
-# GDPVal agent web search
+# GDPVal agent web search (local_..._gdpval.yaml).
 TAVILY_API_KEY=???
 
 # === NEL task registry bypass (required when the eval image doesn't embed

--- a/examples/nemotron/nemotron-3-ultra/v0.2/README.md
+++ b/examples/nemotron/nemotron-3-ultra/v0.2/README.md
@@ -37,9 +37,11 @@ Required by every benchmark — the model under test:
 
 | `.env` key | Config block | Set / recommended model |
 |---|---|---|
-| `NGC_API_KEY` | `target.api_endpoint` (instruct + base configs) | endpoint `url` + `model_id` — your model under test |
-| `INFERENCE_API_KEY` | `target.api_endpoint` (Gym agentic configs) | endpoint `url` + `model_id` — your model under test |
-| `HF_TOKEN` | — | HuggingFace token (dataset access) |
+| `INFERENCE_API_KEY` | `_endpoints.yaml` → `target.api_endpoint` (instruct + Gym agentic) | endpoint `url` + `model_id` — your model under test |
+| `HF_TOKEN` | `.env` (`evaluation.env_vars`) | HuggingFace token (dataset access) |
+
+The **base suite** is the exception — it deploys its own local vLLM
+(`deployment: vllm`) and needs no policy API key, only `HF_TOKEN`.
 
 Default instruct params (set in the config): `temperature 1.0`, `top_p 0.95`,
 `parallelism 1`, `request_timeout 3600`, `max_retries 10`, thinking on. To self-host,
@@ -94,25 +96,132 @@ retries, `output_dir` must be an absolute path on stable storage (not tmpfs).
 
 ### Instruct suite
 
-One monolithic config (`local_nemotron-3-ultra-550b-a55b.yaml`); pick a single
-benchmark with `-t <task>` (note the mixed `nemo_skills.` prefix). On top of the
-[policy model](#3-policy-model), each row lists the judge / extra key it needs, the
-repeat count, and benchmark-specific notes:
+One monolithic config — `local_nemotron-3-ultra-550b-a55b.yaml` — with one benchmark
+per section below. Select a single benchmark with `-t <task>` (note the mixed
+`nemo_skills.` prefix on some tasks); every command shares this config and differs only
+in `-t`.
 
-| Benchmark | `-t` task | Judge / extra key | Repeats | Notes |
-|---|---|---|---|---|
-| GPQA (Diamond) | `ns_gpqa` | — | 8 | `++prompt_config=eval/aai/mcq-4choices` |
-| HLE | `nemo_skills.ns_hle_aa` | `JUDGE_API_KEY` (gpt-4o) | 1 | `hle_strict_judge`; `++server.enable_soft_fail=True` |
-| MMLU-Pro | `ns_mmlu_pro` | — | 1 | 10-choice boxed (`++prompt_config=eval/aai/mcq-10choices-boxed`) |
-| MMLU-Pro X | `ns_mmlu_prox` | — | 1 | — |
-| SciCode | `ns_scicode` | — | 8 | — |
-| CritPt | `nemo_skills.ns_critpt` | `ARTIFICIAL_ANALYSIS_API_KEY` | 5 | AA grades fixed 70-problem batches (no sub-sampling) |
-| IFBench | `nemo_skills.ns_ifbench` | — | 8 | — |
-| AA-LCR | `ns_aa_lcr` | `QWEN_API_KEY` (non-reasoning Qwen3-235B) | 16 | fill judge `url`/`model_id` in the config |
-| AA-Omniscience | `nemo_skills.ns_omniscience` | `GEMINI_API_KEY` (Gemini-3-Flash) | 10 | `++parse_reasoning=False` |
-| IMO-AnswerBench | `nemo_skills.ns_imo_answerbench` | `JUDGE_API_KEY` | 5 | — |
-| Multi-Challenge | `multi-challenge` | `JUDGE_API_KEY` / `OPENAI_API_KEY` | 8 | `attempts=1`, `seed=42` |
-| WMT24++ | `ns_wmt24pp_comet` | — | default | download [XCOMET-XXL](https://huggingface.co/Unbabel/XCOMET-XXL), mount it, set `comet.model_path`; COMET runs via `--judge_step_fn` (nemo-skills 26.05 ignores `--judge_type=comet`) |
+Every benchmark needs the [policy model](#3-policy-model). Judge-based benchmarks also
+need a judge — its **API key** comes from `.env` (add it there; these judge keys are not
+in `.env.example`) and its **`url`/`model_id`** are filled inline in that task's
+`extra.judge` block in the config. Fill both before running.
+
+#### GPQA (Diamond)
+
+- **Endpoints / keys:** policy model only.
+- **Recommended:** `num_repeats: 8`; `++prompt_config=eval/aai/mcq-4choices`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t ns_gpqa
+```
+
+#### HLE
+
+- **Endpoints / keys:** `JUDGE_API_KEY` in `.env`; fill the judge `url` in the
+  `nemo_skills.ns_hle_aa` task's `extra.judge` block (`model_id` defaults to **gpt-4o**).
+- **Recommended:** `num_repeats: 1`; `hle_strict_judge: true`; `++server.enable_soft_fail=True`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t nemo_skills.ns_hle_aa
+```
+
+#### MMLU-Pro
+
+- **Endpoints / keys:** policy model only.
+- **Recommended:** `num_repeats: 1`; 10-choice boxed (`++prompt_config=eval/aai/mcq-10choices-boxed`).
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t ns_mmlu_pro
+```
+
+#### MMLU-Pro X
+
+- **Endpoints / keys:** policy model only.
+- **Recommended:** `num_repeats: 1`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t ns_mmlu_prox
+```
+
+#### SciCode
+
+- **Endpoints / keys:** policy model only.
+- **Recommended:** `num_repeats: 8`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t ns_scicode
+```
+
+#### CritPt
+
+- **Endpoints / keys:** `ARTIFICIAL_ANALYSIS_API_KEY` in `.env` — Artificial Analysis grades the runs.
+- **Recommended:** `num_repeats: 5`. AA grades fixed 70-problem batches (no sub-sampling).
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t nemo_skills.ns_critpt
+```
+
+#### IFBench
+
+- **Endpoints / keys:** policy model only.
+- **Recommended:** `num_repeats: 8`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t nemo_skills.ns_ifbench
+```
+
+#### AA-LCR
+
+- **Endpoints / keys:** `QWEN_API_KEY` in `.env` (mapped to `JUDGE_API_KEY` for this task);
+  fill the judge `url`/`model_id` in the `ns_aa_lcr` task's `extra.judge` block — used a
+  **non-reasoning `qwen/qwen3-235b-a22b`**.
+- **Recommended:** `num_repeats: 16`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t ns_aa_lcr
+```
+
+#### AA-Omniscience
+
+- **Endpoints / keys:** `GEMINI_API_KEY` in `.env` (mapped to `JUDGE_API_KEY` for this task);
+  fill the judge `url` in the `nemo_skills.ns_omniscience` task's `extra.judge` block
+  (`model_id` defaults to **`gemini-3-flash-preview`**).
+- **Recommended:** `num_repeats: 10`; `++parse_reasoning=False`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t nemo_skills.ns_omniscience
+```
+
+#### IMO-AnswerBench
+
+- **Endpoints / keys:** `JUDGE_API_KEY` in `.env` — used **gpt-4o**.
+- **Recommended:** `num_repeats: 5`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t nemo_skills.ns_imo_answerbench
+```
+
+#### Multi-Challenge
+
+- **Endpoints / keys:** `JUDGE_API_KEY` and `OPENAI_API_KEY` in `.env` (the config maps
+  both to the same judge key).
+- **Recommended:** `num_repeats: 8`; `attempts: 1`; `seed: 42`.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t multi-challenge
+```
+
+#### WMT24++
+
+- **Endpoints / keys:** policy model only — COMET scores locally, no judge endpoint.
+- **Prepare:** download [XCOMET-XXL](https://huggingface.co/Unbabel/XCOMET-XXL), mount it,
+  and set `comet.model_path` in the `ns_wmt24pp_comet` task. COMET runs via
+  `--judge_step_fn` (nemo-skills 26.05 ignores `--judge_type=comet`).
+- **Recommended:** suite default repeats.
+
+```bash
+nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t ns_wmt24pp_comet
+```
 
 ### LiveCodeBench v6 Cascade
 

--- a/examples/nemotron/nemotron-3-ultra/v0.2/README.md
+++ b/examples/nemotron/nemotron-3-ultra/v0.2/README.md
@@ -203,8 +203,8 @@ nel run --config local_nemotron-3-ultra-550b-a55b.yaml --env-file .env -t nemo_s
 
 #### Multi-Challenge
 
-- **Endpoints / keys:** `JUDGE_API_KEY` and `OPENAI_API_KEY` in `.env` (the config maps
-  both to the same judge key).
+- **Endpoints / keys:** `JUDGE_API_KEY` in `.env` — the config also exposes it as
+  `OPENAI_API_KEY` inside the container, so no separate var is needed.
 - **Recommended:** `num_repeats: 8`; `attempts: 1`; `seed: 42`.
 
 ```bash

--- a/examples/nemotron/nemotron-3-ultra/v0.3/README.md
+++ b/examples/nemotron/nemotron-3-ultra/v0.3/README.md
@@ -46,6 +46,11 @@ Every benchmark runs inside an ECS Fargate sandbox via `harbor`, which needs:
 | harbor ECR | `sandbox.ecr_repository` | replace `<AWS_ACCOUNT_ID>` with your harbor ECR account |
 | Terraform applied | — | for the sandbox region (creates the SSM parameter) |
 
+The ECS Fargate sandbox infrastructure is not provisioned by `nemo-evaluator`. You
+must self-provision it in your own AWS account — a reference Terraform stack that
+creates the exact topology `harbor`'s `ECSFargateSandbox` backend expects is in
+[`terraform/`](../../../../terraform/README.md).
+
 ---
 
 ## Running


### PR DESCRIPTION
## Summary

Documentation-only improvements to the Nemotron 3 Ultra recipes:

- **v0.3 README** — note that the ECS Fargate sandbox infra is self-provisioned, linking the reference `terraform/` stack.
- **v0.2 README** — decompose the instruct-suite table into one section per benchmark (keys/endpoints + where to set them, recommended params, prep, run command).
- **v0.2 `.env.example`** — add the previously-undocumented instruct judge keys; annotate every var with which config needs it.
- **reproducibility.md** — deep-link each instruct benchmark to its specific v0.2 section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)