### PR TITLE
feat(harbor): flush partial trajectory on agent crash

### DIFF
--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -239,7 +239,9 @@ async def _download_agent_logs_inner(
             pass
 
 
-async def _patch_openhands_sdk(sandbox: "Sandbox", *, cmd_timeout: float | None = None) -> None:
+async def _patch_openhands_sdk(
+    sandbox: "Sandbox", *, cmd_timeout: float | None = None
+) -> None:
     """Apply runtime patches to the OpenHands SDK inside the sandbox.
 
     1. **Prevent premature FINISHED on text-only responses** — when the
@@ -541,6 +543,113 @@ print(f'cmd_timeout_{{_MAX}}s={{ok}} at {{p}}')
             )
     else:
         logger.info("Cmd timeout patch: skipped (cmd_timeout not configured)")
+
+    # -- Patch 4: flush trajectory on exit; handle session_budget_exhausted --
+    # events_list is populated AFTER conversation.run() returns, so anchoring
+    # there is too late — an exception during run() skips that code entirely.
+    # Instead anchor on conversation.send_message() (just before run()), capture
+    # references to conversation and llm, and reconstruct events in the flush
+    # handler from conversation.state.events.
+    _budget_flush_script = """\
+import sys
+p = '/installed-agent/run_agent.py'
+c = open(p).read()
+
+# Find 'conversation.send_message(' — executes before run(), so our setup
+# code runs even if run() raises.
+old = ind = None
+for line in c.splitlines():
+    s = line.lstrip()
+    if s.startswith('conversation.send_message('):
+        old = line
+        ind = line[: len(line) - len(s)]
+        break
+already = '_nel_flush_traj' in c
+ok = old is not None and not already
+print(f'anchor={repr(old)} ind={repr(ind)} already={already} ok={ok}')
+
+if ok:
+    lines = [
+        # capture refs before run() is called
+        '_nel_conv_ref = conversation',
+        '_nel_llm_ref = llm',
+        '_nel_model_ref = model',
+        'import atexit as _nel_at, json as _nel_json, os as _nel_os, sys as _nel_sys',
+        'def _nel_build_events():',
+        '    el = []',
+        '    try:',
+        '        from openhands.sdk.event import MessageEvent, ActionEvent, ObservationEvent',
+        '        for ev in _nel_conv_ref.state.events:',
+        '            ts = str(getattr(ev, "timestamp", ""))',
+        '            src = getattr(ev, "source", "")',
+        '            if isinstance(ev, MessageEvent):',
+        '                lm = getattr(ev, "llm_message", None)',
+        '                content = ""',
+        '                if lm:',
+        '                    mc = getattr(lm, "content", None)',
+        '                    if isinstance(mc, list):',
+        '                        content = chr(10).join(getattr(c, "text", str(c)) for c in mc if getattr(c, "text", None))',
+        '                    elif mc:',
+        '                        content = str(mc)',
+        '                tcs = []',
+        '                for tc in (getattr(ev, "tool_calls", None) or []):',
+        '                    tcs.append({"id": getattr(tc, "id", ""), "name": getattr(tc, "function_name", getattr(tc, "name", "")), "arguments": getattr(tc, "arguments", {})})',
+        '                entry = {"type": "user_message" if src == "user" else "assistant_message", "content": content, "timestamp": ts}',
+        '                if tcs: entry["tool_calls"] = tcs',
+        '                el.append(entry)',
+        '            elif isinstance(ev, ActionEvent):',
+        '                tcs = [{"id": getattr(ev, "tool_call_id", ""), "name": getattr(ev, "tool_name", ""), "arguments": {}}]',
+        '                el.append({"type": "assistant_message", "content": "", "tool_calls": tcs, "timestamp": ts})',
+        '            elif isinstance(ev, ObservationEvent):',
+        '                el.append({"type": "tool_result", "tool_call_id": getattr(ev, "tool_call_id", ""), "content": str(getattr(ev, "observation", "")), "timestamp": ts})',
+        '    except Exception: pass',
+        '    return el',
+        'def _nel_flush_traj():',
+        "    _p = '/logs/agent/trajectory.json'",
+        '    if _nel_os.path.exists(_p): return',
+        '    el = _nel_build_events()',
+        '    if not el: return',
+        "    bt = globals().get('build_trajectory')",
+        '    if bt is None:',
+        '        try:',
+        "            open(_p, 'w').write(_nel_json.dumps({'steps': el, 'agent': {'name': 'openhands-sdk'}, 'final_metrics': {}}))",
+        '        except Exception: pass',
+        '        return',
+        '    try:',
+        '        tu = getattr(getattr(_nel_llm_ref, "metrics", None), "accumulated_token_usage", None)',
+        '        metrics = {"prompt_tokens": getattr(tu, "prompt_tokens", 0), "completion_tokens": getattr(tu, "completion_tokens", 0), "cached_tokens": getattr(tu, "cache_read_tokens", 0), "cost_usd": 0}',
+        '        traj = bt(el, metrics, _nel_model_ref)',
+        '    except Exception: return',
+        '    try:',
+        "        open(_p, 'w').write(_nel_json.dumps(traj))",
+        '    except Exception: pass',
+        '_nel_at.register(_nel_flush_traj)',
+        '_nel_orig_eh = _nel_sys.excepthook',
+        'def _nel_eh(et, ev, tb):',
+        '    _nel_flush_traj()',
+        "    if et.__name__ == 'RateLimitError' and 'session_budget_exhausted' in str(ev):",
+        '        _nel_sys.exit(0)',
+        '    _nel_orig_eh(et, ev, tb)',
+        '_nel_sys.excepthook = _nel_eh',
+    ]
+    patch = '\\n' + '\\n'.join(ind + l for l in lines) + '\\n'
+    c = c.replace(old, old + patch, 1)
+    open(p, 'w').write(c)
+print(f'budget_flush={ok}')
+"""
+    encoded4 = base64.b64encode(_budget_flush_script.encode()).decode()
+    r4 = await sandbox.exec(
+        f"echo {encoded4} | base64 -d | python3",
+        timeout_sec=10,
+    )
+    stdout4 = (r4.stdout or "").strip()
+    logger.info("Budget-flush patch: %s", stdout4)
+    if r4.return_code != 0 or "False" in stdout4:
+        logger.warning(
+            "Budget-flush patch problem (rc=%d): %s",
+            r4.return_code,
+            stdout4 or (r4.stderr or "")[:300],
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1128,6 +1237,7 @@ class HarborSolver:
             if not adapter.is_mounted and sandbox.is_running:
                 await _download_agent_logs(sandbox, agent_logs_dir)
 
+
             # Let agent parse its own logs into context
             if context.is_empty() and hasattr(agent, "populate_context_post_run"):
                 try:
@@ -1201,8 +1311,15 @@ class HarborSolver:
                 etype = type(agent_error).__name__
                 if etype in _infra_error_names:
                     raise InfraError(f"Agent infrastructure failure: {etype}: {agent_error}") from agent_error
-                error = f"Agent crashed: {etype}: {agent_error}"
-                logger.warning("HarborSolver: %s", error)
+                if etype == "RateLimitError" and "session_budget_exhausted" in str(agent_error):
+                    # Patch 4 should have already caught this and exited cleanly;
+                    # if we still see the error here the patch anchor didn't match.
+                    # Treat as a turn-limit stop: no crash, no trajectory (patch failed).
+                    error = f"Agent reached turn limit (session_budget_exhausted): {agent_error}"
+                    logger.info("HarborSolver: turn limit exhausted (Patch 4 anchor may have missed): %s", agent_error)
+                else:
+                    error = f"Agent crashed: {etype}: {agent_error}"
+                    logger.warning("HarborSolver: %s", error)
             elif agent_timed_out and workspace_diff and _confirmed_zero_tokens:
                 error = (
                     f"Agent timed out with workspace changes but 0 completion "
@@ -1257,6 +1374,7 @@ class HarborSolver:
             except Exception:
                 logger.debug("Post-failure recovery failed", exc_info=True)
 
+
             recovered = _recover_from_logs(agent_logs_dir)
             trajectory = recovered["trajectory"] or build_atif_trajectory(
                 steps=[{"source": "system", "message": str(exc)}],
@@ -1299,6 +1417,7 @@ class HarborSolver:
                     await _download_agent_logs(sandbox, agent_logs_dir)
             except Exception:
                 logger.debug("Post-failure recovery failed", exc_info=True)
+
 
             recovered = _recover_from_logs(agent_logs_dir)
             trajectory = recovered["trajectory"] or build_atif_trajectory(

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -544,94 +544,40 @@ print(f'cmd_timeout_{{_MAX}}s={{ok}} at {{p}}')
     else:
         logger.info("Cmd timeout patch: skipped (cmd_timeout not configured)")
 
-    # -- Patch 4: flush trajectory on exit; handle session_budget_exhausted --
-    # events_list is populated AFTER conversation.run() returns, so anchoring
-    # there is too late — an exception during run() skips that code entirely.
-    # Instead anchor on conversation.send_message() (just before run()), capture
-    # references to conversation and llm, and reconstruct events in the flush
-    # handler from conversation.state.events.
+    # -- Patch 4: wrap conversation.run() so any crash still saves trajectory --
+    # Anchor 1: wrap `conversation.run()` in try/except BaseException so main()
+    # continues to the existing event-reconstruction + build_trajectory + save
+    # code on any failure — no duplication needed.
+    # Anchor 2: after the final print in main(), exit(0) cleanly so Harbor
+    # treats the run as a normal completion and downloads the trajectory.
     _budget_flush_script = """\
 import sys
 p = '/installed-agent/run_agent.py'
 c = open(p).read()
 
-# Find 'conversation.send_message(' — executes before run(), so our setup
-# code runs even if run() raises.
-old = ind = None
+old1 = ind = None
 for line in c.splitlines():
     s = line.lstrip()
-    if s.startswith('conversation.send_message('):
-        old = line
-        ind = line[: len(line) - len(s)]
-        break
-already = '_nel_flush_traj' in c
-ok = old is not None and not already
-print(f'anchor={repr(old)} ind={repr(ind)} already={already} ok={ok}')
+    if s == 'conversation.run()':
+        old1 = line; ind = line[:len(line)-len(s)]; break
+
+old2 = None
+for line in c.splitlines():
+    if 'Total cost:' in line and 'print' in line:
+        old2 = line; break
+
+already = '_nel_run_exc' in c
+ok = old1 is not None and old2 is not None and not already
+print(f'anchor1={repr(old1)} anchor2={repr(old2)} already={already} ok={ok}')
 
 if ok:
-    lines = [
-        # capture refs before run() is called
-        '_nel_conv_ref = conversation',
-        '_nel_llm_ref = llm',
-        '_nel_model_ref = model',
-        'import atexit as _nel_at, json as _nel_json, os as _nel_os, sys as _nel_sys',
-        'def _nel_build_events():',
-        '    el = []',
-        '    try:',
-        '        from openhands.sdk.event import MessageEvent, ActionEvent, ObservationEvent',
-        '        for ev in _nel_conv_ref.state.events:',
-        '            ts = str(getattr(ev, "timestamp", ""))',
-        '            src = getattr(ev, "source", "")',
-        '            if isinstance(ev, MessageEvent):',
-        '                lm = getattr(ev, "llm_message", None)',
-        '                content = ""',
-        '                if lm:',
-        '                    mc = getattr(lm, "content", None)',
-        '                    if isinstance(mc, list):',
-        '                        content = chr(10).join(getattr(c, "text", str(c)) for c in mc if getattr(c, "text", None))',
-        '                    elif mc:',
-        '                        content = str(mc)',
-        '                tcs = []',
-        '                for tc in (getattr(ev, "tool_calls", None) or []):',
-        '                    tcs.append({"id": getattr(tc, "id", ""), "name": getattr(tc, "function_name", getattr(tc, "name", "")), "arguments": getattr(tc, "arguments", {})})',
-        '                entry = {"type": "user_message" if src == "user" else "assistant_message", "content": content, "timestamp": ts}',
-        '                if tcs: entry["tool_calls"] = tcs',
-        '                el.append(entry)',
-        '            elif isinstance(ev, ActionEvent):',
-        '                tcs = [{"id": getattr(ev, "tool_call_id", ""), "name": getattr(ev, "tool_name", ""), "arguments": {}}]',
-        '                el.append({"type": "assistant_message", "content": "", "tool_calls": tcs, "timestamp": ts})',
-        '            elif isinstance(ev, ObservationEvent):',
-        '                el.append({"type": "tool_result", "tool_call_id": getattr(ev, "tool_call_id", ""), "content": str(getattr(ev, "observation", "")), "timestamp": ts})',
-        '    except Exception: pass',
-        '    return el',
-        'def _nel_flush_traj():',
-        "    _p = '/logs/agent/trajectory.json'",
-        '    if _nel_os.path.exists(_p): return',
-        '    el = _nel_build_events()',
-        '    if not el: return',
-        "    bt = globals().get('build_trajectory')",
-        '    if bt is None:',
-        '        try:',
-        "            open(_p, 'w').write(_nel_json.dumps({'steps': el, 'agent': {'name': 'openhands-sdk'}, 'final_metrics': {}}))",
-        '        except Exception: pass',
-        '        return',
-        '    try:',
-        '        tu = getattr(getattr(_nel_llm_ref, "metrics", None), "accumulated_token_usage", None)',
-        '        metrics = {"prompt_tokens": getattr(tu, "prompt_tokens", 0), "completion_tokens": getattr(tu, "completion_tokens", 0), "cached_tokens": getattr(tu, "cache_read_tokens", 0), "cost_usd": 0}',
-        '        traj = bt(el, metrics, _nel_model_ref)',
-        '    except Exception: return',
-        '    try:',
-        "        open(_p, 'w').write(_nel_json.dumps(traj))",
-        '    except Exception: pass',
-        '_nel_at.register(_nel_flush_traj)',
-        '_nel_orig_eh = _nel_sys.excepthook',
-        'def _nel_eh(et, ev, tb):',
-        '    _nel_flush_traj()',
-        '    _nel_sys.exit(0)',
-        '_nel_sys.excepthook = _nel_eh',
-    ]
-    patch = '\\n' + '\\n'.join(ind + l for l in lines) + '\\n'
-    c = c.replace(old, old + patch, 1)
+    wrap = (ind + '_nel_run_exc = None\\n' +
+            ind + 'try:\\n' +
+            ind + '    conversation.run()\\n' +
+            ind + 'except BaseException as _e:\\n' +
+            ind + '    _nel_run_exc = _e')
+    c = c.replace(old1, wrap, 1)
+    c = c.replace(old2, old2 + '\\n' + ind + 'if _nel_run_exc is not None: sys.exit(0)', 1)
     open(p, 'w').write(c)
 print(f'budget_flush={ok}')
 """

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -39,6 +39,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_INFRA_ERROR_NAMES = frozenset(
+    {
+        "ServiceUnavailableError",
+        "ConnectionError",
+        "TimeoutError",
+        "ConnectError",
+        "ReadTimeout",
+        "APIConnectionError",
+    }
+)
+
 
 def _resolve_agent_timeout(
     strategy: str,
@@ -239,7 +250,7 @@ async def _download_agent_logs_inner(
             pass
 
 
-async def _patch_openhands_sdk(sandbox: "Sandbox", *, cmd_timeout: float | None = None) -> None:
+async def _patch_openhands_sdk(sandbox: Sandbox, *, cmd_timeout: float | None = None) -> None:
     """Apply runtime patches to the OpenHands SDK inside the sandbox.
 
     1. **Prevent premature FINISHED on text-only responses** — when the
@@ -690,6 +701,26 @@ def _recover_from_logs(agent_logs_dir: Path) -> dict[str, Any]:
             return out
 
     return out
+
+
+def _error_from_crash_marker(agent_logs_dir: Path) -> str | None:
+    """Return a user-facing crash error from the agent sidecar, or raise infra errors."""
+    crash_file = agent_logs_dir / "nel_agent_error.json"
+    if not crash_file.is_file():
+        return None
+
+    try:
+        crash = json.loads(crash_file.read_text())
+        etype = crash.get("etype", "AgentCrash")
+        emsg = crash.get("emsg", "")
+        if etype in _INFRA_ERROR_NAMES:
+            raise InfraError(f"Agent infrastructure failure: {etype}: {emsg}")
+        return f"Agent crashed: {etype}: {emsg}"
+    except InfraError:
+        raise
+    except Exception:
+        logger.warning("HarborSolver: failed to read crash marker", exc_info=True)
+        return None
 
 
 def _parse_atif(raw: Any) -> dict[str, Any] | None:
@@ -1244,33 +1275,17 @@ class HarborSolver:
                 context.n_output_tokens is None and recovered["completion_tokens"] == 0 and not recovered["response"]
             )
 
