### PR TITLE
feat(reports): enrich step fields from wire row + propagate enrich config to sidecar

### DIFF
--- a/src/nemo_evaluator/config/output.py
+++ b/src/nemo_evaluator/config/output.py
@@ -21,6 +21,21 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field
 
 
+class TrajectoriesConfig(BaseModel):
+    """Configuration for the trajectories audit/enrichment report.
+
+    The audit report (``trajectories_report.json``) is emitted unconditionally
+    by the orchestrator finalize step when ``trajectories.jsonl`` exists. The
+    optional ``enrich`` flag is reserved for splicing ``model_traffic.jsonl``
+    captures into per-trial trajectories; it is wired in but the writer is
+    not yet implemented (audit-only release).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enrich: bool = False
+
+
 class OutputConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -30,3 +45,4 @@ class OutputConfig(BaseModel):
     report: list[str] = Field(default_factory=lambda: ["markdown"])
     export: list[str] = Field(default_factory=list)
     export_config: dict[str, Any] = Field(default_factory=dict)
+    trajectories: TrajectoriesConfig = Field(default_factory=TrajectoriesConfig)

--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -61,6 +61,22 @@ class InterceptorConfig(BaseModel):
     config: dict[str, Any] = Field(default_factory=dict)
 
 
+class ModelTrafficCaptureConfig(BaseModel):
+    """Opt-in extras for what ``model_traffic.jsonl`` captures per call.
+
+    By default the store records stats only (tokens, finish_reason, latency,
+    model, tool_calls.count). Set any of these flags to ``true`` to also
+    persist the corresponding fields from the upstream response.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    capture_tool_calls: bool = False  # full {id, name, arguments} per call
+    capture_reasoning: bool = False  # message.reasoning_content (or SSE delta)
+    capture_messages: bool = False  # message.content
+    max_content_chars: int = 100_000  # truncation guard for the three above
+
+
 class ProxyConfig(BaseModel):
     """Adapter proxy settings for a service.
 
@@ -71,6 +87,7 @@ class ProxyConfig(BaseModel):
     ``request_timeout`` sets the HTTP timeout for upstream requests.
     ``max_retries`` and ``retry_on_status`` control retry behavior.
     ``max_concurrent_upstream`` limits concurrent requests to the upstream.
+    ``model_traffic`` controls what model_traffic.jsonl captures per call.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -83,6 +100,7 @@ class ProxyConfig(BaseModel):
     max_retries: int = 0
     retry_on_status: list[int] = Field(default_factory=lambda: [429, 502, 503, 504])
     max_concurrent_upstream: int = 64
+    model_traffic: ModelTrafficCaptureConfig = Field(default_factory=ModelTrafficCaptureConfig)
 
     @property
     def needs_proxy(self) -> bool:

--- a/src/nemo_evaluator/engine/model_traffic_log.py
+++ b/src/nemo_evaluator/engine/model_traffic_log.py
@@ -97,5 +97,11 @@ def format_model_traffic_log_records(
             row["token_provenance"] = _PROVIDER
         if record.get("error_type"):
             row["error_type"] = record["error_type"]
+        # Opt-in capture fields from ModelTrafficStore.finish_response: only
+        # forwarded when present in the in-memory record (controlled by the
+        # service's proxy.model_traffic.capture_{tool_calls,reasoning,messages}).
+        for key in ("tool_calls_full", "reasoning_content", "message_content"):
+            if key in record:
+                row[key] = record[key]
         rows.append(row)
     return rows

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -126,9 +126,49 @@ def _tool_names_from_message(message: dict[str, Any]) -> list[str]:
     return names
 
 
-def _summary_from_json(body: dict[str, Any]) -> dict[str, Any]:
+def _truncate(value: Any, limit: int) -> Any:
+    if isinstance(value, str) and limit > 0 and len(value) > limit:
+        return value[:limit] + f"...[truncated, {len(value) - limit} chars dropped]"
+    return value
+
+
+def _full_tool_calls_from_message(message: dict[str, Any], limit: int) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for raw in message.get("tool_calls") or []:
+        if not isinstance(raw, dict):
+            continue
+        function = raw.get("function") if isinstance(raw.get("function"), dict) else {}
+        args = function.get("arguments") if "arguments" in function else raw.get("arguments")
+        if isinstance(args, str):
+            args = _truncate(args, limit)
+        elif isinstance(args, (dict, list)):
+            try:
+                args = _truncate(json.dumps(args), limit)
+            except (TypeError, ValueError):
+                args = None
+        out.append(
+            {
+                "id": raw.get("id") or "",
+                "name": function.get("name") or raw.get("name") or "",
+                "arguments": args,
+            }
+        )
+    return out
+
+
+def _summary_from_json(
+    body: dict[str, Any],
+    *,
+    capture_tool_calls: bool = False,
+    capture_reasoning: bool = False,
+    capture_messages: bool = False,
+    max_content_chars: int = 100_000,
+) -> dict[str, Any]:
     tool_names: list[str] = []
     finish_reason = ""
+    full_tool_calls: list[dict[str, Any]] = []
+    reasoning_parts: list[str] = []
+    message_parts: list[str] = []
     for choice in body.get("choices") or []:
         if not isinstance(choice, dict):
             continue
@@ -136,12 +176,29 @@ def _summary_from_json(body: dict[str, Any]) -> dict[str, Any]:
         message = choice.get("message") or choice.get("delta") or {}
         if isinstance(message, dict):
             tool_names.extend(_tool_names_from_message(message))
-    return {
+            if capture_tool_calls:
+                full_tool_calls.extend(_full_tool_calls_from_message(message, max_content_chars))
+            if capture_reasoning:
+                rc = message.get("reasoning_content")
+                if isinstance(rc, str):
+                    reasoning_parts.append(rc)
+            if capture_messages:
+                ct = message.get("content")
+                if isinstance(ct, str):
+                    message_parts.append(ct)
+    out: dict[str, Any] = {
         "model": str(body.get("model") or ""),
         "finish_reason": finish_reason,
         "usage": _usage(body.get("usage")),
         "tool_calls": _tool_stats(tool_names),
     }
+    if capture_tool_calls:
+        out["tool_calls_full"] = full_tool_calls
+    if capture_reasoning:
+        out["reasoning_content"] = _truncate("".join(reasoning_parts), max_content_chars)
+    if capture_messages:
+        out["message_content"] = _truncate("".join(message_parts), max_content_chars)
+    return out
 
 
 def _iter_sse(body: Any) -> Iterator[dict[str, Any]]:
@@ -181,11 +238,22 @@ def _iter_sse(body: Any) -> Iterator[dict[str, Any]]:
         yield chunk
 
 
-def _summary_from_sse(body: Any) -> dict[str, Any]:
+def _summary_from_sse(
+    body: Any,
+    *,
+    capture_tool_calls: bool = False,
+    capture_reasoning: bool = False,
+    capture_messages: bool = False,
+    max_content_chars: int = 100_000,
+) -> dict[str, Any]:
     model = ""
     finish_reason = ""
     usage: dict[str, int] = {}
     stream_tools: dict[tuple[int, int], str] = {}
+    # Per (choice, tool) index buffers for the full-capture path.
+    tool_full: dict[tuple[int, int], dict[str, Any]] = {}
+    reasoning_parts: list[str] = []
+    message_parts: list[str] = []
     for chunk in _iter_sse(body):
         model = str(chunk.get("model") or model)
         if isinstance(chunk.get("usage"), dict):
@@ -202,17 +270,49 @@ def _summary_from_sse(body: Any) -> dict[str, Any]:
                     continue
                 idx = (_int(choice.get("index")), _int(raw.get("index")))
                 function = raw.get("function") if isinstance(raw.get("function"), dict) else {}
-                stream_tools[idx] = f"{stream_tools.get(idx, '')}{function.get('name') or raw.get('name') or ''}"
-    return {
+                name_chunk = function.get("name") or raw.get("name") or ""
+                stream_tools[idx] = f"{stream_tools.get(idx, '')}{name_chunk}"
+                if capture_tool_calls:
+                    entry = tool_full.setdefault(idx, {"id": "", "name": "", "arguments": ""})
+                    if raw.get("id"):
+                        entry["id"] = raw["id"]
+                    if name_chunk:
+                        entry["name"] = entry["name"] + name_chunk
+                    args_chunk = function.get("arguments") if "arguments" in function else raw.get("arguments")
+                    if isinstance(args_chunk, str):
+                        entry["arguments"] = entry["arguments"] + args_chunk
+            if capture_reasoning:
+                rc = delta.get("reasoning_content")
+                if isinstance(rc, str):
+                    reasoning_parts.append(rc)
+            if capture_messages:
+                ct = delta.get("content")
+                if isinstance(ct, str):
+                    message_parts.append(ct)
+    out: dict[str, Any] = {
         "model": model,
         "finish_reason": finish_reason,
         "usage": usage,
         "tool_calls": _tool_stats(list(stream_tools.values())),
     }
+    if capture_tool_calls:
+        out["tool_calls_full"] = [
+            {
+                "id": v["id"],
+                "name": v["name"],
+                "arguments": _truncate(v["arguments"], max_content_chars) or None,
+            }
+            for v in tool_full.values()
+        ]
+    if capture_reasoning:
+        out["reasoning_content"] = _truncate("".join(reasoning_parts), max_content_chars)
+    if capture_messages:
+        out["message_content"] = _truncate("".join(message_parts), max_content_chars)
+    return out
 
 
-def _summary(body: Any) -> dict[str, Any]:
-    return _summary_from_json(body) if isinstance(body, dict) else _summary_from_sse(body)
+def _summary(body: Any, **opts: Any) -> dict[str, Any]:
+    return _summary_from_json(body, **opts) if isinstance(body, dict) else _summary_from_sse(body, **opts)
 
 
 def _is_success(record: dict[str, Any]) -> bool:
@@ -220,12 +320,27 @@ def _is_success(record: dict[str, Any]) -> bool:
 
 
 class ModelTrafficStore:
-    def __init__(self, *, service_name: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        service_name: str | None = None,
+        capture_tool_calls: bool = False,
+        capture_reasoning: bool = False,
+        capture_messages: bool = False,
+        max_content_chars: int = 100_000,
+    ) -> None:
         self.store_id = uuid.uuid4().hex
         self.service_name = service_name
         self._lock = threading.Lock()
         self._pending: dict[str, dict[str, Any]] = {}
         self._records_by_session: dict[str, list[dict[str, Any]]] = {}
+        # Opt-in capture: extra fields persisted to model_traffic.jsonl when set.
+        self._capture_opts = {
+            "capture_tool_calls": capture_tool_calls,
+            "capture_reasoning": capture_reasoning,
+            "capture_messages": capture_messages,
+            "max_content_chars": max_content_chars,
+        }
 
     def close(self) -> None:
         unregister_store(self.store_id)
@@ -258,7 +373,7 @@ class ModelTrafficStore:
                 "timestamp": time.time(),
             }
 
-        summary = _summary(resp.body)
+        summary = _summary(resp.body, **self._capture_opts)
         success = 200 <= resp.status_code < 400
         record.update(
             {
@@ -270,6 +385,11 @@ class ModelTrafficStore:
                 "tool_calls": summary["tool_calls"] if success else {"count": 0, "names": {}},
             }
         )
+        # Persist opt-in capture fields when present (and the call succeeded).
+        if success:
+            for key in ("tool_calls_full", "reasoning_content", "message_content"):
+                if key in summary:
+                    record[key] = summary[key]
         session_id = record.get("session_id")
         if session_id:
             with self._lock:

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -2,12 +2,29 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import hashlib
 import json
 import threading
 import time
 import uuid
 from collections import Counter
 from typing import TYPE_CHECKING, Any, Iterator
+
+
+def _request_hash(body: Any) -> str | None:
+    """Deterministic content hash of an upstream request body.
+
+    Returns 16 hex chars (a sha1 prefix) suitable for grouping duplicate
+    calls. ``None`` when *body* isn't a dict (e.g. raw bytes / unset).
+    """
+    if not isinstance(body, dict):
+        return None
+    try:
+        payload = json.dumps(body, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return None
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()[:16]
+
 
 if TYPE_CHECKING:
     from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse
@@ -223,6 +240,10 @@ class ModelTrafficStore:
             "path": req.path,
             "service": self.service_name,
             "model": body.get("model") if isinstance(body, dict) else "",
+            # Content-derived id of the upstream request body. Lets downstream
+            # tooling (e.g. trajectories audit report) detect duplicate calls
+            # exactly, instead of fingerprinting on response stats.
+            "request_hash": _request_hash(body),
         }
         with self._lock:
             self._pending[req.ctx.request_id] = record

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -1226,6 +1226,19 @@ def _generate_reports(
         paths.append(path)
         click.echo(f"Report: {path}")
 
+    try:
+        from nemo_evaluator.reports.trajectories import generate_trajectories_report
+
+        traj_path = generate_trajectories_report(
+            output_dir,
+            enrich=config.output.trajectories.enrich,
+        )
+        if traj_path is not None:
+            paths.append(traj_path)
+            click.echo(f"Trajectories report: {traj_path}")
+    except Exception:
+        logger.warning("Trajectories report generation failed", exc_info=True)
+
     export_bundles = in_memory_bundles if in_memory_bundles else bundles
 
     for exporter_name in config.output.export:

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -765,7 +765,14 @@ def _start_proxy(
 
     from nemo_evaluator.observability.model_traffic import ModelTrafficStore, register_store
 
-    traffic_store = ModelTrafficStore(service_name=service_name)
+    capture_cfg = getattr(proxy_cfg, "model_traffic", None) if proxy_cfg is not None else None
+    traffic_store = ModelTrafficStore(
+        service_name=service_name,
+        capture_tool_calls=getattr(capture_cfg, "capture_tool_calls", False),
+        capture_reasoning=getattr(capture_cfg, "capture_reasoning", False),
+        capture_messages=getattr(capture_cfg, "capture_messages", False),
+        max_content_chars=getattr(capture_cfg, "max_content_chars", 100_000),
+    )
     register_store(traffic_store)
     proxy_kwargs["model_traffic_store_id"] = traffic_store.store_id
 

--- a/src/nemo_evaluator/orchestration/slurm_gen.py
+++ b/src/nemo_evaluator/orchestration/slurm_gen.py
@@ -1905,7 +1905,13 @@ def _extract_bench_config(config: EvalConfig, bench_idx: int, svc_url_var: str, 
     return {
         "services": services,
         "benchmarks": [bench_dict],
-        "output": {"dir": "${NEL_OUTPUT_DIR}"},
+        "output": {
+            "dir": "${NEL_OUTPUT_DIR}",
+            # Carry the per-shard finalize flags through to the eval driver.
+            # Hand-picking these (instead of dumping config.output wholesale)
+            # avoids overriding NEL_OUTPUT_DIR and bench-specific export wiring.
+            "trajectories": config.output.trajectories.model_dump(exclude_none=True),
+        },
     }
 
 

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -321,6 +321,7 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
         },
         "wire_calls": {
             "total": len(traffic_rows),
+            "successful": sum(1 for r in traffic_rows if _is_successful_wire(r)),
             "unique": wire_unique,
             "trials_with_duplicates": trials_with_dup_wire,
             "trials_with_more_wire_than_steps": trials_more_wire,
@@ -339,13 +340,17 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
 def _enrich_bench(bench_dir: Path) -> dict[str, int]:
     """All-or-nothing per-trial enrichment from ``model_traffic.jsonl``.
 
+    ``wire_calls`` below is the list of **successful (2xx/3xx)** rows for the
+    trial -- failed/retry rows live in the log too but are filtered out by
+    ``_index_traffic_by_trial`` so they never get attributed to a step.
+
     For each trial:
 
-    * If ``len(agent_steps) == len(wire_calls)`` — splice 1:1 by order
-      (backfill ``metrics.{prompt,completion}_tokens`` and
+    * If ``len(agent_steps) == len(successful_wire_calls)`` — splice 1:1
+      by order (backfill ``metrics.{prompt,completion}_tokens`` and
       ``metrics.extra.{latency_ms, finish_reason}``).
-    * Otherwise — leave the steps alone and stash **all** wire calls
-      under ``trajectory[0].extra.captured_model_calls``. We never
+    * Otherwise — leave the steps alone and stash **all** successful wire
+      calls under ``trajectory[0].extra.captured_model_calls``. We never
       mix-and-match when the counts don't line up: a partial splice
       would attribute the wrong call to the wrong step.
 

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 import json
 import logging
-import statistics
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -83,29 +82,6 @@ def _wire_dedup_key(record: dict[str, Any]) -> tuple[Any, ...]:
     )
 
 
-def _percentile(values: list[float], pct: float) -> float | None:
-    if not values:
-        return None
-    s = sorted(values)
-    k = (len(s) - 1) * pct
-    lo, hi = int(k), min(int(k) + 1, len(s) - 1)
-    if lo == hi:
-        return float(s[lo])
-    return float(s[lo] + (s[hi] - s[lo]) * (k - lo))
-
-
-def _stats(values: list[float]) -> dict[str, float | None]:
-    if not values:
-        return {"mean": None, "median": None, "p10": None, "p90": None, "max": None}
-    return {
-        "mean": round(statistics.fmean(values), 4),
-        "median": round(statistics.median(values), 4),
-        "p10": _percentile(values, 0.10),
-        "p90": _percentile(values, 0.90),
-        "max": round(max(values), 4),
-    }
-
-
 def _agent_steps(row: dict[str, Any]) -> list[dict[str, Any]]:
     traj = row.get("trajectory") or []
     if not traj:
@@ -144,22 +120,38 @@ def _load_eval_summary(bench_dir: Path) -> dict[str, Any] | None:
     return scores.get("summary") or scores.get("mean_reward")
 
 
-def _present_count(rows: list[dict[str, Any]], path: tuple[str, ...]) -> int:
-    n = 0
-    for r in rows:
-        cur: Any = r
-        for key in path:
-            if not isinstance(cur, dict) or key not in cur:
-                cur = None
-                break
-            cur = cur[key]
-        if cur is not None and cur != "":
-            n += 1
-    return n
-
-
 def _trial_key(row: dict[str, Any]) -> tuple[Any, Any]:
     return (row.get("problem_idx"), row.get("repeat"))
+
+
+def _present_at(items: list[dict[str, Any]], *keys: Any) -> str:
+    """Render ``N/total`` -- how many items have a non-empty value at the given path.
+
+    Keys may be strings (dict lookup) or ints (list index). A value counts as
+    present when it is not None, not an empty string, and not an empty
+    list/dict -- so ``reward: 0.0`` counts but ``trajectory: []`` doesn't.
+    """
+    n = 0
+    for item in items:
+        cur: Any = item
+        ok = True
+        for key in keys:
+            if isinstance(cur, list):
+                if not isinstance(key, int) or key >= len(cur):
+                    ok = False
+                    break
+                cur = cur[key]
+            elif isinstance(cur, dict):
+                if key not in cur:
+                    ok = False
+                    break
+                cur = cur[key]
+            else:
+                ok = False
+                break
+        if ok and cur is not None and cur != "" and not (isinstance(cur, (list, dict)) and not cur):
+            n += 1
+    return f"{n}/{len(items)}"
 
 
 def _fraction(numer: int, denom: int) -> str:
