### PR TITLE
feat: guard chat-template kwargs on /v1/completions

### DIFF
--- a/src/nemo_evaluator/adapters/interceptors/endpoint.py
+++ b/src/nemo_evaluator/adapters/interceptors/endpoint.py
@@ -27,6 +27,7 @@ from nemo_evaluator.adapters.types import (
     AdapterResponse,
     RequestToResponseInterceptor,
 )
+from nemo_evaluator.completions_guard import enforce_text_completions_body
 from nemo_evaluator.observability.model_traffic import get_store
 
 logger = logging.getLogger(__name__)
@@ -144,6 +145,7 @@ class Interceptor(RequestToResponseInterceptor):
         url = f"{self._upstream_url}{req.path}"
 
         body = {**req.body, **self._extra_body}
+        enforce_text_completions_body(req.path, body)
         # Capture the effective upstream request, including endpoint-level
         # body overrides, before sending it.
         self._request_stream_usage_chunks(req.path, body)

--- a/src/nemo_evaluator/completions_guard.py
+++ b/src/nemo_evaluator/completions_guard.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Guard against chat-template controls leaking onto text completions.
+
+``chat_template_kwargs`` / ``chat_template`` only take effect on a chat
+endpoint, where the server renders the prompt from ``messages``. The text
+completions endpoint (``/v1/completions``) consumes an already-rendered
+``prompt`` and never applies a chat template, so these fields are inert: a
+toggle such as ``chat_template_kwargs.enable_thinking=false`` injected through
+the adapter never reaches the model. That produces a run that *looks* correctly
+configured but silently scores with the wrong generation mode.
+
+The policy is tiered and model-agnostic — it never needs to know a model's
+specific reasoning key:
+
+* **present (any value)** -> strip the field and log a warning. Removes the
+  silent inert field so it can never quietly change (or fail to change) a run.
+* **disable intent** (a boolean ``False`` anywhere inside
+  ``chat_template_kwargs``, e.g. ``enable_thinking: false`` / ``thinking:
+  false``) -> hard error. Someone is trying to turn model behavior *off* in a
+  place that is silently ignored, so the behavior would stay *on* and scores
+  would be misleading. Failing fast is safer than a misconfigured run.
+* ``NEMO_EVALUATOR_STRICT_COMPLETIONS=1`` -> escalate *any* present field
+  (even enabling ones) to a hard error, for CI.
+
+A boolean ``False`` is the model-agnostic signal for "turn this off": it does
+not matter whether the key is ``enable_thinking``, ``thinking``, ``reasoning``,
+etc. String-encoded disables (e.g. ``thinking_mode: "chat"``) are not treated
+as a hard error and degrade to strip+warn — still safe, never silent.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+CHAT_TEMPLATE_ONLY_FIELDS: frozenset[str] = frozenset({"chat_template_kwargs", "chat_template"})
+
+STRICT_ENV_VAR = "NEMO_EVALUATOR_STRICT_COMPLETIONS"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+
+def strict_completions_enabled() -> bool:
+    """True when ``NEMO_EVALUATOR_STRICT_COMPLETIONS`` requests hard failures."""
+    return os.environ.get(STRICT_ENV_VAR, "").strip().lower() in _TRUTHY
+
+
+def is_text_completions_path(path: str) -> bool:
+    """True for the OpenAI *text* completions endpoint (``/v1/completions``).
+
+    The chat endpoint ``/v1/chat/completions`` also ends in ``/completions``,
+    so it is explicitly excluded.
+    """
+    clean = path.rstrip("/")
+    return clean.endswith("/completions") and not clean.endswith("/chat/completions")
+
+
+def is_text_completions_endpoint_type(endpoint_type: str | None) -> bool:
+    """True for the legacy ``endpoint_type: completions`` selector."""
+    return (endpoint_type or "").strip().lower() == "completions"
+
+
+def _has_boolean_false(obj: Any) -> bool:
+    """True when a boolean ``False`` appears anywhere inside *obj*.
+
+    ``is False`` (not ``== False``) so the integer ``0`` is not mistaken for a
+    disable toggle.
+    """
+    if obj is False:
+        return True
+    if isinstance(obj, dict):
+        return any(_has_boolean_false(v) for v in obj.values())
+    if isinstance(obj, list):
+        return any(_has_boolean_false(item) for item in obj)
+    return False
+
+
+def _scan_chat_template_fields(obj: Any, prefix: str = "") -> tuple[list[str], list[str]]:
+    """Find chat-template-only keys inside *obj*.
+
+    Returns ``(locations, disabling_locations)`` as dotted paths.
+    ``disabling_locations`` are the ``chat_template_kwargs`` occurrences that
+    carry a boolean ``False`` (a disable intent).
+    """
+    locations: list[str] = []
+    disabling: list[str] = []
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            path = f"{prefix}.{key}" if prefix else str(key)
+            if key in CHAT_TEMPLATE_ONLY_FIELDS:
+                locations.append(path)
+                if key == "chat_template_kwargs" and _has_boolean_false(value):
+                    disabling.append(path)
+            else:
+                sub_locations, sub_disabling = _scan_chat_template_fields(value, path)
+                locations.extend(sub_locations)
+                disabling.extend(sub_disabling)
+    elif isinstance(obj, list):
+        for idx, item in enumerate(obj):
+            sub_locations, sub_disabling = _scan_chat_template_fields(item, f"{prefix}[{idx}]")
+            locations.extend(sub_locations)
+            disabling.extend(sub_disabling)
+    return locations, disabling
+
+
+def _strip_chat_template_fields(obj: Any) -> Any:
+    """Return a deep copy of *obj* with chat-template-only keys removed."""
+    if isinstance(obj, dict):
+        return {
+            key: _strip_chat_template_fields(value)
+            for key, value in obj.items()
+            if key not in CHAT_TEMPLATE_ONLY_FIELDS
+        }
+    if isinstance(obj, list):
+        return [_strip_chat_template_fields(item) for item in obj]
+    return obj
+
+
+def _build_message(
+    locations: list[str],
+    *,
+    context: str,
+    disabling: list[str],
+    strict: bool,
+) -> str:
+    fields = sorted({loc.rsplit(".", 1)[-1] for loc in locations})
+    where = f" (found at: {', '.join(sorted(set(locations)))})"
+    base = (
+        f"Chat-template-only field(s) [{', '.join(fields)}] present in {context}{where}. "
+        "The text completions endpoint (/v1/completions) consumes an already-rendered "
+        "'prompt' and never applies a chat template, so these fields are inert and never "
+        "reach the model."
+    )
+    guidance = (
+        " Configure the prompt-side toggle where the prompt is rendered client-side instead "
+        "(for nemo-skills harnesses pass it via params.extra.args, e.g. "
+        "'++chat_template_kwargs.enable_thinking=false'; the exact key is model-specific), "
+        "or use a /v1/chat/completions endpoint for server-side templating."
+    )
+    if disabling:
+        why = (
+            f" A disabling value (boolean false) is set under {', '.join(sorted(set(disabling)))} — "
+            "an attempt to turn model behavior (e.g. reasoning) OFF that is silently ignored here, "
+            "so the model would run with it still ON and scores would be misleading. Failing fast."
+        )
+        return base + why + guidance
+    if strict:
+        why = f" {STRICT_ENV_VAR} is set, so any chat-template field on a completions endpoint is a hard error."
+        return base + why + guidance
+    why = (
+        " They were stripped before reaching the model. A disabling value (boolean false) here would "
+        f"be a hard error; set {STRICT_ENV_VAR}=1 to make any such field a hard error."
+    )
+    return base + why + guidance
+
+
+def enforce_text_completions_body(path: str, body: dict[str, Any], *, strict: bool | None = None) -> None:
+    """Enforce the chat-template policy on a text-completions request *body*.
+
+    Mutates *body* in place (strips inert fields). No-op for chat endpoints or
+    clean bodies. Raises ``ValueError`` when a disable intent is present, or for
+    any present field when strict mode is enabled.
+    """
+    if not is_text_completions_path(path):
+        return
+    locations, disabling = _scan_chat_template_fields(body)
+    if not locations:
+        return
+    strict = strict_completions_enabled() if strict is None else strict
+    message = _build_message(locations, context=f"a request to {path!r}", disabling=disabling, strict=strict)
+    if disabling or strict:
+        raise ValueError(message)
+    logger.warning(message)
+    for name in [key for key in body if key in CHAT_TEMPLATE_ONLY_FIELDS]:
+        body.pop(name, None)
+
+
+def normalize_adapter_config_for_endpoint(
+    adapter_config: dict[str, Any] | None,
+    endpoint_type: str | None,
+    *,
+    strict: bool | None = None,
+) -> dict[str, Any] | None:
+    """Enforce the chat-template policy on a legacy ``adapter_config``.
+
+    Only acts when *endpoint_type* selects the text completions endpoint and
+    the config carries a chat-template-only field (e.g.
+    ``params_to_add.chat_template_kwargs``). Returns the config with inert
+    fields stripped, or the input unchanged when there is nothing to do. Raises
+    ``ValueError`` when a disable intent is present, or for any present field
+    when strict mode is enabled.
+    """
+    if not adapter_config:
+        return adapter_config
+    if not is_text_completions_endpoint_type(endpoint_type):
+        return adapter_config
+    locations, disabling = _scan_chat_template_fields(adapter_config)
+    if not locations:
+        return adapter_config
+    strict = strict_completions_enabled() if strict is None else strict
+    message = _build_message(
+        locations,
+        context="adapter_config for a completions endpoint",
+        disabling=disabling,
+        strict=strict,
+    )
+    if disabling or strict:
+        raise ValueError(message)
+    logger.warning(message)
+    return _strip_chat_template_fields(adapter_config)

