### PR TITLE
feat: make swebench-multilingual hint stripping configurable

### DIFF
--- a/src/nemo_evaluator/environments/harbor.py
+++ b/src/nemo_evaluator/environments/harbor.py
@@ -703,11 +703,13 @@ class HarborEnvironment(EvalEnvironment):
         self,
         dataset_path: str | Path,
         num_examples: int | None = None,
+        keep_swebench_multilingual_hints: bool = True,
     ) -> None:
         super().__init__()
         self._dataset_path = Path(dataset_path)
         self._tasks: list[Path] = []
         self.name = self._dataset_path.name
+        self._keep_swebench_multilingual_hints = keep_swebench_multilingual_hints
         self._hints_strip_logged = False
 
         if not self._dataset_path.is_dir():
@@ -782,7 +784,7 @@ class HarborEnvironment(EvalEnvironment):
         # TODO: remove once harbor/adapters/swebench_multilingual/adapter.py
         # stops concatenating hints_text into instruction.md.
         hints_stripped = False
-        if _is_swebench_multilingual(self.name):
+        if _is_swebench_multilingual(self.name) and not self._keep_swebench_multilingual_hints:
             instruction, hints_stripped = _strip_swebench_hints_block(instruction)
             if hints_stripped and not self._hints_strip_logged:
                 logger.info(

--- a/src/nemo_evaluator/environments/registry.py
+++ b/src/nemo_evaluator/environments/registry.py
@@ -173,9 +173,16 @@ def _make_harbor(rest: str, **kwargs: Any) -> "EvalEnvironment":
         if not dataset_path.is_dir():
             raise KeyError(f"Harbor dataset {rest!r} not found in registry and {dataset_path} does not exist on disk.")
 
+    params = kwargs.get("params") or {}
+    keep_hints = params.get("keep_swebench_multilingual_hints", True)
+    if not isinstance(keep_hints, bool):
+        raise TypeError(
+            f"keep_swebench_multilingual_hints must be a bool, got {type(keep_hints).__name__}: {keep_hints!r}"
+        )
     return HarborEnvironment(
         dataset_path=dataset_path,
         num_examples=kwargs.get("num_examples"),
+        keep_swebench_multilingual_hints=keep_hints,
     )
 
 

--- a/src/nemo_evaluator/playbooks/swebench_multilingual.yaml
+++ b/src/nemo_evaluator/playbooks/swebench_multilingual.yaml
@@ -10,6 +10,11 @@ name: harbor://swebench_multilingual@1.0
 instruction_template: swebench-instruction.md
 max_concurrent: 20
 timeout: 10800.0
+params:
+  # The adapter concatenates the PR author's hints_text under a "## Hints"
+  # header. Kept by default pending FEP-1103 (whether to use hints is undecided);
+  # set false to strip them (official SWE-bench excludes hints_text).
+  keep_swebench_multilingual_hints: true
 solver:
   type: harbor
   service: model

--- a/tests/test_environments/test_harbor_instruction.py
+++ b/tests/test_environments/test_harbor_instruction.py
@@ -137,7 +137,7 @@ async def test_seed_strips_multilingual_hints_block(tmp_path):
         "apache__druid-12345",
         "Original bug report.\nSteps to reproduce.\n\n## Hints\n\nReviewer said: patch should go in X.java line 10.",
     )
-    env = HarborEnvironment(dataset_path=str(dataset))
+    env = HarborEnvironment(dataset_path=str(dataset), keep_swebench_multilingual_hints=False)
     seed = await env.seed(0)
     assert "## Hints" not in seed.prompt
     assert "Reviewer said" not in seed.prompt
@@ -182,7 +182,7 @@ async def test_seed_records_hints_stripped_in_metadata(tmp_path):
         "apache__druid-12345",
         "Problem body.\n\n## Hints\n\nsome body.",
     )
-    env = HarborEnvironment(dataset_path=str(dataset))
+    env = HarborEnvironment(dataset_path=str(dataset), keep_swebench_multilingual_hints=False)
     seed = await env.seed(0)
     assert seed.metadata.get("hints_stripped") is True
 
