### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nemo-evaluator"
-version = "0.3.1"
+version = "0.3.2"
 description = "NeMo Evaluator — benchmark environments, pluggable solvers, interceptor proxy, and decision-grade scoring for LLMs"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"


### PR DESCRIPTION
Patch release to follow #1077.

`0.3.1` never produced a working container image (broken `Dockerfile.base` and `Dockerfile.skills` from two partial bulk syncs). `0.3.2` is the first buildable release.

**Merge order**: #1077 first, then this.