### PR TITLE
feat: report AA-split solvable/unsolvable subset accuracy

### DIFF
--- a/src/nemo_evaluator/benchmarks/terminal_bench_hard.py
+++ b/src/nemo_evaluator/benchmarks/terminal_bench_hard.py
@@ -32,6 +32,7 @@ import logging
 from pathlib import Path
 
 from nemo_evaluator.benchmarks.terminal_bench_v1 import _ensure_dataset
+from nemo_evaluator.environments.base import SeedResult
 from nemo_evaluator.environments.harbor import HarborEnvironment
 from nemo_evaluator.environments.registry import register
 
@@ -98,6 +99,11 @@ class TerminalBenchHard(HarborEnvironment):
 
     _TASK_SET: frozenset[str] = _TB_HARD_TASKS
     _LABEL: str = "terminal-bench-hard"
+    # Tasks that fail even under the oracle solver — infra / task / upstream caps,
+    # not model capability. When non-empty, ``seed`` tags each task's ``category``
+    # as "solvable"/"unsolvable" so the standard category breakdown surfaces both
+    # subset accuracies alongside the full headline. Empty here; subsets opt in.
+    _UNSOLVABLE_TASKS: frozenset[str] = frozenset()
 
     def __init__(self, num_examples: int | None = None) -> None:
         dataset_path = _ensure_dataset()
@@ -119,6 +125,21 @@ class TerminalBenchHard(HarborEnvironment):
         if num_examples is not None:
             tasks = tasks[:num_examples]
         return tasks
+
+    @classmethod
+    def _subset_category(cls, task_id: str) -> str | None:
+        """Solvable/unsolvable bucket for ``task_id``; None when the benchmark
+        declares no unsolvable tasks (leaves ``category`` unset)."""
+        if not cls._UNSOLVABLE_TASKS:
+            return None
+        return "unsolvable" if task_id in cls._UNSOLVABLE_TASKS else "solvable"
+
+    async def seed(self, idx: int) -> SeedResult:
+        result = await super().seed(idx)
+        category = self._subset_category(result.metadata.get("task_id", ""))
+        if category is not None:
+            result.metadata["category"] = category
+        return result
 
 
 # AA-split — 44-task subset used by the AA scoring pipeline.
@@ -172,9 +193,24 @@ _TB_HARD_AA_SPLIT_TASKS: frozenset[str] = frozenset(
 )
 
 
+# AA-split tasks that fail even under the oracle solver — known infra/task/upstream
+# caps (oracle KNOWN_FAILURES; see FEVPR-175), not model capability. Tagged as the
+# "unsolvable" category so the "solvable"-subset accuracy is reported alongside the
+# full headline.
+_TB_HARD_AA_SPLIT_UNSOLVABLE: frozenset[str] = frozenset(
+    {
+        "feal-differential-cryptanalysis",
+        "install-windows-xp",
+        "make-doom-for-mips",
+        "run-pdp11-code",
+    }
+)
+
+
 @register("terminal-bench-hard-aa-split")
 class TerminalBenchHardAASplit(TerminalBenchHard):
     """Terminal-Bench Hard AA-split — 44-task subset for AA scoring."""
 
     _TASK_SET: frozenset[str] = _TB_HARD_AA_SPLIT_TASKS
     _LABEL: str = "terminal-bench-hard-aa-split"
+    _UNSOLVABLE_TASKS: frozenset[str] = _TB_HARD_AA_SPLIT_UNSOLVABLE

--- a/src/nemo_evaluator/benchmarks/terminal_bench_v1.py
+++ b/src/nemo_evaluator/benchmarks/terminal_bench_v1.py
@@ -100,6 +100,25 @@ def _find_tasks_dir(repo: Path) -> Path | None:
     return None
 
 
