### PR TITLE
docs: drop 0.1.0 (NeMo Eval predecessor) from version switcher

### DIFF
--- a/docs/versions1.json
+++ b/docs/versions1.json
@@ -13,10 +13,5 @@
       "name": "0.2.5",
       "version": "0.2.5",
       "url": "https://docs.nvidia.com/nemo/evaluator/0.2.5/"
-    },
-    {
-      "name": "0.1.0",
-      "version": "0.1.0",
-      "url": "https://docs.nvidia.com/nemo/evaluator/0.1.0/"
     }
 ]


### PR DESCRIPTION
## What
Removes the `0.1.0` entry from `docs/versions1.json`.

## Why
The published `/0.1.0/` docs are the **predecessor product "NeMo Eval"** (`project = "NeMo Eval"`, repo `NVIDIA-NeMo/Eval`), not NeMo Evaluator. It only shares the docs URL slug. NeMo Evaluator's published doc versions start at 0.2.5, so 0.1.0 should not appear in our switcher.

## Follow-ups (not in this PR)
- Build fix (`fix/release-docs-build`) must merge first — docs publishing is currently broken for all versions (`uv sync --only-group docs` fails; docs deps are an extra, not a dependency-group).
- After merge, a release-docs run with `update-version-picker: true` publishes this updated switcher.
- Infra: delete the stale `/0.1.0/` folder from S3 (no CI path) and confirm bucket versioning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)