### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nemo-evaluator"
-version = "0.3.0"
+version = "0.3.1"
 description = "NeMo Evaluator — benchmark environments, pluggable solvers, interceptor proxy, and decision-grade scoring for LLMs"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"

--- a/src/nemo_evaluator/__init__.py
+++ b/src/nemo_evaluator/__init__.py
@@ -18,7 +18,7 @@
 # can safely back-reference ``nemo_evaluator.__version__`` without triggering
 # a circular import while ``__init__.py`` is partially loaded. ``package_info``
 # remains the canonical source for the FW-CI-templates wheel patcher.
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 __package_name__ = "nemo_evaluator"
 
 from nemo_evaluator.engine.eval_loop import run_evaluation

--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -26,7 +26,7 @@ to keep them in sync.
 # Below is the _next_ version that will be published, not the currently published one.
 MAJOR = 0
 MINOR = 3
-PATCH = 0
+PATCH = 1
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
## Summary
- Bump `nemo-evaluator` `0.3.0` → `0.3.1` across the **three in-sync version sources**: `pyproject.toml`, `src/nemo_evaluator/__init__.py` (`__version__`), and `src/nemo_evaluator/package_info.py` (`MAJOR/MINOR/PATCH`).

## Why
We are aligning the harbor container-image tag line with the package version so the image tag and the packaged version stop diverging (today the image line is `0.18.x` while the package is `0.3.0`). This bump is the precursor to cutting the next image release as `0.3.1` (tagged on the GitLab mirror, where the image build infra lives) instead of continuing the legacy `0.18.x` line.

## Note for reviewers
`package_info.py` documents that its constants are kept in sync manually when `pyproject` is bumped (and that CI patches `PATCH` in-place for dry-run wheels). If the intended path is to bump the version via the release workflow rather than a manual PR, let me know and I will close this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package version to 0.3.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->