### PR TITLE
fix: preserve OpenHands tool timing

### DIFF
--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -249,10 +249,10 @@ async def _patch_openhands_sdk(sandbox: "Sandbox", *, cmd_timeout: float | None 
        patched loop continues until ``finish`` is called or
        ``max_iterations`` is reached.
 
-    2. **Capture reasoning in ATIF trajectory** — the runner's event
-       serialization drops ``reasoning_content`` / ``thinking_blocks``.
-       Both the event-to-dict conversion and ``build_trajectory`` are
-       patched so reasoning appears in the output JSON.
+    2. **Capture reasoning, metrics, and tool timing in ATIF trajectory** —
+       the runner's event serialization drops reasoning, per-turn token
+       usage, and observation timestamps.  The event conversion and
+       ``build_trajectory`` stages are patched to preserve them.
 
     3. **Enforce 300 s hard timeout on terminal commands** — the SDK
        only applies a hard timeout when the model passes an explicit
@@ -357,14 +357,13 @@ print(f'agent.py FINISHED={ok1} nudge={ok2} at {p}')
             stdout2 or (r2.stderr or "")[:300],
         )
 
-    # -- Patch 2: capture reasoning + per-step metrics in ATIF trajectory ----
+    # -- Patch 2: capture reasoning, metrics, and tool timing in ATIF --------
     # The runner converts SDK events → intermediate dicts → ATIF steps but
-    # never copies reasoning_content / thinking_blocks or per-turn token usage.
-    # We add both at the event-conversion and step-building stages.
+    # never copies reasoning, per-turn token usage, or observation timestamps.
     #
     # Event-collection (A, B): extract reasoning_content and LLM usage from
     # the SDK event object and store in the intermediate dict.
-    # build_trajectory (C): propagate both to ATIF step fields.
+    # build_trajectory (C, D): propagate step fields and observation timing.
 
     _reasoning_script = """\
 import sys
@@ -451,14 +450,62 @@ new_c = (
     '        elif event_type == "tool_result":'
 )
 
+# D: build_trajectory - preserve observation timing
+old_d = (
+    '        elif event_type == "tool_result":\\n'
+    '            # Find the previous step and add observation\\n'
+    '            if steps and steps[-1].get("source") == "agent":\\n'
+    '                steps[-1]["observation"] = {\\n'
+    '                    "results": [\\n'
+    '                        {\\n'
+    '                            "source_call_id": event.get("tool_call_id"),\\n'
+    '                            "content": event.get("content", ""),\\n'
+    '                        }\\n'
+    '                    ]\\n'
+    '                }'
+)
+new_d = (
+    '        elif event_type == "tool_result":\\n'
+    '            if steps and steps[-1].get("source") == "agent":\\n'
+    '                _started_at = steps[-1].get("timestamp")\\n'
+    '                _completed_at = event.get("timestamp")\\n'
+    '                _timing = {\\n'
+    '                    key: value\\n'
+    '                    for key, value in (("started_at", _started_at), ("completed_at", _completed_at))\\n'
+    '                    if value\\n'
+    '                }\\n'
+    '                if _started_at and _completed_at:\\n'
+    '                    try:\\n'
+    '                        from datetime import datetime as _datetime\\n'
+    '                        _start = _datetime.fromisoformat(str(_started_at).replace("Z", "+00:00"))\\n'
+    '                        _end = _datetime.fromisoformat(str(_completed_at).replace("Z", "+00:00"))\\n'
+    '                        _timing["duration_ms"] = max(0.0, (_end - _start).total_seconds() * 1000)\\n'
+    '                    except (TypeError, ValueError):\\n'
+    '                        pass\\n'
+    '                _result = {\\n'
+    '                    "source_call_id": event.get("tool_call_id"),\\n'
+    '                    "content": event.get("content", ""),\\n'
+    '                }\\n'
+    '                if _timing:\\n'
+    '                    _result["extra"] = _timing\\n'
+    '                steps[-1]["observation"] = {"results": [_result]}'
+)
+
+old_schema = '"schema_version": "ATIF-v1.5",'
+new_schema = '"schema_version": "ATIF-v1.7",'
+
 ok_a = old_a in c
 c = c.replace(old_a, new_a, 1) if ok_a else c
 ok_b = old_b in c
 c = c.replace(old_b, new_b, 1) if ok_b else c
 ok_c = old_c in c
 c = c.replace(old_c, new_c, 1) if ok_c else c
+ok_d = old_d in c
+c = c.replace(old_d, new_d, 1) if ok_d else c
+ok_schema = old_schema in c
+c = c.replace(old_schema, new_schema, 1) if ok_d and ok_schema else c
 open(p, 'w').write(c)
-print(f'reasoning+metrics: msg={ok_a} action={ok_b} traj={ok_c}')
+print(f'reasoning+metrics+timing: msg={ok_a} action={ok_b} traj={ok_c} timing={ok_d} schema={ok_schema}')
 """
     encoded = base64.b64encode(_reasoning_script.encode()).decode()
     r3 = await sandbox.exec(

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -226,6 +226,116 @@ class TestPatchOpenhandsSDK:
             f"runner patch must disable the default visualizer to avoid rich grapheme hang; got:\n{runner_patch}"
         )
 
