### PR TITLE
fix: make OpenClaw agent timeout configurable via timeout_strategy

### DIFF
--- a/src/nemo_evaluator/config/solvers.py
+++ b/src/nemo_evaluator/config/solvers.py
@@ -168,6 +168,30 @@ class OpenClawSolverConfig(BaseModel):
     context_window: int | None = None
     max_concurrent: int = 4
     idle_timeout_seconds: int = 600
+    run_timeout: float | None = Field(
+        default=None,
+        description=(
+            "NEL wall-clock timeout (seconds) for the OpenClaw agent on a "
+            "task. Used as the NEL timeout when resolving against a task's "
+            "own timeout_seconds via timeout_strategy. Defaults to the "
+            "benchmark timeout when unset."
+        ),
+    )
+    timeout_strategy: Literal["override", "task", "max"] = Field(
+        default="task",
+        description=(
+            "How to resolve the agent timeout against a task's own "
+            "timeout_seconds. 'task' (default): the task budget bounded by "
+            "the NEL timeout (min) — preserves prior behavior. 'override': "
+            "the NEL run_timeout always wins, ignoring the task budget (use "
+            "for slow models / degraded endpoints). 'max': the larger of NEL "
+            "and task timeout."
+        ),
+    )
+    max_agent_timeout: float | None = Field(
+        default=None,
+        description="Hard ceiling (seconds) on the resolved agent timeout, regardless of strategy.",
+    )
     web_search_provider: Literal["tavily"] | None = None
     config_path: str | None = None
     skip_preflight: bool = False

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -406,6 +406,9 @@ def _make_solver(
             max_tokens=gen.max_tokens if gen else None,
             max_concurrent=solver_cfg.max_concurrent,
             idle_timeout_seconds=solver_cfg.idle_timeout_seconds,
+            run_timeout=solver_cfg.run_timeout,
+            timeout_strategy=solver_cfg.timeout_strategy,
+            max_agent_timeout=solver_cfg.max_agent_timeout,
             config_path=solver_cfg.config_path,
             skip_preflight=solver_cfg.skip_preflight or uses_sandbox,
         )

--- a/src/nemo_evaluator/solvers/openclaw.py
+++ b/src/nemo_evaluator/solvers/openclaw.py
@@ -334,6 +334,9 @@ class OpenClawSolver:
         max_tokens: int | None = None,
         max_concurrent: int = _DEFAULT_MAX_CONCURRENT,
         idle_timeout_seconds: int = _DEFAULT_IDLE_TIMEOUT_SECONDS,
+        run_timeout: float | None = None,
+        timeout_strategy: str = "task",
+        max_agent_timeout: float | None = None,
         web_search_provider: Literal["tavily"] | None = None,
         config_path: str | None = None,
         *,
@@ -342,6 +345,9 @@ class OpenClawSolver:
         self._bin = openclaw_bin
         self._thinking = thinking
         self._timeout = timeout
+        self._run_timeout = run_timeout
+        self._timeout_strategy = timeout_strategy
+        self._max_agent_timeout = max_agent_timeout
         self._model_url = model_url
         self._model_id = model_id
         self._api_key = api_key
@@ -358,12 +364,23 @@ class OpenClawSolver:
             _check_web_search_env(web_search_provider)
 
     def _effective_timeout(self, task: SeedResult) -> float:
+        # Resolve the agent wall-clock against the task's own ``timeout_seconds``.
+        # ``timeout_strategy`` selects how (default ``task`` preserves the prior
+        # min() behavior); ``override`` lets the NEL timeout win so slow-but-
+        # healthy rollouts aren't SIGKILLed when upstream latency is high.
         task_timeout = _coerce_timeout(task.metadata.get("timeout_seconds"))
         if task_timeout is None:
             task_timeout = _coerce_timeout(task.metadata.get("agent_timeout_sec"))
