### PR TITLE
fix: recover ECS Fargate sandbox tunnels and capture task-death cause

### DIFF
--- a/src/nemo_evaluator/sandbox/ecs_fargate.py
+++ b/src/nemo_evaluator/sandbox/ecs_fargate.py
@@ -428,6 +428,19 @@ def download_secret_to_string(secret_arn: str, region: str | None = None) -> str
 
 # ── SSH tunnel ───────────────────────────────────────────────────────
 
+# ssh stderr substrings worth a tunnel-open retry: connection-level blips, plus a
+# reverse-forward bind failing because the sandbox sshd still holds the port from a
+# prior dead tunnel (frees once reclaimed/reaped). Matched case-insensitively.
+_SSH_RETRYABLE_STDERR: tuple[str, ...] = (
+    "connection refused",
+    "connection timed out",
+    "no route to host",
+    "connection reset",
+    "remote port forwarding failed",
+    "address already in use",
+    "cannot listen to port",
+)
+
 
 class SshTunnel:
     """Manages an ``ssh -N`` subprocess with ``-L`` / ``-R`` tunnels."""
@@ -492,15 +505,7 @@ class SshTunnel:
             stderr = self._proc.stderr.read().decode(errors="replace") if self._proc.stderr else ""
             last_err = stderr.strip()
             self._proc = None