+    async def test_runner_patch_preserves_tool_timing(self, tmp_path):
+        import base64
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            """\
+import os
+
+
+def build_trajectory(events, llm_metrics, model_name):
+    steps = []
+    step_id = 1
+
+    for event in events:
+        event_type = event.get("type", "")
+
+        if event_type == "assistant_message":
+            step = {
+                "step_id": step_id,
+                "timestamp": event.get("timestamp"),
+                "source": "agent",
+                "message": event.get("content", ""),
+                "model_name": model_name,
+            }
+            tool_calls = event.get("tool_calls", [])
+            if tool_calls:
+                step["tool_calls"] = [
+                    {
+                        "tool_call_id": tc.get("id", ""),
+                        "function_name": tc.get("name", ""),
+                        "arguments": tc.get("arguments", {}),
+                    }
+                    for tc in tool_calls
+                ]
+            steps.append(step)
+            step_id += 1
+
+        elif event_type == "tool_result":
+            # Find the previous step and add observation
+            if steps and steps[-1].get("source") == "agent":
+                steps[-1]["observation"] = {
+                    "results": [
+                        {
+                            "source_call_id": event.get("tool_call_id"),
+                            "content": event.get("content", ""),
+                        }
+                    ]
+                }
+
+    trajectory = {
+        "schema_version": "ATIF-v1.5",
+        "session_id": os.environ.get("SESSION_ID", "harbor-session"),
+        "agent": {"name": "openhands-sdk", "version": "unknown"},
+        "steps": steps,
+        "final_metrics": {},
+    }
+    return trajectory
+"""
+        )
+
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = MagicMock(stdout="ok", stderr="", return_code=0)
+        await _patch_openhands_sdk(sandbox)
+
+        decoded_scripts = []
+        for call in sandbox.exec.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+            if "base64 -d" in cmd:
+                encoded = cmd.split("echo ", 1)[1].split(" ", 1)[0]
+                decoded_scripts.append(base64.b64decode(encoded).decode())
+
+        trajectory_patch = next(s for s in decoded_scripts if "reasoning+metrics" in s)
+        trajectory_patch = trajectory_patch.replace(
+            "p = '/installed-agent/run_agent.py'",
+            f"p = {str(runner)!r}",
+        )
+        exec(compile(trajectory_patch, "trajectory_patch.py", "exec"), {})
+
+        namespace = {}
+        exec(compile(runner.read_text(), str(runner), "exec"), namespace)
+        trajectory = namespace["build_trajectory"](
+            [
+                {
+                    "type": "assistant_message",
+                    "timestamp": "2026-06-05T12:00:00.000Z",
+                    "tool_calls": [{"id": "call_1", "name": "terminal", "arguments": {"command": "pwd"}}],
+                },
+                {
+                    "type": "tool_result",
+                    "tool_call_id": "call_1",
+                    "content": "/testbed",
+                    "timestamp": "2026-06-05T12:00:01.250Z",
+                },
+            ],
+            {},
+            "model",
+        )
+
+        assert trajectory["schema_version"] == "ATIF-v1.7"
+        result = trajectory["steps"][0]["observation"]["results"][0]
+        assert result["source_call_id"] == "call_1"
+        assert result["content"] == "/testbed"
+        assert result["extra"] == {
+            "started_at": "2026-06-05T12:00:00.000Z",
+            "completed_at": "2026-06-05T12:00:01.250Z",
+            "duration_ms": 1250.0,
+        }
+
 
 class TestSandboxEnvironmentAdapter:
     def test_exposes_all_base_environment_public_attrs(self, tmp_path):