@@ -219,40 +211,8 @@ def _build_bench_report(
             failures[cat] += 1
 
     # ─── trajectory_native ────────────────────────────────────────────
-    all_agent_steps: list[dict[str, Any]] = []
-    per_trial_step_counts: list[int] = []
-    tool_calls_total = 0
-    reasoning_chars_total = 0
-    for r in traj_rows:
-        steps = _agent_steps(r)
-        per_trial_step_counts.append(len(steps))
-        all_agent_steps.extend(steps)
-        for s in steps:
-            tc = s.get("tool_calls") or []
-            if isinstance(tc, list):
-                tool_calls_total += len(tc)
-            rc = s.get("reasoning_content")
-            if isinstance(rc, str):
-                reasoning_chars_total += len(rc)
+    all_agent_steps: list[dict[str, Any]] = [s for r in traj_rows for s in _agent_steps(r)]
     n_steps = len(all_agent_steps)
-
-    def _field_present(field: str) -> str:
-        n = sum(1 for s in all_agent_steps if s.get(field) is not None)
-        return f"{n}/{n_steps}"
-
-    def _nested_present(*keys: str) -> str:
-        n = 0
-        for s in all_agent_steps:
-            cur: Any = s
-            ok = True
-            for key in keys:
-                if not isinstance(cur, dict) or cur.get(key) is None:
-                    ok = False
-                    break
-                cur = cur[key]
-            if ok:
-                n += 1
-        return f"{n}/{n_steps}"
 
     # ─── wire_captures (model_traffic.jsonl) ──────────────────────────
     total_wire = len(traffic_rows)
@@ -329,60 +289,13 @@ def _build_bench_report(
         "final_metrics.total_completion_tokens": ("trajectory", 0, "final_metrics", "total_completion_tokens"),
         "final_metrics.total_steps": ("trajectory", 0, "final_metrics", "total_steps"),
     }
-    atif_presence: dict[str, str] = {}
-    for label, path in atif_paths.items():
-        n = 0
-        for r in traj_rows:
-            cur: Any = r
-            ok = True
-            for key in path:
-                if isinstance(cur, list):
-                    if not isinstance(key, int) or key >= len(cur):
-                        ok = False
-                        break
-                    cur = cur[key]
-                elif isinstance(cur, dict):
-                    if key not in cur:
-                        ok = False
-                        break
-                    cur = cur[key]
-                else:
-                    ok = False
-                    break
-            if ok and cur is not None and cur != "":
-                n += 1
-        atif_presence[label] = f"{n}/{n_trials}"
+    atif_presence = {label: _present_at(traj_rows, *path) for label, path in atif_paths.items()}
 
-    # ─── anomalies (the things you actually want to know) ────────────
-    # Zero / None tokens per step + per trial
-    steps_with_zero_or_none_tokens = 0
-    trials_with_any_zero_step = 0
-    trials_all_zero_token_steps = 0
-    for r in traj_rows:
-        steps = _agent_steps(r)
-        if not steps:
-            continue
-        zero_in_trial = 0
-        for s in steps:
-            m = s.get("metrics") or {}
-            pt = m.get("prompt_tokens")
-            ct = m.get("completion_tokens")
-            if (not pt) and (not ct):
-                steps_with_zero_or_none_tokens += 1
-                zero_in_trial += 1
-        if zero_in_trial > 0:
-            trials_with_any_zero_step += 1
-        if zero_in_trial == len(steps):
-            trials_all_zero_token_steps += 1
-
-    # Duplicate wire calls inside a single trial (request_hash-based)
-    duplicate_wire_calls_in_trial = 0
+    # Trials that have ≥1 duplicate wire call (request_hash-based, or fallback key).
     trials_with_duplicate_wire_calls = 0
-    for key, recs in traffic_by_trial.items():
+    for recs in traffic_by_trial.values():
         hashes = Counter(_wire_dedup_key(r) for r in recs)
-        per_trial_dups = sum(v - 1 for v in hashes.values() if v > 1)
-        if per_trial_dups > 0:
-            duplicate_wire_calls_in_trial += per_trial_dups
+        if any(v > 1 for v in hashes.values()):
             trials_with_duplicate_wire_calls += 1
 
     # After removing duplicate wire calls, does the mismatch resolve?
@@ -409,30 +322,31 @@ def _build_bench_report(
     if traj_mean is not None and reported_mean is not None:
         is_mean_reward_correct = abs(traj_mean - reported_mean) < 1e-6
 
-    step_field_coverage = {
-        "step_id": _field_present("step_id"),
-        "source": _field_present("source"),
-        "timestamp": _field_present("timestamp"),
-        "model_name": _field_present("model_name"),
-        "status_code": _field_present("status_code"),
-        "message": _field_present("message"),
-        "reasoning_content": _field_present("reasoning_content"),
-        "tool_calls": _field_present("tool_calls"),
-        "metrics.prompt_tokens": _nested_present("metrics", "prompt_tokens"),
-        "metrics.completion_tokens": _nested_present("metrics", "completion_tokens"),
-        "metrics.total_tokens": _nested_present("metrics", "total_tokens"),
-        "metrics.extra.latency_ms": _nested_present("metrics", "extra", "latency_ms"),
-        "metrics.extra.finish_reason": _nested_present("metrics", "extra", "finish_reason"),
-        "metrics.extra.cached_tokens": _nested_present("metrics", "extra", "cached_tokens"),
-        "metrics.extra.reasoning_tokens": _nested_present("metrics", "extra", "reasoning_tokens"),
-    }
+    _STEP_FIELDS: tuple[tuple[str, ...], ...] = (
+        ("step_id",),
+        ("source",),
+        ("timestamp",),
+        ("model_name",),
+        ("status_code",),
+        ("message",),
+        ("reasoning_content",),
+        ("tool_calls",),
+        ("metrics", "prompt_tokens"),
+        ("metrics", "completion_tokens"),
+        ("metrics", "total_tokens"),
+        ("metrics", "extra", "latency_ms"),
+        ("metrics", "extra", "finish_reason"),
+        ("metrics", "extra", "cached_tokens"),
+        ("metrics", "extra", "reasoning_tokens"),
+    )
+    step_field_coverage = {".".join(p): _present_at(all_agent_steps, *p) for p in _STEP_FIELDS}
 
     row_field_coverage = {
-        "problem_idx": f"{sum(1 for r in traj_rows if r.get('problem_idx') is not None)}/{n_trials}",
-        "repeat": f"{sum(1 for r in traj_rows if r.get('repeat') is not None)}/{n_trials}",
-        "reward": f"{sum(1 for r in traj_rows if isinstance(r.get('reward'), (int, float)))}/{n_trials}",
-        "trajectory": f"{sum(1 for r in traj_rows if r.get('trajectory'))}/{n_trials}",
-        "model": f"{sum(1 for r in traj_rows if r.get('model'))}/{n_trials}",
+        "problem_idx": _present_at(traj_rows, "problem_idx"),
+        "repeat": _present_at(traj_rows, "repeat"),
+        "reward": _present_at(traj_rows, "reward"),
+        "trajectory": _present_at(traj_rows, "trajectory"),
+        "model": _present_at(traj_rows, "model"),
         **{f"trajectory[0].{k}": v for k, v in atif_presence.items()},
     }
 
@@ -628,35 +542,16 @@ def generate_trajectories_report(
             enriched_path = d / "trajectories_enriched.jsonl"
             enriched_step_coverage: dict[str, str] = {}
             if enriched_path.is_file():
-                enriched_rows = _read_jsonl(enriched_path)
-                enriched_steps: list[dict[str, Any]] = []
-                for r in enriched_rows:
-                    enriched_steps.extend(_agent_steps(r))
-                en_n = len(enriched_steps)
-                if en_n:
-
-                    def _enpresent(field: str) -> str:
-                        return f"{sum(1 for s in enriched_steps if s.get(field) is not None)}/{en_n}"
-
-                    def _ennested(*keys: str) -> str:
-                        n = 0
-                        for s in enriched_steps:
-                            cur: Any = s
-                            ok = True
-                            for k in keys:
-                                if not isinstance(cur, dict) or cur.get(k) is None:
-                                    ok = False
-                                    break
-                                cur = cur[k]
-                            if ok:
-                                n += 1
-                        return f"{n}/{en_n}"
-
+                enriched_steps = [s for r in _read_jsonl(enriched_path) for s in _agent_steps(r)]
+                if enriched_steps:
                     enriched_step_coverage = {
-                        "metrics.prompt_tokens": _ennested("metrics", "prompt_tokens"),
-                        "metrics.completion_tokens": _ennested("metrics", "completion_tokens"),
-                        "metrics.extra.latency_ms": _ennested("metrics", "extra", "latency_ms"),
-                        "metrics.extra.finish_reason": _ennested("metrics", "extra", "finish_reason"),
+                        ".".join(p): _present_at(enriched_steps, *p)
+                        for p in (
+                            ("metrics", "prompt_tokens"),
+                            ("metrics", "completion_tokens"),
+                            ("metrics", "extra", "latency_ms"),
+                            ("metrics", "extra", "finish_reason"),
+                        )
                     }
             bench_report["enrichment"] = {
                 "_note": (

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -373,8 +373,14 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
         "trials_spliced": 0,
         "trials_stashed_unmatched": 0,
         "trials_no_wire_data": 0,
+        "steps_backfilled_timestamp": 0,
+        "steps_backfilled_model_name": 0,
+        "steps_backfilled_status_code": 0,
         "steps_backfilled_prompt_tokens": 0,
         "steps_backfilled_completion_tokens": 0,
+        "steps_backfilled_total_tokens": 0,
+        "steps_backfilled_cached_tokens": 0,
+        "steps_backfilled_reasoning_tokens": 0,
         "steps_backfilled_latency_ms": 0,
         "steps_backfilled_finish_reason": 0,
         "steps_backfilled_reasoning_content": 0,
@@ -392,6 +398,17 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
             elif len(steps) == len(wire):
                 # 1:1 splice
                 for s, w in zip(steps, wire):
+                    # Top-level step fields populated directly from wire row.
+                    if not s.get("timestamp") and w.get("timestamp"):
+                        s["timestamp"] = w["timestamp"]
+                        counts["steps_backfilled_timestamp"] += 1
+                    if not s.get("model_name") and w.get("model"):
+                        s["model_name"] = w["model"]
+                        counts["steps_backfilled_model_name"] += 1
+                    if s.get("status_code") is None and w.get("status_code") is not None:
+                        s["status_code"] = w["status_code"]
+                        counts["steps_backfilled_status_code"] += 1
+
                     metrics = s.setdefault("metrics", {})
                     usage = w.get("usage") or {}
                     if metrics.get("prompt_tokens") in (None, 0) and usage.get("prompt_tokens"):
@@ -400,7 +417,16 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
                     if metrics.get("completion_tokens") in (None, 0) and usage.get("completion_tokens"):
                         metrics["completion_tokens"] = usage["completion_tokens"]
                         counts["steps_backfilled_completion_tokens"] += 1
+                    if metrics.get("total_tokens") in (None, 0) and usage.get("total_tokens"):
+                        metrics["total_tokens"] = usage["total_tokens"]
+                        counts["steps_backfilled_total_tokens"] += 1
                     extra = metrics.setdefault("extra", {})
+                    if extra.get("cached_tokens") in (None, 0) and usage.get("cached_tokens"):
+                        extra["cached_tokens"] = usage["cached_tokens"]
+                        counts["steps_backfilled_cached_tokens"] += 1
+                    if extra.get("reasoning_tokens") in (None, 0) and usage.get("reasoning_tokens"):
+                        extra["reasoning_tokens"] = usage["reasoning_tokens"]
+                        counts["steps_backfilled_reasoning_tokens"] += 1
                     if extra.get("latency_ms") in (None, 0) and w.get("latency_ms"):
                         extra["latency_ms"] = w["latency_ms"]
                         counts["steps_backfilled_latency_ms"] += 1
@@ -464,8 +490,14 @@ def generate_trajectories_report(
                 "trials_with_unmatched_calls_stashed": counts["trials_stashed_unmatched"],
                 "trials_with_no_wire_data": counts["trials_no_wire_data"],
                 "steps_backfilled": {
+                    "timestamp": counts["steps_backfilled_timestamp"],
+                    "model_name": counts["steps_backfilled_model_name"],
+                    "status_code": counts["steps_backfilled_status_code"],
                     "prompt_tokens": counts["steps_backfilled_prompt_tokens"],
                     "completion_tokens": counts["steps_backfilled_completion_tokens"],
+                    "total_tokens": counts["steps_backfilled_total_tokens"],
+                    "cached_tokens": counts["steps_backfilled_cached_tokens"],
+                    "reasoning_tokens": counts["steps_backfilled_reasoning_tokens"],
                     "latency_ms": counts["steps_backfilled_latency_ms"],
                     "finish_reason": counts["steps_backfilled_finish_reason"],
                     "reasoning_content": counts["steps_backfilled_reasoning_content"],
@@ -477,8 +509,14 @@ def generate_trajectories_report(
                     {
                         ".".join(p): p
                         for p in (
+                            ("timestamp",),
+                            ("model_name",),
+                            ("status_code",),
                             ("metrics", "prompt_tokens"),
                             ("metrics", "completion_tokens"),
+                            ("metrics", "total_tokens"),
+                            ("metrics", "extra", "cached_tokens"),
+                            ("metrics", "extra", "reasoning_tokens"),
                             ("metrics", "extra", "latency_ms"),
                             ("metrics", "extra", "finish_reason"),
                         )

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -14,22 +14,26 @@
 # limitations under the License.
 """Trajectory audit + optional enrichment.
 
-Reads two files from a run directory:
+Reads two files from each per-benchmark subdir of a run dir:
 
   trajectories.jsonl   -- one row per trial (rewards, ATIF trajectory)
   model_traffic.jsonl  -- one row per upstream model call
 
-Writes ``trajectories_report.json`` summarising counts, score reconciliation,
-ATIF field presence, step/wire mismatches, duplicates, and token totals.
-Each metric is reported as ``{value, from}`` so the calculation is explicit.
+Writes ``trajectories_report.json`` with four sections per benchmark:
+
+  counts          -- trial / problem / repeat shape
+  score           -- mean(row.reward) vs the bundle's reported summary.mean
+  tokens          -- per-step token sum vs wire-call token sum
+  wire_calls      -- duplicates, step/wire alignment, silent-failure trials
+                     (step/wire alignment uses only successful 2xx/3xx rows)
+  field_coverage  -- ATIF / per-step fields that aren't 100% populated
 
 With ``enrich=True``, also writes ``trajectories_enriched.jsonl``: per-trial,
 when the agent-step count equals the wire-call count, step metrics are
 backfilled 1:1 from the matching wire call; otherwise all wire calls land in
 ``trajectory[0].extra.captured_model_calls`` (no partial splice).
 
-The module is read-only over the eval pipeline -- runs offline against any
-existing run directory, including archived bundles.
+Read-only over the eval pipeline -- runs offline against any run directory.
 """
 
 from __future__ import annotations
@@ -60,26 +64,13 @@ def _is_successful_wire(record: dict[str, Any]) -> bool:
     return 200 <= sc_int < 400
 
 
-def _wire_dedup_key(record: dict[str, Any]) -> tuple[Any, ...]:
-    """Duplicate-detection key for a single ``model_traffic.jsonl`` row.
+def _wire_dedup_key(record: dict[str, Any], fallback_id: int) -> Any:
+    """Dedup key based on ``request_hash`` (sha1 prefix of the upstream body).
 
-    Prefers ``record.request_hash`` (sha1 prefix of the upstream request body,
-    written by ``ModelTrafficStore.start_request``). Falls back to a coarse
-    response-side fingerprint for older runs that don't carry ``request_hash``.
+    Rows without a ``request_hash`` (older logs) fall back to a per-row unique
+    sentinel so they never collapse into each other.
     """
-    rh = record.get("request_hash")
-    if rh:
-        return ("rh", rh)
-    usage = record.get("usage") or {}
-    return (
-        "resp",
-        record.get("model"),
-        record.get("path"),
-        record.get("finish_reason"),
-        usage.get("prompt_tokens"),
-        usage.get("completion_tokens"),
-        round(float(record.get("latency_ms") or 0), 1),
-    )
+    return record.get("request_hash") or ("_no_hash", fallback_id)
 
 
 def _agent_steps(row: dict[str, Any]) -> list[dict[str, Any]]:
@@ -124,12 +115,12 @@ def _trial_key(row: dict[str, Any]) -> tuple[Any, Any]:
     return (row.get("problem_idx"), row.get("repeat"))
 
 
-def _present_at(items: list[dict[str, Any]], *keys: Any) -> str:
-    """Render ``N/total`` -- how many items have a non-empty value at the given path.
+def _count_present(items: list[dict[str, Any]], *keys: Any) -> int:
+    """How many items have a non-empty value at the given path.
 
-    Keys may be strings (dict lookup) or ints (list index). A value counts as
-    present when it is not None, not an empty string, and not an empty
-    list/dict -- so ``reward: 0.0`` counts but ``trajectory: []`` doesn't.
+    Keys may be strings (dict lookup) or ints (list index). Counts when the
+    value is not None, not "", and not an empty list/dict -- so ``reward: 0.0``
+    counts but ``trajectory: []`` doesn't.
     """
     n = 0
     for item in items:
@@ -151,7 +142,23 @@ def _present_at(items: list[dict[str, Any]], *keys: Any) -> str:
                 break
         if ok and cur is not None and cur != "" and not (isinstance(cur, (list, dict)) and not cur):
             n += 1
-    return f"{n}/{len(items)}"
+    return n
+
+
+def _missing_fields(items: list[dict[str, Any]], paths: dict[str, tuple[Any, ...]]) -> list[dict[str, str]]:
+    """Return entries where fewer than all items carry the field, as ``{field, presence}``.
+
+    A fully-populated field is silent: only gaps show up in the report.
+    """
+    total = len(items)
+    if not total:
+        return []
+    out: list[dict[str, str]] = []
+    for label, path in paths.items():
+        n = _count_present(items, *path)
+        if n < total:
+            out.append({"field": label, "presence": f"{n}/{total}"})
+    return out
 
 
 def _fraction(numer: int, denom: int) -> str:
@@ -176,257 +183,157 @@ def _index_traffic_by_trial(
     return bucket
 
 
-def _build_bench_report(
-    bench_name: str,
-    bench_dir: Path,
-) -> dict[str, Any]:
+_TRIAL_FIELDS: dict[str, tuple[Any, ...]] = {
+    "problem_idx": ("problem_idx",),
+    "repeat": ("repeat",),
+    "reward": ("reward",),
+    "trajectory": ("trajectory",),
+    "model": ("model",),
+    "trajectory[0].schema_version": ("trajectory", 0, "schema_version"),
+    "trajectory[0].session_id": ("trajectory", 0, "session_id"),
+    "trajectory[0].agent.name": ("trajectory", 0, "agent", "name"),
+    "trajectory[0].agent.version": ("trajectory", 0, "agent", "version"),
+    "trajectory[0].agent.model_name": ("trajectory", 0, "agent", "model_name"),
+    "trajectory[0].agent.parent_agent": ("trajectory", 0, "agent", "parent_agent"),
+    "trajectory[0].extra": ("trajectory", 0, "extra"),
+    "trajectory[0].steps": ("trajectory", 0, "steps"),
+    "trajectory[0].final_metrics.total_prompt_tokens": ("trajectory", 0, "final_metrics", "total_prompt_tokens"),
+    "trajectory[0].final_metrics.total_completion_tokens": ("trajectory", 0, "final_metrics", "total_completion_tokens"),
+    "trajectory[0].final_metrics.total_steps": ("trajectory", 0, "final_metrics", "total_steps"),
+}
+
+_STEP_FIELDS: dict[str, tuple[Any, ...]] = {
+    "step_id": ("step_id",),
+    "source": ("source",),
+    "timestamp": ("timestamp",),
+    "model_name": ("model_name",),
+    "status_code": ("status_code",),
+    "message": ("message",),
+    "reasoning_content": ("reasoning_content",),
+    "tool_calls": ("tool_calls",),
+    "metrics.prompt_tokens": ("metrics", "prompt_tokens"),
+    "metrics.completion_tokens": ("metrics", "completion_tokens"),
+    "metrics.total_tokens": ("metrics", "total_tokens"),
+    "metrics.extra.latency_ms": ("metrics", "extra", "latency_ms"),
+    "metrics.extra.finish_reason": ("metrics", "extra", "finish_reason"),
+    "metrics.extra.cached_tokens": ("metrics", "extra", "cached_tokens"),
+    "metrics.extra.reasoning_tokens": ("metrics", "extra", "reasoning_tokens"),
+}
+
+
+def _step_tokens(s: dict[str, Any]) -> int:
+    m = s.get("metrics") or {}
+    return int(m.get("prompt_tokens") or 0) + int(m.get("completion_tokens") or 0)
+
+
+def _wire_tokens(r: dict[str, Any]) -> int:
+    usage = r.get("usage") or {}
+    if not isinstance(usage, dict):
+        return 0
+    if usage.get("total_tokens") is not None:
+        try:
+            return int(usage["total_tokens"])
+        except (TypeError, ValueError):
+            return 0
+    return int(usage.get("prompt_tokens") or 0) + int(usage.get("completion_tokens") or 0)
+
+
+def _repeats_summary(traj_rows: list[dict[str, Any]]) -> Any:
+    """Single int when every problem has the same trial count; otherwise a histogram."""
+    counts = Counter(r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None)
+    distinct = set(counts.values())
+    if not distinct:
+        return 0
+    if len(distinct) == 1:
+        return next(iter(distinct))
+    return dict(Counter(counts.values()))
+
+
+def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
     traj_rows = _read_jsonl(bench_dir / "trajectories.jsonl")
     traffic_rows = _read_jsonl(bench_dir / "model_traffic.jsonl")
     traffic_by_trial = _index_traffic_by_trial(traffic_rows)
 
     n_trials = len(traj_rows)
     n_problems = len({r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None})
-    # Repeats: count trials per problem; if uniform, that's the repeats value,
-    # otherwise expose the histogram so a partial run (e.g. shard) is visible.
-    per_problem_repeat_counts = Counter(r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None)
-    distinct_counts = set(per_problem_repeat_counts.values())
-    repeats: Any = (
-        next(iter(distinct_counts))
-        if len(distinct_counts) == 1
-        else (dict(Counter(per_problem_repeat_counts.values())) if distinct_counts else 0)
-    )
 
-    # ─── score reconciliation ──────────────────────────────────────────
     rewards = [r["reward"] for r in traj_rows if isinstance(r.get("reward"), (int, float))]
     traj_mean = round(sum(rewards) / len(rewards), 6) if rewards else None
     reported = _load_eval_summary(bench_dir)
-    reported_mean = None
-    if isinstance(reported, dict):
-        reported_mean = reported.get("mean")
-    failures = Counter()
+    reported_mean = reported.get("mean") if isinstance(reported, dict) else None
+
+    # Single pass over traj_rows: collect everything per-trial needs.
+    all_agent_steps: list[dict[str, Any]] = []
+    failures: Counter[str] = Counter()
+    trials_more_wire = trials_fewer_wire = 0
+    trials_no_steps = trials_no_wire = trials_silent = 0
+    per_step_vs_fm_mismatch = 0
     for r in traj_rows:
-        sd = r.get("scoring_details") or {}
-        cat = sd.get("error_category") or r.get("failure_category")
+        steps = _agent_steps(r)
+        all_agent_steps.extend(steps)
+
+        cat = (r.get("scoring_details") or {}).get("error_category") or r.get("failure_category")
         if cat:
             failures[cat] += 1
 
-    # ─── trajectory_native ────────────────────────────────────────────
-    all_agent_steps: list[dict[str, Any]] = [s for r in traj_rows for s in _agent_steps(r)]
-    n_steps = len(all_agent_steps)
+        step_n = len(steps)
+        wire_n = len(traffic_by_trial.get(_trial_key(r), []))
+        if wire_n > step_n:
+            trials_more_wire += 1
+        elif wire_n < step_n:
+            trials_fewer_wire += 1
+        if step_n == 0:
+            trials_no_steps += 1
+        if wire_n == 0:
+            trials_no_wire += 1
+        if step_n == 0 or wire_n == 0:
+            trials_silent += 1
 
-    # ─── wire_captures (model_traffic.jsonl) ──────────────────────────
-    total_wire = len(traffic_rows)
-    successful_wire = sum(1 for r in traffic_rows if _is_successful_wire(r))
-    finish_reason_hist = Counter()
-    for r in traffic_rows:
-        fr = r.get("finish_reason")
-        if fr:
-            finish_reason_hist[fr] += 1
-
-    # ─── step <-> wire mismatch + silent-failure trials ───────────────
-    delta_signs = {"captures>steps": 0, "captures<steps": 0, "equal": 0}
-    trials_no_agent_steps = 0
-    trials_no_wire_calls = 0
-    trials_silent_either = 0
-    for r in traj_rows:
-        key = _trial_key(r)
-        cap_n = len(traffic_by_trial.get(key, []))
-        step_n = len(_agent_steps(r))
-        if cap_n > step_n:
-            delta_signs["captures>steps"] += 1
-        elif cap_n < step_n:
-            delta_signs["captures<steps"] += 1
-        else:
-            delta_signs["equal"] += 1
-        no_steps = step_n == 0
-        no_wire = cap_n == 0
-        if no_steps:
-            trials_no_agent_steps += 1
-        if no_wire:
-            trials_no_wire_calls += 1
-        if no_steps or no_wire:
-            trials_silent_either += 1
-
-    # ─── token reconciliation ─────────────────────────────────────────
-    def _step_tokens(s: dict[str, Any]) -> int:
-        m = s.get("metrics") or {}
-        return int(m.get("prompt_tokens") or 0) + int(m.get("completion_tokens") or 0)
-
-    per_step_total = sum(_step_tokens(s) for s in all_agent_steps)
-
-    def _wire_tokens(r: dict[str, Any]) -> int:
-        usage = r.get("usage") or {}
-        if not isinstance(usage, dict):
-            return 0
-        if usage.get("total_tokens") is not None:
-            try:
-                return int(usage["total_tokens"])
-            except (TypeError, ValueError):
-                return 0
-        return int(usage.get("prompt_tokens") or 0) + int(usage.get("completion_tokens") or 0)
-
-    wire_total = sum(_wire_tokens(r) for r in traffic_rows)
-
-    ref_total = 0
-    for r in traj_rows:
-        model = r.get("model") or {}
-        tokens = model.get("tokens") if isinstance(model, dict) else None
-        total = tokens.get("total") if isinstance(tokens, dict) else None
-        if isinstance(total, (int, float)):
-            ref_total += int(total)
-
-    # ─── ATIF per-trial presence (full ATIF-v1.6 coverage) ────────────
-    atif_paths = {
-        "schema_version": ("trajectory", 0, "schema_version"),
-        "session_id": ("trajectory", 0, "session_id"),
-        "agent.name": ("trajectory", 0, "agent", "name"),
-        "agent.version": ("trajectory", 0, "agent", "version"),
-        "agent.model_name": ("trajectory", 0, "agent", "model_name"),
-        "agent.parent_agent": ("trajectory", 0, "agent", "parent_agent"),
-        "extra": ("trajectory", 0, "extra"),
-        "steps": ("trajectory", 0, "steps"),
-        "final_metrics.total_prompt_tokens": ("trajectory", 0, "final_metrics", "total_prompt_tokens"),
-        "final_metrics.total_completion_tokens": ("trajectory", 0, "final_metrics", "total_completion_tokens"),
-        "final_metrics.total_steps": ("trajectory", 0, "final_metrics", "total_steps"),
-    }
-    atif_presence = {label: _present_at(traj_rows, *path) for label, path in atif_paths.items()}
-
-    # Trials that have ≥1 duplicate wire call (request_hash-based, or fallback key).
-    trials_with_duplicate_wire_calls = 0
-    for recs in traffic_by_trial.values():
-        hashes = Counter(_wire_dedup_key(r) for r in recs)
-        if any(v > 1 for v in hashes.values()):
-            trials_with_duplicate_wire_calls += 1
-
-    # After removing duplicate wire calls, does the mismatch resolve?
-    mismatched_steps_vs_wire_trials_after_wire_dedup = 0
-    for r in traj_rows:
-        key = _trial_key(r)
-        step_n = len(_agent_steps(r))
-        uniq_wire = len({_wire_dedup_key(w) for w in traffic_by_trial.get(key, [])})
-        if step_n != uniq_wire:
-            mismatched_steps_vs_wire_trials_after_wire_dedup += 1
-
-    # Per-trial: sum of step.metrics.{prompt+completion}_tokens equal to
-    # final_metrics.{total_prompt_tokens + total_completion_tokens}?
-    per_step_vs_final_metrics_mismatch = 0
-    for r in traj_rows:
-        steps = _agent_steps(r)
         per_step = sum(_step_tokens(s) for s in steps)
         fm = ((r.get("trajectory") or [{}])[0]).get("final_metrics") or {}
         fm_total = int(fm.get("total_prompt_tokens") or 0) + int(fm.get("total_completion_tokens") or 0)
         if (per_step or fm_total) and per_step != fm_total:
-            per_step_vs_final_metrics_mismatch += 1
+            per_step_vs_fm_mismatch += 1
 
-    is_mean_reward_correct: bool | None = None
-    if traj_mean is not None and reported_mean is not None:
-        is_mean_reward_correct = abs(traj_mean - reported_mean) < 1e-6
+    per_step_token_sum = sum(_step_tokens(s) for s in all_agent_steps)
+    wire_token_sum = sum(_wire_tokens(r) for r in traffic_rows)
 
-    _STEP_FIELDS: tuple[tuple[str, ...], ...] = (
-        ("step_id",),
-        ("source",),
-        ("timestamp",),
-        ("model_name",),
-        ("status_code",),
-        ("message",),
-        ("reasoning_content",),
-        ("tool_calls",),
-        ("metrics", "prompt_tokens"),
-        ("metrics", "completion_tokens"),
-        ("metrics", "total_tokens"),
-        ("metrics", "extra", "latency_ms"),
-        ("metrics", "extra", "finish_reason"),
-        ("metrics", "extra", "cached_tokens"),
-        ("metrics", "extra", "reasoning_tokens"),
-    )
-    step_field_coverage = {".".join(p): _present_at(all_agent_steps, *p) for p in _STEP_FIELDS}
+    # Wire dedup: how many trials had ≥1 dup, and the unique count overall.
+    trials_with_dup_wire = 0
+    for recs in traffic_by_trial.values():
+        keys = Counter(_wire_dedup_key(r, i) for i, r in enumerate(recs))
+        if any(v > 1 for v in keys.values()):
+            trials_with_dup_wire += 1
+    wire_unique = len({_wire_dedup_key(r, i) for i, r in enumerate(traffic_rows)})
 
-    row_field_coverage = {
-        "problem_idx": _present_at(traj_rows, "problem_idx"),
-        "repeat": _present_at(traj_rows, "repeat"),
-        "reward": _present_at(traj_rows, "reward"),
-        "trajectory": _present_at(traj_rows, "trajectory"),
-        "model": _present_at(traj_rows, "model"),
-        **{f"trajectory[0].{k}": v for k, v in atif_presence.items()},
-    }
-
-    # Wire-call dedup (request_hash-based, falls back to heuristic)
-    wire_keys_total = [_wire_dedup_key(r) for r in traffic_rows]
-    wire_keys_unique = set(wire_keys_total)
-    duplicates_total = total_wire - len(wire_keys_unique)
-
-    out: dict[str, Any] = {
+    return {
         "bench": bench_name,
-        "_note": (
-            "Health check over a run dir. Sections answer four questions, in order: "
-            "(1) score -- did the eval score what the bundle reported? "
-            "(2) tokens -- do the three independent token totals agree? "
-            "(3) wire_calls -- any duplicates or unexpected counts on the wire? "
-            "(4) field_coverage -- what fields are populated in trajectories.jsonl?"
-        ),
-        "counts": {
-            "trials": n_trials,
-            "problems": n_problems,
-            "repeats": repeats,
-        },
-        # ── 1. Did the eval score match what's reported in the bundle? ──
+        "counts": {"trials": n_trials, "problems": n_problems, "repeats": _repeats_summary(traj_rows)},
         "score": {
-            "_note": "mean_reward = mean(row.reward) across trials; reported_mean = bundle's eval-*.json summary.mean",
             "mean_reward": traj_mean,
             "reported_mean": reported_mean,
-            "is_mean_reward_correct": is_mean_reward_correct,
             "failures_by_category": dict(failures),
         },
-        # ── 2. Do per-step / trajectory-declared / wire totals agree? ──
         "tokens": {
-            "_note": (
-                "Three independent totals for prompt+completion tokens across all trials. "
-                "When all three agree, the trajectory faithfully encoded what the wire saw. "
-                "When per_step is 0 but wire isn't, the solver dropped per-step metrics "
-                "(enable enrich=true to backfill them from model_traffic.jsonl)."
-            ),
-            "per_step_sum": per_step_total,
-            "final_metrics_total": ref_total,
-            "wire_total": wire_total,
-            "per_step_matches_wire": (per_step_total == wire_total) if (per_step_total or wire_total) else None,
-            "final_metrics_matches_wire": (ref_total == wire_total) if (ref_total or wire_total) else None,
-            "trials_with_per_step_vs_final_metrics_mismatch": per_step_vs_final_metrics_mismatch,
+            "per_step_sum": per_step_token_sum,
+            "wire_total": wire_token_sum,
+            "trials_with_per_step_vs_final_metrics_mismatch": per_step_vs_fm_mismatch,
         },
-        # ── 3. Wire call summary + duplicates ──
         "wire_calls": {
-            "_note": (
-                "model_traffic.jsonl row stats. Step/wire alignment and the silent-failure "
-                "metrics below count only successful (2xx/3xx) wire rows -- a 500 or aborted "
-                "request is not a 'captured' model call. 'total' is raw (all statuses) so the "
-                "failure volume stays visible. duplicates_total is via record.request_hash "
-                "(sha1 prefix of the upstream body)."
-            ),
-            "total": total_wire,
-            "successful": successful_wire,
-            "unique": len(wire_keys_unique),
-            "duplicates_total": duplicates_total,
-            "trials_with_duplicates": trials_with_duplicate_wire_calls,
-            "trials_with_more_wire_than_steps": delta_signs["captures>steps"],
-            "trials_with_fewer_wire_than_steps": delta_signs["captures<steps"],
-            "trials_with_step_wire_mismatch_after_dedup": mismatched_steps_vs_wire_trials_after_wire_dedup,
-            "trials_with_no_agent_steps": _fraction(trials_no_agent_steps, n_trials),
-            "trials_with_no_wire_calls": _fraction(trials_no_wire_calls, n_trials),
-            "trials_silent_either_way": _fraction(trials_silent_either, n_trials),
-            "finish_reasons": dict(finish_reason_hist),
+            "total": len(traffic_rows),
+            "unique": wire_unique,
+            "trials_with_duplicates": trials_with_dup_wire,
+            "trials_with_more_wire_than_steps": trials_more_wire,
+            "trials_with_fewer_wire_than_steps": trials_fewer_wire,
+            "trials_with_no_agent_steps": _fraction(trials_no_steps, n_trials),
+            "trials_with_no_wire_calls": _fraction(trials_no_wire, n_trials),
+            "trials_silent_either_way": _fraction(trials_silent, n_trials),
         },
-        # ── 4. Field coverage (presence audit) ──
         "field_coverage": {
-            "_note": (
-                "How many trials/steps actually have each ATIF-v1.6 field. "
-                "Format 'N/total' means N populated out of total. "
-                "Run with enrich=true to backfill metrics.* on steps from the wire layer."
-            ),
-            "per_trial": row_field_coverage,
-            "per_agent_step": step_field_coverage,
-            "agent_step_count": n_steps,
+            "per_trial_missing": _missing_fields(traj_rows, _TRIAL_FIELDS),
+            "per_agent_step_missing": _missing_fields(all_agent_steps, _STEP_FIELDS),
         },
     }
-    return out
 
 
 def _enrich_bench(bench_dir: Path) -> dict[str, int]:
@@ -538,28 +445,11 @@ def generate_trajectories_report(
         bench_report = _build_bench_report(d.name, d)
         if enrich:
             counts = _enrich_bench(d)
-            # After-enrichment coverage so the diff is right there in the report.
+            enriched_steps: list[dict[str, Any]] = []
             enriched_path = d / "trajectories_enriched.jsonl"
-            enriched_step_coverage: dict[str, str] = {}
             if enriched_path.is_file():
                 enriched_steps = [s for r in _read_jsonl(enriched_path) for s in _agent_steps(r)]
-                if enriched_steps:
-                    enriched_step_coverage = {
-                        ".".join(p): _present_at(enriched_steps, *p)
-                        for p in (
-                            ("metrics", "prompt_tokens"),
-                            ("metrics", "completion_tokens"),
-                            ("metrics", "extra", "latency_ms"),
-                            ("metrics", "extra", "finish_reason"),
-                        )
-                    }
             bench_report["enrichment"] = {
-                "_note": (
-                    "trajectories_enriched.jsonl was written next to trajectories.jsonl. "
-                    "For each trial: if #agent_steps == #wire_calls, splice 1:1; otherwise "
-                    "stash all wire calls into trajectory[0].extra.captured_model_calls "
-                    "(so failures still preserve every captured call)."
-                ),
                 "trials_spliced_1_to_1": counts["trials_spliced"],
                 "trials_with_unmatched_calls_stashed": counts["trials_stashed_unmatched"],
                 "trials_with_no_wire_data": counts["trials_no_wire_data"],
@@ -572,7 +462,15 @@ def generate_trajectories_report(
                     "message": counts["steps_backfilled_message"],
                     "tool_calls": counts["steps_backfilled_tool_calls"],
                 },
-                "step_field_coverage_after_enrichment": enriched_step_coverage,
+                "step_field_coverage_after_enrichment_missing": _missing_fields(
+                    enriched_steps,
+                    {".".join(p): p for p in (
+                        ("metrics", "prompt_tokens"),
+                        ("metrics", "completion_tokens"),
+                        ("metrics", "extra", "latency_ms"),
+                        ("metrics", "extra", "finish_reason"),
+                    )},
+                ),
             }
         benches.append(bench_report)
 

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -228,6 +228,7 @@ def _build_bench_report(
             if isinstance(v, (str, list, dict)) and not v:
                 return False
             return True
+
         n = sum(1 for s in all_agent_steps if _ok(s.get(field)))
         return f"{n}/{n_steps}"
 
@@ -363,9 +364,7 @@ def _build_bench_report(
 
     # Trials where step count != wire-call count (a different mismatch axis
     # than ref/wire token totals; signals lost or duplicated captures).
-    mismatched_steps_vs_wire_trials = (
-        delta_signs["captures>steps"] + delta_signs["captures<steps"]
-    )
+    mismatched_steps_vs_wire_trials = delta_signs["captures>steps"] + delta_signs["captures<steps"]
 
     # After removing duplicates on both sides, does the mismatch resolve?
     mismatched_steps_vs_wire_trials_after_dedup = 0
@@ -628,11 +627,7 @@ def generate_trajectories_report(
     ``model_traffic.jsonl`` row (1:1 by order within a trial), and any
     extra wire calls are stashed under ``trajectory[0].extra.captured_model_calls``.
     """
-    bench_dirs = sorted(
-        p
-        for p in output_dir.iterdir()
-        if p.is_dir() and (p / "trajectories.jsonl").is_file()
-    )
+    bench_dirs = sorted(p for p in output_dir.iterdir() if p.is_dir() and (p / "trajectories.jsonl").is_file())
     if not bench_dirs:
         logger.info("trajectories_report: no <bench>/trajectories.jsonl found under %s", output_dir)
         return None

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -30,6 +30,7 @@ Pure file-to-file. No adapter, no in-memory store, no eval-loop coupling.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import statistics
@@ -38,6 +39,49 @@ from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _step_content_hash(step: dict[str, Any]) -> str:
+    """Deterministic hash of an agent step's user-visible content.
+
+    Two steps with identical message + reasoning_content + tool-call names
+    + tool-call arguments hash to the same value — a strong duplicate
+    signal when it repeats inside a single trial.
+    """
+    msg = step.get("message") or ""
+    reasoning = step.get("reasoning_content") or ""
+    tool_calls = step.get("tool_calls") or []
+    tc_repr: list[Any] = []
+    if isinstance(tool_calls, list):
+        for tc in tool_calls:
+            if not isinstance(tc, dict):
+                continue
+            fn = tc.get("function") or {}
+            name = tc.get("function_name") or fn.get("name") or ""
+            args = tc.get("arguments") if "arguments" in tc else fn.get("arguments")
+            tc_repr.append((name, args))
+    payload = json.dumps([msg, reasoning, tc_repr], sort_keys=True, default=str)
+    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
+
+
+def _wire_dedup_key(record: dict[str, Any]) -> tuple[Any, ...]:
+    """Coarse duplicate-detection key for a single ``model_traffic.jsonl`` row.
+
+    ``model_traffic.jsonl`` currently stores per-call response stats but not
+    the request body, so we can't fingerprint the actual prompt yet. Two rows
+    with identical (model, path, finish_reason, prompt_tokens, completion_tokens,
+    latency_ms_rounded) on the same trial almost certainly indicate the same
+    upstream call being captured twice.
+    """
+    usage = record.get("usage") or {}
+    return (
+        record.get("model"),
+        record.get("path"),
+        record.get("finish_reason"),
+        usage.get("prompt_tokens"),
+        usage.get("completion_tokens"),
+        round(float(record.get("latency_ms") or 0), 1),
+    )
 
 
 def _percentile(values: list[float], pct: float) -> float | None:
@@ -273,6 +317,58 @@ def _build_bench_report(
                 n += 1
         atif_presence[label] = f"{n}/{n_trials}"
 
+    # ─── anomalies (the things you actually want to know) ────────────
+    # Zero / None tokens per step + per trial
+    steps_with_zero_or_none_tokens = 0
+    trials_with_any_zero_step = 0
+    trials_all_zero_token_steps = 0
+    for r in traj_rows:
+        steps = _agent_steps(r)
+        if not steps:
+            continue
+        zero_in_trial = 0
+        for s in steps:
+            m = s.get("metrics") or {}
+            pt = m.get("prompt_tokens")
+            ct = m.get("completion_tokens")
+            if (not pt) and (not ct):
+                steps_with_zero_or_none_tokens += 1
+                zero_in_trial += 1
+        if zero_in_trial > 0:
+            trials_with_any_zero_step += 1
+        if zero_in_trial == len(steps):
+            trials_all_zero_token_steps += 1
+
+    # Duplicate agent steps inside a single trial (content hash)
+    duplicate_steps_in_trial = 0
+    trials_with_duplicate_steps = 0
+    for r in traj_rows:
+        hashes = Counter(_step_content_hash(s) for s in _agent_steps(r))
+        per_trial_dups = sum(v - 1 for v in hashes.values() if v > 1)
+        if per_trial_dups > 0:
+            duplicate_steps_in_trial += per_trial_dups
+            trials_with_duplicate_steps += 1
+
+    # Duplicate wire calls inside a single trial (coarse fingerprint)
+    duplicate_wire_calls_in_trial = 0
+    trials_with_duplicate_wire_calls = 0
+    for key, recs in traffic_by_trial.items():
+        hashes = Counter(_wire_dedup_key(r) for r in recs)
+        per_trial_dups = sum(v - 1 for v in hashes.values() if v > 1)
+        if per_trial_dups > 0:
+            duplicate_wire_calls_in_trial += per_trial_dups
+            trials_with_duplicate_wire_calls += 1
+
+    # Trials where step count != wire-call count (a different mismatch axis
+    # than ref/wire token totals; signals lost or duplicated captures).
+    mismatched_steps_vs_wire_trials = (
+        delta_signs["captures>steps"] + delta_signs["captures<steps"]
+    )
+
+    is_mean_reward_correct: bool | None = None
+    if traj_mean is not None and reported_mean is not None:
+        is_mean_reward_correct = abs(traj_mean - reported_mean) < 1e-6
+
     return {
         "bench": bench_name,
         "counts": {
@@ -283,15 +379,22 @@ def _build_bench_report(
         "score": {
             "mean_reward": traj_mean,
             "reported_mean": reported_mean,
-            "trajectories_vs_reported_match": (
-                None
-                if traj_mean is None or reported_mean is None
-                else abs(traj_mean - reported_mean) < 1e-6
-            ),
+            "is_mean_reward_correct": is_mean_reward_correct,
             "failures": {
                 "total": sum(failures.values()),
                 "counts_by_category": dict(failures),
             },
+        },
+        # The actionable summary: what's broken, in counts.
+        "anomalies": {
+            "steps_with_zero_or_none_tokens": steps_with_zero_or_none_tokens,
+            "trials_with_any_zero_token_step": trials_with_any_zero_step,
+            "trials_with_all_zero_token_steps": trials_all_zero_token_steps,
+            "duplicate_steps_in_trial_total": duplicate_steps_in_trial,
+            "trials_with_duplicate_steps": trials_with_duplicate_steps,
+            "duplicate_wire_calls_in_trial_total": duplicate_wire_calls_in_trial,
+            "trials_with_duplicate_wire_calls": trials_with_duplicate_wire_calls,
+            "mismatched_steps_vs_wire_trials": mismatched_steps_vs_wire_trials,
         },
         "trajectory_native": {
             "agent_steps_total": n_steps,

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -499,6 +499,9 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
         "steps_backfilled_completion_tokens": 0,
         "steps_backfilled_latency_ms": 0,
         "steps_backfilled_finish_reason": 0,
+        "steps_backfilled_reasoning_content": 0,
+        "steps_backfilled_message": 0,
+        "steps_backfilled_tool_calls": 0,
         "rows_written": 0,
     }
 
@@ -526,6 +529,17 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
                     if not extra.get("finish_reason") and w.get("finish_reason"):
                         extra["finish_reason"] = w["finish_reason"]
                         counts["steps_backfilled_finish_reason"] += 1
+                    # Opt-in capture fields: backfill iff present on the wire row
+                    # and missing on the step.
+                    if w.get("reasoning_content") and not s.get("reasoning_content"):
+                        s["reasoning_content"] = w["reasoning_content"]
+                        counts["steps_backfilled_reasoning_content"] += 1
+                    if w.get("message_content") and not s.get("message"):
+                        s["message"] = w["message_content"]
+                        counts["steps_backfilled_message"] += 1
+                    if w.get("tool_calls_full") and not s.get("tool_calls"):
+                        s["tool_calls"] = w["tool_calls_full"]
+                        counts["steps_backfilled_tool_calls"] += 1
                 counts["trials_spliced"] += 1
             else:
                 # Count mismatch — stash ALL wire calls; don't touch steps.
@@ -612,6 +626,9 @@ def generate_trajectories_report(
                     "completion_tokens": counts["steps_backfilled_completion_tokens"],
                     "latency_ms": counts["steps_backfilled_latency_ms"],
                     "finish_reason": counts["steps_backfilled_finish_reason"],
+                    "reasoning_content": counts["steps_backfilled_reasoning_content"],
+                    "message": counts["steps_backfilled_message"],
+                    "tool_calls": counts["steps_backfilled_tool_calls"],
                 },
                 "step_field_coverage_after_enrichment": enriched_step_coverage,
             }

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -34,7 +34,6 @@ existing run directory, including archived bundles.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import statistics

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -281,13 +281,15 @@ def _build_bench_report(
         if isinstance(total, (int, float)):
             ref_total += int(total)
 
-    # ─── ATIF per-trial presence ──────────────────────────────────────
+    # ─── ATIF per-trial presence (full ATIF-v1.6 coverage) ────────────
     atif_paths = {
         "schema_version": ("trajectory", 0, "schema_version"),
         "session_id": ("trajectory", 0, "session_id"),
         "agent.name": ("trajectory", 0, "agent", "name"),
         "agent.version": ("trajectory", 0, "agent", "version"),
         "agent.model_name": ("trajectory", 0, "agent", "model_name"),
+        "agent.parent_agent": ("trajectory", 0, "agent", "parent_agent"),
+        "extra": ("trajectory", 0, "extra"),
         "steps": ("trajectory", 0, "steps"),
         "final_metrics.total_prompt_tokens": ("trajectory", 0, "final_metrics", "total_prompt_tokens"),
         "final_metrics.total_completion_tokens": ("trajectory", 0, "final_metrics", "total_completion_tokens"),
@@ -365,73 +367,234 @@ def _build_bench_report(
         delta_signs["captures>steps"] + delta_signs["captures<steps"]
     )
 
+    # After removing duplicates on both sides, does the mismatch resolve?
+    mismatched_steps_vs_wire_trials_after_dedup = 0
+    for r in traj_rows:
+        key = _trial_key(r)
+        uniq_steps = len({_step_content_hash(s) for s in _agent_steps(r)})
+        uniq_wire = len({_wire_dedup_key(w) for w in traffic_by_trial.get(key, [])})
+        if uniq_steps != uniq_wire:
+            mismatched_steps_vs_wire_trials_after_dedup += 1
+
+    # Per-trial: sum of step.metrics.{prompt+completion}_tokens equal to
+    # final_metrics.{total_prompt_tokens + total_completion_tokens}?
+    per_step_vs_final_metrics_mismatch = 0
+    for r in traj_rows:
+        steps = _agent_steps(r)
+        per_step = sum(_step_tokens(s) for s in steps)
+        fm = ((r.get("trajectory") or [{}])[0]).get("final_metrics") or {}
+        fm_total = int(fm.get("total_prompt_tokens") or 0) + int(fm.get("total_completion_tokens") or 0)
+        if (per_step or fm_total) and per_step != fm_total:
+            per_step_vs_final_metrics_mismatch += 1
+
     is_mean_reward_correct: bool | None = None
     if traj_mean is not None and reported_mean is not None:
         is_mean_reward_correct = abs(traj_mean - reported_mean) < 1e-6
 
+    def vf(value: Any, formula: str) -> dict[str, Any]:
+        """{value, from} pair where `from` documents the calculation."""
+        return {"value": value, "from": formula}
+
     return {
         "bench": bench_name,
         "counts": {
-            "n_trials": n_trials,
-            "n_problems": n_problems,
-            "repeats": repeats,
+            "n_trials": vf(n_trials, "trajectories.jsonl row count"),
+            "n_problems": vf(n_problems, "distinct trajectories.jsonl row.problem_idx"),
+            "repeats": vf(repeats, "n_trials // n_problems"),
         },
         "score": {
-            "mean_reward": traj_mean,
-            "reported_mean": reported_mean,
-            "is_mean_reward_correct": is_mean_reward_correct,
-            "failures": {
-                "total": sum(failures.values()),
-                "counts_by_category": dict(failures),
-            },
+            "mean_reward": vf(traj_mean, "mean(row.reward) across trajectories.jsonl trials"),
+            "reported_mean": vf(
+                reported_mean,
+                "latest <bench>/eval-*.json benchmark.scores.summary.mean",
+            ),
+            "is_mean_reward_correct": vf(
+                is_mean_reward_correct,
+                "|mean_reward - reported_mean| < 1e-6 (null if either side is missing)",
+            ),
+            "failures": vf(
+                {"total": sum(failures.values()), "counts_by_category": dict(failures)},
+                "row.scoring_details.error_category OR row.failure_category",
+            ),
         },
         # The actionable summary: what's broken, in counts.
         "anomalies": {
-            "steps_with_zero_or_none_tokens": steps_with_zero_or_none_tokens,
-            "trials_with_any_zero_token_step": trials_with_any_zero_step,
-            "trials_with_all_zero_token_steps": trials_all_zero_token_steps,
-            "duplicate_steps_in_trial_total": duplicate_steps_in_trial,
-            "trials_with_duplicate_steps": trials_with_duplicate_steps,
-            "duplicate_wire_calls_in_trial_total": duplicate_wire_calls_in_trial,
-            "trials_with_duplicate_wire_calls": trials_with_duplicate_wire_calls,
-            "mismatched_steps_vs_wire_trials": mismatched_steps_vs_wire_trials,
+            "steps_with_zero_or_none_tokens": vf(
+                steps_with_zero_or_none_tokens,
+                "agent steps where (metrics.prompt_tokens or 0) + (metrics.completion_tokens or 0) == 0",
+            ),
+            "trials_with_any_zero_token_step": vf(
+                trials_with_any_zero_step,
+                "trials with at least one zero-or-none-tokens agent step",
+            ),
+            "trials_with_all_zero_token_steps": vf(
+                trials_all_zero_token_steps,
+                "trials where every agent step is zero-or-none-tokens",
+            ),
+            "duplicate_steps_in_trial_total": vf(
+                duplicate_steps_in_trial,
+                "sum over trials of (#repeated step content_hashes - 1); "
+                "content_hash = sha1(message + reasoning_content + tool_calls names+args)",
+            ),
+            "trials_with_duplicate_steps": vf(
+                trials_with_duplicate_steps,
+                "trials with at least one duplicate step content_hash",
+            ),
+            "duplicate_wire_calls_in_trial_total": vf(
+                duplicate_wire_calls_in_trial,
+                "sum over trials of (#repeated wire_dedup_keys - 1); "
+                "wire_dedup_key = (model, path, finish_reason, prompt_tokens, "
+                "completion_tokens, round(latency_ms,1))",
+            ),
+            "trials_with_duplicate_wire_calls": vf(
+                trials_with_duplicate_wire_calls,
+                "trials with at least one duplicate wire_dedup_key",
+            ),
+            "mismatched_steps_vs_wire_trials": vf(
+                mismatched_steps_vs_wire_trials,
+                "trials where len(agent_steps) != len(model_traffic rows for that trial)",
+            ),
+            "mismatched_steps_vs_wire_trials_after_dedup": vf(
+                mismatched_steps_vs_wire_trials_after_dedup,
+                "same as above but on unique sets: "
+                "trials where len(set(step content_hashes)) != len(set(wire_dedup_keys)); "
+                "non-zero here means the mismatch is NOT explained by duplicates",
+            ),
+            "trials_with_per_step_vs_final_metrics_token_mismatch": vf(
+                per_step_vs_final_metrics_mismatch,
+                "trials where sum(step.metrics.prompt+completion_tokens) != "
+                "final_metrics.total_prompt+total_completion_tokens; "
+                "non-zero means the trajectory's internal totals are inconsistent",
+            ),
         },
         "trajectory_native": {
-            "agent_steps_total": n_steps,
-            "agent_steps_per_trial": _stats([float(x) for x in per_trial_step_counts]),
-            "tool_calls_total": tool_calls_total,
-            "reasoning_chars_total": reasoning_chars_total,
-            "fields_present_on_steps": {
-                "step_id": _field_present("step_id"),
-                "source": _field_present("source"),
-                "message": _field_present("message"),
-                "reasoning_content": _field_present("reasoning_content"),
-                "tool_calls": _field_present("tool_calls"),
-            },
-            "fields_nonempty_on_steps": {
-                "step_id": _field_nonempty("step_id"),
-                "source": _field_nonempty("source"),
-                "message": _field_nonempty("message"),
-                "reasoning_content": _field_nonempty("reasoning_content"),
-                "tool_calls": _field_nonempty("tool_calls"),
-            },
+            "agent_steps_total": vf(
+                n_steps,
+                "len(row.trajectory[0].steps[source=='agent']) summed across trials",
+            ),
+            "agent_steps_per_trial": vf(
+                _stats([float(x) for x in per_trial_step_counts]),
+                "stats of agent-step counts per trial",
+            ),
+            "tool_calls_total": vf(
+                tool_calls_total,
+                "sum of len(step.tool_calls) over agent steps",
+            ),
+            "reasoning_chars_total": vf(
+                reasoning_chars_total,
+                "sum of len(step.reasoning_content) over agent steps",
+            ),
+            "fields_present_on_steps": vf(
+                {
+                    "step_id": _field_present("step_id"),
+                    "source": _field_present("source"),
+                    "message": _field_present("message"),
+                    "reasoning_content": _field_present("reasoning_content"),
+                    "tool_calls": _field_present("tool_calls"),
+                },
+                f"N/{n_steps} agent steps where the field is non-None",
+            ),
+            "fields_nonempty_on_steps": vf(
+                {
+                    "step_id": _field_nonempty("step_id"),
+                    "source": _field_nonempty("source"),
+                    "message": _field_nonempty("message"),
+                    "reasoning_content": _field_nonempty("reasoning_content"),
+                    "tool_calls": _field_nonempty("tool_calls"),
+                },
+                f"N/{n_steps} agent steps where the field is non-empty (non-None and not '' / [] / {{}})",
+            ),
         },
         "wire_captures": {
-            "total_observed": total_wire,
-            "captures_per_trial": _stats([float(x) for x in captures_per_trial]) if captures_per_trial else None,
-            "finish_reasons": dict(finish_reason_hist),
+            "total_observed": vf(
+                total_wire,
+                "model_traffic.jsonl row count",
+            ),
+            "captures_per_trial": vf(
+                _stats([float(x) for x in captures_per_trial]) if captures_per_trial else None,
+                "stats of len(model_traffic rows) grouped by (problem_idx, repeat)",
+            ),
+            "finish_reasons": vf(
+                dict(finish_reason_hist),
+                "histogram of model_traffic.jsonl row.finish_reason",
+            ),
         },
         "mismatches": {
-            "agent_steps_vs_wire_calls": delta_signs,
-            "tokens": {
-                "ref_total": ref_total,
-                "per_step_total": per_step_total,
-                "wire_total": wire_total,
-                "match_ref_vs_wire": (ref_total == wire_total) if ref_total or wire_total else None,
-            },
+            "agent_steps_vs_wire_calls": vf(
+                delta_signs,
+                "for each trial: sign(len(wire_rows) - len(agent_steps))",
+            ),
+            "tokens": vf(
+                {
+                    "ref_total": ref_total,
+                    "per_step_total": per_step_total,
+                    "wire_total": wire_total,
+                    "match_ref_vs_wire": (ref_total == wire_total) if ref_total or wire_total else None,
+                },
+                "ref_total = sum(row.model.tokens.total); "
+                "per_step_total = sum(step.metrics.prompt_tokens + step.metrics.completion_tokens); "
+                "wire_total = sum(model_traffic row.usage.total_tokens, fallback to prompt+completion)",
+            ),
         },
-        "atif_per_trial_presence": atif_presence,
+        "atif_per_trial_presence": vf(
+            atif_presence,
+            f"N/{n_trials} trajectories.jsonl rows where the dotted-path field is non-None and non-empty",
+        ),
     }
+
+
+def _enrich_bench(bench_dir: Path) -> dict[str, int]:
+    """Backfill agent-step metrics from ``model_traffic.jsonl``.
+
+    Splice strategy is intentionally simple: for each trial, pair the
+    i-th wire call with the i-th agent step in order. Any extra wire
+    calls are stashed under ``trajectory[0].extra.captured_model_calls``
+    so nothing is lost. Returns counts of what was changed for the report.
+    """
+    traj_path = bench_dir / "trajectories.jsonl"
+    traffic_path = bench_dir / "model_traffic.jsonl"
+    enriched_path = bench_dir / "trajectories_enriched.jsonl"
+
+    traj_rows = _read_jsonl(traj_path)
+    traffic_rows = _read_jsonl(traffic_path)
+    by_trial = _index_traffic_by_trial(traffic_rows)
+
+    counts = {
+        "steps_backfilled_prompt_tokens": 0,
+        "steps_backfilled_completion_tokens": 0,
+        "steps_backfilled_latency_ms": 0,
+        "steps_backfilled_finish_reason": 0,
+        "trials_with_stashed_extra_calls": 0,
+        "rows_written": 0,
+    }
+
+    with enriched_path.open("w", encoding="utf-8") as fh:
+        for r in traj_rows:
+            steps = _agent_steps(r)
+            wire = by_trial.get(_trial_key(r), [])
+            for s, w in zip(steps, wire):
+                metrics = s.setdefault("metrics", {})
+                usage = w.get("usage") or {}
+                if metrics.get("prompt_tokens") in (None, 0) and usage.get("prompt_tokens"):
+                    metrics["prompt_tokens"] = usage["prompt_tokens"]
+                    counts["steps_backfilled_prompt_tokens"] += 1
+                if metrics.get("completion_tokens") in (None, 0) and usage.get("completion_tokens"):
+                    metrics["completion_tokens"] = usage["completion_tokens"]
+                    counts["steps_backfilled_completion_tokens"] += 1
+                extra = metrics.setdefault("extra", {})
+                if extra.get("latency_ms") in (None, 0) and w.get("latency_ms"):
+                    extra["latency_ms"] = w["latency_ms"]
+                    counts["steps_backfilled_latency_ms"] += 1
+                if not extra.get("finish_reason") and w.get("finish_reason"):
+                    extra["finish_reason"] = w["finish_reason"]
+                    counts["steps_backfilled_finish_reason"] += 1
+            if len(wire) > len(steps):
+                traj = (r.get("trajectory") or [{}])[0]
+                traj.setdefault("extra", {})["captured_model_calls"] = wire[len(steps) :]
+                counts["trials_with_stashed_extra_calls"] += 1
+            fh.write(json.dumps(r) + "\n")
+            counts["rows_written"] += 1
+    return counts
 
 
 def generate_trajectories_report(
@@ -439,15 +602,16 @@ def generate_trajectories_report(
     *,
     enrich: bool = False,
 ) -> Path | None:
-    """Audit-mode report over an evaluation run dir.
+    """Audit (and optionally enrich) trajectories under *output_dir*.
 
-    Walks each per-benchmark subdir under *output_dir*, reads
-    ``trajectories.jsonl`` + ``model_traffic.jsonl`` if present, and writes
-    ``<output_dir>/trajectories_report.json`` summarizing coverage and any
-    mismatches between native trajectory data and wire captures.
+    Walks each per-benchmark subdir, reads ``trajectories.jsonl`` +
+    ``model_traffic.jsonl`` if present, and writes
+    ``<output_dir>/trajectories_report.json``.
 
-    The *enrich* flag is reserved for the next iteration (splicing wire
-    captures into trajectories.jsonl); currently it only triggers a warning.
+    With ``enrich=True``, also writes ``<bench>/trajectories_enriched.jsonl``
+    per benchmark — agent-step ``metrics`` are backfilled from the matching
+    ``model_traffic.jsonl`` row (1:1 by order within a trial), and any
+    extra wire calls are stashed under ``trajectory[0].extra.captured_model_calls``.
     """
     bench_dirs = sorted(
         p
@@ -458,18 +622,29 @@ def generate_trajectories_report(
         logger.info("trajectories_report: no <bench>/trajectories.jsonl found under %s", output_dir)
         return None
 
-    payload = {
-        "schema_version": "trajectories_report-v0.1",
-        "benchmarks": [_build_bench_report(d.name, d) for d in bench_dirs],
-    }
+    benches: list[dict[str, Any]] = []
+    for d in bench_dirs:
+        bench_report = _build_bench_report(d.name, d)
+        if enrich:
+            counts = _enrich_bench(d)
+            bench_report["enrichment"] = {
+                "value": counts,
+                "from": (
+                    "trajectories_enriched.jsonl written next to trajectories.jsonl; "
+                    "agent steps backfilled 1:1 with model_traffic.jsonl rows for the same trial; "
+                    "extra wire calls stashed in trajectory[0].extra.captured_model_calls"
+                ),
+            }
+        benches.append(bench_report)
 
-    if enrich:
-        logger.warning(
-            "trajectories_report: enrich=True requested; "
-            "enrichment writes are not implemented in this release (audit-only)."
-        )
+    payload = {"schema_version": "trajectories_report-v0.1", "benchmarks": benches}
 
     out_path = output_dir / "trajectories_report.json"
     out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
-    logger.info("trajectories_report: wrote %s (%d benchmark(s))", out_path, len(bench_dirs))
+    logger.info(
+        "trajectories_report: wrote %s (%d benchmark(s)%s)",
+        out_path,
+        len(bench_dirs),
+        ", enriched" if enrich else "",
+    )
     return out_path

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -167,7 +167,19 @@ def _build_bench_report(
 
     n_trials = len(traj_rows)
     n_problems = len({r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None})
-    repeats = (n_trials // n_problems) if n_problems else 0
+    # Repeats: count trials per problem; if uniform, that's the repeats value,
+    # otherwise expose the histogram so a partial run (e.g. shard) is visible.
+    per_problem_repeat_counts = Counter(r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None)
+    distinct_counts = set(per_problem_repeat_counts.values())
+    if len(distinct_counts) == 1:
+        repeats: Any = next(iter(distinct_counts))
+        repeats_from = "trials-per-problem (uniform across problems)"
+    elif distinct_counts:
+        repeats = dict(Counter(per_problem_repeat_counts.values()))
+        repeats_from = "histogram of trials-per-problem counts (non-uniform)"
+    else:
+        repeats = 0
+        repeats_from = "no problems found"
 
     # ─── score reconciliation ──────────────────────────────────────────
     rewards = [r["reward"] for r in traj_rows if isinstance(r.get("reward"), (int, float))]
@@ -411,7 +423,7 @@ def _build_bench_report(
         "counts": {
             "n_trials": vf(n_trials, "trajectories.jsonl row count"),
             "n_problems": vf(n_problems, "distinct trajectories.jsonl row.problem_idx"),
-            "repeats": vf(repeats, "n_trials // n_problems"),
+            "repeats": vf(repeats, repeats_from),
         },
         "score": {
             "mean_reward": vf(traj_mean, "mean(row.reward) across trajectories.jsonl trials"),

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -12,20 +12,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Trajectory coverage / audit report.
+"""Trajectory audit + optional enrichment.
 
-Post-processes ``trajectories.jsonl`` (per-trial trajectory native data) and
-``model_traffic.jsonl`` (per-call wire captures, gchlebus's MR #117) to
-produce a single ``trajectories_report.json`` describing:
+Reads two files from a run directory:
 
-  * dataset counts (trials / problems / repeats)
-  * score reconciliation (mean_reward in trajectories vs reported in eval-*.json)
-  * trajectory_native field coverage (which ATIF-v1.6 fields are present)
-  * wire_captures summary (counts, per-session distribution, finish_reasons)
-  * step <-> capture mismatches and token reconciliation
-  * per-trial ATIF presence audit
+  trajectories.jsonl   -- one row per trial (rewards, ATIF trajectory)
+  model_traffic.jsonl  -- one row per upstream model call
 
-Pure file-to-file. No adapter, no in-memory store, no eval-loop coupling.
+Writes ``trajectories_report.json`` summarising counts, score reconciliation,
+ATIF field presence, step/wire mismatches, duplicates, and token totals.
+Each metric is reported as ``{value, from}`` so the calculation is explicit.
+
+With ``enrich=True``, also writes ``trajectories_enriched.jsonl``: per-trial,
+when the agent-step count equals the wire-call count, step metrics are
+backfilled 1:1 from the matching wire call; otherwise all wire calls land in
+``trajectory[0].extra.captured_model_calls`` (no partial splice).
+
+The module is read-only over the eval pipeline -- runs offline against any
+existing run directory, including archived bundles.
 """
 
 from __future__ import annotations

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -1,0 +1,372 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trajectory coverage / audit report.
+
+Post-processes ``trajectories.jsonl`` (per-trial trajectory native data) and
+``model_traffic.jsonl`` (per-call wire captures, gchlebus's MR #117) to
+produce a single ``trajectories_report.json`` describing:
+
+  * dataset counts (trials / problems / repeats)
+  * score reconciliation (mean_reward in trajectories vs reported in eval-*.json)
+  * trajectory_native field coverage (which ATIF-v1.6 fields are present)
+  * wire_captures summary (counts, per-session distribution, finish_reasons)
+  * step <-> capture mismatches and token reconciliation
+  * per-trial ATIF presence audit
+
+Pure file-to-file. No adapter, no in-memory store, no eval-loop coupling.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import statistics
+from collections import Counter
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    s = sorted(values)
+    k = (len(s) - 1) * pct
+    lo, hi = int(k), min(int(k) + 1, len(s) - 1)
+    if lo == hi:
+        return float(s[lo])
+    return float(s[lo] + (s[hi] - s[lo]) * (k - lo))
+
+
+def _stats(values: list[float]) -> dict[str, float | None]:
+    if not values:
+        return {"mean": None, "median": None, "p10": None, "p90": None, "max": None}
+    return {
+        "mean": round(statistics.fmean(values), 4),
+        "median": round(statistics.median(values), 4),
+        "p10": _percentile(values, 0.10),
+        "p90": _percentile(values, 0.90),
+        "max": round(max(values), 4),
+    }
+
+
+def _agent_steps(row: dict[str, Any]) -> list[dict[str, Any]]:
+    traj = row.get("trajectory") or []
+    if not traj:
+        return []
+    steps = traj[0].get("steps") or []
+    return [s for s in steps if isinstance(s, dict) and s.get("source") == "agent"]
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.is_file():
+        return []
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                logger.warning("trajectories_report: skipping invalid JSON line in %s", path)
+    return rows
+
+
+def _load_eval_summary(bench_dir: Path) -> dict[str, Any] | None:
+    """Pick the most recent ``eval-*.json`` bundle's score summary, if any."""
+    bundles = sorted(bench_dir.glob("eval-*.json"))
+    if not bundles:
+        return None
+    try:
+        data = json.loads(bundles[-1].read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    bench = data.get("benchmark") or {}
+    scores = bench.get("scores") or {}
+    return scores.get("summary") or scores.get("mean_reward")
+
+
+def _present_count(rows: list[dict[str, Any]], path: tuple[str, ...]) -> int:
+    n = 0
+    for r in rows:
+        cur: Any = r
+        for key in path:
+            if not isinstance(cur, dict) or key not in cur:
+                cur = None
+                break
+            cur = cur[key]
+        if cur is not None and cur != "":
+            n += 1
+    return n
+
+
+def _trial_key(row: dict[str, Any]) -> tuple[Any, Any]:
+    return (row.get("problem_idx"), row.get("repeat"))
+
+
+def _index_traffic_by_trial(
+    traffic_rows: list[dict[str, Any]],
+) -> dict[tuple[Any, Any], list[dict[str, Any]]]:
+    bucket: dict[tuple[Any, Any], list[dict[str, Any]]] = {}
+    for r in traffic_rows:
+        key = (r.get("problem_idx"), r.get("repeat"))
+        bucket.setdefault(key, []).append(r)
+    return bucket
+
+
+def _build_bench_report(
+    bench_name: str,
+    bench_dir: Path,
+) -> dict[str, Any]:
+    traj_rows = _read_jsonl(bench_dir / "trajectories.jsonl")
+    traffic_rows = _read_jsonl(bench_dir / "model_traffic.jsonl")
+    traffic_by_trial = _index_traffic_by_trial(traffic_rows)
+
+    n_trials = len(traj_rows)
+    n_problems = len({r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None})
+    repeats = (n_trials // n_problems) if n_problems else 0
+
+    # ─── score reconciliation ──────────────────────────────────────────
+    rewards = [r["reward"] for r in traj_rows if isinstance(r.get("reward"), (int, float))]
+    traj_mean = round(sum(rewards) / len(rewards), 6) if rewards else None
+    reported = _load_eval_summary(bench_dir)
+    reported_mean = None
+    if isinstance(reported, dict):
+        reported_mean = reported.get("mean")
+    failures = Counter()
+    for r in traj_rows:
+        sd = r.get("scoring_details") or {}
+        cat = sd.get("error_category") or r.get("failure_category")
+        if cat:
+            failures[cat] += 1
+
+    # ─── trajectory_native ────────────────────────────────────────────
+    all_agent_steps: list[dict[str, Any]] = []
+    per_trial_step_counts: list[int] = []
+    tool_calls_total = 0
+    reasoning_chars_total = 0
+    for r in traj_rows:
+        steps = _agent_steps(r)
+        per_trial_step_counts.append(len(steps))
+        all_agent_steps.extend(steps)
+        for s in steps:
+            tc = s.get("tool_calls") or []
+            if isinstance(tc, list):
+                tool_calls_total += len(tc)
+            rc = s.get("reasoning_content")
+            if isinstance(rc, str):
+                reasoning_chars_total += len(rc)
+    n_steps = len(all_agent_steps)
+
+    def _field_present(field: str) -> str:
+        n = sum(1 for s in all_agent_steps if s.get(field) is not None)
+        return f"{n}/{n_steps}"
+
+    def _field_nonempty(field: str) -> str:
+        def _ok(v: Any) -> bool:
+            if v is None:
+                return False
+            if isinstance(v, (str, list, dict)) and not v:
+                return False
+            return True
+        n = sum(1 for s in all_agent_steps if _ok(s.get(field)))
+        return f"{n}/{n_steps}"
+
+    # ─── wire_captures (model_traffic.jsonl) ──────────────────────────
+    total_wire = len(traffic_rows)
+    captures_per_trial = [len(v) for v in traffic_by_trial.values()]
+    finish_reason_hist = Counter()
+    for r in traffic_rows:
+        fr = r.get("finish_reason")
+        if fr:
+            finish_reason_hist[fr] += 1
+
+    # ─── step <-> wire mismatch ───────────────────────────────────────
+    delta_signs = {"captures>steps": 0, "captures<steps": 0, "equal": 0}
+    for r in traj_rows:
+        key = _trial_key(r)
+        cap_n = len(traffic_by_trial.get(key, []))
+        step_n = len(_agent_steps(r))
+        if cap_n > step_n:
+            delta_signs["captures>steps"] += 1
+        elif cap_n < step_n:
+            delta_signs["captures<steps"] += 1
+        else:
+            delta_signs["equal"] += 1
+
+    # ─── token reconciliation ─────────────────────────────────────────
+    def _step_tokens(s: dict[str, Any]) -> int:
+        m = s.get("metrics") or {}
+        return int(m.get("prompt_tokens") or 0) + int(m.get("completion_tokens") or 0)
+
+    per_step_total = sum(_step_tokens(s) for s in all_agent_steps)
+
+    def _wire_tokens(r: dict[str, Any]) -> int:
+        usage = r.get("usage") or {}
+        if not isinstance(usage, dict):
+            return 0
+        if usage.get("total_tokens") is not None:
+            try:
+                return int(usage["total_tokens"])
+            except (TypeError, ValueError):
+                return 0
+        return int(usage.get("prompt_tokens") or 0) + int(usage.get("completion_tokens") or 0)
+
+    wire_total = sum(_wire_tokens(r) for r in traffic_rows)
+
+    ref_total = 0
+    for r in traj_rows:
+        model = r.get("model") or {}
+        tokens = model.get("tokens") if isinstance(model, dict) else None
+        total = tokens.get("total") if isinstance(tokens, dict) else None
+        if isinstance(total, (int, float)):
+            ref_total += int(total)
+
+    # ─── ATIF per-trial presence ──────────────────────────────────────
+    atif_paths = {
+        "schema_version": ("trajectory", 0, "schema_version"),
+        "session_id": ("trajectory", 0, "session_id"),
+        "agent.name": ("trajectory", 0, "agent", "name"),
+        "agent.version": ("trajectory", 0, "agent", "version"),
+        "agent.model_name": ("trajectory", 0, "agent", "model_name"),
+        "steps": ("trajectory", 0, "steps"),
+        "final_metrics.total_prompt_tokens": ("trajectory", 0, "final_metrics", "total_prompt_tokens"),
+        "final_metrics.total_completion_tokens": ("trajectory", 0, "final_metrics", "total_completion_tokens"),
+        "final_metrics.total_steps": ("trajectory", 0, "final_metrics", "total_steps"),
+    }
+    atif_presence: dict[str, str] = {}
+    for label, path in atif_paths.items():
+        n = 0
+        for r in traj_rows:
+            cur: Any = r
+            ok = True
+            for key in path:
+                if isinstance(cur, list):
+                    if not isinstance(key, int) or key >= len(cur):
+                        ok = False
+                        break
+                    cur = cur[key]
+                elif isinstance(cur, dict):
+                    if key not in cur:
+                        ok = False
+                        break
+                    cur = cur[key]
+                else:
+                    ok = False
+                    break
+            if ok and cur is not None and cur != "":
+                n += 1
+        atif_presence[label] = f"{n}/{n_trials}"
+
+    return {
+        "bench": bench_name,
+        "counts": {
+            "n_trials": n_trials,
+            "n_problems": n_problems,
+            "repeats": repeats,
+        },
+        "score": {
+            "mean_reward": traj_mean,
+            "reported_mean": reported_mean,
+            "trajectories_vs_reported_match": (
+                None
+                if traj_mean is None or reported_mean is None
+                else abs(traj_mean - reported_mean) < 1e-6
+            ),
+            "failures": {
+                "total": sum(failures.values()),
+                "counts_by_category": dict(failures),
+            },
+        },
+        "trajectory_native": {
+            "agent_steps_total": n_steps,
+            "agent_steps_per_trial": _stats([float(x) for x in per_trial_step_counts]),
+            "tool_calls_total": tool_calls_total,
+            "reasoning_chars_total": reasoning_chars_total,
+            "fields_present_on_steps": {
+                "step_id": _field_present("step_id"),
+                "source": _field_present("source"),
+                "message": _field_present("message"),
+                "reasoning_content": _field_present("reasoning_content"),
+                "tool_calls": _field_present("tool_calls"),
+            },
+            "fields_nonempty_on_steps": {
+                "step_id": _field_nonempty("step_id"),
+                "source": _field_nonempty("source"),
+                "message": _field_nonempty("message"),
+                "reasoning_content": _field_nonempty("reasoning_content"),
+                "tool_calls": _field_nonempty("tool_calls"),
+            },
+        },
+        "wire_captures": {
+            "total_observed": total_wire,
+            "captures_per_trial": _stats([float(x) for x in captures_per_trial]) if captures_per_trial else None,
+            "finish_reasons": dict(finish_reason_hist),
+        },
+        "mismatches": {
+            "agent_steps_vs_wire_calls": delta_signs,
+            "tokens": {
+                "ref_total": ref_total,
+                "per_step_total": per_step_total,
+                "wire_total": wire_total,
+                "match_ref_vs_wire": (ref_total == wire_total) if ref_total or wire_total else None,
+            },
+        },
+        "atif_per_trial_presence": atif_presence,
+    }
+
+
+def generate_trajectories_report(
+    output_dir: Path,
+    *,
+    enrich: bool = False,
+) -> Path | None:
+    """Audit-mode report over an evaluation run dir.
+
+    Walks each per-benchmark subdir under *output_dir*, reads
+    ``trajectories.jsonl`` + ``model_traffic.jsonl`` if present, and writes
+    ``<output_dir>/trajectories_report.json`` summarizing coverage and any
+    mismatches between native trajectory data and wire captures.
+
+    The *enrich* flag is reserved for the next iteration (splicing wire
+    captures into trajectories.jsonl); currently it only triggers a warning.
+    """
+    bench_dirs = sorted(
+        p
+        for p in output_dir.iterdir()
+        if p.is_dir() and (p / "trajectories.jsonl").is_file()
+    )
+    if not bench_dirs:
+        logger.info("trajectories_report: no <bench>/trajectories.jsonl found under %s", output_dir)
+        return None
+
+    payload = {
+        "schema_version": "trajectories_report-v0.1",
+        "benchmarks": [_build_bench_report(d.name, d) for d in bench_dirs],
+    }
+
+    if enrich:
+        logger.warning(
+            "trajectories_report: enrich=True requested; "
+            "enrichment writes are not implemented in this release (audit-only)."
+        )
+
+    out_path = output_dir / "trajectories_report.json"
+    out_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    logger.info("trajectories_report: wrote %s (%d benchmark(s))", out_path, len(bench_dirs))
+    return out_path

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -544,12 +544,19 @@ def _build_bench_report(
 
 
 def _enrich_bench(bench_dir: Path) -> dict[str, int]:
-    """Backfill agent-step metrics from ``model_traffic.jsonl``.
+    """All-or-nothing per-trial enrichment from ``model_traffic.jsonl``.
 
-    Splice strategy is intentionally simple: for each trial, pair the
-    i-th wire call with the i-th agent step in order. Any extra wire
-    calls are stashed under ``trajectory[0].extra.captured_model_calls``
-    so nothing is lost. Returns counts of what was changed for the report.
+    For each trial:
+
+    * If ``len(agent_steps) == len(wire_calls)`` — splice 1:1 by order
+      (backfill ``metrics.{prompt,completion}_tokens`` and
+      ``metrics.extra.{latency_ms, finish_reason}``).
+    * Otherwise — leave the steps alone and stash **all** wire calls
+      under ``trajectory[0].extra.captured_model_calls``. We never
+      mix-and-match when the counts don't line up: a partial splice
+      would attribute the wrong call to the wrong step.
+
+    Writes ``trajectories_enriched.jsonl`` next to the original.
     """
     traj_path = bench_dir / "trajectories.jsonl"
     traffic_path = bench_dir / "model_traffic.jsonl"
@@ -560,11 +567,13 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
     by_trial = _index_traffic_by_trial(traffic_rows)
 
     counts = {
+        "trials_spliced": 0,
+        "trials_stashed_unmatched": 0,
+        "trials_no_wire_data": 0,
         "steps_backfilled_prompt_tokens": 0,
         "steps_backfilled_completion_tokens": 0,
         "steps_backfilled_latency_ms": 0,
         "steps_backfilled_finish_reason": 0,
-        "trials_with_stashed_extra_calls": 0,
         "rows_written": 0,
     }
 
@@ -572,26 +581,32 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
         for r in traj_rows:
             steps = _agent_steps(r)
             wire = by_trial.get(_trial_key(r), [])
-            for s, w in zip(steps, wire):
-                metrics = s.setdefault("metrics", {})
-                usage = w.get("usage") or {}
-                if metrics.get("prompt_tokens") in (None, 0) and usage.get("prompt_tokens"):
-                    metrics["prompt_tokens"] = usage["prompt_tokens"]
-                    counts["steps_backfilled_prompt_tokens"] += 1
-                if metrics.get("completion_tokens") in (None, 0) and usage.get("completion_tokens"):
-                    metrics["completion_tokens"] = usage["completion_tokens"]
-                    counts["steps_backfilled_completion_tokens"] += 1
-                extra = metrics.setdefault("extra", {})
-                if extra.get("latency_ms") in (None, 0) and w.get("latency_ms"):
-                    extra["latency_ms"] = w["latency_ms"]
-                    counts["steps_backfilled_latency_ms"] += 1
-                if not extra.get("finish_reason") and w.get("finish_reason"):
-                    extra["finish_reason"] = w["finish_reason"]
-                    counts["steps_backfilled_finish_reason"] += 1
-            if len(wire) > len(steps):
+            if not wire:
+                counts["trials_no_wire_data"] += 1
+            elif len(steps) == len(wire):
+                # 1:1 splice
+                for s, w in zip(steps, wire):
+                    metrics = s.setdefault("metrics", {})
+                    usage = w.get("usage") or {}
+                    if metrics.get("prompt_tokens") in (None, 0) and usage.get("prompt_tokens"):
+                        metrics["prompt_tokens"] = usage["prompt_tokens"]
+                        counts["steps_backfilled_prompt_tokens"] += 1
+                    if metrics.get("completion_tokens") in (None, 0) and usage.get("completion_tokens"):
+                        metrics["completion_tokens"] = usage["completion_tokens"]
+                        counts["steps_backfilled_completion_tokens"] += 1
+                    extra = metrics.setdefault("extra", {})
+                    if extra.get("latency_ms") in (None, 0) and w.get("latency_ms"):
+                        extra["latency_ms"] = w["latency_ms"]
+                        counts["steps_backfilled_latency_ms"] += 1
+                    if not extra.get("finish_reason") and w.get("finish_reason"):
+                        extra["finish_reason"] = w["finish_reason"]
+                        counts["steps_backfilled_finish_reason"] += 1
+                counts["trials_spliced"] += 1
+            else:
+                # Count mismatch — stash ALL wire calls; don't touch steps.
                 traj = (r.get("trajectory") or [{}])[0]
-                traj.setdefault("extra", {})["captured_model_calls"] = wire[len(steps) :]
-                counts["trials_with_stashed_extra_calls"] += 1
+                traj.setdefault("extra", {})["captured_model_calls"] = wire
+                counts["trials_stashed_unmatched"] += 1
             fh.write(json.dumps(r) + "\n")
             counts["rows_written"] += 1
     return counts

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -232,6 +232,20 @@ def _build_bench_report(
         n = sum(1 for s in all_agent_steps if _ok(s.get(field)))
         return f"{n}/{n_steps}"
 
+    def _nested_present(*keys: str) -> str:
+        n = 0
+        for s in all_agent_steps:
+            cur: Any = s
+            ok = True
+            for key in keys:
+                if not isinstance(cur, dict) or cur.get(key) is None:
+                    ok = False
+                    break
+                cur = cur[key]
+            if ok:
+                n += 1
+        return f"{n}/{n_steps}"
+
     # ─── wire_captures (model_traffic.jsonl) ──────────────────────────
     total_wire = len(traffic_rows)
     captures_per_trial = [len(v) for v in traffic_by_trial.values()]
@@ -487,11 +501,21 @@ def _build_bench_report(
                 {
                     "step_id": _field_present("step_id"),
                     "source": _field_present("source"),
+                    "timestamp": _field_present("timestamp"),
+                    "model_name": _field_present("model_name"),
+                    "status_code": _field_present("status_code"),
                     "message": _field_present("message"),
                     "reasoning_content": _field_present("reasoning_content"),
                     "tool_calls": _field_present("tool_calls"),
+                    "metrics.prompt_tokens": _nested_present("metrics", "prompt_tokens"),
+                    "metrics.completion_tokens": _nested_present("metrics", "completion_tokens"),
+                    "metrics.total_tokens": _nested_present("metrics", "total_tokens"),
+                    "metrics.extra.latency_ms": _nested_present("metrics", "extra", "latency_ms"),
+                    "metrics.extra.finish_reason": _nested_present("metrics", "extra", "finish_reason"),
+                    "metrics.extra.cached_tokens": _nested_present("metrics", "extra", "cached_tokens"),
+                    "metrics.extra.reasoning_tokens": _nested_present("metrics", "extra", "reasoning_tokens"),
                 },
-                f"N/{n_steps} agent steps where the field is non-None",
+                f"N/{n_steps} agent steps where the dotted-path field is non-None",
             ),
             "fields_nonempty_on_steps": vf(
                 {
@@ -538,6 +562,34 @@ def _build_bench_report(
         "atif_per_trial_presence": vf(
             atif_presence,
             f"N/{n_trials} trajectories.jsonl rows where the dotted-path field is non-None and non-empty",
+        ),
+        "row_required_fields_presence": vf(
+            {
+                "problem_idx": f"{sum(1 for r in traj_rows if r.get('problem_idx') is not None)}/{n_trials}",
+                "repeat": f"{sum(1 for r in traj_rows if r.get('repeat') is not None)}/{n_trials}",
+                "reward": f"{sum(1 for r in traj_rows if isinstance(r.get('reward'), (int, float)))}/{n_trials}",
+                "trajectory": f"{sum(1 for r in traj_rows if r.get('trajectory'))}/{n_trials}",
+                "model": f"{sum(1 for r in traj_rows if r.get('model'))}/{n_trials}",
+            },
+            f"N/{n_trials} trajectories.jsonl rows where the top-level required field is present",
+        ),
+        "stashed_model_calls": vf(
+            {
+                "trials_with_stashed_calls": sum(
+                    1
+                    for r in traj_rows
+                    if isinstance(((r.get("trajectory") or [{}])[0]).get("extra"), dict)
+                    and ((r.get("trajectory") or [{}])[0]).get("extra", {}).get("captured_model_calls")
+                ),
+                "stashed_calls_total": sum(
+                    len(((r.get("trajectory") or [{}])[0]).get("extra", {}).get("captured_model_calls") or [])
+                    for r in traj_rows
+                    if isinstance(((r.get("trajectory") or [{}])[0]).get("extra"), dict)
+                ),
+            },
+            "trajectory[0].extra.captured_model_calls — wire calls that couldn't be spliced 1:1 "
+            "into agent steps (e.g. solver failed before producing a matching step). "
+            "Populated by the enrichment writer when trial step count != wire-call count.",
         ),
     }
 

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -198,7 +198,12 @@ _TRIAL_FIELDS: dict[str, tuple[Any, ...]] = {
     "trajectory[0].extra": ("trajectory", 0, "extra"),
     "trajectory[0].steps": ("trajectory", 0, "steps"),
     "trajectory[0].final_metrics.total_prompt_tokens": ("trajectory", 0, "final_metrics", "total_prompt_tokens"),
-    "trajectory[0].final_metrics.total_completion_tokens": ("trajectory", 0, "final_metrics", "total_completion_tokens"),
+    "trajectory[0].final_metrics.total_completion_tokens": (
+        "trajectory",
+        0,
+        "final_metrics",
+        "total_completion_tokens",
+    ),
     "trajectory[0].final_metrics.total_steps": ("trajectory", 0, "final_metrics", "total_steps"),
 }
 
@@ -469,12 +474,15 @@ def generate_trajectories_report(
                 },
                 "step_field_coverage_after_enrichment_missing": _missing_fields(
                     enriched_steps,
-                    {".".join(p): p for p in (
-                        ("metrics", "prompt_tokens"),
-                        ("metrics", "completion_tokens"),
-                        ("metrics", "extra", "latency_ms"),
-                        ("metrics", "extra", "finish_reason"),
-                    )},
+                    {
+                        ".".join(p): p
+                        for p in (
+                            ("metrics", "prompt_tokens"),
+                            ("metrics", "completion_tokens"),
+                            ("metrics", "extra", "latency_ms"),
+                            ("metrics", "extra", "finish_reason"),
+                        )
+                    },
                 ),
             }
         benches.append(bench_report)

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -45,40 +45,19 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def _step_content_hash(step: dict[str, Any]) -> str:
-    """Deterministic hash of an agent step's user-visible content.
-
-    Two steps with identical message + reasoning_content + tool-call names
-    + tool-call arguments hash to the same value — a strong duplicate
-    signal when it repeats inside a single trial.
-    """
-    msg = step.get("message") or ""
-    reasoning = step.get("reasoning_content") or ""
-    tool_calls = step.get("tool_calls") or []
-    tc_repr: list[Any] = []
-    if isinstance(tool_calls, list):
-        for tc in tool_calls:
-            if not isinstance(tc, dict):
-                continue
-            fn = tc.get("function") or {}
-            name = tc.get("function_name") or fn.get("name") or ""
-            args = tc.get("arguments") if "arguments" in tc else fn.get("arguments")
-            tc_repr.append((name, args))
-    payload = json.dumps([msg, reasoning, tc_repr], sort_keys=True, default=str)
-    return hashlib.sha1(payload.encode("utf-8")).hexdigest()
-
-
 def _wire_dedup_key(record: dict[str, Any]) -> tuple[Any, ...]:
-    """Coarse duplicate-detection key for a single ``model_traffic.jsonl`` row.
+    """Duplicate-detection key for a single ``model_traffic.jsonl`` row.
 
-    ``model_traffic.jsonl`` currently stores per-call response stats but not
-    the request body, so we can't fingerprint the actual prompt yet. Two rows
-    with identical (model, path, finish_reason, prompt_tokens, completion_tokens,
-    latency_ms_rounded) on the same trial almost certainly indicate the same
-    upstream call being captured twice.
+    Prefers ``record.request_hash`` (sha1 prefix of the upstream request body,
+    written by ``ModelTrafficStore.start_request``). Falls back to a coarse
+    response-side fingerprint for older runs that don't carry ``request_hash``.
     """
+    rh = record.get("request_hash")
+    if rh:
+        return ("rh", rh)
     usage = record.get("usage") or {}
     return (
+        "resp",
         record.get("model"),
         record.get("path"),
         record.get("finish_reason"),
@@ -180,6 +159,8 @@ def _index_traffic_by_trial(
 def _build_bench_report(
     bench_name: str,
     bench_dir: Path,
+    *,
+    include_stashed_section: bool = False,
 ) -> dict[str, Any]:
     traj_rows = _read_jsonl(bench_dir / "trajectories.jsonl")
     traffic_rows = _read_jsonl(bench_dir / "model_traffic.jsonl")
@@ -360,17 +341,7 @@ def _build_bench_report(
         if zero_in_trial == len(steps):
             trials_all_zero_token_steps += 1
 
-    # Duplicate agent steps inside a single trial (content hash)
-    duplicate_steps_in_trial = 0
-    trials_with_duplicate_steps = 0
-    for r in traj_rows:
-        hashes = Counter(_step_content_hash(s) for s in _agent_steps(r))
-        per_trial_dups = sum(v - 1 for v in hashes.values() if v > 1)
-        if per_trial_dups > 0:
-            duplicate_steps_in_trial += per_trial_dups
-            trials_with_duplicate_steps += 1
-
-    # Duplicate wire calls inside a single trial (coarse fingerprint)
+    # Duplicate wire calls inside a single trial (request_hash-based)
     duplicate_wire_calls_in_trial = 0
     trials_with_duplicate_wire_calls = 0
     for key, recs in traffic_by_trial.items():
@@ -384,14 +355,14 @@ def _build_bench_report(
     # than ref/wire token totals; signals lost or duplicated captures).
     mismatched_steps_vs_wire_trials = delta_signs["captures>steps"] + delta_signs["captures<steps"]
 
-    # After removing duplicates on both sides, does the mismatch resolve?
-    mismatched_steps_vs_wire_trials_after_dedup = 0
+    # After removing duplicate wire calls, does the mismatch resolve?
+    mismatched_steps_vs_wire_trials_after_wire_dedup = 0
     for r in traj_rows:
         key = _trial_key(r)
-        uniq_steps = len({_step_content_hash(s) for s in _agent_steps(r)})
+        step_n = len(_agent_steps(r))
         uniq_wire = len({_wire_dedup_key(w) for w in traffic_by_trial.get(key, [])})
-        if uniq_steps != uniq_wire:
-            mismatched_steps_vs_wire_trials_after_dedup += 1
+        if step_n != uniq_wire:
+            mismatched_steps_vs_wire_trials_after_wire_dedup += 1
 
     # Per-trial: sum of step.metrics.{prompt+completion}_tokens equal to
     # final_metrics.{total_prompt_tokens + total_completion_tokens}?
@@ -412,7 +383,7 @@ def _build_bench_report(
         """{value, from} pair where `from` documents the calculation."""
         return {"value": value, "from": formula}
 
-    return {
+    out: dict[str, Any] = {
         "bench": bench_name,
         "counts": {
             "n_trials": vf(n_trials, "trajectories.jsonl row count"),
@@ -448,34 +419,24 @@ def _build_bench_report(
                 trials_all_zero_token_steps,
                 "trials where every agent step is zero-or-none-tokens",
             ),
-            "duplicate_steps_in_trial_total": vf(
-                duplicate_steps_in_trial,
-                "sum over trials of (#repeated step content_hashes - 1); "
-                "content_hash = sha1(message + reasoning_content + tool_calls names+args)",
-            ),
-            "trials_with_duplicate_steps": vf(
-                trials_with_duplicate_steps,
-                "trials with at least one duplicate step content_hash",
-            ),
             "duplicate_wire_calls_in_trial_total": vf(
                 duplicate_wire_calls_in_trial,
-                "sum over trials of (#repeated wire_dedup_keys - 1); "
-                "wire_dedup_key = (model, path, finish_reason, prompt_tokens, "
-                "completion_tokens, round(latency_ms,1))",
+                "sum over trials of (#repeated record.request_hash - 1); "
+                "request_hash is sha1(upstream request body) recorded at "
+                "ModelTrafficStore.start_request",
             ),
             "trials_with_duplicate_wire_calls": vf(
                 trials_with_duplicate_wire_calls,
-                "trials with at least one duplicate wire_dedup_key",
+                "trials with at least one repeated record.request_hash",
             ),
             "mismatched_steps_vs_wire_trials": vf(
                 mismatched_steps_vs_wire_trials,
                 "trials where len(agent_steps) != len(model_traffic rows for that trial)",
             ),
-            "mismatched_steps_vs_wire_trials_after_dedup": vf(
-                mismatched_steps_vs_wire_trials_after_dedup,
-                "same as above but on unique sets: "
-                "trials where len(set(step content_hashes)) != len(set(wire_dedup_keys)); "
-                "non-zero here means the mismatch is NOT explained by duplicates",
+            "mismatched_steps_vs_wire_trials_after_wire_dedup": vf(
+                mismatched_steps_vs_wire_trials_after_wire_dedup,
+                "trials where len(agent_steps) != len(set(record.request_hash)); "
+                "non-zero here means the mismatch is NOT explained by duplicate wire calls",
             ),
             "trials_with_per_step_vs_final_metrics_token_mismatch": vf(
                 per_step_vs_final_metrics_mismatch,
@@ -577,7 +538,9 @@ def _build_bench_report(
             },
             f"N/{n_trials} trajectories.jsonl rows where the top-level required field is present",
         ),
-        "stashed_model_calls": vf(
+    }
+    if include_stashed_section:
+        out["stashed_model_calls"] = vf(
             {
                 "trials_with_stashed_calls": sum(
                     1
@@ -591,11 +554,11 @@ def _build_bench_report(
                     if isinstance(((r.get("trajectory") or [{}])[0]).get("extra"), dict)
                 ),
             },
-            "trajectory[0].extra.captured_model_calls — wire calls that couldn't be spliced 1:1 "
-            "into agent steps (e.g. solver failed before producing a matching step). "
-            "Populated by the enrichment writer when trial step count != wire-call count.",
-        ),
-    }
+            "trajectory[0].extra.captured_model_calls populated by the enrichment writer "
+            "when trial step count != wire-call count (so the calls survive even when the "
+            "solver fails before producing a matching step). Only emitted when enrich=True.",
+        )
+    return out
 
 
 def _enrich_bench(bench_dir: Path) -> dict[str, int]:
@@ -690,7 +653,9 @@ def generate_trajectories_report(
 
     benches: list[dict[str, Any]] = []
     for d in bench_dirs:
-        bench_report = _build_bench_report(d.name, d)
+        # When enrich runs we splice into trajectory[0].extra.captured_model_calls;
+        # the stash audit only makes sense in that mode.
+        bench_report = _build_bench_report(d.name, d, include_stashed_section=enrich)
         if enrich:
             counts = _enrich_bench(d)
             bench_report["enrichment"] = {

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -44,6 +44,23 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _is_successful_wire(record: dict[str, Any]) -> bool:
+    """Mirror ``model_traffic._is_success``: only 2xx/3xx responses count.
+
+    Failed calls live in ``model_traffic.jsonl`` too (with ``status_code=None``
+    or ``>=400``); we exclude them from both the silent-failure metric and
+    the enrichment splice so retries/errors don't get attributed to a step.
+    """
+    sc = record.get("status_code")
+    if sc is None:
+        return False
+    try:
+        sc_int = int(sc)
+    except (TypeError, ValueError):
+        return False
+    return 200 <= sc_int < 400
+
+
 def _wire_dedup_key(record: dict[str, Any]) -> tuple[Any, ...]:
     """Duplicate-detection key for a single ``model_traffic.jsonl`` row.
 
@@ -145,11 +162,23 @@ def _trial_key(row: dict[str, Any]) -> tuple[Any, Any]:
     return (row.get("problem_idx"), row.get("repeat"))
 
 
+def _fraction(numer: int, denom: int) -> str:
+    """Render ``N/total (P.P%)``; ``0/0 (0.0%)`` when the denominator is zero."""
+    if denom <= 0:
+        return "0/0 (0.0%)"
+    pct = 100.0 * numer / denom
+    return f"{numer}/{denom} ({pct:.1f}%)"
+
+
 def _index_traffic_by_trial(
     traffic_rows: list[dict[str, Any]],
+    *,
+    only_successful: bool = True,
 ) -> dict[tuple[Any, Any], list[dict[str, Any]]]:
     bucket: dict[tuple[Any, Any], list[dict[str, Any]]] = {}
     for r in traffic_rows:
+        if only_successful and not _is_successful_wire(r):
+            continue
         key = (r.get("problem_idx"), r.get("repeat"))
         bucket.setdefault(key, []).append(r)
     return bucket
@@ -227,14 +256,18 @@ def _build_bench_report(
 
     # ─── wire_captures (model_traffic.jsonl) ──────────────────────────
     total_wire = len(traffic_rows)
+    successful_wire = sum(1 for r in traffic_rows if _is_successful_wire(r))
     finish_reason_hist = Counter()
     for r in traffic_rows:
         fr = r.get("finish_reason")
         if fr:
             finish_reason_hist[fr] += 1
 
-    # ─── step <-> wire mismatch ───────────────────────────────────────
+    # ─── step <-> wire mismatch + silent-failure trials ───────────────
     delta_signs = {"captures>steps": 0, "captures<steps": 0, "equal": 0}
+    trials_no_agent_steps = 0
+    trials_no_wire_calls = 0
+    trials_silent_either = 0
     for r in traj_rows:
         key = _trial_key(r)
         cap_n = len(traffic_by_trial.get(key, []))
@@ -245,6 +278,14 @@ def _build_bench_report(
             delta_signs["captures<steps"] += 1
         else:
             delta_signs["equal"] += 1
+        no_steps = step_n == 0
+        no_wire = cap_n == 0
+        if no_steps:
+            trials_no_agent_steps += 1
+        if no_wire:
+            trials_no_wire_calls += 1
+        if no_steps or no_wire:
+            trials_silent_either += 1
 
     # ─── token reconciliation ─────────────────────────────────────────
     def _step_tokens(s: dict[str, Any]) -> int:
@@ -440,17 +481,23 @@ def _build_bench_report(
         # ── 3. Wire call summary + duplicates ──
         "wire_calls": {
             "_note": (
-                "model_traffic.jsonl row stats. duplicates_total is computed via record.request_hash "
-                "(sha1 prefix of the upstream body); a non-zero value means the same model call landed "
-                "in the log twice (e.g. retry, double-capture)."
+                "model_traffic.jsonl row stats. Step/wire alignment and the silent-failure "
+                "metrics below count only successful (2xx/3xx) wire rows -- a 500 or aborted "
+                "request is not a 'captured' model call. 'total' is raw (all statuses) so the "
+                "failure volume stays visible. duplicates_total is via record.request_hash "
+                "(sha1 prefix of the upstream body)."
             ),
             "total": total_wire,
+            "successful": successful_wire,
             "unique": len(wire_keys_unique),
             "duplicates_total": duplicates_total,
             "trials_with_duplicates": trials_with_duplicate_wire_calls,
             "trials_with_more_wire_than_steps": delta_signs["captures>steps"],
             "trials_with_fewer_wire_than_steps": delta_signs["captures<steps"],
             "trials_with_step_wire_mismatch_after_dedup": mismatched_steps_vs_wire_trials_after_wire_dedup,
+            "trials_with_no_agent_steps": _fraction(trials_no_agent_steps, n_trials),
+            "trials_with_no_wire_calls": _fraction(trials_no_wire_calls, n_trials),
+            "trials_silent_either_way": _fraction(trials_silent_either, n_trials),
             "finish_reasons": dict(finish_reason_hist),
         },
         # ── 4. Field coverage (presence audit) ──

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -382,8 +382,32 @@ def _build_bench_report(
         """{value, from} pair where `from` documents the calculation."""
         return {"value": value, "from": formula}
 
+    # ─── headline summary — the values you'd read first ─────────────
+    headline_zero_token_trials = trials_with_any_zero_step
+    headline_dup_wire = duplicate_wire_calls_in_trial
+    headline_mismatch_after_dedup = mismatched_steps_vs_wire_trials_after_wire_dedup
+    summary = {
+        "trials": n_trials,
+        "mean_reward": traj_mean,
+        "mean_reward_matches_reported": is_mean_reward_correct,
+        "agent_steps_total": n_steps,
+        "wire_calls_total": total_wire,
+        "tokens_in_step_metrics": per_step_total,
+        "tokens_on_wire": wire_total,
+        "trials_with_zero_token_steps": headline_zero_token_trials,
+        "duplicate_wire_calls": headline_dup_wire,
+        "trials_with_step_vs_wire_mismatch_after_dedup": headline_mismatch_after_dedup,
+    }
+
     out: dict[str, Any] = {
         "bench": bench_name,
+        "_note": (
+            "Sections: summary (headline) | counts | score | anomalies | "
+            "presence (ATIF field coverage) | wire_captures (model_traffic.jsonl) | "
+            "trajectory_native (agent step stats) | mismatches (trajectory vs wire). "
+            "Every metric is {value, from} where 'from' documents the calculation."
+        ),
+        "summary": summary,
         "counts": {
             "n_trials": vf(n_trials, "trajectories.jsonl row count"),
             "n_problems": vf(n_problems, "distinct trajectories.jsonl row.problem_idx"),
@@ -406,6 +430,11 @@ def _build_bench_report(
         },
         # The actionable summary: what's broken, in counts.
         "anomalies": {
+            "_note": (
+                "Each entry is a count of trials (or steps) hitting a specific data-quality "
+                "problem. Zero = healthy. Use these as the first thing to scan when reading "
+                "the report — they encode 'is anything wrong here?' in a glance."
+            ),
             "steps_with_zero_or_none_tokens": vf(
                 steps_with_zero_or_none_tokens,
                 "agent steps where (metrics.prompt_tokens or 0) + (metrics.completion_tokens or 0) == 0",
@@ -445,6 +474,11 @@ def _build_bench_report(
             ),
         },
         "trajectory_native": {
+            "_note": (
+                "Aggregate stats over agent steps as written by the solver into "
+                "trajectories.jsonl (before any wire enrichment). 'fields_present_on_steps' "
+                "is the per-step ATIF-v1.6 field audit."
+            ),
             "agent_steps_total": vf(
                 n_steps,
                 "len(row.trajectory[0].steps[source=='agent']) summed across trials",
@@ -493,6 +527,11 @@ def _build_bench_report(
             ),
         },
         "wire_captures": {
+            "_note": (
+                "Aggregate stats over model_traffic.jsonl rows (one row per upstream "
+                "model call observed by the proxy). This is the ground-truth side of the "
+                "trajectory ↔ wire comparison."
+            ),
             "total_observed": vf(
                 total_wire,
                 "model_traffic.jsonl row count",
@@ -507,9 +546,18 @@ def _build_bench_report(
             ),
         },
         "mismatches": {
+            "_note": (
+                "Cross-checks between trajectories.jsonl and model_traffic.jsonl. "
+                "When these don't reconcile, the wire layer captured something the "
+                "solver's trajectory failed to encode (or vice versa)."
+            ),
             "agent_steps_vs_wire_calls": vf(
-                delta_signs,
-                "for each trial: sign(len(wire_rows) - len(agent_steps))",
+                {
+                    "trials_with_more_wire_than_steps": delta_signs["captures>steps"],
+                    "trials_with_fewer_wire_than_steps": delta_signs["captures<steps"],
+                    "trials_with_equal_counts": delta_signs["equal"],
+                },
+                "for each trial: bucket by sign(len(wire_rows) - len(agent_steps))",
             ),
             "tokens": vf(
                 {
@@ -523,20 +571,29 @@ def _build_bench_report(
                 "wire_total = sum(model_traffic row.usage.total_tokens, fallback to prompt+completion)",
             ),
         },
-        "atif_per_trial_presence": vf(
-            atif_presence,
-            f"N/{n_trials} trajectories.jsonl rows where the dotted-path field is non-None and non-empty",
-        ),
-        "row_required_fields_presence": vf(
-            {
-                "problem_idx": f"{sum(1 for r in traj_rows if r.get('problem_idx') is not None)}/{n_trials}",
-                "repeat": f"{sum(1 for r in traj_rows if r.get('repeat') is not None)}/{n_trials}",
-                "reward": f"{sum(1 for r in traj_rows if isinstance(r.get('reward'), (int, float)))}/{n_trials}",
-                "trajectory": f"{sum(1 for r in traj_rows if r.get('trajectory'))}/{n_trials}",
-                "model": f"{sum(1 for r in traj_rows if r.get('model'))}/{n_trials}",
-            },
-            f"N/{n_trials} trajectories.jsonl rows where the top-level required field is present",
-        ),
+        "presence": {
+            "_note": (
+                "Field-coverage audit. All three sub-blocks read 'N/total': "
+                "(N) rows/steps that have the field, out of (total) rows/steps. "
+                "Use to confirm the run actually wrote the data you expect."
+            ),
+            "row_required_fields": vf(
+                {
+                    "problem_idx": f"{sum(1 for r in traj_rows if r.get('problem_idx') is not None)}/{n_trials}",
+                    "repeat": f"{sum(1 for r in traj_rows if r.get('repeat') is not None)}/{n_trials}",
+                    "reward": f"{sum(1 for r in traj_rows if isinstance(r.get('reward'), (int, float)))}/{n_trials}",
+                    "trajectory": f"{sum(1 for r in traj_rows if r.get('trajectory'))}/{n_trials}",
+                    "model": f"{sum(1 for r in traj_rows if r.get('model'))}/{n_trials}",
+                },
+                f"N/{n_trials} trajectories.jsonl rows where the top-level required field is present",
+            ),
+            "atif_trajectory_fields": vf(
+                atif_presence,
+                f"N/{n_trials} trajectory[0].* dotted-path fields non-None and non-empty (ATIF-v1.6)",
+            ),
+            # atif_step_fields already lives under trajectory_native.fields_present_on_steps;
+            # we keep a single source of truth there to avoid duplication.
+        },
     }
     if include_stashed_section:
         out["stashed_model_calls"] = vf(

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -158,8 +158,6 @@ def _index_traffic_by_trial(
 def _build_bench_report(
     bench_name: str,
     bench_dir: Path,
-    *,
-    include_stashed_section: bool = False,
 ) -> dict[str, Any]:
     traj_rows = _read_jsonl(bench_dir / "trajectories.jsonl")
     traffic_rows = _read_jsonl(bench_dir / "model_traffic.jsonl")
@@ -171,15 +169,11 @@ def _build_bench_report(
     # otherwise expose the histogram so a partial run (e.g. shard) is visible.
     per_problem_repeat_counts = Counter(r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None)
     distinct_counts = set(per_problem_repeat_counts.values())
-    if len(distinct_counts) == 1:
-        repeats: Any = next(iter(distinct_counts))
-        repeats_from = "trials-per-problem (uniform across problems)"
-    elif distinct_counts:
-        repeats = dict(Counter(per_problem_repeat_counts.values()))
-        repeats_from = "histogram of trials-per-problem counts (non-uniform)"
-    else:
-        repeats = 0
-        repeats_from = "no problems found"
+    repeats: Any = (
+        next(iter(distinct_counts))
+        if len(distinct_counts) == 1
+        else (dict(Counter(per_problem_repeat_counts.values())) if distinct_counts else 0)
+    )
 
     # ─── score reconciliation ──────────────────────────────────────────
     rewards = [r["reward"] for r in traj_rows if isinstance(r.get("reward"), (int, float))]
@@ -217,17 +211,6 @@ def _build_bench_report(
         n = sum(1 for s in all_agent_steps if s.get(field) is not None)
         return f"{n}/{n_steps}"
 
-    def _field_nonempty(field: str) -> str:
-        def _ok(v: Any) -> bool:
-            if v is None:
-                return False
-            if isinstance(v, (str, list, dict)) and not v:
-                return False
-            return True
-
-        n = sum(1 for s in all_agent_steps if _ok(s.get(field)))
-        return f"{n}/{n_steps}"
-
     def _nested_present(*keys: str) -> str:
         n = 0
         for s in all_agent_steps:
@@ -244,7 +227,6 @@ def _build_bench_report(
 
     # ─── wire_captures (model_traffic.jsonl) ──────────────────────────
     total_wire = len(traffic_rows)
-    captures_per_trial = [len(v) for v in traffic_by_trial.values()]
     finish_reason_hist = Counter()
     for r in traffic_rows:
         fr = r.get("finish_reason")
@@ -362,10 +344,6 @@ def _build_bench_report(
             duplicate_wire_calls_in_trial += per_trial_dups
             trials_with_duplicate_wire_calls += 1
 
-    # Trials where step count != wire-call count (a different mismatch axis
-    # than ref/wire token totals; signals lost or duplicated captures).
-    mismatched_steps_vs_wire_trials = delta_signs["captures>steps"] + delta_signs["captures<steps"]
-
     # After removing duplicate wire calls, does the mismatch resolve?
     mismatched_steps_vs_wire_trials_after_wire_dedup = 0
     for r in traj_rows:
@@ -390,242 +368,103 @@ def _build_bench_report(
     if traj_mean is not None and reported_mean is not None:
         is_mean_reward_correct = abs(traj_mean - reported_mean) < 1e-6
 
-    def vf(value: Any, formula: str) -> dict[str, Any]:
-        """{value, from} pair where `from` documents the calculation."""
-        return {"value": value, "from": formula}
-
-    # ─── headline summary — the values you'd read first ─────────────
-    headline_zero_token_trials = trials_with_any_zero_step
-    headline_dup_wire = duplicate_wire_calls_in_trial
-    headline_mismatch_after_dedup = mismatched_steps_vs_wire_trials_after_wire_dedup
-    summary = {
-        "trials": n_trials,
-        "mean_reward": traj_mean,
-        "mean_reward_matches_reported": is_mean_reward_correct,
-        "agent_steps_total": n_steps,
-        "wire_calls_total": total_wire,
-        "tokens_in_step_metrics": per_step_total,
-        "tokens_on_wire": wire_total,
-        "trials_with_zero_token_steps": headline_zero_token_trials,
-        "duplicate_wire_calls": headline_dup_wire,
-        "trials_with_step_vs_wire_mismatch_after_dedup": headline_mismatch_after_dedup,
+    step_field_coverage = {
+        "step_id": _field_present("step_id"),
+        "source": _field_present("source"),
+        "timestamp": _field_present("timestamp"),
+        "model_name": _field_present("model_name"),
+        "status_code": _field_present("status_code"),
+        "message": _field_present("message"),
+        "reasoning_content": _field_present("reasoning_content"),
+        "tool_calls": _field_present("tool_calls"),
+        "metrics.prompt_tokens": _nested_present("metrics", "prompt_tokens"),
+        "metrics.completion_tokens": _nested_present("metrics", "completion_tokens"),
+        "metrics.total_tokens": _nested_present("metrics", "total_tokens"),
+        "metrics.extra.latency_ms": _nested_present("metrics", "extra", "latency_ms"),
+        "metrics.extra.finish_reason": _nested_present("metrics", "extra", "finish_reason"),
+        "metrics.extra.cached_tokens": _nested_present("metrics", "extra", "cached_tokens"),
+        "metrics.extra.reasoning_tokens": _nested_present("metrics", "extra", "reasoning_tokens"),
     }
+
+    row_field_coverage = {
+        "problem_idx": f"{sum(1 for r in traj_rows if r.get('problem_idx') is not None)}/{n_trials}",
+        "repeat": f"{sum(1 for r in traj_rows if r.get('repeat') is not None)}/{n_trials}",
+        "reward": f"{sum(1 for r in traj_rows if isinstance(r.get('reward'), (int, float)))}/{n_trials}",
+        "trajectory": f"{sum(1 for r in traj_rows if r.get('trajectory'))}/{n_trials}",
+        "model": f"{sum(1 for r in traj_rows if r.get('model'))}/{n_trials}",
+        **{f"trajectory[0].{k}": v for k, v in atif_presence.items()},
+    }
+
+    # Wire-call dedup (request_hash-based, falls back to heuristic)
+    wire_keys_total = [_wire_dedup_key(r) for r in traffic_rows]
+    wire_keys_unique = set(wire_keys_total)
+    duplicates_total = total_wire - len(wire_keys_unique)
 
     out: dict[str, Any] = {
         "bench": bench_name,
         "_note": (
-            "Sections: summary (headline) | counts | score | anomalies | "
-            "presence (ATIF field coverage) | wire_captures (model_traffic.jsonl) | "
-            "trajectory_native (agent step stats) | mismatches (trajectory vs wire). "
-            "Every metric is {value, from} where 'from' documents the calculation."
+            "Health check over a run dir. Sections answer four questions, in order: "
+            "(1) score -- did the eval score what the bundle reported? "
+            "(2) tokens -- do the three independent token totals agree? "
+            "(3) wire_calls -- any duplicates or unexpected counts on the wire? "
+            "(4) field_coverage -- what fields are populated in trajectories.jsonl?"
         ),
-        "summary": summary,
         "counts": {
-            "n_trials": vf(n_trials, "trajectories.jsonl row count"),
-            "n_problems": vf(n_problems, "distinct trajectories.jsonl row.problem_idx"),
-            "repeats": vf(repeats, repeats_from),
+            "trials": n_trials,
+            "problems": n_problems,
+            "repeats": repeats,
         },
+        # ── 1. Did the eval score match what's reported in the bundle? ──
         "score": {
-            "mean_reward": vf(traj_mean, "mean(row.reward) across trajectories.jsonl trials"),
-            "reported_mean": vf(
-                reported_mean,
-                "latest <bench>/eval-*.json benchmark.scores.summary.mean",
-            ),
-            "is_mean_reward_correct": vf(
-                is_mean_reward_correct,
-                "|mean_reward - reported_mean| < 1e-6 (null if either side is missing)",
-            ),
-            "failures": vf(
-                {"total": sum(failures.values()), "counts_by_category": dict(failures)},
-                "row.scoring_details.error_category OR row.failure_category",
-            ),
+            "_note": "mean_reward = mean(row.reward) across trials; reported_mean = bundle's eval-*.json summary.mean",
+            "mean_reward": traj_mean,
+            "reported_mean": reported_mean,
+            "is_mean_reward_correct": is_mean_reward_correct,
+            "failures_by_category": dict(failures),
         },
-        # The actionable summary: what's broken, in counts.
-        "anomalies": {
+        # ── 2. Do per-step / trajectory-declared / wire totals agree? ──
+        "tokens": {
             "_note": (
-                "Each entry is a count of trials (or steps) hitting a specific data-quality "
-                "problem. Zero = healthy. Use these as the first thing to scan when reading "
-                "the report — they encode 'is anything wrong here?' in a glance."
+                "Three independent totals for prompt+completion tokens across all trials. "
+                "When all three agree, the trajectory faithfully encoded what the wire saw. "
+                "When per_step is 0 but wire isn't, the solver dropped per-step metrics "
+                "(enable enrich=true to backfill them from model_traffic.jsonl)."
             ),
-            "steps_with_zero_or_none_tokens": vf(
-                steps_with_zero_or_none_tokens,
-                "agent steps where (metrics.prompt_tokens or 0) + (metrics.completion_tokens or 0) == 0",
-            ),
-            "trials_with_any_zero_token_step": vf(
-                trials_with_any_zero_step,
-                "trials with at least one zero-or-none-tokens agent step",
-            ),
-            "trials_with_all_zero_token_steps": vf(
-                trials_all_zero_token_steps,
-                "trials where every agent step is zero-or-none-tokens",
-            ),
-            "duplicate_wire_calls_in_trial_total": vf(
-                duplicate_wire_calls_in_trial,
-                "sum over trials of (#repeated record.request_hash - 1); "
-                "request_hash is sha1(upstream request body) recorded at "
-                "ModelTrafficStore.start_request",
-            ),
-            "trials_with_duplicate_wire_calls": vf(
-                trials_with_duplicate_wire_calls,
-                "trials with at least one repeated record.request_hash",
-            ),
-            "mismatched_steps_vs_wire_trials": vf(
-                mismatched_steps_vs_wire_trials,
-                "trials where len(agent_steps) != len(model_traffic rows for that trial)",
-            ),
-            "mismatched_steps_vs_wire_trials_after_wire_dedup": vf(
-                mismatched_steps_vs_wire_trials_after_wire_dedup,
-                "trials where len(agent_steps) != len(set(record.request_hash)); "
-                "non-zero here means the mismatch is NOT explained by duplicate wire calls",
-            ),
-            "trials_with_per_step_vs_final_metrics_token_mismatch": vf(
-                per_step_vs_final_metrics_mismatch,
-                "trials where sum(step.metrics.prompt+completion_tokens) != "
-                "final_metrics.total_prompt+total_completion_tokens; "
-                "non-zero means the trajectory's internal totals are inconsistent",
-            ),
+            "per_step_sum": per_step_total,
+            "final_metrics_total": ref_total,
+            "wire_total": wire_total,
+            "per_step_matches_wire": (per_step_total == wire_total) if (per_step_total or wire_total) else None,
+            "final_metrics_matches_wire": (ref_total == wire_total) if (ref_total or wire_total) else None,
+            "trials_with_per_step_vs_final_metrics_mismatch": per_step_vs_final_metrics_mismatch,
         },
-        "trajectory_native": {
+        # ── 3. Wire call summary + duplicates ──
+        "wire_calls": {
             "_note": (
-                "Aggregate stats over agent steps as written by the solver into "
-                "trajectories.jsonl (before any wire enrichment). 'fields_present_on_steps' "
-                "is the per-step ATIF-v1.6 field audit."
+                "model_traffic.jsonl row stats. duplicates_total is computed via record.request_hash "
+                "(sha1 prefix of the upstream body); a non-zero value means the same model call landed "
+                "in the log twice (e.g. retry, double-capture)."
             ),
-            "agent_steps_total": vf(
-                n_steps,
-                "len(row.trajectory[0].steps[source=='agent']) summed across trials",
-            ),
-            "agent_steps_per_trial": vf(
-                _stats([float(x) for x in per_trial_step_counts]),
-                "stats of agent-step counts per trial",
-            ),
-            "tool_calls_total": vf(
-                tool_calls_total,
-                "sum of len(step.tool_calls) over agent steps",
-            ),
-            "reasoning_chars_total": vf(
-                reasoning_chars_total,
-                "sum of len(step.reasoning_content) over agent steps",
-            ),
-            "fields_present_on_steps": vf(
-                {
-                    "step_id": _field_present("step_id"),
-                    "source": _field_present("source"),
-                    "timestamp": _field_present("timestamp"),
-                    "model_name": _field_present("model_name"),
-                    "status_code": _field_present("status_code"),
-                    "message": _field_present("message"),
-                    "reasoning_content": _field_present("reasoning_content"),
-                    "tool_calls": _field_present("tool_calls"),
-                    "metrics.prompt_tokens": _nested_present("metrics", "prompt_tokens"),
-                    "metrics.completion_tokens": _nested_present("metrics", "completion_tokens"),
-                    "metrics.total_tokens": _nested_present("metrics", "total_tokens"),
-                    "metrics.extra.latency_ms": _nested_present("metrics", "extra", "latency_ms"),
-                    "metrics.extra.finish_reason": _nested_present("metrics", "extra", "finish_reason"),
-                    "metrics.extra.cached_tokens": _nested_present("metrics", "extra", "cached_tokens"),
-                    "metrics.extra.reasoning_tokens": _nested_present("metrics", "extra", "reasoning_tokens"),
-                },
-                f"N/{n_steps} agent steps where the dotted-path field is non-None",
-            ),
-            "fields_nonempty_on_steps": vf(
-                {
-                    "step_id": _field_nonempty("step_id"),
-                    "source": _field_nonempty("source"),
-                    "message": _field_nonempty("message"),
-                    "reasoning_content": _field_nonempty("reasoning_content"),
-                    "tool_calls": _field_nonempty("tool_calls"),
-                },
-                f"N/{n_steps} agent steps where the field is non-empty (non-None and not '' / [] / {{}})",
-            ),
+            "total": total_wire,
+            "unique": len(wire_keys_unique),
+            "duplicates_total": duplicates_total,
+            "trials_with_duplicates": trials_with_duplicate_wire_calls,
+            "trials_with_more_wire_than_steps": delta_signs["captures>steps"],
+            "trials_with_fewer_wire_than_steps": delta_signs["captures<steps"],
+            "trials_with_step_wire_mismatch_after_dedup": mismatched_steps_vs_wire_trials_after_wire_dedup,
+            "finish_reasons": dict(finish_reason_hist),
         },
-        "wire_captures": {
+        # ── 4. Field coverage (presence audit) ──
+        "field_coverage": {
             "_note": (
-                "Aggregate stats over model_traffic.jsonl rows (one row per upstream "
-                "model call observed by the proxy). This is the ground-truth side of the "
-                "trajectory ↔ wire comparison."
+                "How many trials/steps actually have each ATIF-v1.6 field. "
+                "Format 'N/total' means N populated out of total. "
+                "Run with enrich=true to backfill metrics.* on steps from the wire layer."
             ),
-            "total_observed": vf(
-                total_wire,
-                "model_traffic.jsonl row count",
-            ),
-            "captures_per_trial": vf(
-                _stats([float(x) for x in captures_per_trial]) if captures_per_trial else None,
-                "stats of len(model_traffic rows) grouped by (problem_idx, repeat)",
-            ),
-            "finish_reasons": vf(
-                dict(finish_reason_hist),
-                "histogram of model_traffic.jsonl row.finish_reason",
-            ),
-        },
-        "mismatches": {
-            "_note": (
-                "Cross-checks between trajectories.jsonl and model_traffic.jsonl. "
-                "When these don't reconcile, the wire layer captured something the "
-                "solver's trajectory failed to encode (or vice versa)."
-            ),
-            "agent_steps_vs_wire_calls": vf(
-                {
-                    "trials_with_more_wire_than_steps": delta_signs["captures>steps"],
-                    "trials_with_fewer_wire_than_steps": delta_signs["captures<steps"],
-                    "trials_with_equal_counts": delta_signs["equal"],
-                },
-                "for each trial: bucket by sign(len(wire_rows) - len(agent_steps))",
-            ),
-            "tokens": vf(
-                {
-                    "ref_total": ref_total,
-                    "per_step_total": per_step_total,
-                    "wire_total": wire_total,
-                    "match_ref_vs_wire": (ref_total == wire_total) if ref_total or wire_total else None,
-                },
-                "ref_total = sum(row.model.tokens.total); "
-                "per_step_total = sum(step.metrics.prompt_tokens + step.metrics.completion_tokens); "
-                "wire_total = sum(model_traffic row.usage.total_tokens, fallback to prompt+completion)",
-            ),
-        },
-        "presence": {
-            "_note": (
-                "Field-coverage audit. All three sub-blocks read 'N/total': "
-                "(N) rows/steps that have the field, out of (total) rows/steps. "
-                "Use to confirm the run actually wrote the data you expect."
-            ),
-            "row_required_fields": vf(
-                {
-                    "problem_idx": f"{sum(1 for r in traj_rows if r.get('problem_idx') is not None)}/{n_trials}",
-                    "repeat": f"{sum(1 for r in traj_rows if r.get('repeat') is not None)}/{n_trials}",
-                    "reward": f"{sum(1 for r in traj_rows if isinstance(r.get('reward'), (int, float)))}/{n_trials}",
-                    "trajectory": f"{sum(1 for r in traj_rows if r.get('trajectory'))}/{n_trials}",
-                    "model": f"{sum(1 for r in traj_rows if r.get('model'))}/{n_trials}",
-                },
-                f"N/{n_trials} trajectories.jsonl rows where the top-level required field is present",
-            ),
-            "atif_trajectory_fields": vf(
-                atif_presence,
-                f"N/{n_trials} trajectory[0].* dotted-path fields non-None and non-empty (ATIF-v1.6)",
-            ),
-            # atif_step_fields already lives under trajectory_native.fields_present_on_steps;
-            # we keep a single source of truth there to avoid duplication.
+            "per_trial": row_field_coverage,
+            "per_agent_step": step_field_coverage,
+            "agent_step_count": n_steps,
         },
     }
-    if include_stashed_section:
-        out["stashed_model_calls"] = vf(
-            {
-                "trials_with_stashed_calls": sum(
-                    1
-                    for r in traj_rows
-                    if isinstance(((r.get("trajectory") or [{}])[0]).get("extra"), dict)
-                    and ((r.get("trajectory") or [{}])[0]).get("extra", {}).get("captured_model_calls")
-                ),
-                "stashed_calls_total": sum(
-                    len(((r.get("trajectory") or [{}])[0]).get("extra", {}).get("captured_model_calls") or [])
-                    for r in traj_rows
-                    if isinstance(((r.get("trajectory") or [{}])[0]).get("extra"), dict)
-                ),
-            },
-            "trajectory[0].extra.captured_model_calls populated by the enrichment writer "
-            "when trial step count != wire-call count (so the calls survive even when the "
-            "solver fails before producing a matching step). Only emitted when enrich=True.",
-        )
     return out
 
 
@@ -721,18 +560,60 @@ def generate_trajectories_report(
 
     benches: list[dict[str, Any]] = []
     for d in bench_dirs:
-        # When enrich runs we splice into trajectory[0].extra.captured_model_calls;
-        # the stash audit only makes sense in that mode.
-        bench_report = _build_bench_report(d.name, d, include_stashed_section=enrich)
+        bench_report = _build_bench_report(d.name, d)
         if enrich:
             counts = _enrich_bench(d)
+            # After-enrichment coverage so the diff is right there in the report.
+            enriched_path = d / "trajectories_enriched.jsonl"
+            enriched_step_coverage: dict[str, str] = {}
+            if enriched_path.is_file():
+                enriched_rows = _read_jsonl(enriched_path)
+                enriched_steps: list[dict[str, Any]] = []
+                for r in enriched_rows:
+                    enriched_steps.extend(_agent_steps(r))
+                en_n = len(enriched_steps)
+                if en_n:
+
+                    def _enpresent(field: str) -> str:
+                        return f"{sum(1 for s in enriched_steps if s.get(field) is not None)}/{en_n}"
+
+                    def _ennested(*keys: str) -> str:
+                        n = 0
+                        for s in enriched_steps:
+                            cur: Any = s
+                            ok = True
+                            for k in keys:
+                                if not isinstance(cur, dict) or cur.get(k) is None:
+                                    ok = False
+                                    break
+                                cur = cur[k]
+                            if ok:
+                                n += 1
+                        return f"{n}/{en_n}"
+
+                    enriched_step_coverage = {
+                        "metrics.prompt_tokens": _ennested("metrics", "prompt_tokens"),
+                        "metrics.completion_tokens": _ennested("metrics", "completion_tokens"),
+                        "metrics.extra.latency_ms": _ennested("metrics", "extra", "latency_ms"),
+                        "metrics.extra.finish_reason": _ennested("metrics", "extra", "finish_reason"),
+                    }
             bench_report["enrichment"] = {
-                "value": counts,
-                "from": (
-                    "trajectories_enriched.jsonl written next to trajectories.jsonl; "
-                    "agent steps backfilled 1:1 with model_traffic.jsonl rows for the same trial; "
-                    "extra wire calls stashed in trajectory[0].extra.captured_model_calls"
+                "_note": (
+                    "trajectories_enriched.jsonl was written next to trajectories.jsonl. "
+                    "For each trial: if #agent_steps == #wire_calls, splice 1:1; otherwise "
+                    "stash all wire calls into trajectory[0].extra.captured_model_calls "
+                    "(so failures still preserve every captured call)."
                 ),
+                "trials_spliced_1_to_1": counts["trials_spliced"],
+                "trials_with_unmatched_calls_stashed": counts["trials_stashed_unmatched"],
+                "trials_with_no_wire_data": counts["trials_no_wire_data"],
+                "steps_backfilled": {
+                    "prompt_tokens": counts["steps_backfilled_prompt_tokens"],
+                    "completion_tokens": counts["steps_backfilled_completion_tokens"],
+                    "latency_ms": counts["steps_backfilled_latency_ms"],
+                    "finish_reason": counts["steps_backfilled_finish_reason"],
+                },
+                "step_field_coverage_after_enrichment": enriched_step_coverage,
             }
         benches.append(bench_report)
 

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -149,22 +149,24 @@ def test_format_log_record_forwards_opt_in_capture_fields() -> None:
             ctx=ctx,
             body={
                 "model": "m",
-                "choices": [{
-                    "message": {
-                        "role": "assistant",
-                        "content": "the answer is 42",
-                        "reasoning_content": "let me think",
-                        "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "w", "arguments": "{}"}}],
-                    },
-                    "finish_reason": "tool_calls",
-                }],
+                "choices": [
+                    {
+                        "message": {
+                            "role": "assistant",
+                            "content": "the answer is 42",
+                            "reasoning_content": "let me think",
+                            "tool_calls": [
+                                {"id": "c1", "type": "function", "function": {"name": "w", "arguments": "{}"}}
+                            ],
+                        },
+                        "finish_reason": "tool_calls",
+                    }
+                ],
                 "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
             },
         )
     )
-    rows = format_model_traffic_log_records(
-        store.drain_session("cap-session"), benchmark="b", problem_idx=0, repeat=0
-    )
+    rows = format_model_traffic_log_records(store.drain_session("cap-session"), benchmark="b", problem_idx=0, repeat=0)
     assert len(rows) == 1
     row = rows[0]
     assert row["tool_calls"] == {"count": 1, "names": {"w": 1}}

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -127,6 +127,53 @@ def _jsonl(path: Path):
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
 
 
+def test_format_log_record_forwards_opt_in_capture_fields() -> None:
+    """When the store captured tool_calls_full / reasoning_content / message_content,
+    they must land on the model_traffic.jsonl row (not be silently dropped)."""
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = "cap-session"
+    store = ModelTrafficStore(
+        service_name="solver",
+        capture_tool_calls=True,
+        capture_reasoning=True,
+        capture_messages=True,
+    )
+    store.start_request(
+        AdapterRequest(method="POST", path="/chat/completions", headers={}, body={"model": "m"}, ctx=ctx)
+    )
+    store.finish_response(
+        AdapterResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            latency_ms=10.0,
+            ctx=ctx,
+            body={
+                "model": "m",
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "the answer is 42",
+                        "reasoning_content": "let me think",
+                        "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "w", "arguments": "{}"}}],
+                    },
+                    "finish_reason": "tool_calls",
+                }],
+                "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+            },
+        )
+    )
+    rows = format_model_traffic_log_records(
+        store.drain_session("cap-session"), benchmark="b", problem_idx=0, repeat=0
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["tool_calls"] == {"count": 1, "names": {"w": 1}}
+    assert "tool_calls_full" in row
+    assert row["tool_calls_full"][0]["name"] == "w"
+    assert row["reasoning_content"] == "let me think"
+    assert row["message_content"] == "the answer is 42"
+
+
 def test_model_traffic_parses_streaming_sse_usage_and_tool_calls() -> None:
     ctx = InterceptorContext()
     ctx.extra["session_id"] = "stream-session"

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -242,3 +242,72 @@ async def test_model_traffic_writes_compact_log_and_inference_stats(tmp_path: Pa
         await handle.async_stop()
         store.close()
         upstream.shutdown()
+
+
+# ─── opt-in capture flags (this MR) ─────────────────────────────────
+
+
+def test_summary_from_json_capture_flags_off_keeps_default_shape() -> None:
+    """Default behavior: stats only — no tool_calls_full / reasoning_content / message_content."""
+    from nemo_evaluator.observability.model_traffic import _summary_from_json
+
+    body = {
+        "model": "qwen",
+        "choices": [
+            {
+                "finish_reason": "stop",
+                "message": {
+                    "content": "hello",
+                    "reasoning_content": "think",
+                    "tool_calls": [{"id": "t1", "function": {"name": "search", "arguments": '{"q":"x"}'}}],
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    out = _summary_from_json(body)
+    assert "tool_calls_full" not in out
+    assert "reasoning_content" not in out
+    assert "message_content" not in out
+    assert out["tool_calls"]["count"] == 1  # stats still there
+
+
+def test_summary_from_json_capture_flags_on_populate_fields() -> None:
+    from nemo_evaluator.observability.model_traffic import _summary_from_json
+
+    body = {
+        "model": "qwen",
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": "calling search",
+                    "reasoning_content": "I need to look this up",
+                    "tool_calls": [
+                        {"id": "t1", "function": {"name": "search", "arguments": '{"q":"x"}'}},
+                        {"id": "t2", "function": {"name": "fetch", "arguments": '{"u":"y"}'}},
+                    ],
+                },
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    out = _summary_from_json(body, capture_tool_calls=True, capture_reasoning=True, capture_messages=True)
+    assert out["reasoning_content"] == "I need to look this up"
+    assert out["message_content"] == "calling search"
+    assert len(out["tool_calls_full"]) == 2
+    assert out["tool_calls_full"][0] == {"id": "t1", "name": "search", "arguments": '{"q":"x"}'}
+
+
+def test_summary_truncates_long_content() -> None:
+    from nemo_evaluator.observability.model_traffic import _summary_from_json
+
+    long_text = "x" * 1000
+    body = {
+        "model": "qwen",
+        "choices": [{"finish_reason": "stop", "message": {"content": long_text, "reasoning_content": long_text}}],
+    }
+    out = _summary_from_json(body, capture_reasoning=True, capture_messages=True, max_content_chars=100)
+    assert out["message_content"].startswith("x" * 100)
+    assert "truncated" in out["message_content"]
+    assert out["reasoning_content"].startswith("x" * 100)

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -59,6 +59,8 @@ def _wire(
     completion: int,
     finish: str = "stop",
     status_code: int = 200,
+    timestamp: str = "2026-05-29T00:00:00.000Z",
+    model: str = "test-model",
 ) -> dict:
     return {
         "problem_idx": problem_idx,
@@ -66,6 +68,8 @@ def _wire(
         "session_id": f"sess-{problem_idx}-{repeat}",
         "status_code": status_code,
         "finish_reason": finish,
+        "timestamp": timestamp,
+        "model": model,
         "usage": {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": prompt + completion},
         "latency_ms": 100.0,
     }
@@ -256,8 +260,11 @@ def test_enrich_writes_enriched_jsonl_and_reports_changes(bundle: Path) -> None:
     # latency / finish_reason weren't on steps before; backfilled now
     assert enrichment["steps_backfilled"]["latency_ms"] >= 1
     assert enrichment["steps_backfilled"]["finish_reason"] >= 1
-    # After backfill, no metric field is missing → the "missing" list is empty.
-    assert enrichment["step_field_coverage_after_enrichment_missing"] == []
+    assert enrichment["steps_backfilled"]["timestamp"] >= 1
+    assert enrichment["steps_backfilled"]["model_name"] >= 1
+    # cached_tokens / reasoning_tokens aren't in the fixture's usage block, so they stay missing.
+    missing = {e["field"] for e in enrichment["step_field_coverage_after_enrichment_missing"]}
+    assert missing == {"metrics.extra.cached_tokens", "metrics.extra.reasoning_tokens"}
 
 
 def test_enrich_all_or_nothing_per_trial(tmp_path: Path) -> None:
@@ -295,6 +302,39 @@ def test_enrich_backfills_zero_token_steps(tmp_path: Path) -> None:
     ][0]
     assert enriched_step["metrics"]["prompt_tokens"] == 42
     assert enriched_step["metrics"]["completion_tokens"] == 7
+
+
+def test_enrich_backfills_step_metadata_from_wire(tmp_path: Path) -> None:
+    """Wire-level fields (timestamp, model, status_code, total/cached/reasoning tokens) backfill onto the matching step."""
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=0, ct=0)])],
+    )
+    wire = {
+        **_wire(0, 0, prompt=42, completion=7),
+        "timestamp": "2026-05-29T01:23:45.000Z",
+        "model": "qwen3.5-122b",
+    }
+    wire["usage"]["cached_tokens"] = 10
+    wire["usage"]["reasoning_tokens"] = 12
+    _write_jsonl(bench / "model_traffic.jsonl", [wire])
+    out = generate_trajectories_report(tmp_path, enrich=True)
+    counts = json.loads(out.read_text())["benchmarks"][0]["enrichment"]["steps_backfilled"]
+    assert counts["timestamp"] == 1
+    assert counts["model_name"] == 1
+    assert counts["status_code"] == 1
+    assert counts["total_tokens"] == 1
+    assert counts["cached_tokens"] == 1
+    assert counts["reasoning_tokens"] == 1
+
+    step = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])["trajectory"][0]["steps"][0]
+    assert step["timestamp"] == "2026-05-29T01:23:45.000Z"
+    assert step["model_name"] == "qwen3.5-122b"
+    assert step["status_code"] == 200
+    assert step["metrics"]["total_tokens"] == 49
+    assert step["metrics"]["extra"]["cached_tokens"] == 10
+    assert step["metrics"]["extra"]["reasoning_tokens"] == 12
 
 
 def test_enrichment_section_absent_when_enrich_false(bundle: Path) -> None:

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -253,6 +253,56 @@ def test_enrich_backfills_zero_token_steps(tmp_path: Path) -> None:
     assert counts["steps_backfilled_completion_tokens"] == 1
 
 
+def test_stashed_model_calls_audit(tmp_path: Path) -> None:
+    """After enrichment with mismatch, the stash audit reflects what's in extra.captured_model_calls."""
+    bench = tmp_path / "pb"
+    # 1 step, 2 wire calls → mismatch → all 2 calls stashed
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=0, ct=0)])],
+    )
+    _write_jsonl(
+        bench / "model_traffic.jsonl",
+        [_wire(0, 0, prompt=10, completion=5), _wire(0, 0, prompt=12, completion=3)],
+    )
+    out = generate_trajectories_report(tmp_path, enrich=True)
+    report = json.loads(out.read_text())["benchmarks"][0]
+    # First call: builds report from ORIGINAL trajectories.jsonl (no stash yet),
+    # so stash audit is 0/0 — that's still useful as a baseline.
+    s = _v(report["stashed_model_calls"])
+    assert s["trials_with_stashed_calls"] == 0
+    # But a second pass on the same dir (now reading the enriched file as
+    # input) is out of scope — the stash audit is over trajectories.jsonl
+    # not trajectories_enriched.jsonl. Still verify the enriched file has
+    # them where they should be:
+    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
+    stash = enriched["trajectory"][0].get("extra", {}).get("captured_model_calls")
+    assert isinstance(stash, list) and len(stash) == 2
+
+
+def test_required_row_fields_presence(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
+    rrf = _v(report["row_required_fields_presence"])
+    assert rrf["problem_idx"] == "2/2"
+    assert rrf["repeat"] == "2/2"
+    assert rrf["reward"] == "2/2"
+    assert rrf["trajectory"] == "2/2"
+    assert rrf["model"] == "2/2"
+
+
+def test_step_field_presence_extended(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
+    fp = _v(report["trajectory_native"]["fields_present_on_steps"])
+    # The fixture sets metrics.{prompt,completion,total}_tokens on every step.
+    assert fp["metrics.prompt_tokens"] == "3/3"
+    assert fp["metrics.completion_tokens"] == "3/3"
+    assert fp["metrics.total_tokens"] == "3/3"
+    # Fixture has no timestamp/model_name/status_code/extra fields → all 0/3
+    assert fp["timestamp"] == "0/3"
+    assert fp["metrics.extra.latency_ms"] == "0/3"
+    assert fp["metrics.extra.finish_reason"] == "0/3"
+
+
 def test_post_dedup_mismatch_and_per_step_total_consistency(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
     # 2 identical steps (1 dup), 2 identical wire rows (1 dup).

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -180,3 +180,73 @@ def test_enrich_flag_warns_but_does_not_write(bundle: Path, caplog) -> None:
     assert out is not None
     assert not (bundle / "trajectories_enriched.jsonl").exists()
     assert any("enrich=True" in rec.message for rec in caplog.records)
+
+
+def test_anomalies_zero_token_steps(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    # trial 0: 2 zero-token steps; trial 1: 1 healthy + 1 zero
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [
+            _trial(0, 0, reward=0.0, steps=[
+                _agent_step(0, msg="a", pt=0, ct=0),
+                _agent_step(1, msg="b", pt=0, ct=0),
+            ]),
+            _trial(1, 0, reward=1.0, steps=[
+                _agent_step(0, msg="c", pt=10, ct=5),
+                _agent_step(1, msg="d", pt=0, ct=0),
+            ]),
+        ],
+    )
+    _write_jsonl(bench / "model_traffic.jsonl", [])
+    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
+    assert a["steps_with_zero_or_none_tokens"] == 3
+    assert a["trials_with_any_zero_token_step"] == 2
+    assert a["trials_with_all_zero_token_steps"] == 1
+
+
+def test_anomalies_duplicate_steps(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    # trial 0: two steps with identical (message, reasoning, tool_calls) → 1 dup
+    dup_step_a = _agent_step(0, msg="thinking…", pt=10, ct=5)
+    dup_step_b = _agent_step(1, msg="thinking…", pt=10, ct=5)
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[dup_step_a, dup_step_b])],
+    )
+    _write_jsonl(bench / "model_traffic.jsonl", [])
+    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
+    assert a["duplicate_steps_in_trial_total"] == 1
+    assert a["trials_with_duplicate_steps"] == 1
+
+
+def test_anomalies_duplicate_wire_calls(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    # Two model_traffic rows with identical fingerprints for trial (0,0)
+    dup = _wire(0, 0, prompt=5, completion=3)
+    _write_jsonl(bench / "model_traffic.jsonl", [dup, dup])
+    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
+    assert a["duplicate_wire_calls_in_trial_total"] == 1
+    assert a["trials_with_duplicate_wire_calls"] == 1
+
+
+def test_is_mean_reward_correct(bundle: Path, tmp_path: Path) -> None:
+    # The bundle fixture doesn't ship an eval-*.json so reported_mean is None
+    # and is_mean_reward_correct stays None. Synthesize a matching bundle.
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    eval_path = bench / "eval-test.json"
+    eval_path.write_text(json.dumps({
+        "benchmark": {"scores": {"summary": {"mean": 1.0}}},
+    }), encoding="utf-8")
+    score = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["score"]
+    assert score["mean_reward"] == 1.0
+    assert score["reported_mean"] == 1.0
+    assert score["is_mean_reward_correct"] is True

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -303,20 +303,21 @@ def test_step_field_presence_extended(bundle: Path) -> None:
     assert fp["metrics.extra.finish_reason"] == "0/3"
 
 
-def test_post_dedup_mismatch_and_per_step_total_consistency(tmp_path: Path) -> None:
+def test_post_wire_dedup_mismatch_and_per_step_total_consistency(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
-    # 2 identical steps (1 dup), 2 identical wire rows (1 dup).
-    # After dedup, sets are both size 1 -> no remaining mismatch.
-    s = _agent_step(0, msg="same", pt=10, ct=5)
-    _write_jsonl(bench / "trajectories.jsonl", [_trial(0, 0, reward=1.0, steps=[s, s])])
-    w = _wire(0, 0, prompt=10, completion=5)
+    # 1 step, 2 identical wire rows (1 dup). After wire-dedup,
+    # unique wire count is 1 -> matches step count.
+    s = _agent_step(0, msg="x", pt=10, ct=5)
+    _write_jsonl(bench / "trajectories.jsonl", [_trial(0, 0, reward=1.0, steps=[s])])
+    w = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "h0"}
     _write_jsonl(bench / "model_traffic.jsonl", [w, w])
     a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert _v(a["duplicate_steps_in_trial_total"]) == 1
     assert _v(a["duplicate_wire_calls_in_trial_total"]) == 1
-    assert _v(a["mismatched_steps_vs_wire_trials"]) == 0
-    assert _v(a["mismatched_steps_vs_wire_trials_after_dedup"]) == 0
-    # 2 steps × 15 tokens = 30; final_metrics.total = 30 → consistent
+    # raw mismatch: 1 step vs 2 wire rows
+    assert _v(a["mismatched_steps_vs_wire_trials"]) == 1
+    # after wire-dedup: 1 step vs 1 unique wire row -> resolved
+    assert _v(a["mismatched_steps_vs_wire_trials_after_wire_dedup"]) == 0
+    # 1 step × 15 tokens = 15; final_metrics.total = 15 → consistent
     assert _v(a["trials_with_per_step_vs_final_metrics_token_mismatch"]) == 0
 
 
@@ -356,19 +357,49 @@ def test_anomalies_zero_token_steps(tmp_path: Path) -> None:
         assert "from" in a[key], f"{key} missing 'from' explanation"
 
 
-def test_anomalies_duplicate_steps(tmp_path: Path) -> None:
+def test_no_step_side_duplicate_tracking(tmp_path: Path) -> None:
+    """Duplicates are only tracked for model_traffic.jsonl, not trajectory steps."""
     bench = tmp_path / "pb"
-    # trial 0: two steps with identical (message, reasoning, tool_calls) → 1 dup
-    dup_step_a = _agent_step(0, msg="thinking…", pt=10, ct=5)
-    dup_step_b = _agent_step(1, msg="thinking…", pt=10, ct=5)
     _write_jsonl(
         bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[dup_step_a, dup_step_b])],
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
     )
     _write_jsonl(bench / "model_traffic.jsonl", [])
     a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert _v(a["duplicate_steps_in_trial_total"]) == 1
-    assert _v(a["trials_with_duplicate_steps"]) == 1
+    assert "duplicate_steps_in_trial_total" not in a
+    assert "trials_with_duplicate_steps" not in a
+
+
+def test_stashed_section_only_when_enrich(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=5, completion=3)])
+
+    audit = json.loads(generate_trajectories_report(tmp_path, enrich=False).read_text())["benchmarks"][0]
+    assert "stashed_model_calls" not in audit
+
+    enriched_run = json.loads(generate_trajectories_report(tmp_path, enrich=True).read_text())["benchmarks"][0]
+    assert "stashed_model_calls" in enriched_run
+
+
+def test_wire_dedup_prefers_request_hash(tmp_path: Path) -> None:
+    """When records carry request_hash, the dedup key is exact (not heuristic)."""
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    # Two records with the SAME request_hash but different response stats —
+    # heuristic would miss this; request_hash catches it as a duplicate.
+    rec_a = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "abc123abc123abc1"}
+    rec_b = {**_wire(0, 0, prompt=999, completion=999), "request_hash": "abc123abc123abc1", "latency_ms": 42.0}
+    _write_jsonl(bench / "model_traffic.jsonl", [rec_a, rec_b])
+    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
+    assert _v(a["duplicate_wire_calls_in_trial_total"]) == 1
+    assert "request_hash" in a["duplicate_wire_calls_in_trial_total"]["from"]
 
 
 def test_anomalies_duplicate_wire_calls(tmp_path: Path) -> None:

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -222,33 +222,27 @@ def test_no_benches_returns_none(tmp_path: Path) -> None:
     assert generate_trajectories_report(tmp_path) is None
 
 
-def test_wire_duplicates_via_request_hash(tmp_path: Path) -> None:
-    bench = tmp_path / "pb"
-    _write_jsonl(
-        bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
-    )
-    # Two records with same request_hash → exact dedup catches it
-    dup = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "abc"}
-    _write_jsonl(bench / "model_traffic.jsonl", [dup, dup])
-    wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
-    assert wc["total"] == 2
-    assert wc["unique"] == 1
-    assert wc["duplicates_total"] == 1
-    assert wc["trials_with_duplicates"] == 1
-
-
-def test_wire_dedup_fallback_when_no_request_hash(tmp_path: Path) -> None:
-    """Older rows without request_hash use the heuristic response-side key."""
+@pytest.mark.parametrize(
+    "request_hash",
+    ["abc", None],
+    ids=["request_hash", "fallback_heuristic"],
+)
+def test_wire_dedup(tmp_path: Path, request_hash: str | None) -> None:
+    """Exact dedup via request_hash; falls back to the response-side key for older rows."""
     bench = tmp_path / "pb"
     _write_jsonl(
         bench / "trajectories.jsonl",
         [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
     )
     rec = _wire(0, 0, prompt=10, completion=5)
+    if request_hash is not None:
+        rec["request_hash"] = request_hash
     _write_jsonl(bench / "model_traffic.jsonl", [rec, rec])
     wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
+    assert wc["total"] == 2
+    assert wc["unique"] == 1
     assert wc["duplicates_total"] == 1
+    assert wc["trials_with_duplicates"] == 1
 
 
 def test_step_wire_mismatch_after_dedup(tmp_path: Path) -> None:

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -108,20 +108,30 @@ def test_audit_writes_report(bundle: Path) -> None:
     assert len(payload["benchmarks"]) == 1
 
 
+def _v(node: dict) -> object:
+    """Convenience: unwrap {value, from} to its value."""
+    return node["value"] if isinstance(node, dict) and "from" in node else node
+
+
 def test_counts_and_score(bundle: Path) -> None:
     out = generate_trajectories_report(bundle)
     report = json.loads(out.read_text())["benchmarks"][0]
-    assert report["counts"] == {"n_trials": 2, "n_problems": 2, "repeats": 1}
+    assert _v(report["counts"]["n_trials"]) == 2
+    assert _v(report["counts"]["n_problems"]) == 2
+    assert _v(report["counts"]["repeats"]) == 1
     # Mean of [1.0, 0.5] == 0.75
-    assert report["score"]["mean_reward"] == 0.75
+    assert _v(report["score"]["mean_reward"]) == 0.75
+    # every metric must carry its calculation explanation
+    assert "from" in report["counts"]["n_trials"]
+    assert "from" in report["score"]["mean_reward"]
 
 
 def test_trajectory_native_stats(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
     nt = report["trajectory_native"]
-    assert nt["agent_steps_total"] == 3
-    assert nt["tool_calls_total"] == 1
-    fp = nt["fields_present_on_steps"]
+    assert _v(nt["agent_steps_total"]) == 3
+    assert _v(nt["tool_calls_total"]) == 1
+    fp = _v(nt["fields_present_on_steps"])
     assert fp["step_id"] == "3/3"
     assert fp["message"] == "3/3"
     assert fp["tool_calls"] == "1/3"
@@ -130,15 +140,15 @@ def test_trajectory_native_stats(bundle: Path) -> None:
 def test_wire_captures_match_steps(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
     wc = report["wire_captures"]
-    assert wc["total_observed"] == 3
-    assert wc["finish_reasons"] == {"stop": 2, "tool_calls": 1}
-    mm = report["mismatches"]
-    assert mm["agent_steps_vs_wire_calls"] == {"captures>steps": 0, "captures<steps": 0, "equal": 2}
+    assert _v(wc["total_observed"]) == 3
+    assert _v(wc["finish_reasons"]) == {"stop": 2, "tool_calls": 1}
+    delta = _v(report["mismatches"]["agent_steps_vs_wire_calls"])
+    assert delta == {"captures>steps": 0, "captures<steps": 0, "equal": 2}
 
 
 def test_token_reconciliation(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    tokens = report["mismatches"]["tokens"]
+    tokens = _v(report["mismatches"]["tokens"])
     # 2 trials × (pt+ct): trial0=15, trial1=20+10+30+8=68 → 83 across all
     assert tokens["per_step_total"] == 83
     assert tokens["wire_total"] == 83
@@ -148,7 +158,7 @@ def test_token_reconciliation(bundle: Path) -> None:
 
 def test_atif_per_trial_presence(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    pres = report["atif_per_trial_presence"]
+    pres = _v(report["atif_per_trial_presence"])
     assert pres["schema_version"] == "2/2"
     assert pres["session_id"] == "2/2"
     assert pres["agent.name"] == "2/2"
@@ -168,18 +178,64 @@ def test_missing_wire_captures_are_flagged(tmp_path: Path) -> None:
     # only 1 wire call vs 2 agent steps
     _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=5, completion=3)])
     report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
-    assert report["mismatches"]["agent_steps_vs_wire_calls"] == {
+    assert _v(report["mismatches"]["agent_steps_vs_wire_calls"]) == {
         "captures>steps": 0,
         "captures<steps": 1,
         "equal": 0,
     }
 
 
-def test_enrich_flag_warns_but_does_not_write(bundle: Path, caplog) -> None:
+def test_enrich_writes_enriched_jsonl_and_reports_changes(bundle: Path) -> None:
     out = generate_trajectories_report(bundle, enrich=True)
     assert out is not None
-    assert not (bundle / "trajectories_enriched.jsonl").exists()
-    assert any("enrich=True" in rec.message for rec in caplog.records)
+    enriched = bundle / "pinchbench" / "trajectories_enriched.jsonl"
+    assert enriched.is_file()
+    report = json.loads(out.read_text())["benchmarks"][0]
+    enrichment = _v(report["enrichment"])
+    # Bundle fixture has steps with non-zero pt/ct already, so no backfill
+    # *for those*, but latency_ms/finish_reason aren't set on the steps and
+    # are present on the wire rows.
+    assert enrichment["rows_written"] == 2
+    assert enrichment["steps_backfilled_latency_ms"] >= 1
+    assert enrichment["steps_backfilled_finish_reason"] >= 1
+
+
+def test_enrich_backfills_zero_token_steps(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    # step with zero tokens, wire call has real tokens — should backfill
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=0, ct=0)])],
+    )
+    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=42, completion=7)])
+    out = generate_trajectories_report(tmp_path, enrich=True)
+    enriched_rows = []
+    with (bench / "trajectories_enriched.jsonl").open() as fh:
+        for line in fh:
+            enriched_rows.append(json.loads(line))
+    step = enriched_rows[0]["trajectory"][0]["steps"][0]
+    assert step["metrics"]["prompt_tokens"] == 42
+    assert step["metrics"]["completion_tokens"] == 7
+    counts = _v(json.loads(out.read_text())["benchmarks"][0]["enrichment"])
+    assert counts["steps_backfilled_prompt_tokens"] == 1
+    assert counts["steps_backfilled_completion_tokens"] == 1
+
+
+def test_post_dedup_mismatch_and_per_step_total_consistency(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    # 2 identical steps (1 dup), 2 identical wire rows (1 dup).
+    # After dedup, sets are both size 1 -> no remaining mismatch.
+    s = _agent_step(0, msg="same", pt=10, ct=5)
+    _write_jsonl(bench / "trajectories.jsonl", [_trial(0, 0, reward=1.0, steps=[s, s])])
+    w = _wire(0, 0, prompt=10, completion=5)
+    _write_jsonl(bench / "model_traffic.jsonl", [w, w])
+    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
+    assert _v(a["duplicate_steps_in_trial_total"]) == 1
+    assert _v(a["duplicate_wire_calls_in_trial_total"]) == 1
+    assert _v(a["mismatched_steps_vs_wire_trials"]) == 0
+    assert _v(a["mismatched_steps_vs_wire_trials_after_dedup"]) == 0
+    # 2 steps × 15 tokens = 30; final_metrics.total = 30 → consistent
+    assert _v(a["trials_with_per_step_vs_final_metrics_token_mismatch"]) == 0
 
 
 def test_anomalies_zero_token_steps(tmp_path: Path) -> None:
@@ -200,9 +256,12 @@ def test_anomalies_zero_token_steps(tmp_path: Path) -> None:
     )
     _write_jsonl(bench / "model_traffic.jsonl", [])
     a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert a["steps_with_zero_or_none_tokens"] == 3
-    assert a["trials_with_any_zero_token_step"] == 2
-    assert a["trials_with_all_zero_token_steps"] == 1
+    assert _v(a["steps_with_zero_or_none_tokens"]) == 3
+    assert _v(a["trials_with_any_zero_token_step"]) == 2
+    assert _v(a["trials_with_all_zero_token_steps"]) == 1
+    # Every anomaly metric carries its calculation note
+    for key in a:
+        assert "from" in a[key], f"{key} missing 'from' explanation"
 
 
 def test_anomalies_duplicate_steps(tmp_path: Path) -> None:
@@ -216,8 +275,8 @@ def test_anomalies_duplicate_steps(tmp_path: Path) -> None:
     )
     _write_jsonl(bench / "model_traffic.jsonl", [])
     a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert a["duplicate_steps_in_trial_total"] == 1
-    assert a["trials_with_duplicate_steps"] == 1
+    assert _v(a["duplicate_steps_in_trial_total"]) == 1
+    assert _v(a["trials_with_duplicate_steps"]) == 1
 
 
 def test_anomalies_duplicate_wire_calls(tmp_path: Path) -> None:
@@ -230,8 +289,8 @@ def test_anomalies_duplicate_wire_calls(tmp_path: Path) -> None:
     dup = _wire(0, 0, prompt=5, completion=3)
     _write_jsonl(bench / "model_traffic.jsonl", [dup, dup])
     a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert a["duplicate_wire_calls_in_trial_total"] == 1
-    assert a["trials_with_duplicate_wire_calls"] == 1
+    assert _v(a["duplicate_wire_calls_in_trial_total"]) == 1
+    assert _v(a["trials_with_duplicate_wire_calls"]) == 1
 
 
 def test_is_mean_reward_correct(bundle: Path, tmp_path: Path) -> None:
@@ -247,6 +306,6 @@ def test_is_mean_reward_correct(bundle: Path, tmp_path: Path) -> None:
         "benchmark": {"scores": {"summary": {"mean": 1.0}}},
     }), encoding="utf-8")
     score = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["score"]
-    assert score["mean_reward"] == 1.0
-    assert score["reported_mean"] == 1.0
-    assert score["is_mean_reward_correct"] is True
+    assert _v(score["mean_reward"]) == 1.0
+    assert _v(score["reported_mean"]) == 1.0
+    assert _v(score["is_mean_reward_correct"]) is True

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -120,9 +120,6 @@ def test_tokens_section(bundle: Path) -> None:
     # 2 trials × (pt+ct): trial0=15, trial1=20+10+30+8=68 → 83 across all
     assert t["per_step_sum"] == 83
     assert t["wire_total"] == 83
-    assert t["final_metrics_total"] == 83
-    assert t["per_step_matches_wire"] is True
-    assert t["final_metrics_matches_wire"] is True
     assert t["trials_with_per_step_vs_final_metrics_mismatch"] == 0
 
 
@@ -130,16 +127,13 @@ def test_wire_calls_section(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
     wc = report["wire_calls"]
     assert wc["total"] == 3
-    assert wc["successful"] == 3
     assert wc["unique"] == 3
-    assert wc["duplicates_total"] == 0
     assert wc["trials_with_duplicates"] == 0
     assert wc["trials_with_more_wire_than_steps"] == 0
     assert wc["trials_with_fewer_wire_than_steps"] == 0
     assert wc["trials_with_no_agent_steps"] == "0/2 (0.0%)"
     assert wc["trials_with_no_wire_calls"] == "0/2 (0.0%)"
     assert wc["trials_silent_either_way"] == "0/2 (0.0%)"
-    assert wc["finish_reasons"] == {"stop": 2, "tool_calls": 1}
 
 
 _OK_STEP = _agent_step(0, msg="x", pt=5, ct=3)
@@ -187,25 +181,26 @@ def test_silent_failure_metric_per_trial(
     assert report["enrichment"][_ENRICHMENT_FIELD[enrich_kind]] == 1
 
 
-def test_field_coverage_per_trial_and_step(bundle: Path) -> None:
+def test_field_coverage_only_lists_missing(bundle: Path) -> None:
+    """Fully-populated fields are silent; only gaps appear -- with their presence ratio."""
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
     fc = report["field_coverage"]
-    assert fc["agent_step_count"] == 3
-    # Per-trial required + ATIF trajectory fields
-    pt = fc["per_trial"]
-    assert pt["problem_idx"] == "2/2"
-    assert pt["reward"] == "2/2"
-    assert pt["trajectory[0].schema_version"] == "2/2"
-    assert pt["trajectory[0].agent.name"] == "2/2"
-    # Per-step ATIF coverage
-    ps = fc["per_agent_step"]
-    assert ps["step_id"] == "3/3"
-    assert ps["metrics.prompt_tokens"] == "3/3"
-    assert ps["metrics.extra.latency_ms"] == "0/3"  # not set in fixture
-    assert ps["metrics.extra.finish_reason"] == "0/3"
+    # Fixture sets problem_idx/reward/agent.name on every trial → those don't appear.
+    trial_misses = {e["field"]: e["presence"] for e in fc["per_trial_missing"]}
+    assert "problem_idx" not in trial_misses
+    assert "trajectory[0].schema_version" not in trial_misses
+    # ...but agent.parent_agent and trajectory[0].extra are never set in the fixture.
+    assert trial_misses["trajectory[0].agent.parent_agent"] == "0/2"
+    assert trial_misses["trajectory[0].extra"] == "0/2"
+    # Per-step: prompt_tokens always set, latency_ms/finish_reason never set.
+    step_misses = {e["field"]: e["presence"] for e in fc["per_agent_step_missing"]}
+    assert "step_id" not in step_misses
+    assert "metrics.prompt_tokens" not in step_misses
+    assert step_misses["metrics.extra.latency_ms"] == "0/3"
+    assert step_misses["metrics.extra.finish_reason"] == "0/3"
 
 
-def test_score_mean_reward_correct(tmp_path: Path) -> None:
+def test_score(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
     _write_jsonl(
         bench / "trajectories.jsonl",
@@ -215,54 +210,29 @@ def test_score_mean_reward_correct(tmp_path: Path) -> None:
     score = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["score"]
     assert score["mean_reward"] == 1.0
     assert score["reported_mean"] == 1.0
-    assert score["is_mean_reward_correct"] is True
 
 
 def test_no_benches_returns_none(tmp_path: Path) -> None:
     assert generate_trajectories_report(tmp_path) is None
 
 
-@pytest.mark.parametrize(
-    "request_hash",
-    ["abc", None],
-    ids=["request_hash", "fallback_heuristic"],
-)
-def test_wire_dedup(tmp_path: Path, request_hash: str | None) -> None:
-    """Exact dedup via request_hash; falls back to the response-side key for older rows."""
+def test_wire_dedup_via_request_hash(tmp_path: Path) -> None:
+    """Identical request_hash → unique drops, the trial is flagged as having dups."""
     bench = tmp_path / "pb"
     _write_jsonl(
         bench / "trajectories.jsonl",
         [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
     )
-    rec = _wire(0, 0, prompt=10, completion=5)
-    if request_hash is not None:
-        rec["request_hash"] = request_hash
-    _write_jsonl(bench / "model_traffic.jsonl", [rec, rec])
+    dup = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "abc"}
+    _write_jsonl(bench / "model_traffic.jsonl", [dup, dup])
     wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
     assert wc["total"] == 2
     assert wc["unique"] == 1
-    assert wc["duplicates_total"] == 1
     assert wc["trials_with_duplicates"] == 1
 
 
-def test_step_wire_mismatch_after_dedup(tmp_path: Path) -> None:
-    """1 step + 2 identical wires → dedup resolves the mismatch."""
-    bench = tmp_path / "pb"
-    _write_jsonl(
-        bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
-    )
-    rec = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "h0"}
-    _write_jsonl(bench / "model_traffic.jsonl", [rec, rec])
-    wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
-    # raw counts disagree (1 step vs 2 wires)
-    assert wc["trials_with_more_wire_than_steps"] == 1
-    # after dedup resolves
-    assert wc["trials_with_step_wire_mismatch_after_dedup"] == 0
-
-
 def test_tokens_per_step_vs_wire_mismatch(tmp_path: Path) -> None:
-    """per_step_sum=0 but wire_total>0 → bug surface that enrichment fixes."""
+    """per_step_sum=0 but wire_total>0 → the two numbers disagree on their own."""
     bench = tmp_path / "pb"
     _write_jsonl(
         bench / "trajectories.jsonl",
@@ -272,7 +242,6 @@ def test_tokens_per_step_vs_wire_mismatch(tmp_path: Path) -> None:
     t = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["tokens"]
     assert t["per_step_sum"] == 0
     assert t["wire_total"] == 49
-    assert t["per_step_matches_wire"] is False
 
 
 def test_enrich_writes_enriched_jsonl_and_reports_changes(bundle: Path) -> None:
@@ -286,10 +255,8 @@ def test_enrich_writes_enriched_jsonl_and_reports_changes(bundle: Path) -> None:
     # latency / finish_reason weren't on steps before; backfilled now
     assert enrichment["steps_backfilled"]["latency_ms"] >= 1
     assert enrichment["steps_backfilled"]["finish_reason"] >= 1
-    # The after-state coverage is right there in the report
-    after = enrichment["step_field_coverage_after_enrichment"]
-    assert after["metrics.extra.latency_ms"] == "3/3"
-    assert after["metrics.extra.finish_reason"] == "3/3"
+    # After backfill, no metric field is missing → the "missing" list is empty.
+    assert enrichment["step_field_coverage_after_enrichment_missing"] == []
 
 
 def test_enrich_all_or_nothing_per_trial(tmp_path: Path) -> None:

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -51,11 +51,20 @@ def _agent_step(step_id: int, *, msg: str, pt: int, ct: int, tool_calls: list | 
     return s
 
 
-def _wire(problem_idx: int, repeat: int, *, prompt: int, completion: int, finish: str = "stop") -> dict:
+def _wire(
+    problem_idx: int,
+    repeat: int,
+    *,
+    prompt: int,
+    completion: int,
+    finish: str = "stop",
+    status_code: int = 200,
+) -> dict:
     return {
         "problem_idx": problem_idx,
         "repeat": repeat,
         "session_id": f"sess-{problem_idx}-{repeat}",
+        "status_code": status_code,
         "finish_reason": finish,
         "usage": {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": prompt + completion},
         "latency_ms": 100.0,
@@ -121,12 +130,61 @@ def test_wire_calls_section(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
     wc = report["wire_calls"]
     assert wc["total"] == 3
+    assert wc["successful"] == 3
     assert wc["unique"] == 3
     assert wc["duplicates_total"] == 0
     assert wc["trials_with_duplicates"] == 0
     assert wc["trials_with_more_wire_than_steps"] == 0
     assert wc["trials_with_fewer_wire_than_steps"] == 0
+    assert wc["trials_with_no_agent_steps"] == "0/2 (0.0%)"
+    assert wc["trials_with_no_wire_calls"] == "0/2 (0.0%)"
+    assert wc["trials_silent_either_way"] == "0/2 (0.0%)"
     assert wc["finish_reasons"] == {"stop": 2, "tool_calls": 1}
+
+
+_OK_STEP = _agent_step(0, msg="x", pt=5, ct=3)
+_OK_WIRE = _wire(0, 0, prompt=5, completion=3)
+_FAILED_WIRE = _wire(0, 0, prompt=5, completion=3, status_code=500)
+_ENRICHMENT_FIELD = {
+    "spliced": "trials_spliced_1_to_1",
+    "stashed": "trials_with_unmatched_calls_stashed",
+    "no_wire": "trials_with_no_wire_data",
+}
+
+
+@pytest.mark.parametrize(
+    "steps, wire_rows, no_steps, no_wire, enrich_kind",
+    [
+        ([_OK_STEP], [_OK_WIRE], False, False, "spliced"),
+        ([], [_OK_WIRE], True, False, "stashed"),
+        ([_OK_STEP], [], False, True, "no_wire"),
+        ([_OK_STEP], [_FAILED_WIRE], False, True, "no_wire"),
+        ([], [], True, True, "no_wire"),
+    ],
+    ids=["healthy", "no_agent_steps", "no_wire", "failed_wire_only", "completely_empty"],
+)
+def test_silent_failure_metric_per_trial(
+    tmp_path: Path,
+    steps: list,
+    wire_rows: list,
+    no_steps: bool,
+    no_wire: bool,
+    enrich_kind: str,
+) -> None:
+    """One-trial bench: silent-failure flags + the failed-wire row is ignored by enrichment."""
+    bench = tmp_path / "pb"
+    _write_jsonl(bench / "trajectories.jsonl", [_trial(0, 0, reward=0.0, steps=steps)])
+    _write_jsonl(bench / "model_traffic.jsonl", wire_rows)
+    report = json.loads(generate_trajectories_report(tmp_path, enrich=True).read_text())["benchmarks"][0]
+    wc = report["wire_calls"]
+
+    def _pct(flag: bool) -> str:
+        return "1/1 (100.0%)" if flag else "0/1 (0.0%)"
+
+    assert wc["trials_with_no_agent_steps"] == _pct(no_steps)
+    assert wc["trials_with_no_wire_calls"] == _pct(no_wire)
+    assert wc["trials_silent_either_way"] == _pct(no_steps or no_wire)
+    assert report["enrichment"][_ENRICHMENT_FIELD[enrich_kind]] == 1
 
 
 def test_field_coverage_per_trial_and_step(bundle: Path) -> None:

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -127,6 +127,7 @@ def test_wire_calls_section(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
     wc = report["wire_calls"]
     assert wc["total"] == 3
+    assert wc["successful"] == 3
     assert wc["unique"] == 3
     assert wc["trials_with_duplicates"] == 0
     assert wc["trials_with_more_wire_than_steps"] == 0

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -200,6 +200,35 @@ def test_enrich_writes_enriched_jsonl_and_reports_changes(bundle: Path) -> None:
     assert enrichment["steps_backfilled_finish_reason"] >= 1
 
 
+def test_enrich_all_or_nothing_per_trial(tmp_path: Path) -> None:
+    """When wire-call count != step count, stash everything in extra and
+    leave step metrics untouched (no partial splice that misattributes)."""
+    bench = tmp_path / "pb"
+    # Trial 0: 2 steps, 1 wire call -> stash (no splice)
+    s1 = _agent_step(0, msg="a", pt=0, ct=0)
+    s2 = _agent_step(1, msg="b", pt=0, ct=0)
+    _write_jsonl(bench / "trajectories.jsonl", [_trial(0, 0, reward=0.0, steps=[s1, s2])])
+    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=10, completion=5)])
+
+    out = generate_trajectories_report(tmp_path, enrich=True)
+    counts = _v(json.loads(out.read_text())["benchmarks"][0]["enrichment"])
+    assert counts["trials_spliced"] == 0
+    assert counts["trials_stashed_unmatched"] == 1
+    # Crucially, step metrics were NOT touched (no partial splice).
+    assert counts["steps_backfilled_prompt_tokens"] == 0
+
+    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
+    steps = [s for s in enriched["trajectory"][0]["steps"] if s.get("source") == "agent"]
+    # both steps still have zero/none tokens
+    for s in steps:
+        m = s.get("metrics") or {}
+        assert not m.get("prompt_tokens")
+        assert not m.get("completion_tokens")
+    # All wire calls stashed in extra.captured_model_calls
+    stash = enriched["trajectory"][0].get("extra", {}).get("captured_model_calls")
+    assert isinstance(stash, list) and len(stash) == 1
+
+
 def test_enrich_backfills_zero_token_steps(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
     # step with zero tokens, wire call has real tokens — should backfill

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -42,9 +42,7 @@ def _trial(problem_idx: int, repeat: int, *, reward: float, steps: list[dict]) -
                 "steps": steps,
                 "final_metrics": {
                     "total_prompt_tokens": sum((s.get("metrics") or {}).get("prompt_tokens", 0) for s in steps),
-                    "total_completion_tokens": sum(
-                        (s.get("metrics") or {}).get("completion_tokens", 0) for s in steps
-                    ),
+                    "total_completion_tokens": sum((s.get("metrics") or {}).get("completion_tokens", 0) for s in steps),
                     "total_steps": len(steps),
                 },
             }
@@ -83,10 +81,15 @@ def bundle(tmp_path: Path) -> Path:
         bench / "trajectories.jsonl",
         [
             _trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="hi", pt=10, ct=5)]),
-            _trial(1, 0, reward=0.5, steps=[
-                _agent_step(0, msg="thinking", pt=20, ct=10, tool_calls=[{"name": "search"}]),
-                _agent_step(1, msg="done", pt=30, ct=8),
-            ]),
+            _trial(
+                1,
+                0,
+                reward=0.5,
+                steps=[
+                    _agent_step(0, msg="thinking", pt=20, ct=10, tool_calls=[{"name": "search"}]),
+                    _agent_step(1, msg="done", pt=30, ct=8),
+                ],
+            ),
         ],
     )
     _write_jsonl(
@@ -273,14 +276,24 @@ def test_anomalies_zero_token_steps(tmp_path: Path) -> None:
     _write_jsonl(
         bench / "trajectories.jsonl",
         [
-            _trial(0, 0, reward=0.0, steps=[
-                _agent_step(0, msg="a", pt=0, ct=0),
-                _agent_step(1, msg="b", pt=0, ct=0),
-            ]),
-            _trial(1, 0, reward=1.0, steps=[
-                _agent_step(0, msg="c", pt=10, ct=5),
-                _agent_step(1, msg="d", pt=0, ct=0),
-            ]),
+            _trial(
+                0,
+                0,
+                reward=0.0,
+                steps=[
+                    _agent_step(0, msg="a", pt=0, ct=0),
+                    _agent_step(1, msg="b", pt=0, ct=0),
+                ],
+            ),
+            _trial(
+                1,
+                0,
+                reward=1.0,
+                steps=[
+                    _agent_step(0, msg="c", pt=10, ct=5),
+                    _agent_step(1, msg="d", pt=0, ct=0),
+                ],
+            ),
         ],
     )
     _write_jsonl(bench / "model_traffic.jsonl", [])
@@ -331,9 +344,14 @@ def test_is_mean_reward_correct(bundle: Path, tmp_path: Path) -> None:
         [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
     )
     eval_path = bench / "eval-test.json"
-    eval_path.write_text(json.dumps({
-        "benchmark": {"scores": {"summary": {"mean": 1.0}}},
-    }), encoding="utf-8")
+    eval_path.write_text(
+        json.dumps(
+            {
+                "benchmark": {"scores": {"summary": {"mean": 1.0}}},
+            }
+        ),
+        encoding="utf-8",
+    )
     score = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["score"]
     assert _v(score["mean_reward"]) == 1.0
     assert _v(score["reported_mean"]) == 1.0

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -282,6 +282,34 @@ def test_enrichment_section_absent_when_enrich_false(bundle: Path) -> None:
     assert "enrichment" not in report
 
 
+def test_enrich_backfills_full_capture_fields(tmp_path: Path) -> None:
+    """When the wire row carries reasoning_content / message_content /
+    tool_calls_full (because model_traffic was configured to capture them),
+    enrichment backfills missing step fields too."""
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="", pt=5, ct=3)])],
+    )
+    wire = {
+        **_wire(0, 0, prompt=5, completion=3),
+        "reasoning_content": "I should call the tool first.",
+        "message_content": "Final assistant message",
+        "tool_calls_full": [{"id": "c1", "name": "search", "arguments": '{"q":"x"}'}],
+    }
+    _write_jsonl(bench / "model_traffic.jsonl", [wire])
+    out = generate_trajectories_report(tmp_path, enrich=True)
+    counts = json.loads(out.read_text())["benchmarks"][0]["enrichment"]["steps_backfilled"]
+    assert counts["reasoning_content"] == 1
+    assert counts["message"] == 1
+    assert counts["tool_calls"] == 1
+    # And the enriched step actually carries the fields
+    step = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])["trajectory"][0]["steps"][0]
+    assert step["reasoning_content"] == "I should call the tool first."
+    assert step["message"] == "Final assistant message"
+    assert step["tool_calls"] == [{"id": "c1", "name": "search", "arguments": '{"q":"x"}'}]
+
+
 def test_non_uniform_repeats_returns_histogram(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
     # problem 0: 2 repeats; problem 1: 1 repeat → non-uniform

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -1,17 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-# http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 """Audit report tests — pure file-to-file behavior over fixture jsonls."""
 
 from __future__ import annotations
@@ -95,9 +83,9 @@ def bundle(tmp_path: Path) -> Path:
     _write_jsonl(
         bench / "model_traffic.jsonl",
         [
-            _wire(0, 0, prompt=10, completion=5),
-            _wire(1, 0, prompt=20, completion=10, finish="tool_calls"),
-            _wire(1, 0, prompt=30, completion=8),
+            {**_wire(0, 0, prompt=10, completion=5), "request_hash": "hA"},
+            {**_wire(1, 0, prompt=20, completion=10, finish="tool_calls"), "request_hash": "hB"},
+            {**_wire(1, 0, prompt=30, completion=8), "request_hash": "hC"},
         ],
     )
     return tmp_path
@@ -111,335 +99,201 @@ def test_audit_writes_report(bundle: Path) -> None:
     assert len(payload["benchmarks"]) == 1
 
 
-def _v(node: dict) -> object:
-    """Convenience: unwrap {value, from} to its value."""
-    return node["value"] if isinstance(node, dict) and "from" in node else node
-
-
 def test_counts_and_score(bundle: Path) -> None:
-    out = generate_trajectories_report(bundle)
-    report = json.loads(out.read_text())["benchmarks"][0]
-    assert _v(report["counts"]["n_trials"]) == 2
-    assert _v(report["counts"]["n_problems"]) == 2
-    assert _v(report["counts"]["repeats"]) == 1
-    # Mean of [1.0, 0.5] == 0.75
-    assert _v(report["score"]["mean_reward"]) == 0.75
-    # every metric must carry its calculation explanation
-    assert "from" in report["counts"]["n_trials"]
-    assert "from" in report["score"]["mean_reward"]
-
-
-def test_trajectory_native_stats(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    nt = report["trajectory_native"]
-    assert _v(nt["agent_steps_total"]) == 3
-    assert _v(nt["tool_calls_total"]) == 1
-    fp = _v(nt["fields_present_on_steps"])
-    assert fp["step_id"] == "3/3"
-    assert fp["message"] == "3/3"
-    assert fp["tool_calls"] == "1/3"
+    assert report["counts"] == {"trials": 2, "problems": 2, "repeats": 1}
+    assert report["score"]["mean_reward"] == 0.75
 
 
-def test_wire_captures_match_steps(bundle: Path) -> None:
+def test_tokens_section(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    wc = report["wire_captures"]
-    assert _v(wc["total_observed"]) == 3
-    assert _v(wc["finish_reasons"]) == {"stop": 2, "tool_calls": 1}
-    delta = _v(report["mismatches"]["agent_steps_vs_wire_calls"])
-    assert delta == {
-        "trials_with_more_wire_than_steps": 0,
-        "trials_with_fewer_wire_than_steps": 0,
-        "trials_with_equal_counts": 2,
-    }
-
-
-def test_token_reconciliation(bundle: Path) -> None:
-    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    tokens = _v(report["mismatches"]["tokens"])
+    t = report["tokens"]
     # 2 trials × (pt+ct): trial0=15, trial1=20+10+30+8=68 → 83 across all
-    assert tokens["per_step_total"] == 83
-    assert tokens["wire_total"] == 83
-    assert tokens["ref_total"] == 83
-    assert tokens["match_ref_vs_wire"] is True
+    assert t["per_step_sum"] == 83
+    assert t["wire_total"] == 83
+    assert t["final_metrics_total"] == 83
+    assert t["per_step_matches_wire"] is True
+    assert t["final_metrics_matches_wire"] is True
+    assert t["trials_with_per_step_vs_final_metrics_mismatch"] == 0
 
 
-def test_atif_per_trial_presence(bundle: Path) -> None:
+def test_wire_calls_section(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    pres = _v(report["presence"]["atif_trajectory_fields"])
-    assert pres["schema_version"] == "2/2"
-    assert pres["session_id"] == "2/2"
-    assert pres["agent.name"] == "2/2"
-    assert pres["final_metrics.total_steps"] == "2/2"
+    wc = report["wire_calls"]
+    assert wc["total"] == 3
+    assert wc["unique"] == 3
+    assert wc["duplicates_total"] == 0
+    assert wc["trials_with_duplicates"] == 0
+    assert wc["trials_with_more_wire_than_steps"] == 0
+    assert wc["trials_with_fewer_wire_than_steps"] == 0
+    assert wc["finish_reasons"] == {"stop": 2, "tool_calls": 1}
+
+
+def test_field_coverage_per_trial_and_step(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
+    fc = report["field_coverage"]
+    assert fc["agent_step_count"] == 3
+    # Per-trial required + ATIF trajectory fields
+    pt = fc["per_trial"]
+    assert pt["problem_idx"] == "2/2"
+    assert pt["reward"] == "2/2"
+    assert pt["trajectory[0].schema_version"] == "2/2"
+    assert pt["trajectory[0].agent.name"] == "2/2"
+    # Per-step ATIF coverage
+    ps = fc["per_agent_step"]
+    assert ps["step_id"] == "3/3"
+    assert ps["metrics.prompt_tokens"] == "3/3"
+    assert ps["metrics.extra.latency_ms"] == "0/3"  # not set in fixture
+    assert ps["metrics.extra.finish_reason"] == "0/3"
+
+
+def test_score_mean_reward_correct(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    (bench / "eval-test.json").write_text(json.dumps({"benchmark": {"scores": {"summary": {"mean": 1.0}}}}))
+    score = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["score"]
+    assert score["mean_reward"] == 1.0
+    assert score["reported_mean"] == 1.0
+    assert score["is_mean_reward_correct"] is True
 
 
 def test_no_benches_returns_none(tmp_path: Path) -> None:
     assert generate_trajectories_report(tmp_path) is None
 
 
-def test_missing_wire_captures_are_flagged(tmp_path: Path) -> None:
+def test_wire_duplicates_via_request_hash(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
     _write_jsonl(
         bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="hi", pt=5, ct=3), _agent_step(1, msg="bye", pt=4, ct=2)])],
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
     )
-    # only 1 wire call vs 2 agent steps
-    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=5, completion=3)])
-    report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
-    assert _v(report["mismatches"]["agent_steps_vs_wire_calls"]) == {
-        "trials_with_more_wire_than_steps": 0,
-        "trials_with_fewer_wire_than_steps": 1,
-        "trials_with_equal_counts": 0,
-    }
+    # Two records with same request_hash → exact dedup catches it
+    dup = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "abc"}
+    _write_jsonl(bench / "model_traffic.jsonl", [dup, dup])
+    wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
+    assert wc["total"] == 2
+    assert wc["unique"] == 1
+    assert wc["duplicates_total"] == 1
+    assert wc["trials_with_duplicates"] == 1
 
 
-def test_enrich_writes_enriched_jsonl_and_reports_changes(bundle: Path) -> None:
-    out = generate_trajectories_report(bundle, enrich=True)
-    assert out is not None
-    enriched = bundle / "pinchbench" / "trajectories_enriched.jsonl"
-    assert enriched.is_file()
-    report = json.loads(out.read_text())["benchmarks"][0]
-    enrichment = _v(report["enrichment"])
-    # Bundle fixture has steps with non-zero pt/ct already, so no backfill
-    # *for those*, but latency_ms/finish_reason aren't set on the steps and
-    # are present on the wire rows.
-    assert enrichment["rows_written"] == 2
-    assert enrichment["steps_backfilled_latency_ms"] >= 1
-    assert enrichment["steps_backfilled_finish_reason"] >= 1
-
-
-def test_enrich_all_or_nothing_per_trial(tmp_path: Path) -> None:
-    """When wire-call count != step count, stash everything in extra and
-    leave step metrics untouched (no partial splice that misattributes)."""
+def test_wire_dedup_fallback_when_no_request_hash(tmp_path: Path) -> None:
+    """Older rows without request_hash use the heuristic response-side key."""
     bench = tmp_path / "pb"
-    # Trial 0: 2 steps, 1 wire call -> stash (no splice)
-    s1 = _agent_step(0, msg="a", pt=0, ct=0)
-    s2 = _agent_step(1, msg="b", pt=0, ct=0)
-    _write_jsonl(bench / "trajectories.jsonl", [_trial(0, 0, reward=0.0, steps=[s1, s2])])
-    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=10, completion=5)])
-
-    out = generate_trajectories_report(tmp_path, enrich=True)
-    counts = _v(json.loads(out.read_text())["benchmarks"][0]["enrichment"])
-    assert counts["trials_spliced"] == 0
-    assert counts["trials_stashed_unmatched"] == 1
-    # Crucially, step metrics were NOT touched (no partial splice).
-    assert counts["steps_backfilled_prompt_tokens"] == 0
-
-    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
-    steps = [s for s in enriched["trajectory"][0]["steps"] if s.get("source") == "agent"]
-    # both steps still have zero/none tokens
-    for s in steps:
-        m = s.get("metrics") or {}
-        assert not m.get("prompt_tokens")
-        assert not m.get("completion_tokens")
-    # All wire calls stashed in extra.captured_model_calls
-    stash = enriched["trajectory"][0].get("extra", {}).get("captured_model_calls")
-    assert isinstance(stash, list) and len(stash) == 1
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    rec = _wire(0, 0, prompt=10, completion=5)
+    _write_jsonl(bench / "model_traffic.jsonl", [rec, rec])
+    wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
+    assert wc["duplicates_total"] == 1
 
 
-def test_enrich_backfills_zero_token_steps(tmp_path: Path) -> None:
+def test_step_wire_mismatch_after_dedup(tmp_path: Path) -> None:
+    """1 step + 2 identical wires → dedup resolves the mismatch."""
     bench = tmp_path / "pb"
-    # step with zero tokens, wire call has real tokens — should backfill
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    rec = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "h0"}
+    _write_jsonl(bench / "model_traffic.jsonl", [rec, rec])
+    wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
+    # raw counts disagree (1 step vs 2 wires)
+    assert wc["trials_with_more_wire_than_steps"] == 1
+    # after dedup resolves
+    assert wc["trials_with_step_wire_mismatch_after_dedup"] == 0
+
+
+def test_tokens_per_step_vs_wire_mismatch(tmp_path: Path) -> None:
+    """per_step_sum=0 but wire_total>0 → bug surface that enrichment fixes."""
+    bench = tmp_path / "pb"
     _write_jsonl(
         bench / "trajectories.jsonl",
         [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=0, ct=0)])],
     )
     _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=42, completion=7)])
-    out = generate_trajectories_report(tmp_path, enrich=True)
-    enriched_rows = []
-    with (bench / "trajectories_enriched.jsonl").open() as fh:
-        for line in fh:
-            enriched_rows.append(json.loads(line))
-    step = enriched_rows[0]["trajectory"][0]["steps"][0]
-    assert step["metrics"]["prompt_tokens"] == 42
-    assert step["metrics"]["completion_tokens"] == 7
-    counts = _v(json.loads(out.read_text())["benchmarks"][0]["enrichment"])
-    assert counts["steps_backfilled_prompt_tokens"] == 1
-    assert counts["steps_backfilled_completion_tokens"] == 1
+    t = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["tokens"]
+    assert t["per_step_sum"] == 0
+    assert t["wire_total"] == 49
+    assert t["per_step_matches_wire"] is False
 
 
-def test_stashed_model_calls_audit(tmp_path: Path) -> None:
-    """After enrichment with mismatch, the stash audit reflects what's in extra.captured_model_calls."""
+def test_enrich_writes_enriched_jsonl_and_reports_changes(bundle: Path) -> None:
+    out = generate_trajectories_report(bundle, enrich=True)
+    enriched = bundle / "pinchbench" / "trajectories_enriched.jsonl"
+    assert enriched.is_file()
+    report = json.loads(out.read_text())["benchmarks"][0]
+    enrichment = report["enrichment"]
+    assert enrichment["trials_spliced_1_to_1"] == 2
+    assert enrichment["trials_with_unmatched_calls_stashed"] == 0
+    # latency / finish_reason weren't on steps before; backfilled now
+    assert enrichment["steps_backfilled"]["latency_ms"] >= 1
+    assert enrichment["steps_backfilled"]["finish_reason"] >= 1
+    # The after-state coverage is right there in the report
+    after = enrichment["step_field_coverage_after_enrichment"]
+    assert after["metrics.extra.latency_ms"] == "3/3"
+    assert after["metrics.extra.finish_reason"] == "3/3"
+
+
+def test_enrich_all_or_nothing_per_trial(tmp_path: Path) -> None:
+    """When wire-call count != step count, stash everything; never partial-splice."""
     bench = tmp_path / "pb"
-    # 1 step, 2 wire calls → mismatch → all 2 calls stashed
+    # 2 steps, 1 wire call → stash
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=0.0, steps=[_agent_step(0, msg="a", pt=0, ct=0), _agent_step(1, msg="b", pt=0, ct=0)])],
+    )
+    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=10, completion=5)])
+    report = json.loads(generate_trajectories_report(tmp_path, enrich=True).read_text())["benchmarks"][0]
+    enr = report["enrichment"]
+    assert enr["trials_spliced_1_to_1"] == 0
+    assert enr["trials_with_unmatched_calls_stashed"] == 1
+    # No step-level backfill (partial splice would misattribute)
+    assert enr["steps_backfilled"]["prompt_tokens"] == 0
+    # The wire call landed in extra.captured_model_calls
+    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
+    stash = enriched["trajectory"][0].get("extra", {}).get("captured_model_calls")
+    assert isinstance(stash, list) and len(stash) == 1
+
+
+def test_enrich_backfills_zero_token_steps(tmp_path: Path) -> None:
+    """1 step with zero tokens + 1 wire call → splice fills them in."""
+    bench = tmp_path / "pb"
     _write_jsonl(
         bench / "trajectories.jsonl",
         [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=0, ct=0)])],
     )