--- a/src/nemo_evaluator/completions_guard.py
+++ b/src/nemo_evaluator/completions_guard.py
@@ -187,8 +187,9 @@ def enforce_text_completions_body(path: str, body: dict[str, Any], *, strict: bo
     if disabling or strict:
         raise ValueError(message)
     logger.warning(message)
-    for name in [key for key in body if key in CHAT_TEMPLATE_ONLY_FIELDS]:
-        body.pop(name, None)
+    stripped = _strip_chat_template_fields(body)
+    body.clear()
+    body.update(stripped)
 
 
 def normalize_adapter_config_for_endpoint(

--- a/src/nemo_evaluator/completions_guard.py
+++ b/src/nemo_evaluator/completions_guard.py
@@ -22,23 +22,30 @@ toggle such as ``chat_template_kwargs.enable_thinking=false`` injected through
 the adapter never reaches the model. That produces a run that *looks* correctly
 configured but silently scores with the wrong generation mode.
 
-The policy is tiered and model-agnostic — it never needs to know a model's
-specific reasoning key:
+The policy is model-agnostic — it never needs to know a model's specific
+reasoning key:
 
-* **present (any value)** -> strip the field and log a warning. Removes the
-  silent inert field so it can never quietly change (or fail to change) a run.
-* **disable intent** (a boolean ``False`` anywhere inside
-  ``chat_template_kwargs``, e.g. ``enable_thinking: false`` / ``thinking:
-  false``) -> hard error. Someone is trying to turn model behavior *off* in a
-  place that is silently ignored, so the behavior would stay *on* and scores
-  would be misleading. Failing fast is safer than a misconfigured run.
-* ``NEMO_EVALUATOR_STRICT_COMPLETIONS=1`` -> escalate *any* present field
-  (even enabling ones) to a hard error, for CI.
+* a **boolean toggle** (``True`` or ``False``) anywhere inside
+  ``chat_template_kwargs`` (e.g. ``enable_thinking: true`` / ``thinking:
+  false``) -> hard error. A boolean is a deliberate attempt to switch model
+  behavior on or off; on a text completions endpoint that switch is silently
+  ignored, so the run would score in the wrong mode. Failing fast is safer
+  than a misconfigured run.
+* any other present field (a ``chat_template`` string, non-boolean
+  ``chat_template_kwargs`` values such as ``thinking_mode: "chat"``, etc.) ->
+  strip the field and log a warning. It is inert here but carries no explicit
+  on/off intent, so the run continues without it.
+* ``NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE=1`` -> opt out of the hard
+  error. Every chat-template field, booleans included, is stripped with a
+  warning instead of failing. Use this when a boolean toggle is inherited from
+  a shared config and is known to be safe to ignore on this endpoint.
 
-A boolean ``False`` is the model-agnostic signal for "turn this off": it does
-not matter whether the key is ``enable_thinking``, ``thinking``, ``reasoning``,
-etc. String-encoded disables (e.g. ``thinking_mode: "chat"``) are not treated
-as a hard error and degrade to strip+warn — still safe, never silent.
+Why *any* boolean and not only ``False``: model key names are not standardized
+(``enable_thinking``, ``disable_thinking``, ``thinking``, ...), so the value
+alone cannot distinguish an "on" from an "off" (``disable_thinking: true`` is a
+disable expressed as ``True``). Treating any boolean as a deliberate toggle is
+the model-agnostic signal that someone tried to control generation in a place
+where it is silently ignored.
 """
 
 from __future__ import annotations
@@ -51,14 +58,14 @@ logger = logging.getLogger(__name__)
 
 CHAT_TEMPLATE_ONLY_FIELDS: frozenset[str] = frozenset({"chat_template_kwargs", "chat_template"})
 
-STRICT_ENV_VAR = "NEMO_EVALUATOR_STRICT_COMPLETIONS"
+ALLOW_ENV_VAR = "NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE"
 
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 
-def strict_completions_enabled() -> bool:
-    """True when ``NEMO_EVALUATOR_STRICT_COMPLETIONS`` requests hard failures."""
-    return os.environ.get(STRICT_ENV_VAR, "").strip().lower() in _TRUTHY
+def allow_completions_chat_template() -> bool:
+    """True when ``NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE`` downgrades the hard error to a warning."""
+    return os.environ.get(ALLOW_ENV_VAR, "").strip().lower() in _TRUTHY
 
 
 def is_text_completions_path(path: str) -> bool:
@@ -76,47 +83,47 @@ def is_text_completions_endpoint_type(endpoint_type: str | None) -> bool:
     return (endpoint_type or "").strip().lower() == "completions"
 
 
-def _has_boolean_false(obj: Any) -> bool:
-    """True when a boolean ``False`` appears anywhere inside *obj*.
+def _has_boolean(obj: Any) -> bool:
+    """True when a boolean (``True`` or ``False``) appears anywhere inside *obj*.
 
-    ``is False`` (not ``== False``) so the integer ``0`` is not mistaken for a
-    disable toggle.
+    ``isinstance(..., bool)`` so the integers ``0``/``1`` are not mistaken for a
+    toggle (``isinstance(0, bool)`` is ``False``).
     """
-    if obj is False:
+    if isinstance(obj, bool):
         return True
     if isinstance(obj, dict):
-        return any(_has_boolean_false(v) for v in obj.values())
+        return any(_has_boolean(v) for v in obj.values())
     if isinstance(obj, list):
-        return any(_has_boolean_false(item) for item in obj)
+        return any(_has_boolean(item) for item in obj)
     return False
 
 
 def _scan_chat_template_fields(obj: Any, prefix: str = "") -> tuple[list[str], list[str]]:
     """Find chat-template-only keys inside *obj*.
 
-    Returns ``(locations, disabling_locations)`` as dotted paths.
-    ``disabling_locations`` are the ``chat_template_kwargs`` occurrences that
-    carry a boolean ``False`` (a disable intent).
+    Returns ``(locations, boolean_locations)`` as dotted paths.
+    ``boolean_locations`` are the ``chat_template_kwargs`` occurrences whose
+    value carries a boolean (``True``/``False``) — a deliberate on/off toggle.
     """
     locations: list[str] = []
-    disabling: list[str] = []
+    boolean_locations: list[str] = []
     if isinstance(obj, dict):
         for key, value in obj.items():
             path = f"{prefix}.{key}" if prefix else str(key)
             if key in CHAT_TEMPLATE_ONLY_FIELDS:
                 locations.append(path)
-                if key == "chat_template_kwargs" and _has_boolean_false(value):
-                    disabling.append(path)
+                if key == "chat_template_kwargs" and _has_boolean(value):
+                    boolean_locations.append(path)
             else:
-                sub_locations, sub_disabling = _scan_chat_template_fields(value, path)
+                sub_locations, sub_boolean = _scan_chat_template_fields(value, path)
                 locations.extend(sub_locations)
-                disabling.extend(sub_disabling)
+                boolean_locations.extend(sub_boolean)
     elif isinstance(obj, list):
         for idx, item in enumerate(obj):
-            sub_locations, sub_disabling = _scan_chat_template_fields(item, f"{prefix}[{idx}]")
+            sub_locations, sub_boolean = _scan_chat_template_fields(item, f"{prefix}[{idx}]")
             locations.extend(sub_locations)
-            disabling.extend(sub_disabling)
-    return locations, disabling
+            boolean_locations.extend(sub_boolean)
+    return locations, boolean_locations
 
 
 def _strip_chat_template_fields(obj: Any) -> Any:
@@ -136,8 +143,8 @@ def _build_message(
     locations: list[str],
     *,
     context: str,
-    disabling: list[str],
-    strict: bool,
+    boolean_locations: list[str],
+    fatal: bool,
 ) -> str:
     fields = sorted({loc.rsplit(".", 1)[-1] for loc in locations})
     where = f" (found at: {', '.join(sorted(set(locations)))})"
@@ -153,38 +160,49 @@ def _build_message(
         "'++chat_template_kwargs.enable_thinking=false'; the exact key is model-specific), "
         "or use a /v1/chat/completions endpoint for server-side templating."
     )
-    if disabling:
+    if fatal:
         why = (
-            f" A disabling value (boolean false) is set under {', '.join(sorted(set(disabling)))} — "
-            "an attempt to turn model behavior (e.g. reasoning) OFF that is silently ignored here, "
-            "so the model would run with it still ON and scores would be misleading. Failing fast."
+            f" A boolean toggle is set under {', '.join(sorted(set(boolean_locations)))} — "
+            "an attempt to switch model behavior (e.g. reasoning) on or off that is silently "
+            "ignored here, so the model would run in the wrong mode and scores would be "
+            f"misleading. Failing fast. If this was intentional, set {ALLOW_ENV_VAR}=1 to "
+            "deactivate this failure (the field is stripped and only a warning is logged)."
         )
         return base + why + guidance
-    if strict:
-        why = f" {STRICT_ENV_VAR} is set, so any chat-template field on a completions endpoint is a hard error."
-        return base + why + guidance
-    why = (
-        " They were stripped before reaching the model. A disabling value (boolean false) here would "
-        f"be a hard error; set {STRICT_ENV_VAR}=1 to make any such field a hard error."
-    )
+    why = " They were stripped before reaching the model."
+    if boolean_locations:
+        why += (
+            f" {ALLOW_ENV_VAR} is set, so the boolean toggle under "
+            f"{', '.join(sorted(set(boolean_locations)))} was downgraded to this warning "
+            "instead of a hard error."
+        )
+    else:
+        why += (
+            f" A boolean toggle here would be a hard error; set {ALLOW_ENV_VAR}=1 to "
+            "downgrade any such failure to a warning."
+        )
     return base + why + guidance
 
 
-def enforce_text_completions_body(path: str, body: dict[str, Any], *, strict: bool | None = None) -> None:
+def enforce_text_completions_body(path: str, body: dict[str, Any], *, allow: bool | None = None) -> None:
     """Enforce the chat-template policy on a text-completions request *body*.
 
     Mutates *body* in place (strips inert fields). No-op for chat endpoints or
-    clean bodies. Raises ``ValueError`` when a disable intent is present, or for
-    any present field when strict mode is enabled.
+    clean bodies. Raises ``ValueError`` when a boolean toggle is present inside
+    ``chat_template_kwargs``, unless ``NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE``
+    downgrades it to a warning.
     """
     if not is_text_completions_path(path):
         return
-    locations, disabling = _scan_chat_template_fields(body)
+    locations, boolean_locations = _scan_chat_template_fields(body)
     if not locations:
         return
-    strict = strict_completions_enabled() if strict is None else strict
-    message = _build_message(locations, context=f"a request to {path!r}", disabling=disabling, strict=strict)
-    if disabling or strict:
+    allow = allow_completions_chat_template() if allow is None else allow
+    fatal = bool(boolean_locations) and not allow
+    message = _build_message(
+        locations, context=f"a request to {path!r}", boolean_locations=boolean_locations, fatal=fatal
+    )
+    if fatal:
         raise ValueError(message)
     logger.warning(message)
     stripped = _strip_chat_template_fields(body)
@@ -196,7 +214,7 @@ def normalize_adapter_config_for_endpoint(
     adapter_config: dict[str, Any] | None,
     endpoint_type: str | None,
     *,
-    strict: bool | None = None,
+    allow: bool | None = None,
 ) -> dict[str, Any] | None:
     """Enforce the chat-template policy on a legacy ``adapter_config``.
 
@@ -204,24 +222,26 @@ def normalize_adapter_config_for_endpoint(
     the config carries a chat-template-only field (e.g.
     ``params_to_add.chat_template_kwargs``). Returns the config with inert
     fields stripped, or the input unchanged when there is nothing to do. Raises
-    ``ValueError`` when a disable intent is present, or for any present field
-    when strict mode is enabled.
+    ``ValueError`` when a boolean toggle is present inside ``chat_template_kwargs``,
+    unless ``NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE`` downgrades it to a
+    warning.
     """
     if not adapter_config:
         return adapter_config
     if not is_text_completions_endpoint_type(endpoint_type):
         return adapter_config
-    locations, disabling = _scan_chat_template_fields(adapter_config)
+    locations, boolean_locations = _scan_chat_template_fields(adapter_config)
     if not locations:
         return adapter_config
-    strict = strict_completions_enabled() if strict is None else strict
+    allow = allow_completions_chat_template() if allow is None else allow
+    fatal = bool(boolean_locations) and not allow
     message = _build_message(
         locations,
         context="adapter_config for a completions endpoint",
-        disabling=disabling,
-        strict=strict,
+        boolean_locations=boolean_locations,
+        fatal=fatal,
     )
-    if disabling or strict:
+    if fatal:
         raise ValueError(message)
     logger.warning(message)
     return _strip_chat_template_fields(adapter_config)

--- a/src/nemo_evaluator/environments/container.py
+++ b/src/nemo_evaluator/environments/container.py
@@ -56,6 +56,7 @@ if TYPE_CHECKING:
 
 import yaml
 
+from nemo_evaluator.completions_guard import normalize_adapter_config_for_endpoint
 from nemo_evaluator.environments.base import EvalEnvironment, SeedResult, VerifyResult
 
 logger = logging.getLogger(__name__)
@@ -106,6 +107,10 @@ def build_legacy_run_config(
     }
     if api_key:
         api_endpoint["api_key_name"] = _API_KEY_ENV
+    # Chat-template controls are inert on a text-completions endpoint and would
+    # silently leave reasoning enabled; strip (or reject under strict mode)
+    # before the container's in-process adapter ever sees them.
+    adapter_config = normalize_adapter_config_for_endpoint(adapter_config, endpoint_type)
     if adapter_config:
         api_endpoint["adapter_config"] = adapter_config
     run_config: dict[str, Any] = {

--- a/src/nemo_evaluator/environments/container.py
+++ b/src/nemo_evaluator/environments/container.py
@@ -108,8 +108,9 @@ def build_legacy_run_config(
     if api_key:
         api_endpoint["api_key_name"] = _API_KEY_ENV
     # Chat-template controls are inert on a text-completions endpoint and would
-    # silently leave reasoning enabled; strip (or reject under strict mode)
-    # before the container's in-process adapter ever sees them.
+    # silently leave reasoning enabled; reject a boolean toggle (or strip other
+    # fields) before the container's in-process adapter ever sees them, unless
+    # NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE downgrades it to a warning.
     adapter_config = normalize_adapter_config_for_endpoint(adapter_config, endpoint_type)
     if adapter_config:
         api_endpoint["adapter_config"] = adapter_config

--- a/tests/test_completions_guard.py
+++ b/tests/test_completions_guard.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the chat-template-on-text-completions guard."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from nemo_evaluator.completions_guard import (
+    STRICT_ENV_VAR,
+    enforce_text_completions_body,
+    is_text_completions_endpoint_type,
+    is_text_completions_path,
+    normalize_adapter_config_for_endpoint,
+    strict_completions_enabled,
+)
+from nemo_evaluator.environments.container import build_legacy_run_config
+
+
+@pytest.fixture(autouse=True)
+def _clear_strict_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(STRICT_ENV_VAR, raising=False)
+
+
+# ── predicates ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/v1/completions", True),
+        ("/v1/completions/", True),
+        ("/completions", True),
+        ("/v1/chat/completions", False),
+        ("/v1/chat/completions/", False),
+        ("/v1/embeddings", False),
+        ("/v1/responses", False),
+    ],
+)
+def test_is_text_completions_path(path: str, expected: bool) -> None:
+    assert is_text_completions_path(path) is expected
+
+
+@pytest.mark.parametrize(
+    ("endpoint_type", "expected"),
+    [
+        ("completions", True),
+        ("Completions", True),
+        (" completions ", True),
+        ("chat", False),
+        ("chat_completions", False),
+        (None, False),
+        ("", False),
+    ],
+)
+def test_is_text_completions_endpoint_type(endpoint_type: str | None, expected: bool) -> None:
+    assert is_text_completions_endpoint_type(endpoint_type) is expected
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [("1", True), ("true", True), ("YES", True), ("on", True), ("0", False), ("false", False), ("", False)],
+)
+def test_strict_completions_enabled(monkeypatch: pytest.MonkeyPatch, value: str, expected: bool) -> None:
+    monkeypatch.setenv(STRICT_ENV_VAR, value)
+    assert strict_completions_enabled() is expected
+
+
+# ── request body (#2, in-container send path) ────────────────────────────────
+
+
+@pytest.mark.parametrize("disable", [{"enable_thinking": False}, {"thinking": False}, {"nested": {"x": False}}])
+def test_body_hard_fails_on_disable_intent(disable: dict) -> None:
+    body = {"prompt": "rendered", "chat_template_kwargs": disable}
+    with pytest.raises(ValueError, match="disabling value"):
+        enforce_text_completions_body("/v1/completions", body)
+    assert "chat_template_kwargs" in body
+
+
+@pytest.mark.parametrize(
+    "enabling",
+    [{"thinking": True, "reasoning_effort": "max"}, {"thinking_mode": "chat"}, {"enable_thinking": True}],
+)
+def test_body_strips_and_warns_on_non_disabling(enabling: dict, caplog: pytest.LogCaptureFixture) -> None:
+    body = {"prompt": "rendered", "chat_template_kwargs": enabling}
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
+        enforce_text_completions_body("/v1/completions", body)
+    assert body == {"prompt": "rendered"}
+    assert "chat_template_kwargs" in caplog.text
+    assert "params.extra.args" in caplog.text
+
+
+def test_body_integer_zero_is_not_a_disable(caplog: pytest.LogCaptureFixture) -> None:
+    body = {"prompt": "rendered", "chat_template_kwargs": {"some_count": 0}}
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
+        enforce_text_completions_body("/v1/completions", body)
+    assert body == {"prompt": "rendered"}
+
+
+def test_body_strict_hard_fails_even_when_enabling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(STRICT_ENV_VAR, "1")
+    body = {"prompt": "rendered", "chat_template_kwargs": {"thinking": True}}
+    with pytest.raises(ValueError, match="STRICT"):
+        enforce_text_completions_body("/v1/completions", body)
+
+
+def test_body_chat_template_string_strips_not_fails(caplog: pytest.LogCaptureFixture) -> None:
+    body = {"prompt": "rendered", "chat_template": "{{ jinja }}"}
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
+        enforce_text_completions_body("/v1/completions", body)
+    assert body == {"prompt": "rendered"}
+
+
+@pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/chat/completions/"])
+def test_body_allows_chat_endpoint(path: str) -> None:
+    body = {"messages": [], "chat_template_kwargs": {"enable_thinking": False}}
+    enforce_text_completions_body(path, body)
+    assert body["chat_template_kwargs"] == {"enable_thinking": False}
+
+
+def test_body_noop_on_clean_request() -> None:
+    body = {"prompt": "rendered", "max_tokens": 16}
+    enforce_text_completions_body("/v1/completions", body)
+    assert body == {"prompt": "rendered", "max_tokens": 16}
+
+
+# ── adapter_config (#1, launcher/config-assembly path) ────────────────────────
+
+
+def test_adapter_config_hard_fails_on_nested_disable() -> None:
+    adapter_config = {"params_to_add": {"chat_template_kwargs": {"enable_thinking": False}}}
+    with pytest.raises(ValueError, match="disabling value"):
+        normalize_adapter_config_for_endpoint(adapter_config, "completions")
+
+
+def test_adapter_config_strips_inherited_enabling_value(caplog: pytest.LogCaptureFixture) -> None:
+    # Mirrors the real deepseek RULER merge: _model.yaml injects thinking: true.
+    adapter_config = {
+        "use_reasoning": False,
+        "process_reasoning_traces": False,
+        "params_to_add": {
+            "chat_template_kwargs": {"thinking": True, "reasoning_effort": "max"},
+            "skip_special_tokens": False,
+            "min_tokens": 4,
+        },
+    }
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
+        cleaned = normalize_adapter_config_for_endpoint(adapter_config, "completions")
+    assert cleaned == {
+        "use_reasoning": False,
+        "process_reasoning_traces": False,
+        "params_to_add": {"skip_special_tokens": False, "min_tokens": 4},
+    }
+    assert adapter_config["params_to_add"]["chat_template_kwargs"] == {"thinking": True, "reasoning_effort": "max"}
+    assert "params_to_add.chat_template_kwargs" in caplog.text
+
+
+def test_adapter_config_strict_hard_fails_even_when_enabling(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(STRICT_ENV_VAR, "1")
+    adapter_config = {"params_to_add": {"chat_template_kwargs": {"thinking": True}}}
+    with pytest.raises(ValueError, match="STRICT"):
+        normalize_adapter_config_for_endpoint(adapter_config, "completions")
+
+
+def test_adapter_config_identity_on_chat_endpoint() -> None:
+    adapter_config = {"params_to_add": {"chat_template_kwargs": {"enable_thinking": False}}}
+    result = normalize_adapter_config_for_endpoint(adapter_config, "chat")
+    assert result is adapter_config
+
+
+def test_adapter_config_identity_when_clean() -> None:
+    adapter_config = {"params_to_add": {"temperature": 0.0}}
+    result = normalize_adapter_config_for_endpoint(adapter_config, "completions")
+    assert result is adapter_config
+
+
+def test_adapter_config_none_passthrough() -> None:
+    assert normalize_adapter_config_for_endpoint(None, "completions") is None
+
+
+# ── build_legacy_run_config integration ──────────────────────────────────────
+
+
+def test_build_legacy_run_config_strips_inherited_enabling() -> None:
+    run_config = build_legacy_run_config(
+        task="ruler",
+        model_url="http://localhost:8000/v1/completions",
+        model_id="m",
+        endpoint_type="completions",
+        adapter_config={"params_to_add": {"chat_template_kwargs": {"thinking": True}, "seed": 1}},
+    )
+    embedded = run_config["target"]["api_endpoint"]["adapter_config"]
+    assert embedded == {"params_to_add": {"seed": 1}}
+
+
+def test_build_legacy_run_config_hard_fails_on_disable() -> None:
+    with pytest.raises(ValueError, match="disabling value"):
+        build_legacy_run_config(
+            task="ruler",
+            model_url="http://localhost:8000/v1/completions",
+            model_id="m",
+            endpoint_type="completions",
+            adapter_config={"params_to_add": {"chat_template_kwargs": {"enable_thinking": False}}},
+        )
+
+
+def test_build_legacy_run_config_keeps_for_chat() -> None:
+    adapter_config = {"params_to_add": {"chat_template_kwargs": {"enable_thinking": False}}}
+    run_config = build_legacy_run_config(
+        task="mmlu",
+        model_url="http://localhost:8000/v1/chat/completions",
+        model_id="m",
+        endpoint_type="chat",
+        adapter_config=adapter_config,
+    )
+    embedded = run_config["target"]["api_endpoint"]["adapter_config"]
+    assert embedded == adapter_config

--- a/tests/test_completions_guard.py
+++ b/tests/test_completions_guard.py
@@ -9,19 +9,19 @@ import logging
 import pytest
 
 from nemo_evaluator.completions_guard import (
-    STRICT_ENV_VAR,
+    ALLOW_ENV_VAR,
+    allow_completions_chat_template,
     enforce_text_completions_body,
     is_text_completions_endpoint_type,
     is_text_completions_path,
     normalize_adapter_config_for_endpoint,
-    strict_completions_enabled,
 )
 from nemo_evaluator.environments.container import build_legacy_run_config
 
 
 @pytest.fixture(autouse=True)
-def _clear_strict_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv(STRICT_ENV_VAR, raising=False)
+def _clear_allow_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ALLOW_ENV_VAR, raising=False)
 
 
 # ── predicates ──────────────────────────────────────────────────────────────
