### PR TITLE
fix: [FEP-1087] make reasoning_replay native mode work on vLLM >=0.19

### DIFF
--- a/src/nemo_evaluator/adapters/interceptors/reasoning_replay.py
+++ b/src/nemo_evaluator/adapters/interceptors/reasoning_replay.py
@@ -14,13 +14,18 @@
 # limitations under the License.
 """Cross-turn ``reasoning_content`` recovery.
 
-Caches ``reasoning_content`` from upstream responses (keyed by
-``tool_call.id``, with a content-hash fallback for text-only turns) and
+Caches the model's reasoning from upstream responses — the ``reasoning_content``
+field, falling back to ``reasoning`` (vLLM >=0.19 emits the latter) — keyed by
+``tool_call.id`` with a content-hash fallback for text-only turns, and
 re-injects it into matching assistant messages on the next outbound
-request.  Works around agent SDKs (OpenHands, pi-ai) that drop
-``reasoning_content`` from chat-completions assistant messages on
-replay, which would otherwise lose the model's chain-of-thought across
-turns.
+request.  Works around agent SDKs (OpenHands, pi-ai) that drop reasoning
+from chat-completions assistant messages on replay, which would otherwise
+lose the model's chain-of-thought across turns.
+
+In ``native`` / ``both`` modes the re-injection writes **both** the
+``reasoning`` and ``reasoning_content`` fields, because backends disagree on
+which one their chat-message parser reads on input (vLLM >=0.19 keys on
+``reasoning``; SGLang and older vLLM on ``reasoning_content``).
 
 Cache entries are scoped by ``ctx.extra["session_id"]``.
 
@@ -142,7 +147,7 @@ class Interceptor(RequestInterceptor, ResponseInterceptor):
                 msg = ch.get("message")
                 if not isinstance(msg, dict):
                     continue
-                rc = msg.get("reasoning_content")
+                rc = msg.get("reasoning_content") or msg.get("reasoning")
                 if not isinstance(rc, str) or not rc.strip():
                     continue
                 for key in _message_keys(msg, scope):
@@ -163,7 +168,7 @@ class Interceptor(RequestInterceptor, ResponseInterceptor):
             for msg in messages:
                 if not isinstance(msg, dict) or msg.get("role") != "assistant":
                     continue
-                native = msg.get("reasoning_content")
+                native = msg.get("reasoning_content") or msg.get("reasoning")
                 native_set = isinstance(native, str) and bool(native.strip())
                 if self._mode == "native" and native_set:
                     continue
@@ -199,10 +204,14 @@ class Interceptor(RequestInterceptor, ResponseInterceptor):
 
     def _apply(self, msg: dict, reasoning: str) -> bool:
         changed = False
-        native = msg.get("reasoning_content")
+        native = msg.get("reasoning_content") or msg.get("reasoning")
         native_set = isinstance(native, str) and bool(native.strip())
         if self._mode in ("native", "both") and not native_set:
+            # vLLM >=0.19 reads `reasoning` on input; SGLang and older vLLM read
+            # `reasoning_content`. Write both so re-injection survives whichever
+            # key the backend's chat-message parser honors.
             msg["reasoning_content"] = reasoning
+            msg["reasoning"] = reasoning
             changed = True
         if self._mode in ("think_tags", "both") and not _starts_with(msg.get("content"), self._tag_open):
             msg["content"] = _wrap(msg.get("content"), reasoning, self._tag_open, self._tag_close)

--- a/tests/test_adapters/test_interceptors.py
+++ b/tests/test_adapters/test_interceptors.py
@@ -679,6 +679,7 @@ async def test_reasoning_replay_native_round_trip():
     result = await ic.intercept_request(req)
     assistant = result.body["messages"][0]
     assert assistant["reasoning_content"] == "hidden chain"
+    assert assistant["reasoning"] == "hidden chain"
     assert assistant["content"] == "visible answer"
 
 
@@ -692,7 +693,89 @@ async def test_reasoning_replay_both_mode():
     result = await ic.intercept_request(req)
     assistant = result.body["messages"][0]
     assert assistant["reasoning_content"] == "hidden"
+    assert assistant["reasoning"] == "hidden"
     assert assistant["content"] == "<think>hidden</think>\ntext"
+
+
+async def test_reasoning_replay_native_writes_both_reasoning_fields():
+    ic = InterceptorRegistry.create("reasoning_replay", {"mode": "native"})
+    await ic.intercept_response(_resp_with_tool_call("hidden chain", "call_abc"))
+
+    req = _req({"messages": [_assistant_with_tool_call("call_abc", content="x")]})
+    result = await ic.intercept_request(req)
+    assistant = result.body["messages"][0]
+    assert assistant["reasoning"] == "hidden chain"
+    assert assistant["reasoning_content"] == "hidden chain"
+    assert req.ctx.extra["reasoning_replay_hits"] == 1
+
+
+async def test_reasoning_replay_caches_from_reasoning_field():
+    ic = InterceptorRegistry.create("reasoning_replay")
+    resp = _resp(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning": "from-reasoning-field",
+                        "tool_calls": [
+                            {
+                                "id": "call_v",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+    await ic.intercept_response(resp)
+    assert ic._get("|c:call_v") == "from-reasoning-field"
+
+
+async def test_reasoning_replay_native_skips_when_reasoning_field_set():
+    ic = InterceptorRegistry.create("reasoning_replay", {"mode": "native"})
+    await ic.intercept_response(_resp_with_tool_call("from-cache", "call_abc"))
+
+    msg = _assistant_with_tool_call("call_abc", content="x")
+    msg["reasoning"] = "agent-set"
+    req = _req({"messages": [msg]})
+    result = await ic.intercept_request(req)
+    assert result.body["messages"][0]["reasoning"] == "agent-set"
+    assert "reasoning_replay_hits" not in req.ctx.extra
+
+
+async def test_reasoning_replay_standalone_vllm_field_round_trip():
+    ic = InterceptorRegistry.create("reasoning_replay", {"mode": "native"})
+    resp = _resp(
+        {
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning": "hidden chain",
+                        "tool_calls": [
+                            {
+                                "id": "call_abc",
+                                "type": "function",
+                                "function": {"name": "f", "arguments": "{}"},
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    )
+    await ic.intercept_response(resp)
+
+    req = _req({"messages": [_assistant_with_tool_call("call_abc", content="x")]})
+    result = await ic.intercept_request(req)
+    assistant = result.body["messages"][0]
+    assert assistant["reasoning"] == "hidden chain"
+    assert assistant["reasoning_content"] == "hidden chain"
 
 
 async def test_reasoning_replay_native_skips_when_already_set():


### PR DESCRIPTION
## Summary
- `reasoning_replay` `mode: native` silently dropped cross-turn chain-of-thought on vLLM ≥0.19: it wrote only the `reasoning_content` field, but vLLM's chat input parser (`chat_utils._parse_chat_message_content`) keys on the `reasoning` field and ignores `reasoning_content`, so the CoT was dropped before `apply_chat_template` → no cross-turn reasoning → ~2× longer agentic rollouts (Nemotron-Nano SWE-bench Verified: median 131 vs 69 turns, same accuracy).
- `intercept_response` likewise cached only from `reasoning_content`, which vLLM ≥0.19 never sets on responses.

## Fix
- `native`/`both` re-injection now writes **both** `reasoning` and `reasoning_content` (backends disagree on which key they read on input — vLLM ≥0.19 vs SGLang/older vLLM).
- Response caching falls back to `reasoning` when `reasoning_content` is absent, so `reasoning_replay` is self-sufficient without the companion `reasoning` normalizer for the vLLM field-rename case.
- Request-side skip-guard considers both fields. Default `think_tags` mode is unchanged.

## Testing
- `pytest tests/ -m "not network"` — full offline suite green (1653 passed); 4 new + 2 updated reasoning_replay tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning replay compatibility across backends by reading, caching, and re-injecting reasoning from whichever field is provided.
  * In native/both modes, the interceptor now preserves both `reasoning` and `reasoning_content`, and wraps cached hidden chain with the configured think tags.
  * Request-side replay is now correctly skipped when reasoning is already present.

* **Tests**
  * Expanded interceptor tests to cover native and both-mode behaviors, including round-trip verification and fallback/caching scenarios across different reasoning-field representations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->