-    _write_jsonl(
-        bench / "model_traffic.jsonl",
-        [_wire(0, 0, prompt=10, completion=5), _wire(0, 0, prompt=12, completion=3)],
-    )
-    out = generate_trajectories_report(tmp_path, enrich=True)
-    report = json.loads(out.read_text())["benchmarks"][0]
-    # First call: builds report from ORIGINAL trajectories.jsonl (no stash yet),
-    # so stash audit is 0/0 — that's still useful as a baseline.
-    s = _v(report["stashed_model_calls"])
-    assert s["trials_with_stashed_calls"] == 0
-    # But a second pass on the same dir (now reading the enriched file as
-    # input) is out of scope — the stash audit is over trajectories.jsonl
-    # not trajectories_enriched.jsonl. Still verify the enriched file has
-    # them where they should be:
-    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
-    stash = enriched["trajectory"][0].get("extra", {}).get("captured_model_calls")
-    assert isinstance(stash, list) and len(stash) == 2
+    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=42, completion=7)])
+    generate_trajectories_report(tmp_path, enrich=True)
+    enriched_step = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])["trajectory"][0][
+        "steps"
+    ][0]
+    assert enriched_step["metrics"]["prompt_tokens"] == 42
+    assert enriched_step["metrics"]["completion_tokens"] == 7
 
 
-def test_required_row_fields_presence(bundle: Path) -> None:
-    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    rrf = _v(report["presence"]["row_required_fields"])
-    assert rrf["problem_idx"] == "2/2"
-    assert rrf["repeat"] == "2/2"
-    assert rrf["reward"] == "2/2"
-    assert rrf["trajectory"] == "2/2"
-    assert rrf["model"] == "2/2"
+def test_enrichment_section_absent_when_enrich_false(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle, enrich=False).read_text())["benchmarks"][0]
+    assert "enrichment" not in report
 
 
-def test_step_field_presence_extended(bundle: Path) -> None:
-    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    fp = _v(report["trajectory_native"]["fields_present_on_steps"])
-    # The fixture sets metrics.{prompt,completion,total}_tokens on every step.
-    assert fp["metrics.prompt_tokens"] == "3/3"
-    assert fp["metrics.completion_tokens"] == "3/3"
-    assert fp["metrics.total_tokens"] == "3/3"
-    # Fixture has no timestamp/model_name/status_code/extra fields → all 0/3
-    assert fp["timestamp"] == "0/3"
-    assert fp["metrics.extra.latency_ms"] == "0/3"
-    assert fp["metrics.extra.finish_reason"] == "0/3"
-
-
-def test_post_wire_dedup_mismatch_and_per_step_total_consistency(tmp_path: Path) -> None:
+def test_non_uniform_repeats_returns_histogram(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
-    # 1 step, 2 identical wire rows (1 dup). After wire-dedup,
-    # unique wire count is 1 -> matches step count.
-    s = _agent_step(0, msg="x", pt=10, ct=5)
-    _write_jsonl(bench / "trajectories.jsonl", [_trial(0, 0, reward=1.0, steps=[s])])
-    w = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "h0"}
-    _write_jsonl(bench / "model_traffic.jsonl", [w, w])
-    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert _v(a["duplicate_wire_calls_in_trial_total"]) == 1
-    # raw mismatch: 1 step vs 2 wire rows
-    assert _v(a["mismatched_steps_vs_wire_trials"]) == 1
-    # after wire-dedup: 1 step vs 1 unique wire row -> resolved
-    assert _v(a["mismatched_steps_vs_wire_trials_after_wire_dedup"]) == 0
-    # 1 step × 15 tokens = 15; final_metrics.total = 15 → consistent
-    assert _v(a["trials_with_per_step_vs_final_metrics_token_mismatch"]) == 0
-
-
-def test_anomalies_zero_token_steps(tmp_path: Path) -> None:
-    bench = tmp_path / "pb"
-    # trial 0: 2 zero-token steps; trial 1: 1 healthy + 1 zero
+    # problem 0: 2 repeats; problem 1: 1 repeat → non-uniform
     _write_jsonl(
         bench / "trajectories.jsonl",
         [
-            _trial(
-                0,
-                0,
-                reward=0.0,
-                steps=[
-                    _agent_step(0, msg="a", pt=0, ct=0),
-                    _agent_step(1, msg="b", pt=0, ct=0),
-                ],
-            ),
-            _trial(
-                1,
-                0,
-                reward=1.0,
-                steps=[
-                    _agent_step(0, msg="c", pt=10, ct=5),
-                    _agent_step(1, msg="d", pt=0, ct=0),
-                ],
-            ),
+            _trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="a", pt=5, ct=3)]),
+            _trial(0, 1, reward=1.0, steps=[_agent_step(0, msg="b", pt=5, ct=3)]),
+            _trial(1, 0, reward=0.0, steps=[_agent_step(0, msg="c", pt=5, ct=3)]),
         ],
     )
     _write_jsonl(bench / "model_traffic.jsonl", [])
