### PR TITLE
feat: derive version from git tags via hatch-vcs

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -41,7 +41,8 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 COPY harbor_datasets/registry_overrides/ harbor_datasets/registry_overrides/
 
-RUN pip install --no-cache-dir ".[scoring,stats]"
+RUN pip install --no-cache-dir ".[scoring,stats]" \
+    && python -c "import nemo_evaluator; print('nemo-evaluator:', nemo_evaluator.__version__)"
 
 ENV PYTHONUNBUFFERED=1
 

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -41,7 +41,8 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 COPY harbor_datasets/registry_overrides/ harbor_datasets/registry_overrides/
 
-RUN pip install --no-cache-dir ".[scoring,stats]" \
+ARG NEMO_VERSION="0.3.1"
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=${NEMO_VERSION} pip install --no-cache-dir ".[scoring,stats]" \
     && python -c "import nemo_evaluator; print('nemo-evaluator:', nemo_evaluator.__version__)"
 
 ENV PYTHONUNBUFFERED=1

--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -41,8 +41,8 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 COPY harbor_datasets/registry_overrides/ harbor_datasets/registry_overrides/
 
-ARG NEMO_VERSION="0.3.1"
-RUN SETUPTOOLS_SCM_PRETEND_VERSION=${NEMO_VERSION} pip install --no-cache-dir ".[scoring,stats]" \
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+RUN SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION} pip install --no-cache-dir ".[scoring,stats]" \
     && python -c "import nemo_evaluator; print('nemo-evaluator:', nemo_evaluator.__version__)"
 
 ENV PYTHONUNBUFFERED=1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ nel = "nemo_evaluator.cli.main:cli"
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { version_scheme = "post-release" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nemo_evaluator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ nel = "nemo_evaluator.cli.main:cli"
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = { version_scheme = "post-release" }
+raw-options = { version_scheme = "post-release", fallback_version = "0.3.1" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nemo_evaluator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "nemo-evaluator"
-version = "0.3.1"
+dynamic = ["version"]
 description = "NeMo Evaluator — benchmark environments, pluggable solvers, interceptor proxy, and decision-grade scoring for LLMs"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"
@@ -93,6 +93,9 @@ Issues = "https://github.com/NVIDIA-NeMo/Evaluator/issues"
 
 [project.scripts]
 nel = "nemo_evaluator.cli.main:cli"
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nemo_evaluator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ nel = "nemo_evaluator.cli.main:cli"
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = { version_scheme = "post-release", fallback_version = "0.3.1" }
+raw-options = { version_scheme = "post-release" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/nemo_evaluator"]

--- a/src/nemo_evaluator/__init__.py
+++ b/src/nemo_evaluator/__init__.py
@@ -20,7 +20,7 @@ from importlib.metadata import version as _v
 try:
     __version__ = _v("nemo-evaluator")
 except _E:
-    from nemo_evaluator.package_info import __version__
+    __version__ = "0.3.1"
 __package_name__ = "nemo_evaluator"
 
 from nemo_evaluator.engine.eval_loop import run_evaluation

--- a/src/nemo_evaluator/__init__.py
+++ b/src/nemo_evaluator/__init__.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 """NeMo Evaluator -- environments, solvers, evaluation orchestration."""
 
-# Kept as literals (not imported from package_info) so that submodules below
-# can safely back-reference ``nemo_evaluator.__version__`` without triggering
-# a circular import while ``__init__.py`` is partially loaded. ``package_info``
-# remains the canonical source for the FW-CI-templates wheel patcher.
-__version__ = "0.3.1"
+from importlib.metadata import version as _v, PackageNotFoundError as _E
+
+try:
+    __version__ = _v("nemo-evaluator")
+except _E:
+    __version__ = "0.0.0.dev0"
 __package_name__ = "nemo_evaluator"
 
 from nemo_evaluator.engine.eval_loop import run_evaluation

--- a/src/nemo_evaluator/__init__.py
+++ b/src/nemo_evaluator/__init__.py
@@ -20,7 +20,7 @@ from importlib.metadata import version as _v
 try:
     __version__ = _v("nemo-evaluator")
 except _E:
-    __version__ = "0.3.1"
+    from nemo_evaluator.package_info import __version__
 __package_name__ = "nemo_evaluator"
 
 from nemo_evaluator.engine.eval_loop import run_evaluation

--- a/src/nemo_evaluator/__init__.py
+++ b/src/nemo_evaluator/__init__.py
@@ -14,12 +14,13 @@
 # limitations under the License.
 """NeMo Evaluator -- environments, solvers, evaluation orchestration."""
 
-from importlib.metadata import version as _v, PackageNotFoundError as _E
+from importlib.metadata import PackageNotFoundError as _E
+from importlib.metadata import version as _v
 
 try:
     __version__ = _v("nemo-evaluator")
 except _E:
-    __version__ = "0.0.0.dev0"
+    from nemo_evaluator.package_info import __version__
 __package_name__ = "nemo_evaluator"
 
 from nemo_evaluator.engine.eval_loop import run_evaluation

--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -19,7 +19,8 @@ e.g. ``0.3.1.post5+g1a2b3c4`` for untagged commits). MAJOR/MINOR/PATCH
 are kept for FW-CI-templates compatibility.
 """
 
-from importlib.metadata import version as _v, PackageNotFoundError as _E
+from importlib.metadata import PackageNotFoundError as _E
+from importlib.metadata import version as _v
 
 MAJOR = 0
 MINOR = 3

--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -15,7 +15,7 @@
 """Package version constants.
 
 Version is derived from git tags via hatch-vcs (PEP 440 local version,
-e.g. ``0.3.0.post5+g1a2b3c4`` for untagged commits). MAJOR/MINOR/PATCH
+e.g. ``0.3.1.post5+g1a2b3c4`` for untagged commits). MAJOR/MINOR/PATCH
 are kept for FW-CI-templates compatibility.
 """
 

--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -23,7 +23,7 @@ from importlib.metadata import version as _v, PackageNotFoundError as _E
 
 MAJOR = 0
 MINOR = 3
-PATCH = 0
+PATCH = 1
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)

--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -14,26 +14,27 @@
 # limitations under the License.
 """Package version constants.
 
-The canonical version is in pyproject.toml; this file mirrors it as
-``MAJOR/MINOR/PATCH/PRE_RELEASE`` constants because the FW-CI-templates
-``_build_test_publish_wheel.yml`` reusable workflow patches ``PATCH``
-in-place for dry-run wheel builds. Removing it would break that build.
-
-When pyproject.toml's ``version`` is bumped, update the constants below
-to keep them in sync.
+Version is derived from git tags via hatch-vcs (PEP 440 local version,
+e.g. ``0.3.0.post5+g1a2b3c4`` for untagged commits). MAJOR/MINOR/PATCH
+are kept for FW-CI-templates compatibility.
 """
 
-# Below is the _next_ version that will be published, not the currently published one.
+from importlib.metadata import version as _v, PackageNotFoundError as _E
+
 MAJOR = 0
 MINOR = 3
-PATCH = 1
+PATCH = 0
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)
 VERSION = (MAJOR, MINOR, PATCH, PRE_RELEASE)
 
-__shortversion__ = ".".join(map(str, VERSION[:3]))
-__version__ = ".".join(map(str, VERSION[:3])) + "".join(VERSION[3:])
+try:
+    __version__ = _v("nemo-evaluator")
+except _E:
+    __version__ = ".".join(map(str, VERSION[:3])) + "".join(VERSION[3:])
+
+__shortversion__ = __version__.split("+")[0]
 
 __package_name__ = "nemo_evaluator"
 __contact_names__ = "NVIDIA"


### PR DESCRIPTION
## What

Removes hardcoded version strings from three places (`pyproject.toml`, `__init__.py`, `package_info.py`). `hatch-vcs` reads the nearest ancestor git tag and produces PEP 440 local versions for untagged commits.

## Why

Containers and `nel --version` will now show e.g. `0.3.1.post5+g1b5304d` — traceable to the exact commit without requiring a manual version bump for every change.

## Result (tested locally)

```
$ nel --version  # from untagged commit after v0.3.1
0.3.1.post3+g3b7a2fef3
```

## Notes

- `package_info.py` kept for FW-CI-templates compatibility (`PATCH` constant)
- `v0.3.1` tag pushed to GitHub as the base (initial public branch had no tags in ancestry)
- Independent of #1077 — can merge in either order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved version reporting by deriving the package version from installed distribution metadata, with a fallback when metadata isn’t available.
  * Updated short-version reporting to align with the published version format (including handling of local “+” version segments).
* **Documentation**
  * Refreshed the module’s versioning description to reflect the git-tag-based (hatch-vcs) scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->