-            if not any(
-                m in last_err
-                for m in (
-                    "Connection refused",
-                    "Connection timed out",
-                    "No route to host",
-                    "Connection reset",
-                )
-            ):
+            if not any(m in last_err.lower() for m in _SSH_RETRYABLE_STDERR):
                 raise RuntimeError(f"SSH tunnel exited immediately (attempt {attempt}): {last_err}")
             logger.warning(
                 "SSH tunnel attempt %d/%d failed: %s — retrying in %.0fs", attempt, max_retries, last_err, backoff
@@ -640,7 +645,8 @@ def build_ssh_sidecar_container(
             "kill 1 2>/dev/null; sleep 3; kill -9 1 2>/dev/null ) & "
         )
     sshd_cmd = (
-        "set -e; apk add --no-cache openssh-server netcat-openbsd; "
+        # psmisc provides `fuser`, used to reclaim a stale reverse-forward port on reconnect.
+        "set -e; apk add --no-cache openssh-server netcat-openbsd psmisc; "
         "mkdir -p /root/.ssh; chmod 700 /root/.ssh; "
         'printf "%s\\n" "$SSH_PUBLIC_KEY" > /root/.ssh/authorized_keys; '
         "chmod 600 /root/.ssh/authorized_keys; ssh-keygen -A; "
@@ -1297,6 +1303,11 @@ class EcsFargateSandbox:
         self._outside_endpoints: list[OutsideEndpoint] = []
         self._outside_endpoint_routing = _OutsideEndpointRouting.empty()
         self._run_id = uuid.uuid4().hex[:12]
+        # Serializes reconnects so a burst of failing execs triggers one reconnect,
+        # not a storm of competing `ssh -R` binds. Lazily bound to the running loop.
+        self._reconnect_lock: asyncio.Lock | None = None
+        # Set once ECS confirms the task itself died, so reconnects fail fast.
+        self._task_confirmed_dead = False
 
     # ── Protocol properties ──────────────────────────────────────────
 
@@ -1394,22 +1405,9 @@ class EcsFargateSandbox:
         try:
             return await self._exec_client.exec(shell_cmd, timeout=int(timeout_sec))  # type: ignore[union-attr]
         except ConnectionError:
-            if self._ssh_tunnel and not self._ssh_tunnel.is_open:
-                logger.warning("SSH tunnel dead — attempting reconnect before re-raising")
-                try:
-                    await self.reconnect_tunnel()
-                    sidecar = self._cfg.ssh_sidecar
-                    if sidecar and sidecar.exec_server_port is not None:
-                        health_url = f"http://127.0.0.1:{self._ssh_tunnel.local_port}/health"  # type: ignore[union-attr]
-                        self._ssh_tunnel.wait_ready(health_url=health_url, timeout=60.0)  # type: ignore[union-attr]
-                        old_client = self._exec_client
-                        self._exec_client = ExecClient(port=self._ssh_tunnel.local_port)  # type: ignore[union-attr]
-                        if old_client is not None:
-                            await old_client.close()
-                        return await self._exec_client.exec(shell_cmd, timeout=int(timeout_sec))
-                except Exception as reconnect_err:
-                    logger.warning("Tunnel reconnect failed: %s", reconnect_err)
-            raise
+            if not await self._ensure_tunnel_recovered():
+                raise
+            return await self._exec_client.exec(shell_cmd, timeout=int(timeout_sec))  # type: ignore[union-attr]
 
     async def upload(self, local_path: Path, remote_path: str) -> None:
         self._require_exec_client()
@@ -1453,6 +1451,148 @@ class EcsFargateSandbox:
             self._ssh_tunnel.close()
             self._ssh_tunnel = None
         await asyncio.to_thread(self._open_tunnel, sidecar)
+
+    # ── Tunnel recovery (exec-server mode) ───────────────────────────
+
+    def _get_reconnect_lock(self) -> asyncio.Lock:
+        # Lazily bound to the running loop; check-and-set has no await, so it's race-free.
+        if self._reconnect_lock is None:
+            self._reconnect_lock = asyncio.Lock()
+        return self._reconnect_lock
+
+    async def _ensure_tunnel_recovered(self) -> bool:
+        """Reconnect after a dead-tunnel ConnectionError; return True if exec should retry.
+
+        Serialized so a burst of failing execs triggers one reconnect, not a storm of
+        competing ``ssh -R`` binds colliding on the reverse port.
+        """
+        tunnel = self._ssh_tunnel
+        if tunnel is None or self._task_confirmed_dead:
+            return False
+        if tunnel.is_open:
+            return True
+        async with self._get_reconnect_lock():
+            # Another caller may have reconnected (or proven the task dead) while we waited.
+            if self._task_confirmed_dead:
+                return False
+            if self._ssh_tunnel is not None and self._ssh_tunnel.is_open:
+                return True
+            try:
+                await self._reconnect_exec_tunnel()
+                return True
+            except Exception as exc:
+                logger.warning("Tunnel reconnect failed: %s", exc)
+                return False
+
+    async def _reconnect_exec_tunnel(self) -> None:
+        sidecar = self._cfg.ssh_sidecar
+        if sidecar is None or sidecar.exec_server_port is None:
+            raise RuntimeError("Tunnel reconnect is only supported in exec-server mode")
+        logger.warning("SSH tunnel dead — reconnecting exec tunnel")
+        # Capture why the tunnel died while ECS metadata is still fresh; if the task
+        # itself is gone, reconnect can't help — record the reason and abort.
+        status, diag = await asyncio.to_thread(self._describe_task_diagnostics)
+        if status not in ("RUNNING", "UNKNOWN"):
+            self._task_confirmed_dead = True
+            logger.error(
+                "ECS task %s is %s — the sandbox died (root cause of the tunnel death); "
+                "reconnect aborted. ECS diagnostics: %s",
+                self._task_arn,
+                status,
+                diag,
+            )
+            raise RuntimeError(f"ECS task not RUNNING ({status}): {diag}")
+        logger.info("ECS task still %s after tunnel death — reconnecting (%s)", status, diag)
+        # Free the reverse port the dead tunnel may still hold so the new `ssh -R`
+        # can rebind without waiting for the server to reap it.
+        await asyncio.to_thread(self._free_remote_reverse_ports)
+        await self.reconnect_tunnel()
+        new_client = await asyncio.to_thread(self._refresh_exec_client)
+        old_client = self._exec_client
+        self._exec_client = new_client
+        if old_client is not None:
+            await old_client.close()
+
+    def _refresh_exec_client(self) -> ExecClient:
+        assert self._ssh_tunnel is not None
+        health_url = f"http://127.0.0.1:{self._ssh_tunnel.local_port}/health"
+        self._ssh_tunnel.wait_ready(health_url=health_url, timeout=60.0)
+        return ExecClient(port=self._ssh_tunnel.local_port)
+
+    def _reverse_listen_ports(self) -> list[int]:
+        """Reverse-tunnel listen ports bound on the sandbox sshd (de-duplicated)."""
+        ports: list[int] = []
+        for spec in self._outside_endpoint_routing.reverse_specs:
+            head = spec.split(":", 1)[0]
+            if head.isdigit():
+                ports.append(int(head))
+        if self._ssh_tunnel_port is not None:
+            ports.append(self._ssh_tunnel_port)
+        return list(dict.fromkeys(ports))
+
+    def _free_remote_reverse_ports(self) -> None:
+        """``fuser -k`` the reverse listen port(s) a dead tunnel may still hold on the
+        sandbox sshd, so the reconnect's ``ssh -R`` can rebind. Best-effort."""
+        ports = self._reverse_listen_ports()
+        sidecar = self._cfg.ssh_sidecar
+        if not ports or not self._task_ip or not self._ssh_key_file or sidecar is None:
+            return
+        port_list = " ".join(str(p) for p in ports)
+        remote_cmd = f'for P in {port_list}; do fuser -k -n tcp "$P" 2>/dev/null || true; done; true'
+        cmd = [
+            "ssh",
+            "-T",
+            "-o",
+            "StrictHostKeyChecking=no",
+            "-o",
+            "UserKnownHostsFile=/dev/null",
+            "-o",
+            "ConnectTimeout=10",
+            "-o",
+            "LogLevel=ERROR",
+            "-i",
+            self._ssh_key_file,
+            "-p",
+            str(sidecar.sshd_port),
+            f"root@{self._task_ip}",
+            remote_cmd,
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, timeout=30, check=False)  # best-effort
+            logger.info("Reclaimed reverse port(s) %s on %s (rc=%d)", port_list, self._task_ip, result.returncode)
+        except Exception as exc:
+            logger.warning("Could not reclaim reverse port(s) %s on %s: %s", port_list, self._task_ip, exc)
+
+    def _describe_task_diagnostics(self) -> tuple[str, str]:
+        """Return ``(last_status, diagnostics)`` for the ECS task, captured at failure
+        time before ECS's stopped-task metadata expires. ``UNKNOWN`` on any API error
+        so callers still attempt a reconnect."""
+        if not self._ecs or not self._task_arn:
+            return ("UNKNOWN", "no ECS client/task ARN available")
+        try:
+            resp = self._ecs.describe_tasks(cluster=self._cfg.cluster, tasks=[self._task_arn])
+        except Exception as exc:
+            return ("UNKNOWN", f"describe_tasks failed: {exc}")
+        tasks = resp.get("tasks") or []
+        if not tasks:
+            return ("GONE", "task not found in ECS (stopped-task metadata may have expired)")
+        task = tasks[0]
+        status = task.get("lastStatus", "UNKNOWN")
+        parts = [f"lastStatus={status}"]
+        if task.get("stopCode"):
+            parts.append(f"stopCode={task['stopCode']}")
+        if task.get("stoppedReason"):
+            parts.append(f"stoppedReason={task['stoppedReason']!r}")
+        for c in task.get("containers") or []:
+            cbits = [f"{c.get('name')}={c.get('lastStatus')}"]
+            if c.get("exitCode") is not None:
+                cbits.append(f"exit={c['exitCode']}")
+            if c.get("reason"):
+                cbits.append(f"reason={c['reason']!r}")
+            if c.get("healthStatus"):
+                cbits.append(f"health={c['healthStatus']}")
+            parts.append("container(" + " ".join(cbits) + ")")
+        return (status, "; ".join(parts))
 
     # ── Sync start (runs via asyncio.to_thread) ──────────────────────
 

--- a/tests/test_sandbox/test_ecs_fargate.py
+++ b/tests/test_sandbox/test_ecs_fargate.py
@@ -585,12 +585,227 @@ class TestEcsFargateExec:
 
         with (
             patch.object(sb, "reconnect_tunnel", side_effect=_reconnect),
+            patch.object(sb, "_free_remote_reverse_ports") as mock_free,
             patch(f"{_PATCH_PREFIX}.ExecClient", return_value=new_client),
         ):
             tunnel.wait_ready = MagicMock()
             await sb.exec("echo hi")
 
         client.close.assert_awaited_once()
+        # Reconnect must reclaim the stale reverse listen port before rebinding.
+        mock_free.assert_called_once()
+
+    async def test_concurrent_reconnect_happens_once(self):
+        """A burst of concurrent execs hitting a dead tunnel must trigger a
+        *single* serialized reconnect, not one `ssh -R` storm per failing exec
+        (the 'bind: Address in use' pileup across task streams in the EVAL).
+        """
+        import asyncio as _asyncio
+
+        sb, client = self._started_sb()
+        client.exec.side_effect = ConnectionError("tunnel down")
+
+        tunnel = MagicMock()
+        tunnel.is_open = False
+        tunnel.local_port = 19010
+        tunnel.wait_ready = MagicMock()
+        sb._ssh_tunnel = tunnel
+
+        new_client = MagicMock()
+        new_client.exec = AsyncMock(return_value=ExecResult("ok", "", 0))
+        new_client.close = AsyncMock(return_value=None)
+
+        reconnect_calls = 0
+
+        async def _reconnect():
+            nonlocal reconnect_calls
+            reconnect_calls += 1
+            await _asyncio.sleep(0.05)  # let the burst pile up on the lock
+            tunnel.is_open = True
+
+        with (
+            patch.object(sb, "reconnect_tunnel", side_effect=_reconnect),
+            patch.object(sb, "_free_remote_reverse_ports"),
+            patch(f"{_PATCH_PREFIX}.ExecClient", return_value=new_client),
+        ):
+            results = await _asyncio.gather(*(sb.exec(f"echo {i}") for i in range(10)))
+
+        assert all(r.stdout == "ok" for r in results)
+        assert reconnect_calls == 1
+
+    async def test_exec_reraises_original_error_when_reconnect_fails(self):
+        """If recovery can't reopen the tunnel, the original ConnectionError
+        propagates (so callers/Harbor still see the real failure)."""
+        sb, client = self._started_sb()
+        client.exec.side_effect = ConnectionError("tunnel down")
+
+        tunnel = MagicMock()
+        tunnel.is_open = False
+        sb._ssh_tunnel = tunnel
+
+        async def _boom():
+            raise RuntimeError("cannot reopen")
+
+        with (
+            patch.object(sb, "reconnect_tunnel", side_effect=_boom),
+            patch.object(sb, "_free_remote_reverse_ports"),
+        ):
+            with pytest.raises(ConnectionError, match="tunnel down"):
+                await sb.exec("echo hi")
+
+    def test_free_remote_reverse_ports_kills_stale_listener(self):
+        from nemo_evaluator.sandbox.ecs_fargate import _OutsideEndpointRouting
+
+        sb = _make_sandbox()
+        sb._outside_endpoint_routing = _OutsideEndpointRouting.for_exec_server(
+            [OutsideEndpoint(url="http://host-a:5000/v1", env_var="MODEL_BASE_URL")],
+            _sidecar(),
+        )
+        sb._task_ip = "10.0.0.7"
+        sb._ssh_key_file = "/tmp/key"
+
+        with patch(f"{_PATCH_PREFIX}.subprocess.run", return_value=MagicMock(returncode=0)) as mock_run:
+            sb._free_remote_reverse_ports()
+
+        mock_run.assert_called_once()
+        joined = " ".join(mock_run.call_args[0][0])
+        assert "root@10.0.0.7" in joined
+        assert "fuser" in joined
+        # exec_server_port (5000) is reserved, so host-a:5000 maps to 20000.
+        assert "20000" in joined
+
+    def test_free_remote_reverse_ports_noop_without_ports(self):
+        sb = _make_sandbox()
+        sb._task_ip = "10.0.0.7"
+        sb._ssh_key_file = "/tmp/key"
+
+        with patch(f"{_PATCH_PREFIX}.subprocess.run") as mock_run:
+            sb._free_remote_reverse_ports()
+
+        mock_run.assert_not_called()
+
+    async def test_reconnect_aborts_when_ecs_task_stopped(self):
+        """Bug: when the sandbox task itself died, reconnect can't help. Record
+        WHY (stop reason captured before ECS metadata expires) and abort with the
+        original error — don't churn on a dead container (re-triggering the
+        reverse-port bind pileup)."""
+        sb, client = self._started_sb()
+        client.exec.side_effect = ConnectionError("tunnel down")
+        tunnel = MagicMock()
+        tunnel.is_open = False
+        sb._ssh_tunnel = tunnel
+        sb._task_arn = "arn:aws:ecs:us-west-2:1234:task/test/dead"
+
+        diag = "lastStatus=STOPPED; stopCode=EssentialContainerExited; stoppedReason='OOM'; container(main=STOPPED exit=137)"
+        with (
+            patch.object(sb, "_describe_task_diagnostics", return_value=("STOPPED", diag)),
+            patch.object(sb, "reconnect_tunnel") as mock_reconnect,
+            patch.object(sb, "_free_remote_reverse_ports") as mock_free,
+        ):
+            with pytest.raises(ConnectionError, match="tunnel down"):
+                await sb.exec("echo hi")
+
+        # Dead task → no reverse-port reclaim, no reconnect churn.
+        mock_reconnect.assert_not_called()
+        mock_free.assert_not_called()
+        assert sb._task_confirmed_dead is True
+
+    async def test_reconnect_short_circuits_after_task_confirmed_dead(self):
+        """Once the task is known dead, later execs fail fast without re-probing ECS."""
+        sb, client = self._started_sb()
+        client.exec.side_effect = ConnectionError("tunnel down")
+        tunnel = MagicMock()
+        tunnel.is_open = False
+        sb._ssh_tunnel = tunnel
+        sb._task_confirmed_dead = True
+
+        with patch.object(sb, "_describe_task_diagnostics") as mock_diag:
+            with pytest.raises(ConnectionError):
+                await sb.exec("echo hi")
+
+        mock_diag.assert_not_called()
+
+    async def test_reconnect_proceeds_when_task_running(self):
+        """A transient tunnel death with the task still RUNNING reconnects normally."""
+        sb, client = self._started_sb()
+        client.exec.side_effect = ConnectionError("tunnel down")
+        tunnel = MagicMock()
+        tunnel.is_open = False
+        tunnel.local_port = 19020
+        tunnel.wait_ready = MagicMock()
+        sb._ssh_tunnel = tunnel
+
+        new_client = MagicMock()
+        new_client.exec = AsyncMock(return_value=ExecResult("ok", "", 0))
+        new_client.close = AsyncMock(return_value=None)
+
+        async def _reconnect():
+            tunnel.is_open = True
+
+        with (
+            patch.object(sb, "_describe_task_diagnostics", return_value=("RUNNING", "lastStatus=RUNNING")),
+            patch.object(sb, "reconnect_tunnel", side_effect=_reconnect) as mock_reconnect,
+            patch.object(sb, "_free_remote_reverse_ports"),
+            patch(f"{_PATCH_PREFIX}.ExecClient", return_value=new_client),
+        ):
+            result = await sb.exec("echo hi")
+
+        assert result.stdout == "ok"
+        mock_reconnect.assert_called_once()
+        assert sb._task_confirmed_dead is False
+
+    def test_describe_task_diagnostics_captures_stop_reason(self):
+        """Stop reason + container exit code must be surfaced for the post-mortem."""
+        sb = _make_sandbox()
+        sb._task_arn = "arn:aws:ecs:us-west-2:1234:task/test/x"
+        ecs = MagicMock()
+        ecs.describe_tasks.return_value = {
+            "tasks": [
+                {
+                    "lastStatus": "STOPPED",
+                    "stopCode": "EssentialContainerExited",
+                    "stoppedReason": "Essential container in task exited",
+                    "containers": [
+                        {"name": "main", "lastStatus": "STOPPED", "exitCode": 137, "reason": "OutOfMemory"},
+                        {"name": "ssh-tunnel", "lastStatus": "STOPPED", "exitCode": 0},
+                    ],
+                }
+            ]
+        }
+        sb._ecs = ecs
+
+        status, diag = sb._describe_task_diagnostics()
+
+        assert status == "STOPPED"
+        assert "stopCode=EssentialContainerExited" in diag
+        assert "stoppedReason='Essential container in task exited'" in diag
+        assert "exit=137" in diag
+        assert "OutOfMemory" in diag
+
+    def test_describe_task_diagnostics_handles_expired_metadata(self):
+        sb = _make_sandbox()
+        sb._task_arn = "arn:aws:ecs:us-west-2:1234:task/test/x"
+        ecs = MagicMock()
+        ecs.describe_tasks.return_value = {"tasks": []}
+        sb._ecs = ecs
+
+        status, diag = sb._describe_task_diagnostics()
+
+        assert status == "GONE"
+        assert "expired" in diag
+
+    def test_describe_task_diagnostics_best_effort_on_api_error(self):
+        sb = _make_sandbox()
+        sb._task_arn = "arn:aws:ecs:us-west-2:1234:task/test/x"
+        ecs = MagicMock()
+        ecs.describe_tasks.side_effect = RuntimeError("throttled")
+        sb._ecs = ecs
+
+        status, diag = sb._describe_task_diagnostics()
+
+        # UNKNOWN → caller still attempts reconnect (transient API hiccup).
+        assert status == "UNKNOWN"
+        assert "throttled" in diag
 
 
 class TestExecClientAsync:
@@ -694,6 +909,34 @@ class TestSshTunnel:
         assert t.is_open
         assert mock_popen.call_count == 2
 
+    @patch(f"{_PATCH_PREFIX}._free_port", return_value=44444)
+    @patch(f"{_PATCH_PREFIX}.subprocess.Popen")
+    def test_open_retries_on_remote_port_forwarding_failed(self, mock_popen, mock_free_port):
+        """Regression: a reconnect whose reverse port is still held by the dead
+        tunnel's stale listener must retry (the server frees it shortly) instead
+        of aborting immediately — the EVAL connection-refused rollout failures.
+        """
+        fail_proc = MagicMock()
+        fail_proc.poll.return_value = 255
+        fail_proc.stderr = MagicMock()
+        # ssh emits this (via error(), shown even at LogLevel=ERROR) when the
+        # sandbox sshd can't rebind the reverse listen port (address in use).
+        fail_proc.stderr.read.return_value = b"Warning: remote port forwarding failed for listen port 59579"
+
+        ok_proc = MagicMock()
+        ok_proc.poll.return_value = None
+        ok_proc.pid = 777
+
+        mock_popen.side_effect = [fail_proc, ok_proc]
+
+        t = self._make_tunnel(forward_port=5000, reverses=["59579:host-a:5000"])
+        with patch.object(t, "_wait_for_local_port"):
+            with patch(f"{_PATCH_PREFIX}.time.sleep"):
+                t.open(max_retries=3)
+
+        assert t.is_open
+        assert mock_popen.call_count == 2
+
     @patch(f"{_PATCH_PREFIX}._free_port", return_value=33333)
     @patch(f"{_PATCH_PREFIX}.subprocess.Popen")
     def test_open_raises_on_non_retryable_error(self, mock_popen, mock_free_port):
@@ -737,6 +980,31 @@ class TestSshTunnel:
 
         t.wait_ready(health_url="http://127.0.0.1:5000/health", timeout=5)
         mock_urlopen.assert_called_once()
+
+
+# ── TestSshSidecarContainer ───────────────────────────────────────────
+
+
+class TestSshSidecarContainer:
+    """The generated sidecar must ship the tools the reconnect path relies on."""
+
+    def test_sidecar_installs_fuser_for_reverse_port_reclaim(self):
+        from nemo_evaluator.sandbox.ecs_fargate import build_ssh_sidecar_container
+
+        container = build_ssh_sidecar_container(_sidecar(), public_key_value="ssh-rsa fake", max_lifetime_sec=0)
+        cmd = container["command"][0]
+        # psmisc provides `fuser`, used to free a stale reverse listen port.
+        assert "psmisc" in cmd
+
+    def test_sidecar_keeps_long_keepalive_tolerance(self):
+        """EVAL-1143: keepalive stays long so tunnels survive ~2min container
+        setup and multi-hour tasks. The reconnect fix must not regress this."""
+        from nemo_evaluator.sandbox.ecs_fargate import build_ssh_sidecar_container
+
+        container = build_ssh_sidecar_container(_sidecar(), public_key_value="ssh-rsa fake", max_lifetime_sec=0)
+        cmd = container["command"][0]
+        assert "ClientAliveInterval 30" in cmd
+        assert "ClientAliveCountMax 20" in cmd
 
 
 # ── TestImageBuilder ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Makes the ECS Fargate sandbox recover from SSH-tunnel deaths instead of failing `POST /exec` with connection-refused, and captures *why* a tunnel died so failures are diagnosable. Addresses two issues from a GPT-OSS-120B SWE-bench Verified run where 122 rollouts were misclassified as infra failures.

## Root cause
**Reconnect became terminal.** On reconnect, the sandbox reused the same `ssh -R <port>` while the sandbox sshd still held the reverse listener from the dead tunnel (kept up to the keepalive window). The bind failed with `remote port forwarding failed (address in use)`, which `SshTunnel.open()` treated as fatal, so `POST /exec` failed with connection-refused. Under high concurrency a burst of failing execs each spawned its own competing reconnect — the `bind [127.0.0.1]:<port>: Address in use` pileup across task streams.

**Tunnel-death cause was unknowable.** Post-mortems could not explain the original death: ECS stopped-task metadata expires (~1h) and CloudWatch retained no stop reason / OOM / container exit cause.

## Changes
- `SshTunnel.open()` retries remote-forward bind failures (previously connection-level errors only).
- Serialize reconnects behind a per-sandbox `asyncio.Lock` so a burst triggers a single reconnect, not a storm of competing `ssh -R` binds.
- Reclaim the stale reverse listen port via `fuser -k` (adds `psmisc` to the sidecar image) before rebinding, so recovery doesn't wait out the keepalive window.
- Capture ECS `lastStatus` / `stopCode` / `stoppedReason` / container `exitCode` at failure time; if the task is gone, abort reconnect instead of churning on a dead container.
- Move the blocking health-wait / cleanup off the event loop.

## Test plan
- [x] `pytest tests/test_sandbox/test_ecs_fargate.py` -> 84 passed; ruff check + format clean.
- [x] New regression tests confirmed to fail against pre-fix code.
- [x] **Live end-to-end on real ECS Fargate** (us-east-2): start -> exec -> simulated tunnel death -> reverse-port reclaim via real `fuser` (`rc=0`) -> reconnect -> exec; then out-of-band `stop_task` -> captured `stopCode=UserInitiated; stoppedReason=...; container(main=STOPPED exit=137)` -> reconnect aborted; task torn down.

## Notes
- `psmisc` changes the sidecar container definition, so the task-definition content hash changes once (one-time re-register; self-healing). Sidecars built before this change lack `fuser` -> graceful fallback to the bind-retry path.
- SSH keepalive tolerance is intentionally left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of the SSH tunnel used by the ECS Fargate sandbox, with smarter retry handling for tunnel startup and connection failures.
  * Added reliable recovery for “dead tunnel” exec sessions, including prevention of reconnect storms during concurrent requests.
  * Enhanced diagnostics capture and best-effort reclamation of stale reverse-port listeners to restore connectivity faster.
* **Tests**
  * Expanded coverage for reconnect/recovery scenarios, stale port reclamation, sidecar command composition, and failure-fast behavior when tasks are already stopped or confirmed dead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->