### PR DESCRIPTION
*All credit goes to Shelby Thomas*

## Summary

Harbor's OpenHands SDK runner receives timestamps for both the tool-call action
and its observation, but drops the observation timestamp while constructing the
ATIF trajectory. The trace therefore contains the tool name, arguments, and
output, but not enough information to calculate the agent-visible tool wait.

This MR applies an OpenHands-specific downstream workaround in NeMo Evaluator:

- preserve the action timestamp as `started_at`;
- preserve the observation timestamp as `completed_at`;
- derive a non-negative `duration_ms`;
- store those fields in `observation.results[].extra`;
- emit `ATIF-v1.7`, where result-level `extra` is defined.

## Why this matters

Without both ends of the interval, downstream trace processing can count tool
calls but cannot answer:

- What percentage of a run was spent waiting for tools?
- What is tool time versus inference/orchestration time?
- Which tools dominate p50, p95, and total wait time?
- Do concurrent tool calls overlap and need de-overlapping?
- Did a tool, sandbox, or harness regression make evaluations slower?

The interval captured here is agent-visible wall time from tool-call emission
to observation completion. It includes dispatch and output collection. It is
not command CPU time or an executor-only monotonic measurement.

## Ownership

| Component | Current behavior | Required action |
|---|---|---|
| OpenHands SDK | Emits action and observation timestamps | No fix required for this loss |
| Harbor OpenHands adapter | Drops observation timing during ATIF serialization | Permanent fix belongs upstream |
| NeMo Evaluator | Receives the incomplete Harbor trajectory | Temporary runtime patch in this MR |
| Other Harbor agents | Use separate serializers and trace formats | Audit individually; this patch does not alter them |

This runtime patch executes only when the configured Harbor agent is
`openhands-sdk`. It does not change mini-SWE-agent, Codex, Terminus, Tau2, or
other Harbor agents.

## Before and after

The following is a real before/after run using:

- OpenHands SDK in a real Docker sandbox;
- NVIDIA inference API `/v1/chat/completions`;
- model `nvidia/nvidia/nemotron-3-ultra`;
- a real `terminal` call running `printf 'timing-proof\n'`;
- two successful model requests: one tool call and one finish call;
- reward `1.0` in both runs.

### Before: successful tool call, timing discarded

Base commit: `986d0650db067e08f9061993870e4273f4d7d50a`

```json
{
  "reward": 1.0,
  "schema_version": "ATIF-v1.5",
  "model_name": "openai/nvidia/nvidia/nemotron-3-ultra",
  "tool_call": {
    "function_name": "terminal",
    "arguments": {
      "command": "printf 'timing-proof\\n'"
    }
  },
  "observation_result": {
    "content": "timing-proof\n"
  }
}
```

The model and terminal both ran successfully, but the result has no completion
timestamp. It cannot be paired into a measured tool-wait interval.

### After: successful tool call with usable wall-clock interval

```json
{
  "reward": 1.0,
  "schema_version": "ATIF-v1.7",
  "model_name": "openai/nvidia/nvidia/nemotron-3-ultra",
  "tool_call": {
    "function_name": "terminal",
    "arguments": {
      "command": "printf 'timing-proof\\n'"
    }
  },
  "observation_result": {
    "content": "timing-proof\n",
    "extra": {
      "started_at": "2026-06-06T22:07:45.490649",
      "completed_at": "2026-06-06T22:07:45.512004",
      "duration_ms": 21.355
    }
  }
}
```

ANSI terminal control sequences are omitted from the displayed content for
readability.

## Where Harbor loses the data

The OpenHands event conversion already preserves the observation timestamp in
an intermediate event:

```python
{
    "type": "tool_result",
    "tool_call_id": event.tool_call_id,
    "content": obs_content,
    "timestamp": event.timestamp,
}
```

