### PR TITLE
fix: propagate llm_kwargs.timeout to OpenHands LLM_TIMEOUT

### DIFF
--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -281,6 +281,12 @@ async def _patch_openhands_sdk(sandbox: Sandbox, *, cmd_timeout: float | None = 
        ``run_timeout`` without ever reaching the LLM.  ``stuck_detection``
        is also disabled in the same patch because its heuristic
        mis-flags reasoning-model turns.
+
+    5. **Honor ``LLM_TIMEOUT`` in the Harbor runner** — older Harbor
+       images ship ``run_agent.py`` without reading ``LLM_TIMEOUT``.
+       Inject the env lookup so ``solver.agent_kwargs.llm_kwargs.timeout``
+       (mapped to ``container_env.LLM_TIMEOUT``) reaches OpenHands
+       ``LLM(timeout=...)`` and LiteLLM per-request timeouts.
     """
     # -- Patch 0: disable stuck detection + default visualizer -----------
     # stuck_detection=False: the SDK's heuristic mis-flags reasoning-model
@@ -316,6 +322,40 @@ async def _patch_openhands_sdk(sandbox: Sandbox, *, cmd_timeout: float | None = 
         timeout_sec=10,
     )
     logger.info("Runner patch: %s", (r0.stdout or "").strip())
+
+    _llm_timeout_patch_script = """\
+p = '/installed-agent/run_agent.py'
+c = open(p).read()
+if 'LLM_TIMEOUT' in c:
+    print('llm_timeout: already present')
+else:
+    old = '    llm = LLM(**llm_kwargs)'
+    new = (
+        '    import os\\n'
+        '    timeout_raw = os.environ.get("LLM_TIMEOUT")\\n'
+        '    if timeout_raw:\\n'
+        '        llm_kwargs["timeout"] = int(timeout_raw)\\n'
+        '    llm = LLM(**llm_kwargs)'
+    )
+    if old in c:
+        open(p, 'w').write(c.replace(old, new, 1))
+        print('llm_timeout: patched')
+    else:
+        print('llm_timeout: pattern not found')
+"""
+    encoded_timeout = base64.b64encode(_llm_timeout_patch_script.encode()).decode()
+    r_timeout = await sandbox.exec(
+        f"echo {encoded_timeout} | base64 -d | python3",
+        timeout_sec=10,
+    )
+    stdout_timeout = (r_timeout.stdout or "").strip()
+    logger.info("LLM timeout patch: %s", stdout_timeout)
+    if r_timeout.return_code != 0 or "pattern not found" in stdout_timeout:
+        logger.warning(
+            "LLM timeout patch problem (rc=%d): %s",
+            r_timeout.return_code,
+            stdout_timeout or (r_timeout.stderr or "")[:300],
+        )
 
     # -- Patch 1: don't FINISHED on text-only responses ------------------
     # In agent.py, when the LLM produces text without a tool call the SDK
@@ -1365,6 +1405,11 @@ class HarborSolver:
             self._container_env.setdefault("SECURITY_CONFIRMATION_MODE", "false")
             self._container_env.setdefault("SECURITY_ENABLE_SECURITY_ANALYZER", "false")
             self._container_env.setdefault("LLM_NATIVE_TOOL_CALLING", "true")
+            llm_kw = self._harbor_agent_kwargs.get("llm_kwargs")
+            if isinstance(llm_kw, dict):
+                llm_timeout = llm_kw.get("timeout")
+                if llm_timeout is not None:
+                    self._container_env.setdefault("LLM_TIMEOUT", str(int(float(llm_timeout))))
         self._max_input_tokens = max_input_tokens
         self._max_output_tokens = max_output_tokens
         self._tokenizer = tokenizer

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -204,7 +204,7 @@ class TestPatchOpenhandsSDK:
         sandbox = AsyncMock()
         sandbox.exec.return_value = MagicMock(stdout="stuck_detection disabled", stderr="", return_code=0)
         await _patch_openhands_sdk(sandbox)
-        assert sandbox.exec.call_count >= 3
+        assert sandbox.exec.call_count >= 4
 
     async def test_runner_patch_disables_visualizer(self):
         """Patch 0 must inject both stuck_detection=False AND visualizer=None.
@@ -244,6 +244,42 @@ class TestPatchOpenhandsSDK:
         assert 'conv_kwargs["visualizer"] = None' in runner_patch, (
             f"runner patch must disable the default visualizer to avoid rich grapheme hang; got:\n{runner_patch}"
         )
+
+    async def test_runner_patch_injects_llm_timeout(self, tmp_path):
+        import base64
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text("import os\nllm_kwargs = {'model': 'm'}\n    llm = LLM(**llm_kwargs)\n")
+
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = MagicMock(stdout="ok", stderr="", return_code=0)
+        await _patch_openhands_sdk(sandbox)
+
+        decoded_scripts = []
+        for call in sandbox.exec.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+            if "base64 -d" in cmd:
+                encoded = cmd.split("echo ", 1)[1].split(" ", 1)[0]
+                decoded_scripts.append(base64.b64decode(encoded).decode())
+
+        timeout_patch = next(
+            (s for s in decoded_scripts if "llm_timeout" in s and "LLM_TIMEOUT" in s),
+            None,
+        )
+        assert timeout_patch is not None, "LLM timeout patch script not emitted"
+
+        timeout_patch = timeout_patch.replace(
+            "p = '/installed-agent/run_agent.py'",
+            f"p = {str(runner)!r}",
+        )
+        exec(compile(timeout_patch, "llm_timeout_patch.py", "exec"), {})  # noqa: S102
+
+        patched = runner.read_text()
+        assert "import os" in patched
+        assert 'os.environ.get("LLM_TIMEOUT")' in patched
+        assert 'llm_kwargs["timeout"] = int(timeout_raw)' in patched
 
     async def test_runner_patch_preserves_tool_timing(self, tmp_path):
         import base64
@@ -577,6 +613,39 @@ class TestResolveAgentTimeout:
     )
     def test_effective_timeout(self, strategy, config, task, cap, expected):
         assert _resolve_agent_timeout(strategy, config, task, cap) == expected
