### PR TITLE
build: add managed = true to [tool.uv]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ exclude_lines = [
 ]
 
 [tool.uv]
+managed = true
 # Force resolver-wide overrides to break dependency conflicts that come from
 # transitive pins we can't easily change upstream. These are honored by `uv`
 # (uv pip / uv sync) but ignored by plain pip — Dockerfiles using plain pip


### PR DESCRIPTION
## Summary
- Adds `managed = true` to `[tool.uv]` in `pyproject.toml`, declaring that uv manages this project's environment

## Test plan
- No functional change; CI passes as-is