### PR TITLE
fix: [EVAL-1459] fix summarization issues (token miscounting, fallback logic)

### DIFF
--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -135,6 +135,7 @@ class _ModelServerBase(BaseModel):
     reasoning_pattern: str | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    tokenizer: str | None = None
     generation: GenerationConfig = Field(default_factory=GenerationConfig)
     proxy: ProxyConfig | None = None
     depends_on: list[str] = Field(default_factory=list)
@@ -248,6 +249,7 @@ class ExternalApiService(BaseModel):
     health_path: str | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    tokenizer: str | None = None
     generation: GenerationConfig = Field(default_factory=GenerationConfig)
     proxy: ProxyConfig | None = None
 

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -305,6 +305,7 @@ def _make_solver(
             container_env=container_env,
             max_input_tokens=getattr(svc, "max_input_tokens", None),
             max_output_tokens=getattr(svc, "max_output_tokens", None),
+            tokenizer=getattr(svc, "tokenizer", None),
             cmd_timeout=getattr(solver_cfg, "cmd_timeout", None),
             timeout_strategy=getattr(solver_cfg, "timeout_strategy", "override"),
             max_agent_timeout=getattr(solver_cfg, "max_agent_timeout", None),

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -776,6 +776,8 @@ def _silence_harbor_debug(level: int = logging.INFO) -> None:
 
 _TOKENIZER_REGISTRY: dict[str, dict] = {}
 _TOKEN_COUNTER_PATCHED = False
+_MISSING_TOKENIZER_WARNED: set[str] = set()
+_IGNORED_TOKENIZER_LOGGED: set[str] = set()
 
 
 def _build_custom_tokenizer(spec: str) -> dict:
@@ -807,19 +809,55 @@ def _install_token_counter_patch() -> None:
     _TOKEN_COUNTER_PATCHED = True
 
 
-def _register_harbor_tokenizer(model_id: str, spec: str) -> None:
-    if model_id not in _TOKENIZER_REGISTRY:
-        _TOKENIZER_REGISTRY[model_id] = _build_custom_tokenizer(spec)
-        logger.info("Registered custom tokenizer %r for model %r", spec, model_id)
+def _register_harbor_tokenizer(model_name: str, spec: str) -> None:
+    if model_name not in _TOKENIZER_REGISTRY:
+        try:
+            tokenizer = _build_custom_tokenizer(spec)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to load tokenizer {spec!r} configured for model {model_name!r}. "
+                "Provide a valid Hugging Face repo id or a local tokenizer.json path, or "
+                "remove the 'tokenizer' field from the model service config. "
+                f"Underlying error: {exc}"
+            ) from exc
+        _TOKENIZER_REGISTRY[model_name] = tokenizer
+        logger.info("Registered custom tokenizer %r for model %r", spec, model_name)
     _install_token_counter_patch()