-            _infra_error_names = {
-                "ServiceUnavailableError",
-                "ConnectionError",
-                "TimeoutError",
-                "ConnectError",
-                "ReadTimeout",
-                "APIConnectionError",
-            }
-
             error = None
             error_kind = ErrorKind.NONE
             if agent_error is not None:
                 etype = type(agent_error).__name__
-                if etype in _infra_error_names:
+                if etype in _INFRA_ERROR_NAMES:
                     raise InfraError(f"Agent infrastructure failure: {etype}: {agent_error}") from agent_error
                 error = f"Agent crashed: {etype}: {agent_error}"
                 logger.warning("HarborSolver: %s", error)
-            elif (_crash_file := agent_logs_dir / "nel_agent_error.json").is_file():
-                try:
-                    _crash = json.loads(_crash_file.read_text())
-                    _etype = _crash.get("etype", "AgentCrash")
-                    _emsg = _crash.get("emsg", "")
-                    if _etype not in _infra_error_names:
-                        error = f"Agent crashed: {_etype}: {_emsg}"
-                        logger.warning("HarborSolver: %s", error)
-                except Exception:
-                    logger.warning("HarborSolver: failed to read crash marker", exc_info=True)
+            elif crash_error := _error_from_crash_marker(agent_logs_dir):
+                error = crash_error
+                logger.warning("HarborSolver: %s", error)
             elif agent_timed_out and workspace_diff and _confirmed_zero_tokens:
                 error = (
                     f"Agent timed out with workspace changes but 0 completion "

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -627,9 +627,7 @@ if ok:
         '_nel_orig_eh = _nel_sys.excepthook',
         'def _nel_eh(et, ev, tb):',
         '    _nel_flush_traj()',
-        "    if et.__name__ == 'RateLimitError' and 'session_budget_exhausted' in str(ev):",
-        '        _nel_sys.exit(0)',
-        '    _nel_orig_eh(et, ev, tb)',
+        '    _nel_sys.exit(0)',
         '_nel_sys.excepthook = _nel_eh',
     ]
     patch = '\\n' + '\\n'.join(ind + l for l in lines) + '\\n'