-        if task_timeout is None:
-            return self._timeout
-        return min(self._timeout, task_timeout)
+        nel_timeout = self._run_timeout if self._run_timeout is not None else self._timeout
+        if task_timeout is None or self._timeout_strategy == "override":
+            effective = nel_timeout
+        elif self._timeout_strategy == "max":
+            effective = max(nel_timeout, task_timeout)
+        else:  # "task": task budget bounded by the NEL timeout
+            effective = min(nel_timeout, task_timeout)
+        if self._max_agent_timeout is not None:
+            effective = min(effective, self._max_agent_timeout)
+        return effective
 
     async def solve(
         self,

--- a/tests/test_solvers/test_openclaw_config.py
+++ b/tests/test_solvers/test_openclaw_config.py
@@ -219,3 +219,23 @@ class TestEffectiveTimeout:
     def test_never_exceeds_solver_default(self) -> None:
         task = SeedResult(prompt="p", expected_answer="", metadata={"timeout_seconds": 9999})
         assert self._solver(timeout=100.0)._effective_timeout(task) == 100.0
+
+    def test_override_ignores_task_timeout(self) -> None:
+        task = SeedResult(prompt="p", expected_answer="", metadata={"timeout_seconds": 10})
+        solver = OpenClawSolver(timeout=100.0, timeout_strategy="override", skip_preflight=True)
+        assert solver._effective_timeout(task) == 100.0
+
+    def test_override_uses_run_timeout_over_benchmark(self) -> None:
+        task = SeedResult(prompt="p", expected_answer="", metadata={"timeout_seconds": 10})
+        solver = OpenClawSolver(timeout=100.0, run_timeout=500.0, timeout_strategy="override", skip_preflight=True)
+        assert solver._effective_timeout(task) == 500.0
+
+    def test_max_takes_larger_of_nel_and_task(self) -> None:
+        task = SeedResult(prompt="p", expected_answer="", metadata={"timeout_seconds": 9999})
+        solver = OpenClawSolver(timeout=100.0, timeout_strategy="max", skip_preflight=True)
+        assert solver._effective_timeout(task) == 9999.0
+
+    def test_max_agent_timeout_caps_result(self) -> None:
+        task = SeedResult(prompt="p", expected_answer="", metadata={"timeout_seconds": 9999})
+        solver = OpenClawSolver(timeout=100.0, timeout_strategy="max", max_agent_timeout=500.0, skip_preflight=True)
+        assert solver._effective_timeout(task) == 500.0


### PR DESCRIPTION
The OpenClaw solver resolved the agent wall-clock as `min(benchmark_timeout, task.timeout_seconds)`, so a task's own `timeout_seconds` (e.g. PinchBench's per-task 120/180/300s budgets) was a hard SIGKILL ceiling with no override. Under high endpoint latency (30-70s/call), a slow-but-healthy multi-turn rollout exhausts the tight per-task budget and gets killed mid-task (exit 137) - scored as a failure even though it would have completed. Genuine runaways are already caught by the `turn_counter` cap, so the per-task wall-clock conflates "slow endpoint" with "stuck agent".

Adds `run_timeout` / `timeout_strategy` / `max_agent_timeout` to `OpenClawSolverConfig`, mirroring `HarborSolverConfig` / `OracleSolverConfig`. Default `timeout_strategy="task"` preserves the prior `min()` behavior; `override` lets the NEL `run_timeout` win (for slow models / degraded endpoints) and `max` takes the larger, with `max_agent_timeout` as a hard ceiling.

Verified on a PinchBench sanity run (Nemotron-3-Super via some endpoint: the two tasks previously SIGKILLed at their 180s budget now complete, mean reward +20pp  (few samples), failures 2 -> 0.

- ruff check + format clean
- `tests/test_solvers/test_openclaw_config.py`: original 4 timeout tests still pass (default behavior preserved); 4 new tests cover `override`/`max`/`max_agent_timeout`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended OpenClaw solver configuration with timeout controls: a configurable run timeout, selectable timeout resolution strategy (override/task/max), and an optional maximum timeout ceiling.

* **Tests**
  * Added unit tests to validate the new timeout strategy behaviors, including override and max-capped outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->