-    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert _v(a["steps_with_zero_or_none_tokens"]) == 3
-    assert _v(a["trials_with_any_zero_token_step"]) == 2
-    assert _v(a["trials_with_all_zero_token_steps"]) == 1
-    # Every anomaly metric carries its calculation note
-    for key, val in a.items():
-        if key == "_note":
-            continue
-        assert "from" in val, f"{key} missing 'from' explanation"
-
-
-def test_no_step_side_duplicate_tracking(tmp_path: Path) -> None:
-    """Duplicates are only tracked for model_traffic.jsonl, not trajectory steps."""
-    bench = tmp_path / "pb"
-    _write_jsonl(
-        bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
-    )
-    _write_jsonl(bench / "model_traffic.jsonl", [])
-    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert "duplicate_steps_in_trial_total" not in a
-    assert "trials_with_duplicate_steps" not in a
-
-
-def test_stashed_section_only_when_enrich(tmp_path: Path) -> None:
-    bench = tmp_path / "pb"
-    _write_jsonl(
-        bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
-    )
-    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=5, completion=3)])
-
-    audit = json.loads(generate_trajectories_report(tmp_path, enrich=False).read_text())["benchmarks"][0]
-    assert "stashed_model_calls" not in audit
-
-    enriched_run = json.loads(generate_trajectories_report(tmp_path, enrich=True).read_text())["benchmarks"][0]
-    assert "stashed_model_calls" in enriched_run
-
-
-def test_wire_dedup_prefers_request_hash(tmp_path: Path) -> None:
-    """When records carry request_hash, the dedup key is exact (not heuristic)."""
-    bench = tmp_path / "pb"
-    _write_jsonl(
-        bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
-    )
-    # Two records with the SAME request_hash but different response stats —
-    # heuristic would miss this; request_hash catches it as a duplicate.
-    rec_a = {**_wire(0, 0, prompt=10, completion=5), "request_hash": "abc123abc123abc1"}
-    rec_b = {**_wire(0, 0, prompt=999, completion=999), "request_hash": "abc123abc123abc1", "latency_ms": 42.0}
-    _write_jsonl(bench / "model_traffic.jsonl", [rec_a, rec_b])
-    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert _v(a["duplicate_wire_calls_in_trial_total"]) == 1
-    assert "request_hash" in a["duplicate_wire_calls_in_trial_total"]["from"]
-
-
-def test_anomalies_duplicate_wire_calls(tmp_path: Path) -> None:
-    bench = tmp_path / "pb"
-    _write_jsonl(
-        bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
-    )
-    # Two model_traffic rows with identical fingerprints for trial (0,0)
-    dup = _wire(0, 0, prompt=5, completion=3)
-    _write_jsonl(bench / "model_traffic.jsonl", [dup, dup])
-    a = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["anomalies"]
-    assert _v(a["duplicate_wire_calls_in_trial_total"]) == 1
-    assert _v(a["trials_with_duplicate_wire_calls"]) == 1
-
-
-def test_is_mean_reward_correct(bundle: Path, tmp_path: Path) -> None:
-    # The bundle fixture doesn't ship an eval-*.json so reported_mean is None
-    # and is_mean_reward_correct stays None. Synthesize a matching bundle.
-    bench = tmp_path / "pb"
-    _write_jsonl(
-        bench / "trajectories.jsonl",
-        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
-    )
-    eval_path = bench / "eval-test.json"
-    eval_path.write_text(
-        json.dumps(
-            {
-                "benchmark": {"scores": {"summary": {"mean": 1.0}}},
-            }
-        ),
-        encoding="utf-8",
-    )
-    score = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["score"]
-    assert _v(score["mean_reward"]) == 1.0
-    assert _v(score["reported_mean"]) == 1.0
-    assert _v(score["is_mean_reward_correct"]) is True
+    repeats = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["counts"]["repeats"]
+    # Histogram (json keys are strings): 1 problem with 2 trials, 1 problem with 1 trial
+    assert repeats == {"2": 1, "1": 1}

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -146,7 +146,11 @@ def test_wire_captures_match_steps(bundle: Path) -> None:
     assert _v(wc["total_observed"]) == 3
     assert _v(wc["finish_reasons"]) == {"stop": 2, "tool_calls": 1}
     delta = _v(report["mismatches"]["agent_steps_vs_wire_calls"])