The affected `build_trajectory()` path then emits only:

```json
{
  "observation": {
    "results": [
      {
        "source_call_id": "call_1",
        "content": "/workspace"
      }
    ]
  }
}
```

The action step still has its start timestamp, but the observation completion
timestamp has been discarded.

## Deterministic reproduction

The regression test applies the same encoded runtime patch used in production
to a representative Harbor runner and executes `build_trajectory()` with:

```json
[
  {
    "type": "assistant_message",
    "timestamp": "2026-06-05T12:00:00.000Z",
    "tool_calls": [
      {
        "id": "call_1",
        "name": "terminal",
        "arguments": {"command": "pwd"}
      }
    ]
  },
  {
    "type": "tool_result",
    "tool_call_id": "call_1",
    "content": "/testbed",
    "timestamp": "2026-06-05T12:00:01.250Z"
  }
]
```

Run:

```bash
python -m pytest \
  tests/test_solvers/test_harbor_solver.py::TestPatchOpenhandsSDK::test_runner_patch_preserves_tool_timing \
  -q
```

Expected result:

```json
{
  "source_call_id": "call_1",
  "content": "/testbed",
  "extra": {
    "started_at": "2026-06-05T12:00:00.000Z",
    "completed_at": "2026-06-05T12:00:01.250Z",
    "duration_ms": 1250.0
  }
}
```

The test also verifies the emitted schema is `ATIF-v1.7`.

## Live model and endpoint coverage

The serializer change runs after model inference, once OpenHands has emitted
the action and observation events. Testing every model name would add little
confidence, but representative protocol paths were exercised:

| Model | Model API path used by OpenHands | Live result |
|---|---|---|
| `openai/openai/gpt-5.5` | `/responses` | Timing preserved; terminal interval `21.292 ms` |
| `nvidia/nvidia/nemotron-3-ultra` | `/chat/completions` | Live before/after; terminal interval `21.355 ms` |

Both tests used the NVIDIA inference API, real model requests, OpenHands SDK,
and a real Docker terminal tool. Additional model testing is useful when a
provider introduces a new OpenHands event shape or execution path, not for
every model producing the same action/observation events.

## Why ATIF v1.7

ATIF v1.5 does not define `ObservationResult.extra`. Emitting the new fields
while retaining the v1.5 declaration would make the trajectory's schema label
incorrect. ATIF v1.7 provides the result-level `extra` field used here.

## Upstream status and downstream lifecycle

Harbor `main` was checked on June 6, 2026. Its OpenHands runner still:

1. preserves the observation timestamp in the intermediate `tool_result`;
2. drops it while constructing `observation.results[]`;
3. emits only `source_call_id` and `content`;
4. declares the trajectory as `ATIF-v1.5`.

Relevant upstream runner:
[`src/harbor/agents/installed/openhands_sdk_runner.py`](https://github.com/harbor-framework/harbor/blob/main/src/harbor/agents/installed/openhands_sdk_runner.py)

The permanent Harbor fix should preserve both timestamps, pair results to
actions by `tool_call_id`, emit the timing fields under result `extra`, move to
ATIF v1.7, and add an upstream regression test.

Once a fixed Harbor revision is released and pinned:

1. update NeMo Evaluator's Harbor revision;
2. confirm a live OpenHands trace still contains result timing;
3. remove this timing portion of the runtime string patch;
4. retain an integration/regression test.

Until then, this scoped downstream patch prevents timing data loss in NeMo
Evaluator OpenHands runs.

## Validation

```text
ruff check src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_solver.py
All checks passed!

python -m pytest tests/test_solvers/test_harbor_solver.py -q --tb=short
39 passed
```

The live ATIF artifact was also validated against Harbor 0.6.6's ATIF v1.7
model. The repository-wide offline suite was attempted separately but stalled
in the pre-existing
`tests/test_adapters/test_disk_cache.py::test_get_set_roundtrip` test, so it is
not reported as passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced trajectory data capture to include tool timing metrics alongside existing reasoning data.
  * Updated schema version to support expanded timing information (timestamps and duration).

* **Tests**
  * Added validation test for timing metric preservation in trajectory generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->