+_WORD2VEC_TASK = "word2vec-from-scratch"
+# Upstream downloads wikitext at build time by the bare id 'wikitext'; current
+# huggingface_hub rejects bare ids (requires 'namespace/name'), failing the image
+# build. 'Salesforce/wikitext' is the canonical namespaced location (same configs).
+_WORD2VEC_BAD_DATASET_ID = "load_dataset('wikitext',"
+_WORD2VEC_FIXED_DATASET_ID = "load_dataset('Salesforce/wikitext',"
+
+
+def _patch_word2vec_dataset_id(output_dir: Path) -> None:
+    """Namespace the wikitext dataset id so the build-time download resolves."""
+    dockerfile = output_dir / _WORD2VEC_TASK / "environment" / "Dockerfile"
+    if not dockerfile.exists():
+        return
+    text = dockerfile.read_text(encoding="utf-8")
+    if _WORD2VEC_BAD_DATASET_ID not in text:
+        return
+    dockerfile.write_text(text.replace(_WORD2VEC_BAD_DATASET_ID, _WORD2VEC_FIXED_DATASET_ID), encoding="utf-8")
+
+
 def _patch_install_windows_xp_entrypoint(output_dir: Path) -> None:
     """Patch upstream's service ENTRYPOINT into a command-friendly wrapper."""
     env_dir = output_dir / _XP_TASK / "environment"
@@ -131,6 +150,7 @@ def _ensure_dataset(datasets_dir: str | None = None) -> Path:
 
     if marker.exists():
         _patch_install_windows_xp_entrypoint(output_dir)
+        _patch_word2vec_dataset_id(output_dir)
         n = sum(1 for d in output_dir.iterdir() if d.is_dir() and (d / "instruction.md").exists())
         logger.info("terminal-bench-v1: %d cached tasks", n)
         return output_dir
@@ -168,6 +188,7 @@ def _ensure_dataset(datasets_dir: str | None = None) -> Path:
                 failed += 1
 
         _patch_install_windows_xp_entrypoint(output_dir)