@@ -191,7 +191,7 @@ async def test_seed_records_hints_stripped_in_metadata(tmp_path):
 async def test_seed_omits_hints_stripped_when_noop(tmp_path):
     dataset = tmp_path / "swebench_multilingual@1.0"
     _make_task(dataset, "apache__druid-noop", "No hints here at all.")
-    env = HarborEnvironment(dataset_path=str(dataset))
+    env = HarborEnvironment(dataset_path=str(dataset), keep_swebench_multilingual_hints=False)
     seed = await env.seed(0)
     assert "hints_stripped" not in seed.metadata
 
@@ -202,10 +202,58 @@ async def test_seed_handles_adapter_canary_empty_hints_bytes(tmp_path):
     dataset = tmp_path / "swebench_multilingual@1.0"
     instruction_bytes = "Problem body text.\n\n## Hints\n\n\n"
     _make_task(dataset, "apache__druid-canary", instruction_bytes)
-    env = HarborEnvironment(dataset_path=str(dataset))
+    env = HarborEnvironment(dataset_path=str(dataset), keep_swebench_multilingual_hints=False)
     seed = await env.seed(0)
     assert "## Hints" not in seed.prompt
     assert seed.prompt == "Problem body text."
+    assert seed.metadata.get("hints_stripped") is True
+
+
+@pytest.mark.asyncio
+async def test_seed_keep_hints_true_preserves_multilingual_hints(tmp_path):
+    """``keep_swebench_multilingual_hints=True`` disables the strip."""
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    _make_task(
+        dataset,
+        "apache__druid-12345",
+        "Original bug report.\n\n## Hints\n\nReviewer said: patch X.java line 10.",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset), keep_swebench_multilingual_hints=True)
+    seed = await env.seed(0)
+    assert "## Hints" in seed.prompt
+    assert "Reviewer said" in seed.prompt
+    assert "hints_stripped" not in seed.metadata
+
+
+@pytest.mark.asyncio
+async def test_seed_default_keeps_multilingual_hints(tmp_path):
+    """The default (``keep_swebench_multilingual_hints=True``) preserves hints."""
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    _make_task(
+        dataset,
+        "apache__druid-12345",
+        "Original bug report.\n\n## Hints\n\nReviewer said: patch X.java line 10.",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+    assert "## Hints" in seed.prompt
+    assert "Reviewer said" in seed.prompt
+    assert "hints_stripped" not in seed.metadata
+
+
+@pytest.mark.asyncio
+async def test_seed_keep_hints_false_strips(tmp_path):
+    """``keep_swebench_multilingual_hints=False`` opts into the MR !82 strip."""
+    dataset = tmp_path / "swebench_multilingual@1.0"
+    _make_task(
+        dataset,
+        "apache__druid-12345",
+        "Original bug report.\n\n## Hints\n\nReviewer said: patch X.java line 10.",
+    )
+    env = HarborEnvironment(dataset_path=str(dataset), keep_swebench_multilingual_hints=False)
+    seed = await env.seed(0)
+    assert "## Hints" not in seed.prompt
+    assert "Reviewer said" not in seed.prompt
     assert seed.metadata.get("hints_stripped") is True
 
 
@@ -220,7 +268,7 @@ async def test_seed_handles_adapter_normal_hints_bytes(tmp_path):
         "reply: I'll patch it tomorrow.\n"
     )
     _make_task(dataset, "apache__druid-hints", instruction_bytes)
-    env = HarborEnvironment(dataset_path=str(dataset))
+    env = HarborEnvironment(dataset_path=str(dataset), keep_swebench_multilingual_hints=False)
     seed = await env.seed(0)
     assert "## Hints" not in seed.prompt
     assert "maintainer" not in seed.prompt.lower()

