### PR TITLE
ci: restore codecov.yml from main-legacy

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,20 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 0%
+        base: auto
+        if_ci_failed: error
+        if_not_found: success
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        base: auto
+        if_ci_failed: error
+        if_not_found: success
+        informational: true
+fixes:
+  - "/workspace/::"


### PR DESCRIPTION
<details><summary>Claude summary</summary>

## Background / motivation

- `codecov.yml` lives on `main-legacy` but is absent from the current `main` lineage (the two branches are divergent histories, so the config was never carried over rather than deleted by a commit).
- Without it, Codecov falls back to defaults instead of the project's intended 80% project/patch gates.

## What changed

- Restore `codecov.yml` to `main`, byte-identical to the `main-legacy` copy.

## Details

- `codecov.yml` (20 lines) sourced verbatim from `origin/main-legacy:codecov.yml` (blob `3606e05`):
  - `comment: false`
  - `coverage.status.project.default` → `target: 80%`, `if_ci_failed: error`, `if_not_found: success`
  - `coverage.status.patch.default` → `target: 80%`, `informational: true`
  - `fixes: ["/workspace/::"]` to strip the container path prefix from coverage report paths.

## Tested

- Verified the committed file is byte-identical to `origin/main-legacy:codecov.yml` (`git diff --no-index` clean).
- Pre-commit hooks pass (no Python files touched; large-file check passed).

</details>