+        _patch_word2vec_dataset_id(output_dir)
         logger.info(
             "terminal-bench-v1: mapped %d tasks (%d failed)",
             mapped,

--- a/tests/test_integration/test_terminal_bench_v1.py
+++ b/tests/test_integration/test_terminal_bench_v1.py
@@ -30,6 +30,7 @@ from nemo_evaluator.benchmarks.terminal_bench_v1 import (
     TerminalBenchV1,
     _ensure_dataset,
     _find_tasks_dir,
+    _patch_word2vec_dataset_id,
 )
 from nemo_evaluator.environments.base import SeedResult
 from nemo_evaluator.environments.harbor import HarborEnvironment
@@ -286,3 +287,37 @@ class TestTerminalBenchHardAASplit:
         env = TerminalBenchHardAASplit.__new__(TerminalBenchHardAASplit)
         result = await env.seed(0)
         assert result.metadata["category"] == "unsolvable"
+
+
+WORD2VEC_BAD_DOCKERFILE = """\
+FROM ghcr.io/laude-institute/t-bench/python-3-13:latest
+RUN pip install "datasets==2.21.0"
+RUN python -c "import os; from datasets import load_dataset; ds=load_dataset('wikitext','wikitext-2-v1')"
+WORKDIR /app
+"""
+
+
+class TestWord2vecDatasetPatch:
+    def _make_dockerfile(self, root: Path, text: str) -> Path:
+        env_dir = root / "word2vec-from-scratch" / "environment"
+        env_dir.mkdir(parents=True)
+        df = env_dir / "Dockerfile"
+        df.write_text(text)
+        return df
+
+    def test_namespaces_bare_wikitext_id(self, tmp_path):
+        df = self._make_dockerfile(tmp_path, WORD2VEC_BAD_DOCKERFILE)
+        _patch_word2vec_dataset_id(tmp_path)
+        text = df.read_text()
+        assert "load_dataset('Salesforce/wikitext','wikitext-2-v1')" in text
+        assert "load_dataset('wikitext'," not in text
+
+    def test_idempotent(self, tmp_path):
+        df = self._make_dockerfile(tmp_path, WORD2VEC_BAD_DOCKERFILE)
+        _patch_word2vec_dataset_id(tmp_path)
+        after_first = df.read_text()
+        _patch_word2vec_dataset_id(tmp_path)
+        assert df.read_text() == after_first
+
+    def test_noop_when_dockerfile_missing(self, tmp_path):
+        _patch_word2vec_dataset_id(tmp_path)  # no word2vec task dir → must not raise

--- a/tests/test_integration/test_terminal_bench_v1.py
+++ b/tests/test_integration/test_terminal_bench_v1.py
@@ -20,14 +20,19 @@ from unittest.mock import patch
 import pytest
 
 from nemo_evaluator.benchmarks.terminal_bench_hard import (
+    _TB_HARD_AA_SPLIT_TASKS,
+    _TB_HARD_AA_SPLIT_UNSOLVABLE,
     _TB_HARD_TASKS,
     TerminalBenchHard,
+    TerminalBenchHardAASplit,
 )
 from nemo_evaluator.benchmarks.terminal_bench_v1 import (
     TerminalBenchV1,
     _ensure_dataset,
     _find_tasks_dir,
 )
+from nemo_evaluator.environments.base import SeedResult
+from nemo_evaluator.environments.harbor import HarborEnvironment
 
 MINIMAL_TASK_YAML = """\
 instruction: "Do something useful"
@@ -244,3 +249,40 @@ class TestTerminalBenchHard:
         assert "aimo-airline-departures" in task_names
         assert "blind-maze-explorer-5x5" in task_names
         assert "unknown-task" not in task_names
+
+
+class TestTerminalBenchHardAASplit:
+    def test_registered_as_builtin(self):
+        from nemo_evaluator.environments.registry import _REGISTRY
+
+        assert "terminal-bench-hard-aa-split" in _REGISTRY
+        assert _REGISTRY["terminal-bench-hard-aa-split"] is TerminalBenchHardAASplit
+
+    def test_task_list_has_44_entries(self):
+        assert len(_TB_HARD_AA_SPLIT_TASKS) == 44
+
+    def test_unsolvable_is_subset_of_split(self):
+        # Guard against typos / drift: an "unsolvable" id that is not a real
+        # AA-split task would silently never match and mislabel the breakdown.
+        assert _TB_HARD_AA_SPLIT_UNSOLVABLE <= _TB_HARD_AA_SPLIT_TASKS
+        assert len(_TB_HARD_AA_SPLIT_UNSOLVABLE) == 4
+
+    def test_subset_category_buckets_tasks(self):
+        assert TerminalBenchHardAASplit._subset_category("make-doom-for-mips") == "unsolvable"
+        assert TerminalBenchHardAASplit._subset_category("run-pdp11-code") == "unsolvable"
+        assert TerminalBenchHardAASplit._subset_category("aimo-airline-departures") == "solvable"
+        assert TerminalBenchHardAASplit._subset_category("play-zork") == "solvable"
+
+    def test_base_benchmark_leaves_category_unset(self):
+        # The 47-task variant declares no unsolvable set, so it must not tag a
+        # category (preserves existing behavior; no spurious breakdown).
+        assert TerminalBenchHard._subset_category("make-doom-for-mips") is None
+
+    async def test_seed_tags_category(self, monkeypatch):
+        async def fake_seed(self, idx):
+            return SeedResult(prompt="x", expected_answer="", metadata={"task_id": "make-doom-for-mips"})
+
+        monkeypatch.setattr(HarborEnvironment, "seed", fake_seed)
+        env = TerminalBenchHardAASplit.__new__(TerminalBenchHardAASplit)
+        result = await env.seed(0)
+        assert result.metadata["category"] == "unsolvable"


### PR DESCRIPTION
terminal-bench-hard-aa-split now tags each task's category as "solvable" or "unsolvable", so the existing category breakdown reports solvable-only accuracy (39 tasks) alongside the full headline (43). The 4 unsolvable tasks fail under the oracle solver (infra/task/upstream caps, not model capability), so isolating them keeps the model-capability signal undiluted.

Reuses category_breakdown (no metrics/report changes) and works on both the single-shard and multi-shard merge paths. The 47-task terminal-bench-hard and terminal-bench-v1 variants are untouched (empty _UNSOLVABLE_TASKS leaves category unset).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added opt-in task subset categorization for Terminal Bench Hard, labeling tasks as solvable vs unsolvable and carrying this behavior into the AA-split hard variant.

* **Bug Fixes**
  * Fixed Word2Vec benchmark environment dataset loading by namespacing the wikitext dataset identifier during initial setup.

* **Tests**
  * Expanded terminal-bench-v1 integration coverage for AA-split hard behavior and added checks for the dataset patching helper (including idempotency and no-op behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->