@@ -63,28 +63,48 @@ def test_is_text_completions_endpoint_type(endpoint_type: str | None, expected: 
     ("value", "expected"),
     [("1", True), ("true", True), ("YES", True), ("on", True), ("0", False), ("false", False), ("", False)],
 )
-def test_strict_completions_enabled(monkeypatch: pytest.MonkeyPatch, value: str, expected: bool) -> None:
-    monkeypatch.setenv(STRICT_ENV_VAR, value)
-    assert strict_completions_enabled() is expected
+def test_allow_completions_chat_template(monkeypatch: pytest.MonkeyPatch, value: str, expected: bool) -> None:
+    monkeypatch.setenv(ALLOW_ENV_VAR, value)
+    assert allow_completions_chat_template() is expected
 
 
 # ── request body (#2, in-container send path) ────────────────────────────────
 
 
-@pytest.mark.parametrize("disable", [{"enable_thinking": False}, {"thinking": False}, {"nested": {"x": False}}])
-def test_body_hard_fails_on_disable_intent(disable: dict) -> None:
-    body = {"prompt": "rendered", "chat_template_kwargs": disable}
-    with pytest.raises(ValueError, match="disabling value"):
+@pytest.mark.parametrize(
+    "toggle",
+    [
+        {"enable_thinking": False},
+        {"thinking": False},
+        {"thinking": True},
+        {"enable_thinking": True},
+        {"nested": {"x": False}},
+        {"nested": {"x": True}},
+    ],
+)
+def test_body_hard_fails_on_boolean_toggle(toggle: dict) -> None:
+    body = {"prompt": "rendered", "chat_template_kwargs": toggle}
+    with pytest.raises(ValueError) as exc_info:
         enforce_text_completions_body("/v1/completions", body)