--- a/tests/test_environments/test_registry_override.py
+++ b/tests/test_environments/test_registry_override.py
@@ -152,6 +152,52 @@ def test_make_harbor_dispatch_pre_staged(tmp_path, monkeypatch, uri, expected_ca
     assert env.name == expected_cache_subdir
 
 
+@pytest.mark.parametrize(
+    "params, expected_keep_hints",
+    [
+        (None, True),
+        ({}, True),
+        ({"keep_swebench_multilingual_hints": False}, False),
+        ({"keep_swebench_multilingual_hints": True}, True),
+    ],
+    ids=["no_params", "empty_params", "explicit_false", "explicit_true"],
+)
+def test_make_harbor_forwards_keep_hints_param(tmp_path, monkeypatch, params, expected_keep_hints):
+    """`_make_harbor` threads the ``keep_swebench_multilingual_hints`` param into the env."""
+    datasets_dir = tmp_path / "harbor_datasets"
+    pre_staged = datasets_dir / "swebench_multilingual@1.0"
+    pre_staged.mkdir(parents=True)
+    (pre_staged / "task-a").mkdir()
+    (pre_staged / "task-a" / "instruction.md").write_text("Do something")
+
+    monkeypatch.setenv("HARBOR_DATASETS_DIR", str(datasets_dir))
+    monkeypatch.setenv("HARBOR_REGISTRY", str(_write_base(tmp_path, [])))
+    monkeypatch.setenv("HARBOR_REGISTRY_OVERRIDE_DIR", str(tmp_path / "no-overrides"))
+
+    kwargs = {} if params is None else {"params": params}
+    env = _make_harbor("swebench_multilingual@1.0", **kwargs)
+    assert env._keep_swebench_multilingual_hints is expected_keep_hints
+
+
+@pytest.mark.parametrize(
+    "bad_value", ["false", "true", 1, 0, None], ids=["str_false", "str_true", "int_1", "int_0", "none"]
+)
+def test_make_harbor_rejects_non_bool_keep_hints(tmp_path, monkeypatch, bad_value):
+    """A non-bool ``keep_swebench_multilingual_hints`` fails fast (no truthiness coercion)."""
+    datasets_dir = tmp_path / "harbor_datasets"
+    pre_staged = datasets_dir / "swebench_multilingual@1.0"
+    pre_staged.mkdir(parents=True)
+    (pre_staged / "task-a").mkdir()
+    (pre_staged / "task-a" / "instruction.md").write_text("Do something")
+
+    monkeypatch.setenv("HARBOR_DATASETS_DIR", str(datasets_dir))
+    monkeypatch.setenv("HARBOR_REGISTRY", str(_write_base(tmp_path, [])))
+    monkeypatch.setenv("HARBOR_REGISTRY_OVERRIDE_DIR", str(tmp_path / "no-overrides"))
+
+    with pytest.raises(TypeError, match="keep_swebench_multilingual_hints must be a bool"):
+        _make_harbor("swebench_multilingual@1.0", params={"keep_swebench_multilingual_hints": bad_value})
+
+
 def test_local_override_dir_prefers_in_package_over_repo_root(tmp_path, monkeypatch):
     """Wheel installs ship the override dir as a package sibling.
 


### PR DESCRIPTION
## Summary
- The `## Hints` strip for SWE-bench Multilingual was hardcoded on for any `swebench_multilingual` dataset — no way to keep the PR-author hints (reproduce pre-strip numbers, ablate the effect of hints) without editing code.
- Adds a `keep_swebench_multilingual_hints` flag to `HarborEnvironment` that gates the strip in `seed()`, forwarded from the benchmark `params:` block through the `harbor://` URI factory (with fail-fast bool validation).
- Default is `true` (keep hints) pending **FEP-1103**, which decides whether multilingual hints should be used at all; set `false` to restore the strip (official SWE-bench excludes `hints_text`). Documented in the `swebench_multilingual` playbook.

```yaml
benchmarks:
  - playbook: swebench_multilingual
    params:
      keep_swebench_multilingual_hints: false   # opt back into the strip
```

## Testing
- `pytest tests/test_environments/test_harbor_instruction.py tests/test_environments/test_registry_override.py` — 52 passed
- Covers: default keeps hints, explicit `false` strips + sets `metadata["hints_stripped"]`, non-multilingual datasets untouched, `_make_harbor` param forwarding, and non-bool rejection (`TypeError`).

Ports internal MR (FEP-1102) to the public repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to control whether SWE-bench Multilingual “## Hints” text is preserved in generated prompts (enabled by default). Disabling it strips hints to align with official SWE-bench behavior.

* **Documentation**
  * Updated the SWE-bench Multilingual playbook to include this new default parameter and clarify its effect.

* **Tests**
  * Expanded test coverage for hint preservation/stripping behavior and for rejecting non-boolean configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->