+
+
+class TestHarborSolverLlmTimeout:
+    def test_llm_kwargs_timeout_maps_to_container_env(self):
+        from unittest.mock import patch
+
+        with patch("nemo_evaluator.solvers.harbor._check_harbor_installed"):
+            from nemo_evaluator.solvers.harbor import HarborSolver
+
+            solver = HarborSolver(
+                harbor_agent="openhands-sdk",
+                model_url="http://localhost:8000",
+                model_id="test-model",
+                api_key="test-key",
+                harbor_agent_kwargs={"llm_kwargs": {"timeout": 3600}},
+            )
+            assert solver._container_env["LLM_TIMEOUT"] == "3600"
+
+    def test_explicit_container_env_overrides_llm_kwargs_timeout(self):
+        from unittest.mock import patch
+
+        with patch("nemo_evaluator.solvers.harbor._check_harbor_installed"):
+            from nemo_evaluator.solvers.harbor import HarborSolver
+
+            solver = HarborSolver(
+                harbor_agent="openhands-sdk",
+                model_url="http://localhost:8000",
+                model_id="test-model",
+                api_key="test-key",
+                harbor_agent_kwargs={"llm_kwargs": {"timeout": 3600}},
+                container_env={"LLM_TIMEOUT": "7200"},
+            )
+            assert solver._container_env["LLM_TIMEOUT"] == "7200"
 
 
 class TestInjectSkill:


### PR DESCRIPTION
## Summary
- Map `solver.agent_kwargs.llm_kwargs.timeout` into `container_env.LLM_TIMEOUT` for `openhands-sdk` so existing eval configs take effect without a duplicate env var.
- Patch Harbor `run_agent.py` in the sandbox (when missing) to read `LLM_TIMEOUT` and pass it to `LLM(timeout=...)`, fixing the 300s LiteLLM default on older Harbor images.

## Test plan
- [x] `TestHarborSolverLlmTimeout` — config mapping and explicit `container_env` override
- [x] `TestPatchOpenhandsSDK::test_runner_patch_injects_llm_timeout` — patch script mutates stub runner
- [x] `python -m pytest tests/test_solvers/test_harbor_solver.py -v -m "not network"`
- [x] Local fake-LiteLLM smoke test confitainless-read-timeout: 3600.0` in upstream logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Harbor OpenHands integration now honors the `LLM_TIMEOUT` environment variable, applying configurable LLM timeouts to container execution (including per-request timeout values).

* **Tests**
  * Expanded Harbor solver tests to validate the in-container runner patching for `LLM_TIMEOUT` behavior.
  * Added coverage ensuring `harbor_agent_kwargs["llm_kwargs"]["timeout"]` is mapped into `LLM_TIMEOUT` as a string, and that an explicit `container_env` value overrides the derived timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->