+
+
+def _configure_terminus_tokenizer(*, is_terminus2: bool, model_name: str, tokenizer: str | None) -> None:
+    if not is_terminus2:
+        if tokenizer and model_name and model_name not in _IGNORED_TOKENIZER_LOGGED:
+            _IGNORED_TOKENIZER_LOGGED.add(model_name)
+            logger.info(
+                "Tokenizer %r is configured for model %r but is only used by the "
+                "terminus-2 agent; ignoring it for the current agent.",
+                tokenizer,
+                model_name,
+            )
+        return
+
+    if not tokenizer:
+        if model_name and model_name not in _MISSING_TOKENIZER_WARNED:
+            _MISSING_TOKENIZER_WARNED.add(model_name)
+            logger.warning(
+                "No tokenizer configured for model %r used with terminus-2; token "
+                "counts will use litellm's default tokenizer and may undercount. Set the "
+                "'tokenizer' field (Hugging Face repo id or local tokenizer.json path) on "
+                "the model service config.",
+                model_name,
+            )
+        return
+
+    if model_name:
+        _register_harbor_tokenizer(model_name, tokenizer)
 
 
 _TERMINUS_CLE_RESET_PATCHED = False
 
 _TERMINUS_CLE_RESET_REPLACEMENTS = [
     (
-        "            summary_prompt = None\n"
-        "            # Fallback 1: Try full summary\n",
+        "            summary_prompt = None\n            # Fallback 1: Try full summary\n",
         "            summary_prompt = None\n"
         "            full_summarize_failed_with_cle = False\n"
         "            # Fallback 1: Try full summary\n",
@@ -865,10 +903,7 @@ _TERMINUS_CLE_RESET_REPLACEMENTS = [
 def _terminus2_build_local_fallback_llm_content(self) -> str:
     import json
 
-    analysis = (
-        "Technical difficulties during context recovery. "
-        "All summarization fallbacks failed."
-    )
+    analysis = "Technical difficulties during context recovery. All summarization fallbacks failed."
     plan = "Technical difficulties. Please continue with the task."
     if self._parser_name == "xml":
         return (
@@ -905,9 +940,7 @@ def _patch_terminus_cle_reset() -> None:
 
     if "full_summarize_failed_with_cle" in src:
         _TERMINUS_CLE_RESET_PATCHED = True
-        logger.info(
-            "Terminus2._query_llm already contains the CLE chat-reset logic; skipping patch"
-        )
+        logger.info("Terminus2._query_llm already contains the CLE chat-reset logic; skipping patch")
         return
 
     for anchor, replacement in _TERMINUS_CLE_RESET_REPLACEMENTS:
@@ -921,17 +954,13 @@ def _patch_terminus_cle_reset() -> None:
         src = src.replace(anchor, replacement, 1)
 
     if not hasattr(terminus2_mod.Terminus2, "_build_local_fallback_llm_content"):
-        terminus2_mod.Terminus2._build_local_fallback_llm_content = (
-            _terminus2_build_local_fallback_llm_content
-        )
+        terminus2_mod.Terminus2._build_local_fallback_llm_content = _terminus2_build_local_fallback_llm_content
 
     namespace: dict[str, Any] = {}
     exec(textwrap.dedent(src), terminus2_mod.__dict__, namespace)
     terminus2_mod.Terminus2._query_llm = namespace["_query_llm"]
     _TERMINUS_CLE_RESET_PATCHED = True
-    logger.info(
-        "Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback"
-    )
+    logger.info("Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback")
 
 
 class HarborSolver:
@@ -1010,12 +1039,16 @@ class HarborSolver:
         kwargs = dict(self._harbor_agent_kwargs)
         url = model_url or self._model_url
         model_id = _model_id_for_openai(self._model_id, bool(url), agent=self._harbor_agent) if self._model_id else ""
-        if self._harbor_agent.replace("_", "-").lower() == "terminus-2":
-            _patch_terminus_cle_reset()
-        if self._tokenizer and model_id:
-            _register_harbor_tokenizer(model_id, self._tokenizer)
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
+        is_terminus2 = self._harbor_agent.replace("_", "-").lower() == "terminus-2"
+        if is_terminus2:
+            _patch_terminus_cle_reset()
+        _configure_terminus_tokenizer(
+            is_terminus2=is_terminus2,
+            model_name=kwargs.get("model_name") or model_id,
+            tokenizer=self._tokenizer,
+        )
         if "api_base" not in kwargs and url:
             kwargs["api_base"] = url
         if "api_key" not in kwargs and self._api_key:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -774,6 +774,46 @@ def _silence_harbor_debug(level: int = logging.INFO) -> None:
             logging.getLogger(name).setLevel(level)
 
 
+_TOKENIZER_REGISTRY: dict[str, dict] = {}
+_TOKEN_COUNTER_PATCHED = False
+
+
+def _build_custom_tokenizer(spec: str) -> dict:
+    from litellm.utils import create_pretrained_tokenizer, create_tokenizer
+
+    spec_path = Path(spec)
+    if spec_path.is_file():
+        return create_tokenizer(spec_path.read_text())
+    return create_pretrained_tokenizer(spec)
+
+
+def _install_token_counter_patch() -> None:
+    global _TOKEN_COUNTER_PATCHED
+    if _TOKEN_COUNTER_PATCHED:
+        return
+
+    import litellm.utils as litellm_utils
+
+    _original_token_counter = litellm_utils.token_counter
+
+    def _patched_token_counter(*args, **kwargs):
+        model = kwargs["model"] if "model" in kwargs else (args[0] if args else "")
+        passes_custom = kwargs.get("custom_tokenizer") is not None or len(args) >= 2
+        if model in _TOKENIZER_REGISTRY and not passes_custom:
+            kwargs["custom_tokenizer"] = _TOKENIZER_REGISTRY[model]
+        return _original_token_counter(*args, **kwargs)
+
+    litellm_utils.token_counter = _patched_token_counter
+    _TOKEN_COUNTER_PATCHED = True
+
+
+def _register_harbor_tokenizer(model_id: str, spec: str) -> None:
+    if model_id not in _TOKENIZER_REGISTRY:
+        _TOKENIZER_REGISTRY[model_id] = _build_custom_tokenizer(spec)
+        logger.info("Registered custom tokenizer %r for model %r", spec, model_id)
+    _install_token_counter_patch()
+
+
 class HarborSolver:
     """Runs any Harbor agent inside an evaluator :class:`Sandbox`.
 
@@ -796,6 +836,7 @@ class HarborSolver:
         container_env: dict[str, str] | None = None,
         max_input_tokens: int | None = None,
         max_output_tokens: int | None = None,
+        tokenizer: str | None = None,
         cmd_timeout: float | None = None,
         timeout_strategy: str = "override",
         max_agent_timeout: float | None = None,
@@ -825,6 +866,7 @@ class HarborSolver:
             self._container_env.setdefault("LLM_NATIVE_TOOL_CALLING", "true")
         self._max_input_tokens = max_input_tokens
         self._max_output_tokens = max_output_tokens
+        self._tokenizer = tokenizer
         self._api_key = _resolve_api_key(api_key)
         if not self._api_key:
             self._api_key = "no-key-needed"
@@ -848,6 +890,8 @@ class HarborSolver:
         kwargs = dict(self._harbor_agent_kwargs)
         url = model_url or self._model_url
         model_id = _model_id_for_openai(self._model_id, bool(url), agent=self._harbor_agent) if self._model_id else ""
+        if self._tokenizer and model_id:
+            _register_harbor_tokenizer(model_id, self._tokenizer)
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
         if "api_base" not in kwargs and url:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -814,6 +814,126 @@ def _register_harbor_tokenizer(model_id: str, spec: str) -> None:
     _install_token_counter_patch()
 
 
+_TERMINUS_CLE_RESET_PATCHED = False
+
+_TERMINUS_CLE_RESET_REPLACEMENTS = [
+    (
+        "            summary_prompt = None\n"
+        "            # Fallback 1: Try full summary\n",
+        "            summary_prompt = None\n"
+        "            full_summarize_failed_with_cle = False\n"
+        "            # Fallback 1: Try full summary\n",
+    ),
+    (
+        "            except Exception as e:\n"
+        '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n',
+        "            except Exception as e:\n"
+        "                full_summarize_failed_with_cle = isinstance(\n"
+        "                    e, ContextLengthExceededError\n"
+        "                )\n"
+        '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n',
+    ),
+    (
+        "            if prompt_path is not None:\n"
+        "                prompt_path.write_text(summary_prompt)\n"
+        "\n"
+        "            try:\n"
+        "                start_time = time.time()\n"
+        "                llm_response = await chat.chat(\n",
+        "            if prompt_path is not None:\n"
+        "                prompt_path.write_text(summary_prompt)\n"
+        "\n"
+        "            if full_summarize_failed_with_cle:\n"
+        "                chat._messages = [chat.messages[0]]\n"
+        "                chat.reset_response_chain()\n"
+        "\n"
+        "            try:\n"
+        "                start_time = time.time()\n"
+        "                llm_response = await chat.chat(\n",
+    ),
+    (
+        "                llm_response = LLMResponse(\n"
+        '                    content="Technical difficulties. Please continue with the task."\n'
+        "                )\n",
+        "                llm_response = LLMResponse(\n"
+        "                    content=self._build_local_fallback_llm_content()\n"
+        "                )\n",
+    ),
+]
+
+
+def _terminus2_build_local_fallback_llm_content(self) -> str:
+    import json
+
+    analysis = (
+        "Technical difficulties during context recovery. "
+        "All summarization fallbacks failed."
+    )
+    plan = "Technical difficulties. Please continue with the task."
+    if self._parser_name == "xml":
+        return (
+            "<response>\n"
+            f"<analysis>{analysis}</analysis>\n"
+            f"<plan>{plan}</plan>\n"
+            "<commands>\n"
+            "</commands>\n"
+            "<task_complete>false</task_complete>\n"
+            "</response>"
+        )
+    return json.dumps(
+        {
+            "analysis": analysis,
+            "plan": plan,
+            "commands": [],
+            "task_complete": False,
+        }
+    )
+
+
+def _patch_terminus_cle_reset() -> None:
+    global _TERMINUS_CLE_RESET_PATCHED
+    if _TERMINUS_CLE_RESET_PATCHED:
+        return
+
+    import inspect
+    import textwrap
+
+    from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
+
+    original = terminus2_mod.Terminus2._query_llm
+    src = inspect.getsource(inspect.unwrap(original))
+
+    if "full_summarize_failed_with_cle" in src:
+        _TERMINUS_CLE_RESET_PATCHED = True
+        logger.info(
+            "Terminus2._query_llm already contains the CLE chat-reset logic; skipping patch"
+        )
+        return
+
+    for anchor, replacement in _TERMINUS_CLE_RESET_REPLACEMENTS:
+        occurrences = src.count(anchor)
+        if occurrences != 1:
+            raise RuntimeError(
+                "Cannot patch Terminus2._query_llm for CLE chat reset: expected exactly "
+                f"one match for an anchor but found {occurrences}. Harbor's terminus_2.py "
+                "has diverged from the expected source."
+            )
+        src = src.replace(anchor, replacement, 1)
+
+    if not hasattr(terminus2_mod.Terminus2, "_build_local_fallback_llm_content"):
+        terminus2_mod.Terminus2._build_local_fallback_llm_content = (
+            _terminus2_build_local_fallback_llm_content
+        )
+
+    namespace: dict[str, Any] = {}
+    exec(textwrap.dedent(src), terminus2_mod.__dict__, namespace)
+    terminus2_mod.Terminus2._query_llm = namespace["_query_llm"]
+    _TERMINUS_CLE_RESET_PATCHED = True
+    logger.info(
+        "Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback"
+    )
+
+
 class HarborSolver:
     """Runs any Harbor agent inside an evaluator :class:`Sandbox`.
 
@@ -890,6 +1010,8 @@ class HarborSolver:
         kwargs = dict(self._harbor_agent_kwargs)
         url = model_url or self._model_url
         model_id = _model_id_for_openai(self._model_id, bool(url), agent=self._harbor_agent) if self._model_id else ""
+        if self._harbor_agent.replace("_", "-").lower() == "terminus-2":
+            _patch_terminus_cle_reset()
         if self._tokenizer and model_id:
             _register_harbor_tokenizer(model_id, self._tokenizer)
         if "model_name" not in kwargs and model_id:

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import nemo_evaluator.solvers.harbor as harbor_mod
 from nemo_evaluator.solvers.harbor import (
     _ensure_claude_host_env,
     _ensure_host_env,
@@ -366,6 +367,68 @@ class TestSandboxEnvironmentAdapter:
         adapter = SandboxEnvironmentAdapter(MagicMock(), session_id="test-session", logs_dir=tmp_path)
         missing = {a for a in base_attrs if not hasattr(adapter, a)}
         assert not missing, f"SandboxEnvironmentAdapter missing public attrs: {missing}"
+
+
+class TestConfigureTerminusTokenizer:
+    """Tokenizer is fetched/registered only for terminus-2; failures fail fast."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self, monkeypatch):
+        monkeypatch.setattr(harbor_mod, "_TOKENIZER_REGISTRY", {})
+        monkeypatch.setattr(harbor_mod, "_MISSING_TOKENIZER_WARNED", set())
+        monkeypatch.setattr(harbor_mod, "_IGNORED_TOKENIZER_LOGGED", set())
+
+    def test_non_terminus_with_tokenizer_does_not_fetch(self, monkeypatch, caplog):
+        import logging
+
+        build = MagicMock()
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", build)
+        with caplog.at_level(logging.INFO):
+            harbor_mod._configure_terminus_tokenizer(is_terminus2=False, model_name="my-model", tokenizer="Qwen/Qwen3")
+        build.assert_not_called()
+        assert harbor_mod._TOKENIZER_REGISTRY == {}
+        assert "ignoring it for the current agent" in caplog.text
+
+    def test_non_terminus_info_logged_once(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", MagicMock())
+        with caplog.at_level(logging.INFO):
+            for _ in range(3):
+                harbor_mod._configure_terminus_tokenizer(
+                    is_terminus2=False, model_name="my-model", tokenizer="Qwen/Qwen3"
+                )
+        assert caplog.text.count("ignoring it for the current agent") == 1
+
+    def test_terminus_without_tokenizer_warns_once(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(3):
+                harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer=None)
+        assert caplog.text.count("No tokenizer configured") == 1
+
+    def test_terminus_with_tokenizer_registers(self, monkeypatch):
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", lambda spec: {"spec": spec})
+        monkeypatch.setattr(harbor_mod, "_install_token_counter_patch", MagicMock())
+        harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer="Qwen/Qwen3")
+        assert harbor_mod._TOKENIZER_REGISTRY["my-model"] == {"spec": "Qwen/Qwen3"}
+
+    def test_terminus_tokenizer_fetch_failure_raises(self, monkeypatch):
+        def boom(spec):
+            raise OSError("offline: cannot reach huggingface")
+
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", boom)
+        with pytest.raises(RuntimeError, match="Failed to load tokenizer"):
+            harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer="Qwen/Qwen3")
+
+    def test_terminus_tokenizer_built_once_per_model(self, monkeypatch):
+        build = MagicMock(return_value={"tok": 1})
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", build)
+        monkeypatch.setattr(harbor_mod, "_install_token_counter_patch", MagicMock())
+        for _ in range(3):
+            harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer="Qwen/Qwen3")
+        build.assert_called_once()
 
 
 class TestResolveAgentTimeout:


### PR DESCRIPTION
### Token miscounting

In terminus-2, litellm's token_counter falls back to the tiktoken/OpenAI tokenizer for models
it doesn't recognize, miscounting tokens relative to the serving tokenizer. As a
result terminus-2's internal token estimate can diverge from the model API, so
proactive summarization might trigger too late and the API raises
context-length-exceeded errors while the internal estimate still looks safe.

Add an optional 'tokenizer' field to model service configs, thread it through the
orchestrator into HarborSolver, and monkeypatch litellm.utils.token_counter to
use a custom Hugging Face / local tokenizer (keyed per model) so internal token
counts match the serving tokenizer.

### Summarization fallback logic

When the context is already over the limit, terminus-2's reactive summarization
could itself raise context-length-exceeded: the full-summary attempt fails and
the fallbacks just append the summary prompt to an already-overflowing chat, so
every retry hits the same error.

Patch Terminus2._query_llm to detect when full summarization fails specifically
with a CLE, reset the chat history to the system message before retrying, and
emit an XML/JSON-parseable local fallback response so the agent's parser can
consume it instead of a plain string.