+    # The error must tell the user how to deactivate the failure.
+    assert "boolean toggle" in str(exc_info.value)
+    assert ALLOW_ENV_VAR in str(exc_info.value)
+    # It raises before mutating the body.
     assert "chat_template_kwargs" in body
 
 
-@pytest.mark.parametrize(
-    "enabling",
-    [{"thinking": True, "reasoning_effort": "max"}, {"thinking_mode": "chat"}, {"enable_thinking": True}],
-)
-def test_body_strips_and_warns_on_non_disabling(enabling: dict, caplog: pytest.LogCaptureFixture) -> None:
-    body = {"prompt": "rendered", "chat_template_kwargs": enabling}
+def test_body_hard_fails_on_nested_boolean_toggle() -> None:
+    body = {"prompt": "rendered", "extra_body": {"chat_template_kwargs": {"thinking": True}}}
+    with pytest.raises(ValueError, match="boolean toggle"):
+        enforce_text_completions_body("/v1/completions", body)
+
+
+@pytest.mark.parametrize("toggle", [{"thinking": True}, {"enable_thinking": False}])
+def test_body_allow_env_downgrades_boolean_to_warning(
+    toggle: dict, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv(ALLOW_ENV_VAR, "1")
+    body = {"prompt": "rendered", "chat_template_kwargs": toggle}
     with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
         enforce_text_completions_body("/v1/completions", body)
     assert body == {"prompt": "rendered"}
@@ -92,18 +112,22 @@ def test_body_strips_and_warns_on_non_disabling(enabling: dict, caplog: pytest.L
     assert "params.extra.args" in caplog.text
 
 
-def test_body_integer_zero_is_not_a_disable(caplog: pytest.LogCaptureFixture) -> None:
-    body = {"prompt": "rendered", "chat_template_kwargs": {"some_count": 0}}
+@pytest.mark.parametrize("kwargs", [{"thinking_mode": "chat"}, {"reasoning_effort": "max"}])
+def test_body_strips_and_warns_on_non_boolean(kwargs: dict, caplog: pytest.LogCaptureFixture) -> None:
+    body = {"prompt": "rendered", "chat_template_kwargs": kwargs}
     with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
         enforce_text_completions_body("/v1/completions", body)
     assert body == {"prompt": "rendered"}
+    assert "chat_template_kwargs" in caplog.text
+    assert "params.extra.args" in caplog.text
 
 
-def test_body_strict_hard_fails_even_when_enabling(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(STRICT_ENV_VAR, "1")
-    body = {"prompt": "rendered", "chat_template_kwargs": {"thinking": True}}
-    with pytest.raises(ValueError, match="STRICT"):
+def test_body_integer_is_not_a_boolean(caplog: pytest.LogCaptureFixture) -> None:
+    # 0/1 are ints, not booleans: no toggle, so strip+warn rather than hard fail.
+    body = {"prompt": "rendered", "chat_template_kwargs": {"some_count": 0, "other": 1}}
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
         enforce_text_completions_body("/v1/completions", body)
+    assert body == {"prompt": "rendered"}
 
 
 def test_body_chat_template_string_strips_not_fails(caplog: pytest.LogCaptureFixture) -> None:
@@ -111,6 +135,32 @@ def test_body_chat_template_string_strips_not_fails(caplog: pytest.LogCaptureFix
     with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
         enforce_text_completions_body("/v1/completions", body)
     assert body == {"prompt": "rendered"}
+
+
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (
+            {"prompt": "rendered", "extra_body": {"chat_template_kwargs": {"thinking": True}}},
+            {"prompt": "rendered", "extra_body": {}},
+        ),
+        (
+            {"prompt": "rendered", "items": [{"chat_template_kwargs": {"thinking": True}}]},
+            {"prompt": "rendered", "items": [{}]},
+        ),
+    ],
+    ids=["nested-dict", "nested-list"],
+)
+def test_body_strips_nested_fields_when_allowed(
+    body: dict, expected: dict, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Recursive stripping: with the allow opt-out, nested boolean toggles are
+    # removed everywhere they were detected (not just at the top level).
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
+        enforce_text_completions_body("/v1/completions", body, allow=True)
+    assert body == expected
+    assert "chat_template" in caplog.text
+    assert "params.extra.args" in caplog.text
 
 
 @pytest.mark.parametrize("path", ["/v1/chat/completions", "/v1/chat/completions/"])
@@ -126,43 +176,24 @@ def test_body_noop_on_clean_request() -> None:
     assert body == {"prompt": "rendered", "max_tokens": 16}
 
 
-@pytest.mark.parametrize(
-    ("body", "expected"),
-    [
-        (
-            {"prompt": "rendered", "extra_body": {"chat_template_kwargs": {"thinking": True}}},
-            {"prompt": "rendered", "extra_body": {}},
-        ),
-        (
-            {"prompt": "rendered", "items": [{"chat_template_kwargs": {"thinking": True}}]},
-            {"prompt": "rendered", "items": [{}]},
-        ),
-        (
-            {"prompt": "rendered", "extra_body": {"chat_template": "{{ jinja }}"}},
-            {"prompt": "rendered", "extra_body": {}},
-        ),
-    ],
-    ids=["nested-dict", "nested-list", "nested-chat-template"],
-)
-def test_body_strips_nested_fields(body: dict, expected: dict, caplog: pytest.LogCaptureFixture) -> None:
-    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
-        enforce_text_completions_body("/v1/completions", body)
-    assert body == expected
-    assert "chat_template" in caplog.text
-    assert "params.extra.args" in caplog.text
-
-
 # ── adapter_config (#1, launcher/config-assembly path) ────────────────────────
 
 
-def test_adapter_config_hard_fails_on_nested_disable() -> None:
-    adapter_config = {"params_to_add": {"chat_template_kwargs": {"enable_thinking": False}}}
-    with pytest.raises(ValueError, match="disabling value"):
+@pytest.mark.parametrize("toggle", [{"enable_thinking": False}, {"thinking": True}])
+def test_adapter_config_hard_fails_on_boolean_toggle(toggle: dict) -> None:
+    adapter_config = {"params_to_add": {"chat_template_kwargs": toggle}}
+    with pytest.raises(ValueError) as exc_info:
         normalize_adapter_config_for_endpoint(adapter_config, "completions")
+    assert "boolean toggle" in str(exc_info.value)
+    assert ALLOW_ENV_VAR in str(exc_info.value)
 
 
-def test_adapter_config_strips_inherited_enabling_value(caplog: pytest.LogCaptureFixture) -> None:
+def test_adapter_config_allow_env_strips_inherited_toggle(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
     # Mirrors the real deepseek RULER merge: _model.yaml injects thinking: true.
+    # With the allow opt-out the inherited toggle is stripped instead of failing.
+    monkeypatch.setenv(ALLOW_ENV_VAR, "1")
     adapter_config = {
         "use_reasoning": False,
         "process_reasoning_traces": False,
@@ -183,11 +214,13 @@ def test_adapter_config_strips_inherited_enabling_value(caplog: pytest.LogCaptur
     assert "params_to_add.chat_template_kwargs" in caplog.text
 
 
-def test_adapter_config_strict_hard_fails_even_when_enabling(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setenv(STRICT_ENV_VAR, "1")
-    adapter_config = {"params_to_add": {"chat_template_kwargs": {"thinking": True}}}
-    with pytest.raises(ValueError, match="STRICT"):
-        normalize_adapter_config_for_endpoint(adapter_config, "completions")
+def test_adapter_config_strips_non_boolean_by_default(caplog: pytest.LogCaptureFixture) -> None:
+    # A non-boolean chat-template value carries no on/off intent: strip+warn, no error.
+    adapter_config = {"params_to_add": {"chat_template_kwargs": {"thinking_mode": "chat"}}}
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
+        cleaned = normalize_adapter_config_for_endpoint(adapter_config, "completions")
+    assert cleaned == {"params_to_add": {}}
+    assert "params_to_add.chat_template_kwargs" in caplog.text
 
 
 def test_adapter_config_identity_on_chat_endpoint() -> None:
@@ -209,7 +242,20 @@ def test_adapter_config_none_passthrough() -> None:
 # ── build_legacy_run_config integration ──────────────────────────────────────
 
 
-def test_build_legacy_run_config_strips_inherited_enabling() -> None:
+def test_build_legacy_run_config_hard_fails_on_boolean(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ALLOW_ENV_VAR, raising=False)
+    with pytest.raises(ValueError, match="boolean toggle"):
+        build_legacy_run_config(
+            task="ruler",
+            model_url="http://localhost:8000/v1/completions",
+            model_id="m",
+            endpoint_type="completions",
+            adapter_config={"params_to_add": {"chat_template_kwargs": {"thinking": True}}},
+        )
+
+
+def test_build_legacy_run_config_allow_env_strips_toggle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(ALLOW_ENV_VAR, "1")
     run_config = build_legacy_run_config(
         task="ruler",
         model_url="http://localhost:8000/v1/completions",
@@ -219,17 +265,6 @@ def test_build_legacy_run_config_strips_inherited_enabling() -> None:
     )
     embedded = run_config["target"]["api_endpoint"]["adapter_config"]
     assert embedded == {"params_to_add": {"seed": 1}}
-
-
-def test_build_legacy_run_config_hard_fails_on_disable() -> None:
-    with pytest.raises(ValueError, match="disabling value"):
-        build_legacy_run_config(
-            task="ruler",
-            model_url="http://localhost:8000/v1/completions",
-            model_id="m",
-            endpoint_type="completions",
-            adapter_config={"params_to_add": {"chat_template_kwargs": {"enable_thinking": False}}},
-        )
 
 
 def test_build_legacy_run_config_keeps_for_chat() -> None:

--- a/tests/test_completions_guard.py
+++ b/tests/test_completions_guard.py
@@ -151,9 +151,7 @@ def test_body_chat_template_string_strips_not_fails(caplog: pytest.LogCaptureFix
     ],
     ids=["nested-dict", "nested-list"],
 )
-def test_body_strips_nested_fields_when_allowed(
-    body: dict, expected: dict, caplog: pytest.LogCaptureFixture
-) -> None:
+def test_body_strips_nested_fields_when_allowed(body: dict, expected: dict, caplog: pytest.LogCaptureFixture) -> None:
     # Recursive stripping: with the allow opt-out, nested boolean toggles are
     # removed everywhere they were detected (not just at the top level).
     with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):

--- a/tests/test_completions_guard.py
+++ b/tests/test_completions_guard.py
@@ -126,6 +126,32 @@ def test_body_noop_on_clean_request() -> None:
     assert body == {"prompt": "rendered", "max_tokens": 16}
 
 
+@pytest.mark.parametrize(
+    ("body", "expected"),
+    [
+        (
+            {"prompt": "rendered", "extra_body": {"chat_template_kwargs": {"thinking": True}}},
+            {"prompt": "rendered", "extra_body": {}},
+        ),
+        (
+            {"prompt": "rendered", "items": [{"chat_template_kwargs": {"thinking": True}}]},
+            {"prompt": "rendered", "items": [{}]},
+        ),
+        (
+            {"prompt": "rendered", "extra_body": {"chat_template": "{{ jinja }}"}},
+            {"prompt": "rendered", "extra_body": {}},
+        ),
+    ],
+    ids=["nested-dict", "nested-list", "nested-chat-template"],
+)
+def test_body_strips_nested_fields(body: dict, expected: dict, caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level(logging.WARNING, logger="nemo_evaluator.completions_guard"):
+        enforce_text_completions_body("/v1/completions", body)
+    assert body == expected
+    assert "chat_template" in caplog.text
+    assert "params.extra.args" in caplog.text
+
+
 # ── adapter_config (#1, launcher/config-assembly path) ────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a model-agnostic guard that catches a silent, score-corrupting misconfiguration: chat-template controls (`chat_template_kwargs`, `chat_template`) set on the **text** completions endpoint (`/v1/completions`), where they have no effect.

## Background

`chat_template_kwargs` / `chat_template` only do something on a **chat** endpoint (`/v1/chat/completions`), where the server renders the prompt from `messages` and applies the chat template. The **text** completions endpoint (`/v1/completions`) receives an already-rendered `prompt` string and never applies a chat template, so any chat-template field is **inert**.

Concretely, a user trying to disable reasoning via the adapter on a text-completions endpoint:

```yaml
target:
  api_endpoint:
    adapter_config:
      params_to_add:
        chat_template_kwargs:
          enable_thinking: false   # never reaches the model on /v1/completions
```

…gets a run that _looks_ correctly configured but generates with reasoning still **ON**, and the reported scores are misleading. The correct place to set the toggle is wherever the prompt is rendered client-side (the exact key is model-specific), or to use a chat endpoint so the server applies the chat template.

This is easy to get wrong and impossible to notice from the results, so we want to fail loudly instead of scoring silently.

## What this PR does

A new shared module `nemo_evaluator/completions_guard.py` implements one tiered, model-agnostic policy (it never needs to know a model's specific reasoning key):

| Condition on `/v1/completions`                                                                                                  | Action                                                                          |
| ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
| **Boolean toggle** (`True` **or** `False`) anywhere inside `chat_template_kwargs` (e.g. `enable_thinking: true`, `thinking: false`) | **hard error** (`ValueError`) — fail fast                                       |
| Any other chat-template field present (a bare `chat_template` string, non-boolean `chat_template_kwargs` values like `thinking_mode: "chat"`) | strip it + log a **WARNING**                                                    |
| `NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE=1` set                                                                           | opt out of the hard error: strip **every** chat-template field (booleans included) + **WARNING** |

Notes on the design:

* **Any boolean — not just `False` — is a hard error.** Model key names are not standardized (`enable_thinking`, `disable_thinking`, `thinking`, `high_reasoning`, …), so the value alone cannot distinguish "on" from "off" (`disable_thinking: true` is an *off* expressed as `True`). Treating any boolean as a deliberate toggle is the model-agnostic signal that someone tried to control generation in a place where it is silently ignored.
* Integers `0`/`1` are **not** treated as booleans (`isinstance(..., bool)`), so a value like `some_count: 0` degrades to strip+warn rather than failing.
* String-encoded values (e.g. `thinking_mode: "chat"`) and bare `chat_template` strings degrade to **strip+warn**, never silent and never fatal.
* Detection and stripping are **recursive** — nested `dict`/`list` structures (e.g. `extra_body.chat_template_kwargs`) are handled, not just top-level keys.
* `/v1/chat/completions` is explicitly excluded (it legitimately uses these fields).

### Where it is enforced (two chokepoints)

1. **`adapters/interceptors/endpoint.py`** — per request, on the outgoing body just before it is sent. This is the universal path and covers in-container adapters regardless of how the config was assembled.
2. **`environments/container.py`** (`build_legacy_run_config`) — when the legacy `adapter_config` is assembled into `run_config.yaml`, so the error surfaces early, before the container starts.

## Backward compatibility

The default is now **fail-fast on boolean toggles**. A config that inherits an _enabling_ `chat_template_kwargs` (e.g. `thinking: true`) from a shared default layer via config merge will **hard-error** on `/v1/completions` instead of running in the wrong mode. To keep such a run going when the toggle is known to be safely inert on this endpoint, set `NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE=1` (strips + warns instead of failing). Non-boolean chat-template fields and bare `chat_template` strings continue to strip+warn by default.

> Note: this replaces the opt-in `NEMO_EVALUATOR_STRICT_COMPLETIONS` from earlier revisions of this PR with the opt-out `NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE`, per review feedback (fail on any boolean, allow an explicit escape hatch).

## Testing

`tests/test_completions_guard.py` (49 tests) covers:

* path / endpoint-type / allow-env predicates,
* hard-fail on any boolean toggle, top-level and nested,
* allow-env downgrade to strip+warn,
* strip+warn for non-boolean values and bare `chat_template` strings,
* integer-vs-boolean handling (`0`/`1` are not toggles),
* recursive nested stripping,
* chat-endpoint and clean-body no-ops,
* `adapter_config` normalization (immutability of the input, `None` passthrough),
* `build_legacy_run_config` integration (hard-fail on boolean, allow-env strip, chat-endpoint passthrough).

```bash
ruff check src/ tests/
ruff format --check src/ tests/
pytest tests/test_completions_guard.py -q   # 49 passed
```

## Files changed

* `src/nemo_evaluator/completions_guard.py` (new) — shared tiered policy
* `tests/test_completions_guard.py` (new)
* `src/nemo_evaluator/adapters/interceptors/endpoint.py` — enforce on request body
* `src/nemo_evaluator/environments/container.py` — enforce when building `adapter_config`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Text completion requests now include automatic validation of request body parameters.
  * Added environment variable `NEMO_EVALUATOR_ALLOW_COMPLETIONS_CHAT_TEMPLATE` to control request validation behavior.

* **Bug Fixes**
  * Improved adapter configuration handling during environment setup to prevent incompatible parameter propagation.

* **Tests**
  * Added comprehensive test coverage for request validation and configuration normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->