@@ -1311,15 +1309,8 @@ class HarborSolver:
                 etype = type(agent_error).__name__
                 if etype in _infra_error_names:
                     raise InfraError(f"Agent infrastructure failure: {etype}: {agent_error}") from agent_error
-                if etype == "RateLimitError" and "session_budget_exhausted" in str(agent_error):
-                    # Patch 4 should have already caught this and exited cleanly;
-                    # if we still see the error here the patch anchor didn't match.
-                    # Treat as a turn-limit stop: no crash, no trajectory (patch failed).
-                    error = f"Agent reached turn limit (session_budget_exhausted): {agent_error}"
-                    logger.info("HarborSolver: turn limit exhausted (Patch 4 anchor may have missed): %s", agent_error)
-                else:
-                    error = f"Agent crashed: {etype}: {agent_error}"
-                    logger.warning("HarborSolver: %s", error)
+                error = f"Agent crashed: {etype}: {agent_error}"
+                logger.warning("HarborSolver: %s", error)
             elif agent_timed_out and workspace_diff and _confirmed_zero_tokens:
                 error = (
                     f"Agent timed out with workspace changes but 0 completion "

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1055,6 +1055,7 @@ class HarborSolver:
             raise RuntimeError("HarborSolver requires a sandbox.")
 
         from harbor.models.agent.context import AgentContext
+
         from nemo_evaluator.solvers.harbor_adapter import SandboxEnvironmentAdapter
 
         _silence_harbor_debug()

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -239,9 +239,7 @@ async def _download_agent_logs_inner(
             pass
 
 
-async def _patch_openhands_sdk(
-    sandbox: "Sandbox", *, cmd_timeout: float | None = None
-) -> None:
+async def _patch_openhands_sdk(sandbox: "Sandbox", *, cmd_timeout: float | None = None) -> None:
     """Apply runtime patches to the OpenHands SDK inside the sandbox.
 
     1. **Prevent premature FINISHED on text-only responses** — when the
@@ -577,7 +575,14 @@ if ok:
             ind + 'except BaseException as _e:\\n' +
             ind + '    _nel_run_exc = _e')
     c = c.replace(old1, wrap, 1)
-    c = c.replace(old2, old2 + '\\n' + ind + 'if _nel_run_exc is not None: sys.exit(0)', 1)
+    exit_block = (
+        ind + 'if _nel_run_exc is not None:\\n' +
+        ind + '    import json as _j, os as _os\\n' +
+        ind + '    _os.makedirs("/logs/agent", exist_ok=True)\\n' +
+        ind + '    open("/logs/agent/nel_agent_error.json", "w").write(\\n' +
+        ind + '        _j.dumps({"etype": type(_nel_run_exc).__name__, "emsg": str(_nel_run_exc)}))\\n' +
+        ind + '    sys.exit(0)')
+    c = c.replace(old2, old2 + '\\n' + exit_block, 1)
     open(p, 'w').write(c)
 print(f'budget_flush={ok}')
 """
@@ -1050,7 +1055,6 @@ class HarborSolver:
             raise RuntimeError("HarborSolver requires a sandbox.")
 
         from harbor.models.agent.context import AgentContext
-
         from nemo_evaluator.solvers.harbor_adapter import SandboxEnvironmentAdapter
 
         _silence_harbor_debug()
@@ -1181,7 +1185,6 @@ class HarborSolver:
             if not adapter.is_mounted and sandbox.is_running:
                 await _download_agent_logs(sandbox, agent_logs_dir)
 
-
             # Let agent parse its own logs into context
             if context.is_empty() and hasattr(agent, "populate_context_post_run"):
                 try:
@@ -1257,6 +1260,16 @@ class HarborSolver:
                     raise InfraError(f"Agent infrastructure failure: {etype}: {agent_error}") from agent_error
                 error = f"Agent crashed: {etype}: {agent_error}"
                 logger.warning("HarborSolver: %s", error)
+            elif (_crash_file := agent_logs_dir / "nel_agent_error.json").is_file():
+                try:
+                    _crash = json.loads(_crash_file.read_text())
+                    _etype = _crash.get("etype", "AgentCrash")
+                    _emsg = _crash.get("emsg", "")
+                    if _etype not in _infra_error_names:
+                        error = f"Agent crashed: {_etype}: {_emsg}"
+                        logger.warning("HarborSolver: %s", error)
+                except Exception:
+                    logger.warning("HarborSolver: failed to read crash marker", exc_info=True)
             elif agent_timed_out and workspace_diff and _confirmed_zero_tokens:
                 error = (
                     f"Agent timed out with workspace changes but 0 completion "
@@ -1311,7 +1324,6 @@ class HarborSolver:
             except Exception:
                 logger.debug("Post-failure recovery failed", exc_info=True)
 
-
             recovered = _recover_from_logs(agent_logs_dir)
             trajectory = recovered["trajectory"] or build_atif_trajectory(
                 steps=[{"source": "system", "message": str(exc)}],
@@ -1354,7 +1366,6 @@ class HarborSolver:
                     await _download_agent_logs(sandbox, agent_logs_dir)
             except Exception:
                 logger.debug("Post-failure recovery failed", exc_info=True)
-
 
             recovered = _recover_from_logs(agent_logs_dir)
             trajectory = recovered["trajectory"] or build_atif_trajectory(

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1055,7 +1055,6 @@ class HarborSolver:
             raise RuntimeError("HarborSolver requires a sandbox.")
 
         from harbor.models.agent.context import AgentContext
-
         from nemo_evaluator.solvers.harbor_adapter import SandboxEnvironmentAdapter
 
         _silence_harbor_debug()

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -238,7 +238,6 @@ class TestSandboxEnvironmentAdapter:
         from unittest.mock import MagicMock
 
         from harbor.environments.base import BaseEnvironment
-
         from nemo_evaluator.solvers.harbor_adapter import SandboxEnvironmentAdapter
 
         base_src = inspect.getsource(BaseEnvironment.__init__)

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -10,15 +10,18 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from nemo_evaluator.errors import InfraError
 from nemo_evaluator.solvers.harbor import (
     _ensure_claude_host_env,
     _ensure_host_env,
+    _error_from_crash_marker,
     _extract_response,
     _model_id_for_openai,
     _resolve_agent_timeout,
@@ -173,6 +176,21 @@ class TestDownloadAgentLogs:
 
         await _download_agent_logs_inner(sandbox, tmp_path, max_retries=2)
         assert sandbox.download.call_count == 2
+
+
+class TestCrashMarker:
+    def test_non_infra_marker_returns_agent_crash_error(self, tmp_path):
+        (tmp_path / "nel_agent_error.json").write_text(json.dumps({"etype": "ValueError", "emsg": "bad input"}))
+
+        assert _error_from_crash_marker(tmp_path) == "Agent crashed: ValueError: bad input"
+
+    def test_infra_marker_raises_infra_error(self, tmp_path):
+        (tmp_path / "nel_agent_error.json").write_text(
+            json.dumps({"etype": "APIConnectionError", "emsg": "connection failed"})
+        )
+
+        with pytest.raises(InfraError, match="Agent infrastructure failure: APIConnectionError: connection failed"):
+            _error_from_crash_marker(tmp_path)
 
 
 # ── Patch functions ──────────────────────────────────────────────────────

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -238,6 +238,7 @@ class TestSandboxEnvironmentAdapter:
         from unittest.mock import MagicMock
 
         from harbor.environments.base import BaseEnvironment
+
         from nemo_evaluator.solvers.harbor_adapter import SandboxEnvironmentAdapter
 
         base_src = inspect.getsource(BaseEnvironment.__init__)


### PR DESCRIPTION
## Summary

- Patches the OpenHands SDK runner inside the Harbor sandbox so `conversation.run()` is wrapped and the runner reaches its existing event reconstruction / `build_trajectory()` / `save_trajectory()` path even when the agent crashes.
- Persists `/logs/agent/nel_agent_error.json` when the wrapped runner catches a crash, so NEL can report the original agent exception instead of silently classifying the run as successful.
- Recovers `/logs/agent/trajectory.json` after crash paths and falls back to a minimal log-derived trajectory only when no structured trajectory exists.
- Preserves infrastructure-error behavior: crash-marker errors like `APIConnectionError` are raised as `InfraError`, while non-infra agent crashes are reported as model errors with the partial trajectory attached.

## Before vs After

### Before this PR

Baseline commit tested: `1b5304d` (`v0.3.1`, PR base).

Smoke command shape:

```bash
PYTHONPATH=src:$PYTHONPATH nel eval run /tmp/atif_smoke_swebench_before_turnbudget.yaml
```

Config limits:

- `max_problems: 1`
- `repeats: 1`
- `turn_counter.max_turns: 2`

Observed pre-PR behavior:

- The agent exceeded the turn budget and exited non-zero.
- `/logs/agent/trajectory.json` was missing in the container logs.
- NEL printed: `No trajectory file found at .../agent/trajectory.json`.
- NEL fell back to `openhands_sdk.txt` and wrote only a one-step log-derived trajectory.
- Progress reported `0 tok`, so model token metrics were lost.
- The real partial OpenHands ATIF steps were not preserved.

Evidence from the pre-PR run:

- Output dir: `/tmp/atif_smoke_swebench_before_turnbudget/`
- Log: `/tmp/atif_smoke_swebench_before_turnbudget_run_20260622T094445Z.log`
- Key log lines:
  - `Container /logs/agent/: /logs/agent/openhands_sdk.txt`
  - `No trajectory file found at /tmp/eval_harbor_vs71honr/agent/trajectory.json`
  - `Using openhands_sdk.txt as error log trajectory`
  - `Done 277.6s | pass@1=0.0% (0/1) | 0 tok`

### After this PR

Same one-sample SWE-bench turn-budget smoke on PR head `e1ac084`:

- `/logs/agent/trajectory.json` is written and downloaded.
- `trajectories.jsonl` contains a nested `ATIF-v1.5` trajectory.
- ATIF has 4 steps and preserves token metrics: `18,595` prompt tokens, `233` completion tokens.
- Error is preserved as `ConversationRunError ... Turn budget exhausted: 17/2 turns used`.

## Additional Validation

### 1. Turn-budget crash smoke (`max_turns=2`)

Command on PR head `e1ac084`:

```bash
PYTHONPATH=src:$PYTHONPATH nel eval run adhoc_configs/test_atif_swebench.yaml
```

Config limits:

- `max_problems: 1`
- `repeats: 1`
- `turn_counter.max_turns: 2`

Result on PR head:

- Run completed and wrote `/tmp/atif_smoke_swebench/swebench-verified_1.0/trajectories.jsonl`.
- `trajectories.jsonl` contained 1 record with nested `ATIF-v1.5` trajectory.
- ATIF had 4 steps and preserved token metrics: `18,595` prompt tokens, `233` completion tokens.
- Error was preserved as `ConversationRunError ... Turn budget exhausted: 17/2 turns used`.

### 2. Deterministic fake endpoint smoke: first tool call succeeds, next call returns HTTP 400

Local fake endpoint behavior:

- Request 1 returns HTTP 200 streaming chat-completions with one `terminal` tool call.
- Request 2 returns HTTP 400 with `fake upstream 400 after first tool call`.
- Endpoint request log confirmed exactly 2 chat-completions calls.

Result on PR head `e1ac084`:

- Run completed with `rc=0`.
- Output written to `/tmp/atif_smoke_swebench_fake400/swebench-verified_1.0/trajectories.jsonl`.
- `trajectories.jsonl` contained 1 record with nested `ATIF-v1.5` trajectory.
- ATIF had 3 steps and preserved the first successful tool call:
  - tool: `terminal`
  - command: `echo fake endpoint first tool call`
- Metrics were preserved: `100` prompt tokens, `20` completion tokens, `120` total tokens.
- Failure was reported as `ConversationRunError ... litellm.BadRequestError ... fake upstream 400 after first tool call`.
- The nested ATIF passed the repo validator with both `strict=False` and `strict=True`.

### 3. Model traffic vs trajectory call accounting

Checked the fixed-PR run artifacts against `model_traffic.jsonl` to make sure the preserved ATIF trajectory contains the same successful model responses that were observed by the model-traffic logger.

| Run | `model_traffic` status codes | Successful model calls | ATIF agent/model steps | Token accounting |
| --- | --- | ---: | ---: | --- |
| Turn-budget smoke | `[200, 200]` | 2 | 2 | Matches: `18,595` prompt / `233` completion in both model traffic and ATIF |
| Fake 200-then-400 smoke | `[200, 400]` | 1 | 1 | Matches: `100` prompt / `20` completion in both model traffic and ATIF |

For the fake endpoint run, raw `model_traffic.jsonl` has 2 HTTP records because the second request returned HTTP 400. That failed request has no model completion to serialize as an ATIF agent step, so the trajectory correctly contains 1 agent/model step for the successful 200 response. The failed 400 is still preserved in `model_traffic.jsonl` and surfaced in `model_error`.

## Test plan

- [x] `pre-commit run --all-files --show-diff-on-failure --color=never`
- [x] `.venv/bin/python -m pytest tests/test_solvers/test_harbor_solver.py -q` (`40 passed`)
- [x] Pre-PR baseline turn-budget smoke demonstrates the previous loss mode: no `/logs/agent/trajectory.json`, fallback to log text, `0 tok`
- [x] Manual SWE-bench turn-budget smoke on PR head (`max_turns=2`) preserves partial ATIF trajectory
- [x] Manual fake endpoint 200-then-400 smoke on PR head preserves partial ATIF trajectory
- [x] Verified successful model-call count and token totals match between `model_traffic.jsonl` and the preserved ATIF trajectory on fixed-PR smoke runs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of agent shutdown so trajectory and run logs continue to be generated and downloaded even when unexpected runner failures occur.
  * Improved error reporting by detecting and surfacing runner crash details from a marker log, while preserving existing infrastructure error behavior.

* **Improvements**
  * Enhanced execution tracking to keep trajectory/log reconstruction available after crash scenarios, with a fallback to minimal logging when full details aren’t present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