-    assert delta == {"captures>steps": 0, "captures<steps": 0, "equal": 2}
+    assert delta == {
+        "trials_with_more_wire_than_steps": 0,
+        "trials_with_fewer_wire_than_steps": 0,
+        "trials_with_equal_counts": 2,
+    }
 
 
 def test_token_reconciliation(bundle: Path) -> None:
@@ -161,7 +165,7 @@ def test_token_reconciliation(bundle: Path) -> None:
 
 def test_atif_per_trial_presence(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    pres = _v(report["atif_per_trial_presence"])
+    pres = _v(report["presence"]["atif_trajectory_fields"])
     assert pres["schema_version"] == "2/2"
     assert pres["session_id"] == "2/2"
     assert pres["agent.name"] == "2/2"
@@ -182,9 +186,9 @@ def test_missing_wire_captures_are_flagged(tmp_path: Path) -> None:
     _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=5, completion=3)])
     report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
     assert _v(report["mismatches"]["agent_steps_vs_wire_calls"]) == {
-        "captures>steps": 0,
-        "captures<steps": 1,
-        "equal": 0,
+        "trials_with_more_wire_than_steps": 0,
+        "trials_with_fewer_wire_than_steps": 1,
+        "trials_with_equal_counts": 0,
     }
 
 
@@ -282,7 +286,7 @@ def test_stashed_model_calls_audit(tmp_path: Path) -> None:
 
 def test_required_row_fields_presence(bundle: Path) -> None:
     report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
-    rrf = _v(report["row_required_fields_presence"])
+    rrf = _v(report["presence"]["row_required_fields"])
     assert rrf["problem_idx"] == "2/2"
     assert rrf["repeat"] == "2/2"
     assert rrf["reward"] == "2/2"
@@ -353,8 +357,10 @@ def test_anomalies_zero_token_steps(tmp_path: Path) -> None:
     assert _v(a["trials_with_any_zero_token_step"]) == 2
     assert _v(a["trials_with_all_zero_token_steps"]) == 1
     # Every anomaly metric carries its calculation note
-    for key in a:
-        assert "from" in a[key], f"{key} missing 'from' explanation"
+    for key, val in a.items():
+        if key == "_note":
+            continue
+        assert "from" in val, f"{key} missing 'from' explanation"
 
 
 def test_no_step_side_duplicate_tracking(tmp_path: Path) -> None:

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Audit report tests — pure file-to-file behavior over fixture jsonls."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from nemo_evaluator.reports.trajectories import generate_trajectories_report
+
+
+def _write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+
+
+def _trial(problem_idx: int, repeat: int, *, reward: float, steps: list[dict]) -> dict:
+    return {
+        "problem_idx": problem_idx,
+        "repeat": repeat,
+        "reward": reward,
+        "trajectory": [
+            {
+                "schema_version": "ATIF-v1.6",
+                "session_id": f"sess-{problem_idx}-{repeat}",
+                "agent": {"name": "test-agent", "version": "0.1", "model_name": "test-model"},
+                "steps": steps,
+                "final_metrics": {
+                    "total_prompt_tokens": sum((s.get("metrics") or {}).get("prompt_tokens", 0) for s in steps),
+                    "total_completion_tokens": sum(
+                        (s.get("metrics") or {}).get("completion_tokens", 0) for s in steps
+                    ),
+                    "total_steps": len(steps),
+                },
+            }
+        ],
+        "model": {"tokens": {"total": sum((s.get("metrics") or {}).get("total_tokens", 0) for s in steps)}},
+    }
+
+
+def _agent_step(step_id: int, *, msg: str, pt: int, ct: int, tool_calls: list | None = None) -> dict:
+    s: dict = {
+        "step_id": step_id,
+        "source": "agent",
+        "message": msg,
+        "metrics": {"prompt_tokens": pt, "completion_tokens": ct, "total_tokens": pt + ct},
+    }
+    if tool_calls is not None:
+        s["tool_calls"] = tool_calls
+    return s
+
+
+def _wire(problem_idx: int, repeat: int, *, prompt: int, completion: int, finish: str = "stop") -> dict:
+    return {
+        "problem_idx": problem_idx,
+        "repeat": repeat,
+        "session_id": f"sess-{problem_idx}-{repeat}",
+        "finish_reason": finish,
+        "usage": {"prompt_tokens": prompt, "completion_tokens": completion, "total_tokens": prompt + completion},
+        "latency_ms": 100.0,
+    }
+
+
+@pytest.fixture
+def bundle(tmp_path: Path) -> Path:
+    bench = tmp_path / "pinchbench"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [
+            _trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="hi", pt=10, ct=5)]),
+            _trial(1, 0, reward=0.5, steps=[
+                _agent_step(0, msg="thinking", pt=20, ct=10, tool_calls=[{"name": "search"}]),
+                _agent_step(1, msg="done", pt=30, ct=8),
+            ]),
+        ],
+    )
+    _write_jsonl(
+        bench / "model_traffic.jsonl",
+        [
+            _wire(0, 0, prompt=10, completion=5),
+            _wire(1, 0, prompt=20, completion=10, finish="tool_calls"),
+            _wire(1, 0, prompt=30, completion=8),
+        ],
+    )
+    return tmp_path
+
+
+def test_audit_writes_report(bundle: Path) -> None:
+    out = generate_trajectories_report(bundle)
+    assert out == bundle / "trajectories_report.json"
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "trajectories_report-v0.1"
+    assert len(payload["benchmarks"]) == 1
+
+
+def test_counts_and_score(bundle: Path) -> None:
+    out = generate_trajectories_report(bundle)
+    report = json.loads(out.read_text())["benchmarks"][0]
+    assert report["counts"] == {"n_trials": 2, "n_problems": 2, "repeats": 1}
+    # Mean of [1.0, 0.5] == 0.75
+    assert report["score"]["mean_reward"] == 0.75
+
+
+def test_trajectory_native_stats(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
+    nt = report["trajectory_native"]
+    assert nt["agent_steps_total"] == 3
+    assert nt["tool_calls_total"] == 1
+    fp = nt["fields_present_on_steps"]
+    assert fp["step_id"] == "3/3"
+    assert fp["message"] == "3/3"
+    assert fp["tool_calls"] == "1/3"
+
+
+def test_wire_captures_match_steps(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
+    wc = report["wire_captures"]
+    assert wc["total_observed"] == 3
+    assert wc["finish_reasons"] == {"stop": 2, "tool_calls": 1}
+    mm = report["mismatches"]
+    assert mm["agent_steps_vs_wire_calls"] == {"captures>steps": 0, "captures<steps": 0, "equal": 2}
+
+
+def test_token_reconciliation(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
+    tokens = report["mismatches"]["tokens"]
+    # 2 trials × (pt+ct): trial0=15, trial1=20+10+30+8=68 → 83 across all
+    assert tokens["per_step_total"] == 83
+    assert tokens["wire_total"] == 83
+    assert tokens["ref_total"] == 83
+    assert tokens["match_ref_vs_wire"] is True
+
+
+def test_atif_per_trial_presence(bundle: Path) -> None:
+    report = json.loads(generate_trajectories_report(bundle).read_text())["benchmarks"][0]
+    pres = report["atif_per_trial_presence"]
+    assert pres["schema_version"] == "2/2"
+    assert pres["session_id"] == "2/2"
+    assert pres["agent.name"] == "2/2"
+    assert pres["final_metrics.total_steps"] == "2/2"
+
+
+def test_no_benches_returns_none(tmp_path: Path) -> None:
+    assert generate_trajectories_report(tmp_path) is None
+
+
+def test_missing_wire_captures_are_flagged(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(0, 0, reward=1.0, steps=[_agent_step(0, msg="hi", pt=5, ct=3), _agent_step(1, msg="bye", pt=4, ct=2)])],
+    )
+    # only 1 wire call vs 2 agent steps
+    _write_jsonl(bench / "model_traffic.jsonl", [_wire(0, 0, prompt=5, completion=3)])
+    report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
+    assert report["mismatches"]["agent_steps_vs_wire_calls"] == {
+        "captures>steps": 0,
+        "captures<steps": 1,
+        "equal": 0,
+    }
+
+
+def test_enrich_flag_warns_but_does_not_write(bundle: Path, caplog) -> None:
+    out = generate_trajectories_report(bundle, enrich=True)
+    assert out is not None
+    assert not (bundle / "trajectories_enriched.jsonl").exists()
+    assert any("enrich=True" in rec.message for rec in caplog.records)

--- a/tests/test_slurm_sidecar_services.py
+++ b/tests/test_slurm_sidecar_services.py
@@ -268,6 +268,46 @@ class TestSimpleSolverSidecar:
         assert parsed.benchmarks[0].solver.image_detail == "auto"
 
 
+class TestSidecarOutputTrajectories:
+    """`output.trajectories.enrich` must propagate to the sidecar config so
+    the per-shard eval driver actually writes ``trajectories_enriched.jsonl``.
+
+    Regression: ``_extract_bench_config`` hand-built the sidecar ``output:``
+    block with only ``dir``, silently dropping ``trajectories.enrich``. The
+    runner then defaulted to ``enrich=False`` even when the source config
+    said otherwise, and no enriched JSONL was written.
+    """
+
+    def test_enrich_flag_survives_sidecar(self):
+        cfg = EvalConfig.model_validate(
+            {
+                "services": {
+                    "model": {
+                        "type": "api",
+                        "url": "https://example/v1",
+                        "protocol": "chat_completions",
+                        "model": "m",
+                    },
+                },
+                "benchmarks": [
+                    {
+                        "name": "pinchbench",
+                        "solver": {"type": "simple", "service": "model"},
+                    },
+                ],
+                "cluster": {
+                    "type": "slurm",
+                    "walltime": "02:00:00",
+                    "node_pools": {"gpu": {"partition": "batch", "nodes": 1}},
+                },
+                "output": {"trajectories": {"enrich": True}},
+            }
+        )
+        _, sidecars, _ = generate_sbatch(cfg)
+        parsed = _validate_sidecar(list(sidecars.values())[0])
+        assert parsed.output.trajectories.enrich is True
+
+
 class TestSidecarScoringServices:
     """Services referenced from scoring.metrics must appear in sidecar configs.
 


### PR DESCRIPTION
## Summary

Depends on #1071.

- Enriches agent step fields from `model_traffic.jsonl` wire rows (reasoning tokens, tool calls, timestamps)
- Propagates `output.trajectories.enrich` config to the SLURM sidecar so enrichment runs on cluster jobs

## Test plan

- [ ] `python -m pytest tests/ -v --tb=short -m "not network" -x`
- [ ] Verify enriched fields appear in trajectories report output
- [ ] Verify `nel eval run --dry-run` sbatch script includes enrich config in sidecar

Generated with [Claude Code](https://claude.com/claude-code)