### PR TITLE
fix: [EVAL-1459] fix summarization issues (token miscounting, fallback logic)

### DIFF
--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -135,6 +135,7 @@ class _ModelServerBase(BaseModel):
     reasoning_pattern: str | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    tokenizer: str | None = None
     generation: GenerationConfig = Field(default_factory=GenerationConfig)
     proxy: ProxyConfig | None = None
     depends_on: list[str] = Field(default_factory=list)
@@ -248,6 +249,7 @@ class ExternalApiService(BaseModel):
     health_path: str | None = None
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None
+    tokenizer: str | None = None
     generation: GenerationConfig = Field(default_factory=GenerationConfig)
     proxy: ProxyConfig | None = None
 

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -305,6 +305,7 @@ def _make_solver(
             container_env=container_env,
             max_input_tokens=getattr(svc, "max_input_tokens", None),
             max_output_tokens=getattr(svc, "max_output_tokens", None),
+            tokenizer=getattr(svc, "tokenizer", None),
             cmd_timeout=getattr(solver_cfg, "cmd_timeout", None),
             timeout_strategy=getattr(solver_cfg, "timeout_strategy", "override"),
             max_agent_timeout=getattr(solver_cfg, "max_agent_timeout", None),

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1178,6 +1178,13 @@ def _terminus2_count_total_tokens(self, chat) -> int:
         return anchor_total + token_counter(model=self._model_name, messages=messages[anchor_len:])
     if len(messages) == anchor_len:
         return anchor_total
+    if not getattr(chat, "_api_anchor_below_warned", False):
+        chat._api_anchor_below_warned = True
+        logger.debug(
+            "terminus-2 messages (%d) shrank below the API anchor (%d); using litellm's default tokenizer estimate",
+            len(messages),
+            anchor_len,
+        )
     return token_counter(model=self._model_name, messages=messages)
 
 
@@ -1197,7 +1204,7 @@ def _patch_chat_token_anchor() -> None:
     async def _chat_with_token_anchor(self, *args, **kwargs):
         response = await original_chat(self, *args, **kwargs)
         usage = getattr(response, "usage", None)
-        if usage is not None:
+        if usage is not None and hasattr(usage, "prompt_tokens") and hasattr(usage, "completion_tokens"):
             self._api_token_anchor = (len(self._messages), usage.prompt_tokens + usage.completion_tokens)
         return response
 

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1169,7 +1169,7 @@ def _terminus2_count_total_tokens(self, chat) -> int:
             chat._api_anchor_warned = True
             logger.warning(
                 "No API token-usage anchor available for terminus-2; falling back to litellm's "
-                "default tokenizer, which may provide inaccurate token count estimates."
+                "tokenizer, which may provide inaccurate token count estimates."
             )
         return token_counter(model=self._model_name, messages=messages)
 
@@ -1181,7 +1181,7 @@ def _terminus2_count_total_tokens(self, chat) -> int:
     if not getattr(chat, "_api_anchor_below_warned", False):
         chat._api_anchor_below_warned = True
         logger.debug(
-            "terminus-2 messages (%d) shrank below the API anchor (%d); using litellm's default tokenizer estimate",
+            "terminus-2 messages (%d) shrank below the API anchor (%d); using litellm's tokenizer for token count estimation",
             len(messages),
             anchor_len,
         )
@@ -1233,7 +1233,86 @@ def _patch_terminus_api_token_anchor() -> None:
     _patch_chat_token_anchor()
     terminus2_mod.Terminus2._count_total_tokens = _terminus2_count_total_tokens
     _TERMINUS_API_ANCHOR_PATCHED = True
-    logger.info("Patched Terminus2._count_total_tokens: anchor on API usage + litellm-default token remainder")
+    logger.info("Patched Terminus2._count_total_tokens: anchor on API usage + litellm token remainder")
+
+
+_TOKENIZER_REGISTRY: dict[str, dict] = {}
+_TOKEN_COUNTER_PATCHED = False
+_MISSING_TOKENIZER_WARNED: set[str] = set()
+_IGNORED_TOKENIZER_LOGGED: set[str] = set()
+
+
+def _build_custom_tokenizer(spec: str) -> dict:
+    from litellm.utils import create_pretrained_tokenizer, create_tokenizer
+
+    spec_path = Path(spec)
+    if spec_path.is_file():
+        return create_tokenizer(spec_path.read_text())
+    return create_pretrained_tokenizer(spec)
+
+
+def _install_token_counter_patch() -> None:
+    global _TOKEN_COUNTER_PATCHED
+    if _TOKEN_COUNTER_PATCHED:
+        return
+
+    import litellm.utils as litellm_utils
+
+    _original_token_counter = litellm_utils.token_counter
+
+    def _patched_token_counter(*args, **kwargs):
+        model = kwargs["model"] if "model" in kwargs else (args[0] if args else "")
+        passes_custom = kwargs.get("custom_tokenizer") is not None or len(args) >= 2
+        if model in _TOKENIZER_REGISTRY and not passes_custom:
+            kwargs["custom_tokenizer"] = _TOKENIZER_REGISTRY[model]
+        return _original_token_counter(*args, **kwargs)
+
+    litellm_utils.token_counter = _patched_token_counter
+    _TOKEN_COUNTER_PATCHED = True
+
+
+def _register_harbor_tokenizer(model_name: str, spec: str) -> None:
+    if model_name not in _TOKENIZER_REGISTRY:
+        try:
+            tokenizer = _build_custom_tokenizer(spec)
+        except Exception as exc:
+            raise RuntimeError(
+                f"Failed to load tokenizer {spec!r} configured for model {model_name!r}. "
+                "Provide a valid Hugging Face repo id or a local tokenizer.json path, or "
+                "remove the 'tokenizer' field from the model service config. "
+                f"Underlying error: {exc}"
+            ) from exc
+        _TOKENIZER_REGISTRY[model_name] = tokenizer
+        logger.info("Registered custom tokenizer %r for model %r", spec, model_name)
+    _install_token_counter_patch()
+
+
+def _configure_terminus_tokenizer(*, is_terminus2: bool, model_name: str, tokenizer: str | None) -> None:
+    if not is_terminus2:
+        if tokenizer and model_name and model_name not in _IGNORED_TOKENIZER_LOGGED:
+            _IGNORED_TOKENIZER_LOGGED.add(model_name)
+            logger.info(
+                "Tokenizer %r is configured for model %r but is only used by the "
+                "terminus-2 agent; ignoring it for the current agent.",
+                tokenizer,
+                model_name,
+            )
+        return
+
+    if not tokenizer:
+        if model_name and model_name not in _MISSING_TOKENIZER_WARNED:
+            _MISSING_TOKENIZER_WARNED.add(model_name)
+            logger.warning(
+                "No tokenizer configured for model %r used with terminus-2; token "
+                "counts will use litellm's tokenizer and may be inaccurate. Set the "
+                "'tokenizer' field (Hugging Face repo id or local tokenizer.json path) on "
+                "the model service config.",
+                model_name,
+            )
+        return
+
+    if model_name:
+        _register_harbor_tokenizer(model_name, tokenizer)
 
 
 class HarborSolver:
@@ -1258,6 +1337,7 @@ class HarborSolver:
         container_env: dict[str, str] | None = None,
         max_input_tokens: int | None = None,
         max_output_tokens: int | None = None,
+        tokenizer: str | None = None,
         cmd_timeout: float | None = None,
         timeout_strategy: str = "override",
         max_agent_timeout: float | None = None,
@@ -1287,6 +1367,7 @@ class HarborSolver:
             self._container_env.setdefault("LLM_NATIVE_TOOL_CALLING", "true")
         self._max_input_tokens = max_input_tokens
         self._max_output_tokens = max_output_tokens
+        self._tokenizer = tokenizer
         self._api_key = _resolve_api_key(api_key)
         if not self._api_key:
             self._api_key = "no-key-needed"
@@ -1315,12 +1396,18 @@ class HarborSolver:
         kwargs = dict(self._harbor_agent_kwargs)
         url = model_url or self._model_url
         model_id = _model_id_for_openai(self._model_id, bool(url), agent=self._harbor_agent) if self._model_id else ""
-        if self._harbor_agent.replace("_", "-").lower() == "terminus-2":
+        is_terminus2 = self._harbor_agent.replace("_", "-").lower() == "terminus-2"
+        if is_terminus2:
             _patch_terminus_cle_reset()
             _patch_terminus_unwind_min_pairs()
             _patch_terminus_api_token_anchor()
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
+        _configure_terminus_tokenizer(
+            is_terminus2=is_terminus2,
+            model_name=kwargs.get("model_name") or model_id,
+            tokenizer=self._tokenizer,
+        )
         if "api_base" not in kwargs and url:
             kwargs["api_base"] = url
         if "api_key" not in kwargs and self._api_key:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -974,6 +974,116 @@ def _patch_terminus_tmux_send_keys() -> None:
     logger.info("Applied Harbor terminus-2 tmux send-keys UTF-8 byte-length patch")
 
 
+_TERMINUS_CLE_RESET_PATCHED = False
+
+_TERMINUS_CLE_RESET_REPLACEMENTS = [
+    (
+        "            summary_prompt = None\n            # Fallback 1: Try full summary\n",
+        "            summary_prompt = None\n"
+        "            full_summarize_failed_with_cle = False\n"
+        "            # Fallback 1: Try full summary\n",
+    ),
+    (
+        "            except Exception as e:\n"
+        '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n',
+        "            except Exception as e:\n"
+        "                full_summarize_failed_with_cle = isinstance(\n"
+        "                    e, ContextLengthExceededError\n"
+        "                )\n"
+        '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n',
+    ),
+    (
+        "            if prompt_path is not None:\n"
+        "                prompt_path.write_text(summary_prompt)\n"
+        "\n"
+        "            try:\n"
+        "                start_time = time.time()\n"
+        "                llm_response = await chat.chat(\n",
+        "            if prompt_path is not None:\n"
+        "                prompt_path.write_text(summary_prompt)\n"
+        "\n"
+        "            if full_summarize_failed_with_cle:\n"
+        "                chat._messages = [chat.messages[0]]\n"
+        "                chat.reset_response_chain()\n"
+        "\n"
+        "            try:\n"
+        "                start_time = time.time()\n"
+        "                llm_response = await chat.chat(\n",
+    ),
+    (
+        "                llm_response = LLMResponse(\n"
+        '                    content="Technical difficulties. Please continue with the task."\n'
+        "                )\n",
+        "                llm_response = LLMResponse(\n"
+        "                    content=self._build_local_fallback_llm_content()\n"
+        "                )\n",
+    ),
+]
+
+
+def _terminus2_build_local_fallback_llm_content(self) -> str:
+    import json
+
+    analysis = "Technical difficulties during context recovery. All summarization fallbacks failed."
+    plan = "Technical difficulties. Please continue with the task."
+    if self._parser_name == "xml":
+        return (
+            "<response>\n"
+            f"<analysis>{analysis}</analysis>\n"
+            f"<plan>{plan}</plan>\n"
+            "<commands>\n"
+            "</commands>\n"
+            "<task_complete>false</task_complete>\n"
+            "</response>"
+        )
+    return json.dumps(
+        {
+            "analysis": analysis,
+            "plan": plan,
+            "commands": [],
+            "task_complete": False,
+        }
+    )
+
+
+def _patch_terminus_cle_reset() -> None:
+    global _TERMINUS_CLE_RESET_PATCHED
+    if _TERMINUS_CLE_RESET_PATCHED:
+        return
+
+    import inspect
+    import textwrap
+
+    from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
+
+    original = terminus2_mod.Terminus2._query_llm
+    src = inspect.getsource(inspect.unwrap(original))
+
+    if "full_summarize_failed_with_cle" in src:
+        _TERMINUS_CLE_RESET_PATCHED = True
+        logger.info("Terminus2._query_llm already contains the CLE chat-reset logic; skipping patch")
+        return
+
+    for anchor, replacement in _TERMINUS_CLE_RESET_REPLACEMENTS:
+        occurrences = src.count(anchor)
+        if occurrences != 1:
+            raise RuntimeError(
+                "Cannot patch Terminus2._query_llm for CLE chat reset: expected exactly "
+                f"one match for an anchor but found {occurrences}. Harbor's terminus_2.py "
+                "has diverged from the expected source."
+            )
+        src = src.replace(anchor, replacement, 1)
+
+    if not hasattr(terminus2_mod.Terminus2, "_build_local_fallback_llm_content"):
+        terminus2_mod.Terminus2._build_local_fallback_llm_content = _terminus2_build_local_fallback_llm_content
+
+    namespace: dict[str, Any] = {}
+    exec(textwrap.dedent(src), terminus2_mod.__dict__, namespace)
+    terminus2_mod.Terminus2._query_llm = namespace["_query_llm"]
+    _TERMINUS_CLE_RESET_PATCHED = True
+    logger.info("Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback")
+
+
 class HarborSolver:
     """Runs any Harbor agent inside an evaluator :class:`Sandbox`.
 
@@ -1053,6 +1163,8 @@ class HarborSolver:
         kwargs = dict(self._harbor_agent_kwargs)
         url = model_url or self._model_url
         model_id = _model_id_for_openai(self._model_id, bool(url), agent=self._harbor_agent) if self._model_id else ""
+        if self._harbor_agent.replace("_", "-").lower() == "terminus-2":
+            _patch_terminus_cle_reset()
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
         if "api_base" not in kwargs and url:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1084,6 +1084,77 @@ def _patch_terminus_cle_reset() -> None:
     logger.info("Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback")
 
 
+_TERMINUS_UNWIND_MIN_PAIRS = 3
+_TERMINUS_UNWIND_PATCHED = False
+
+_TERMINUS_UNWIND_REPLACEMENTS = [
+    (
+        "        context_limit = self._llm.get_model_context_limit()\n"
+        "\n"
+        "        while len(chat.messages) > 1:  # Keep at least the first message\n",
+        "        context_limit = self._llm.get_model_context_limit()\n"
+        "\n"
+        f"        min_pairs_to_remove = {_TERMINUS_UNWIND_MIN_PAIRS}\n"
+        "        pairs_removed = 0\n"
+        "        while len(chat.messages) > 1:  # Keep at least the first message\n",
+    ),
+    (
+        "            if free_tokens >= target_free_tokens:\n                break\n",
+        "            if free_tokens >= target_free_tokens and pairs_removed >= min_pairs_to_remove:\n"
+        "                break\n",
+    ),
+    (
+        "            if len(chat.messages) >= 2:\n"
+        "                chat._messages = chat.messages[:-2]\n"
+        "            else:\n"
+        "                break\n",
+        "            if len(chat.messages) >= 2:\n"
+        "                chat._messages = chat.messages[:-2]\n"
+        "                pairs_removed += 1\n"
+        "            else:\n"
+        "                break\n",
+    ),
+]
+
+
+def _patch_terminus_unwind_min_pairs() -> None:
+    global _TERMINUS_UNWIND_PATCHED
+    if _TERMINUS_UNWIND_PATCHED:
+        return
+
+    import inspect
+    import textwrap
+
+    from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
+
+    original = terminus2_mod.Terminus2._unwind_messages_to_free_tokens
+    src = inspect.getsource(inspect.unwrap(original))
+
+    if "min_pairs_to_remove" in src:
+        _TERMINUS_UNWIND_PATCHED = True
+        logger.info("Terminus2._unwind_messages_to_free_tokens already enforces a minimum pair removal; skipping patch")
+        return
+
+    for anchor, replacement in _TERMINUS_UNWIND_REPLACEMENTS:
+        occurrences = src.count(anchor)
+        if occurrences != 1:
+            raise RuntimeError(
+                "Cannot patch Terminus2._unwind_messages_to_free_tokens for minimum pair "
+                f"removal: expected exactly one match for an anchor but found {occurrences}. "
+                "Harbor's terminus_2.py has diverged from the expected source."
+            )
+        src = src.replace(anchor, replacement, 1)
+
+    namespace: dict[str, Any] = {}
+    exec(textwrap.dedent(src), terminus2_mod.__dict__, namespace)
+    terminus2_mod.Terminus2._unwind_messages_to_free_tokens = namespace["_unwind_messages_to_free_tokens"]
+    _TERMINUS_UNWIND_PATCHED = True
+    logger.info(
+        "Patched Terminus2._unwind_messages_to_free_tokens: always remove at least %d message pairs",
+        _TERMINUS_UNWIND_MIN_PAIRS,
+    )
+
+
 class HarborSolver:
     """Runs any Harbor agent inside an evaluator :class:`Sandbox`.
 
@@ -1165,6 +1236,7 @@ class HarborSolver:
         model_id = _model_id_for_openai(self._model_id, bool(url), agent=self._harbor_agent) if self._model_id else ""
         if self._harbor_agent.replace("_", "-").lower() == "terminus-2":
             _patch_terminus_cle_reset()
+            _patch_terminus_unwind_min_pairs()
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
         if "api_base" not in kwargs and url:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1155,6 +1155,80 @@ def _patch_terminus_unwind_min_pairs() -> None:
     )
 
 
+_TERMINUS_API_ANCHOR_PATCHED = False
+_CHAT_TOKEN_ANCHOR_PATCHED = False
+
+
+def _terminus2_count_total_tokens(self, chat) -> int:
+    from litellm.utils import token_counter
+
+    messages = chat.messages
+    anchor = getattr(chat, "_api_token_anchor", None)
+    if anchor is None:
+        if not getattr(chat, "_api_anchor_warned", False):
+            chat._api_anchor_warned = True
+            logger.warning(
+                "No API token-usage anchor available for terminus-2; falling back to litellm's "
+                "default tokenizer, which may provide inaccurate token count estimates."
+            )
+        return token_counter(model=self._model_name, messages=messages)
+
+    anchor_len, anchor_total = anchor
+    if len(messages) > anchor_len:
+        return anchor_total + token_counter(model=self._model_name, messages=messages[anchor_len:])
+    if len(messages) == anchor_len:
+        return anchor_total
+    return token_counter(model=self._model_name, messages=messages)
+
+
+def _patch_chat_token_anchor() -> None:
+    global _CHAT_TOKEN_ANCHOR_PATCHED
+    if _CHAT_TOKEN_ANCHOR_PATCHED:
+        return
+
+    from harbor.llms.chat import Chat
+
+    if getattr(Chat, "_records_api_token_anchor", False):
+        _CHAT_TOKEN_ANCHOR_PATCHED = True
+        return
+
+    original_chat = Chat.chat
+
+    async def _chat_with_token_anchor(self, *args, **kwargs):
+        response = await original_chat(self, *args, **kwargs)
+        usage = getattr(response, "usage", None)
+        if usage is not None:
+            self._api_token_anchor = (len(self._messages), usage.prompt_tokens + usage.completion_tokens)
+        return response
+
+    Chat.chat = _chat_with_token_anchor
+    Chat._records_api_token_anchor = True
+    _CHAT_TOKEN_ANCHOR_PATCHED = True
+    logger.info("Patched Chat.chat to record the API token anchor (prompt + completion) after each call")
+
+
+def _patch_terminus_api_token_anchor() -> None:
+    global _TERMINUS_API_ANCHOR_PATCHED
+    if _TERMINUS_API_ANCHOR_PATCHED:
+        return
+
+    import inspect
+
+    from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
+
+    src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._count_total_tokens))
+    if "token_counter(model=self._model_name, messages=chat.messages)" not in src:
+        raise RuntimeError(
+            "Cannot patch Terminus2._count_total_tokens for API-anchored token counting: "
+            "Harbor's terminus_2.py has diverged from the expected source."
+        )
+
+    _patch_chat_token_anchor()
+    terminus2_mod.Terminus2._count_total_tokens = _terminus2_count_total_tokens
+    _TERMINUS_API_ANCHOR_PATCHED = True
+    logger.info("Patched Terminus2._count_total_tokens: anchor on API usage + litellm-default token remainder")
+
+
 class HarborSolver:
     """Runs any Harbor agent inside an evaluator :class:`Sandbox`.
 
@@ -1237,6 +1311,7 @@ class HarborSolver:
         if self._harbor_agent.replace("_", "-").lower() == "terminus-2":
             _patch_terminus_cle_reset()
             _patch_terminus_unwind_min_pairs()
+            _patch_terminus_api_token_anchor()
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
         if "api_base" not in kwargs and url:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1084,7 +1084,7 @@ def _patch_terminus_cle_reset() -> None:
     logger.info("Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback")
 
 
-_TERMINUS_UNWIND_MIN_PAIRS = 3
+_TERMINUS_UNWIND_MIN_PAIRS = 10
 _TERMINUS_UNWIND_PATCHED = False
 
 _TERMINUS_UNWIND_REPLACEMENTS = [

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import nemo_evaluator.solvers.harbor as harbor_mod
 from nemo_evaluator.errors import InfraError
 from nemo_evaluator.solvers.harbor import (
     _ensure_claude_host_env,
@@ -384,6 +385,164 @@ class TestSandboxEnvironmentAdapter:
         adapter = SandboxEnvironmentAdapter(MagicMock(), session_id="test-session", logs_dir=tmp_path)
         missing = {a for a in base_attrs if not hasattr(adapter, a)}
         assert not missing, f"SandboxEnvironmentAdapter missing public attrs: {missing}"
+
+
+class TestConfigureTerminusTokenizer:
+    """Tokenizer is fetched/registered only for terminus-2; failures fail fast."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self, monkeypatch):
+        monkeypatch.setattr(harbor_mod, "_TOKENIZER_REGISTRY", {})
+        monkeypatch.setattr(harbor_mod, "_MISSING_TOKENIZER_WARNED", set())
+        monkeypatch.setattr(harbor_mod, "_IGNORED_TOKENIZER_LOGGED", set())
+
+    def test_non_terminus_with_tokenizer_does_not_fetch(self, monkeypatch, caplog):
+        import logging
+
+        build = MagicMock()
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", build)
+        with caplog.at_level(logging.INFO):
+            harbor_mod._configure_terminus_tokenizer(is_terminus2=False, model_name="my-model", tokenizer="Qwen/Qwen3")
+        build.assert_not_called()
+        assert harbor_mod._TOKENIZER_REGISTRY == {}
+        assert "ignoring it for the current agent" in caplog.text
+
+    def test_non_terminus_info_logged_once(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", MagicMock())
+        with caplog.at_level(logging.INFO):
+            for _ in range(3):
+                harbor_mod._configure_terminus_tokenizer(
+                    is_terminus2=False, model_name="my-model", tokenizer="Qwen/Qwen3"
+                )
+        assert caplog.text.count("ignoring it for the current agent") == 1
+
+    def test_terminus_without_tokenizer_warns_once(self, caplog):
+        import logging
+
+        with caplog.at_level(logging.WARNING):
+            for _ in range(3):
+                harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer=None)
+        assert caplog.text.count("No tokenizer configured") == 1
+
+    def test_terminus_with_tokenizer_registers(self, monkeypatch):
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", lambda spec: {"spec": spec})
+        monkeypatch.setattr(harbor_mod, "_install_token_counter_patch", MagicMock())
+        harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer="Qwen/Qwen3")
+        assert harbor_mod._TOKENIZER_REGISTRY["my-model"] == {"spec": "Qwen/Qwen3"}
+
+    def test_terminus_tokenizer_fetch_failure_raises(self, monkeypatch):
+        def boom(spec):
+            raise OSError("offline: cannot reach huggingface")
+
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", boom)
+        with pytest.raises(RuntimeError, match="Failed to load tokenizer"):
+            harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer="Qwen/Qwen3")
+
+    def test_terminus_tokenizer_built_once_per_model(self, monkeypatch):
+        build = MagicMock(return_value={"tok": 1})
+        monkeypatch.setattr(harbor_mod, "_build_custom_tokenizer", build)
+        monkeypatch.setattr(harbor_mod, "_install_token_counter_patch", MagicMock())
+        for _ in range(3):
+            harbor_mod._configure_terminus_tokenizer(is_terminus2=True, model_name="my-model", tokenizer="Qwen/Qwen3")
+        build.assert_called_once()
+
+
+class TestBuildCustomTokenizer:
+    """Local tokenizer.json paths use create_tokenizer; repo ids use create_pretrained_tokenizer."""
+
+    def test_local_file_uses_create_tokenizer(self, monkeypatch, tmp_path):
+        token_file = tmp_path / "tokenizer.json"
+        token_file.write_text('{"fake": "tokenizer"}')
+        created = MagicMock(return_value={"type": "local"})
+        pretrained = MagicMock()
+        monkeypatch.setattr("litellm.utils.create_tokenizer", created)
+        monkeypatch.setattr("litellm.utils.create_pretrained_tokenizer", pretrained)
+
+        result = harbor_mod._build_custom_tokenizer(str(token_file))
+
+        created.assert_called_once_with('{"fake": "tokenizer"}')
+        pretrained.assert_not_called()
+        assert result == {"type": "local"}
+
+    def test_repo_id_uses_create_pretrained_tokenizer(self, monkeypatch):
+        created = MagicMock()
+        pretrained = MagicMock(return_value={"type": "hf"})
+        monkeypatch.setattr("litellm.utils.create_tokenizer", created)
+        monkeypatch.setattr("litellm.utils.create_pretrained_tokenizer", pretrained)
+
+        result = harbor_mod._build_custom_tokenizer("Qwen/Qwen3-8B")
+
+        pretrained.assert_called_once_with("Qwen/Qwen3-8B")
+        created.assert_not_called()
+        assert result == {"type": "hf"}
+
+
+class TestPatchedTokenCounter:
+    """litellm.utils.token_counter is wrapped to inject the registered custom tokenizer."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self, monkeypatch):
+        monkeypatch.setattr(harbor_mod, "_TOKEN_COUNTER_PATCHED", False)
+        monkeypatch.setattr(harbor_mod, "_TOKENIZER_REGISTRY", {})
+
+    @staticmethod
+    def _install_recorder(monkeypatch):
+        calls = {}
+
+        def fake_original(*args, **kwargs):
+            calls["custom_tokenizer"] = kwargs.get("custom_tokenizer")
+            calls["args"] = args
+            return 0
+
+        monkeypatch.setattr("litellm.utils.token_counter", fake_original)
+        harbor_mod._install_token_counter_patch()
+        import litellm.utils as litellm_utils
+
+        return litellm_utils.token_counter, calls
+
+    def test_rebinds_litellm_token_counter(self, monkeypatch):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda **kwargs: 0)
+        import litellm.utils as litellm_utils
+
+        before = litellm_utils.token_counter
+        harbor_mod._install_token_counter_patch()
+        assert litellm_utils.token_counter is not before
+        assert harbor_mod._TOKEN_COUNTER_PATCHED is True
+
+    def test_injects_custom_tokenizer_for_registered_model(self, monkeypatch):
+        patched, calls = self._install_recorder(monkeypatch)
+        harbor_mod._TOKENIZER_REGISTRY["M"] = {"sentinel": 1}
+        patched(model="M", messages=[{"role": "user", "content": "x"}])
+        assert calls["custom_tokenizer"] == {"sentinel": 1}
+
+    def test_does_not_inject_for_unregistered_model(self, monkeypatch):
+        patched, calls = self._install_recorder(monkeypatch)
+        patched(model="other", messages=[{"role": "user", "content": "x"}])
+        assert calls["custom_tokenizer"] is None
+
+    def test_respects_explicit_custom_tokenizer_kwarg(self, monkeypatch):
+        patched, calls = self._install_recorder(monkeypatch)
+        harbor_mod._TOKENIZER_REGISTRY["M"] = {"sentinel": 1}
+        patched(model="M", messages=[], custom_tokenizer={"explicit": 2})
+        assert calls["custom_tokenizer"] == {"explicit": 2}
+
+    def test_respects_positional_custom_tokenizer(self, monkeypatch):
+        patched, calls = self._install_recorder(monkeypatch)
+        harbor_mod._TOKENIZER_REGISTRY["M"] = {"sentinel": 1}
+        patched("M", {"explicit": 2})
+        assert calls["custom_tokenizer"] is None
+        assert calls["args"] == ("M", {"explicit": 2})
+
+    def test_idempotent_install(self, monkeypatch):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda **kwargs: 0)
+        harbor_mod._install_token_counter_patch()
+        import litellm.utils as litellm_utils
+
+        first = litellm_utils.token_counter
+        harbor_mod._install_token_counter_patch()
+        assert litellm_utils.token_counter is first
 
 
 class TestResolveAgentTimeout:

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -1,0 +1,410 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+"""Tests for the terminus-2 runtime monkeypatches in nemo_evaluator.solvers.harbor.
+
+All patches mutate the globally-imported harbor ``Terminus2``/``Chat`` classes,
+so :func:`patch_sandbox` snapshots and restores them (and the module-level
+idempotency guards) around every test.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+import nemo_evaluator.solvers.harbor as harbor
+from nemo_evaluator.solvers.harbor import (
+    _patch_chat_token_anchor,
+    _patch_terminus_api_token_anchor,
+    _patch_terminus_cle_reset,
+    _patch_terminus_unwind_min_pairs,
+    _terminus2_build_local_fallback_llm_content,
+    _terminus2_count_total_tokens,
+)
+
+# Module-level stand-ins whose *source* the patch functions inspect. Defining
+# them here (not inline) guarantees ``inspect.getsource`` can read them.
+
+
+def _query_llm_with_marker(self, *args, **kwargs):
+    full_summarize_failed_with_cle = False
+    return full_summarize_failed_with_cle
+
+
+def _unwind_with_marker(self, chat, target_free_tokens=4000):
+    min_pairs_to_remove = 3
+    return min_pairs_to_remove
+
+
+def _diverged_method(self, *args, **kwargs):
+    return None
+
+
+_FLAGS = (
+    "_TERMINUS_CLE_RESET_PATCHED",
+    "_TERMINUS_UNWIND_PATCHED",
+    "_TERMINUS_API_ANCHOR_PATCHED",
+    "_CHAT_TOKEN_ANCHOR_PATCHED",
+)
+
+
+@pytest.fixture
+def patch_sandbox():
+    """Snapshot terminus-2/Chat patch targets and guard flags; restore after."""
+    from harbor.agents.terminus_2 import terminus_2 as t2
+    from harbor.llms.chat import Chat
+
+    terminus = t2.Terminus2
+    saved_methods = {
+        "_query_llm": terminus._query_llm,
+        "_unwind": terminus._unwind_messages_to_free_tokens,
+        "_count": terminus._count_total_tokens,
+        "chat_chat": Chat.chat,
+    }
+    had_fallback = "_build_local_fallback_llm_content" in terminus.__dict__
+    fallback_val = terminus.__dict__.get("_build_local_fallback_llm_content")
+    had_records = "_records_api_token_anchor" in Chat.__dict__
+    records_val = Chat.__dict__.get("_records_api_token_anchor")
+    saved_flags = {name: getattr(harbor, name) for name in _FLAGS}
+
+    for name in _FLAGS:
+        setattr(harbor, name, False)
+
+    yield SimpleNamespace(harbor=harbor, t2=t2, terminus=terminus, Chat=Chat)
+
+    terminus._query_llm = saved_methods["_query_llm"]
+    terminus._unwind_messages_to_free_tokens = saved_methods["_unwind"]
+    terminus._count_total_tokens = saved_methods["_count"]
+    Chat.chat = saved_methods["chat_chat"]
+    if had_fallback:
+        terminus._build_local_fallback_llm_content = fallback_val
+    elif "_build_local_fallback_llm_content" in terminus.__dict__:
+        delattr(terminus, "_build_local_fallback_llm_content")
+    if had_records:
+        Chat._records_api_token_anchor = records_val
+    elif "_records_api_token_anchor" in Chat.__dict__:
+        delattr(Chat, "_records_api_token_anchor")
+    for name, value in saved_flags.items():
+        setattr(harbor, name, value)
+
+
+# ── _terminus2_count_total_tokens ────────────────────────────────────────
+
+
+class TestCountTotalTokens:
+    @staticmethod
+    def _agent():
+        return SimpleNamespace(_model_name="gpt-4o")
+
+    @staticmethod
+    def _messages(n):
+        return [{"role": "user", "content": "x"} for _ in range(n)]
+
+    def test_no_anchor_warns_once_and_falls_back(self, monkeypatch):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda model, messages: len(messages) * 10)
+        chat = SimpleNamespace(messages=self._messages(3))
+        result = _terminus2_count_total_tokens(self._agent(), chat)
+        assert result == 30
+        assert chat._api_anchor_warned is True
+
+    def test_no_anchor_already_warned_does_not_rewarn(self, monkeypatch, caplog):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda model, messages: len(messages) * 10)
+        chat = SimpleNamespace(messages=self._messages(2), _api_anchor_warned=True)
+        with caplog.at_level(logging.WARNING):
+            result = _terminus2_count_total_tokens(self._agent(), chat)
+        assert result == 20
+        assert "No API token-usage anchor" not in caplog.text
+
+    def test_more_messages_than_anchor_adds_delta(self, monkeypatch):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda model, messages: len(messages) * 10)
+        chat = SimpleNamespace(messages=self._messages(5), _api_token_anchor=(2, 1000))
+        result = _terminus2_count_total_tokens(self._agent(), chat)
+        assert result == 1000 + 3 * 10
+
+    def test_exactly_anchor_returns_api_total(self, monkeypatch):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda model, messages: len(messages) * 10)
+        chat = SimpleNamespace(messages=self._messages(5), _api_token_anchor=(5, 1234))
+        result = _terminus2_count_total_tokens(self._agent(), chat)
+        assert result == 1234
+
+    def test_fewer_than_anchor_uses_plain_estimate_and_logs_once(self, monkeypatch, caplog):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda model, messages: len(messages) * 10)
+        chat = SimpleNamespace(messages=self._messages(5), _api_token_anchor=(8, 1000))
+        with caplog.at_level(logging.DEBUG):
+            result = _terminus2_count_total_tokens(self._agent(), chat)
+        assert result == 50
+        assert chat._api_anchor_below_warned is True
+        assert "shrank below the API anchor" in caplog.text
+
+    def test_fewer_than_anchor_does_not_relog(self, monkeypatch, caplog):
+        monkeypatch.setattr("litellm.utils.token_counter", lambda model, messages: len(messages) * 10)
+        chat = SimpleNamespace(messages=self._messages(5), _api_token_anchor=(8, 1000), _api_anchor_below_warned=True)
+        with caplog.at_level(logging.DEBUG):
+            result = _terminus2_count_total_tokens(self._agent(), chat)
+        assert result == 50
+        assert "shrank below the API anchor" not in caplog.text
+
+
+# ── _terminus2_build_local_fallback_llm_content ──────────────────────────
+
+
+class TestBuildLocalFallback:
+    def test_xml_parser_emits_xml(self):
+        out = _terminus2_build_local_fallback_llm_content(SimpleNamespace(_parser_name="xml"))
+        assert "<response>" in out
+        assert "<task_complete>false</task_complete>" in out
+        assert "<commands>" in out
+
+    def test_non_xml_parser_emits_json(self):
+        out = _terminus2_build_local_fallback_llm_content(SimpleNamespace(_parser_name="json"))
+        data = json.loads(out)
+        assert data["task_complete"] is False
+        assert data["commands"] == []
+        assert "analysis" in data and "plan" in data
+
+
+# ── _patch_terminus_cle_reset ────────────────────────────────────────────
+
+
+class TestPatchCleReset:
+    def test_apply(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        original = terminus._query_llm
+        _patch_terminus_cle_reset()
+        assert harbor._TERMINUS_CLE_RESET_PATCHED is True
+        assert terminus._query_llm is not original
+        assert hasattr(terminus, "_build_local_fallback_llm_content")
+
+    def test_idempotent_when_flag_set(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        harbor._TERMINUS_CLE_RESET_PATCHED = True
+        original = terminus._query_llm
+        _patch_terminus_cle_reset()
+        assert terminus._query_llm is original
+
+    def test_skips_when_source_already_marked(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        terminus._query_llm = _query_llm_with_marker
+        _patch_terminus_cle_reset()
+        assert harbor._TERMINUS_CLE_RESET_PATCHED is True
+        assert terminus._query_llm is _query_llm_with_marker
+
+    def test_diverged_source_raises(self, patch_sandbox):
+        patch_sandbox.terminus._query_llm = _diverged_method
+        with pytest.raises(RuntimeError, match="diverged"):
+            _patch_terminus_cle_reset()
+
+
+# ── _patch_terminus_unwind_min_pairs ─────────────────────────────────────
+
+
+class _FakeChat:
+    def __init__(self, messages):
+        self._messages = list(messages)
+
+    @property
+    def messages(self):
+        return self._messages
+
+    def reset_response_chain(self):
+        pass
+
+
+class TestPatchUnwindMinPairs:
+    def test_apply(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        original = terminus._unwind_messages_to_free_tokens
+        _patch_terminus_unwind_min_pairs()
+        assert harbor._TERMINUS_UNWIND_PATCHED is True
+        assert terminus._unwind_messages_to_free_tokens is not original
+
+    def test_removes_at_least_three_pairs_even_when_target_met(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        _patch_terminus_unwind_min_pairs()
+        unwind = terminus._unwind_messages_to_free_tokens
+
+        fake_self = SimpleNamespace(
+            _llm=SimpleNamespace(get_model_context_limit=lambda: 100_000),
+            logger=SimpleNamespace(debug=lambda *a, **k: None),
+            _count_total_tokens=lambda chat: 10,
+        )
+        chat = _FakeChat(["system"] + [f"m{i}" for i in range(8)])  # 1 + 8 = 9 messages
+
+        unwind(fake_self, chat, target_free_tokens=4000)
+
+        # Free-token target is met from the start, but the minimum of 3 pairs
+        # (6 messages) must still be removed: 9 - 6 = 3 remain.
+        assert len(chat.messages) == 3
+
+    def test_idempotent_when_flag_set(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        harbor._TERMINUS_UNWIND_PATCHED = True
+        original = terminus._unwind_messages_to_free_tokens
+        _patch_terminus_unwind_min_pairs()
+        assert terminus._unwind_messages_to_free_tokens is original
+
+    def test_skips_when_source_already_marked(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        terminus._unwind_messages_to_free_tokens = _unwind_with_marker
+        _patch_terminus_unwind_min_pairs()
+        assert harbor._TERMINUS_UNWIND_PATCHED is True
+        assert terminus._unwind_messages_to_free_tokens is _unwind_with_marker
+
+    def test_diverged_source_raises(self, patch_sandbox):
+        patch_sandbox.terminus._unwind_messages_to_free_tokens = _diverged_method
+        with pytest.raises(RuntimeError, match="diverged"):
+            _patch_terminus_unwind_min_pairs()
+
+
+# ── _patch_chat_token_anchor ─────────────────────────────────────────────
+
+
+class _FakeUsage:
+    prompt_tokens = 100
+    completion_tokens = 20
+    cache_tokens = 0
+    cost_usd = 0.0
+
+
+class _FakeModel:
+    async def call(self, prompt, message_history, logging_path=None, previous_response_id=None, **kwargs):
+        return SimpleNamespace(
+            usage=_FakeUsage(),
+            content="ok",
+            response_id=None,
+            prompt_token_ids=None,
+            completion_token_ids=None,
+            logprobs=None,
+            extra=None,
+            reasoning_content=None,
+        )
+
+
+class TestPatchChatTokenAnchor:
+    async def test_records_anchor_after_chat(self, patch_sandbox):
+        Chat = patch_sandbox.Chat
+        _patch_chat_token_anchor()
+        assert harbor._CHAT_TOKEN_ANCHOR_PATCHED is True
+
+        chat = Chat(_FakeModel())
+        await chat.chat("hello")
+
+        # Two messages appended (user + assistant); anchor = prompt + completion.
+        assert chat._api_token_anchor == (2, 120)
+
+    async def test_partial_usage_does_not_record_anchor(self, patch_sandbox):
+        Chat = patch_sandbox.Chat
+
+        async def _stub_chat(self, *args, **kwargs):
+            return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=100))
+
+        Chat.chat = _stub_chat
+        _patch_chat_token_anchor()
+
+        holder = SimpleNamespace(_messages=["user", "assistant"])
+        await Chat.chat(holder, "hi")
+
+        assert getattr(holder, "_api_token_anchor", None) is None
+
+    def test_idempotent_when_flag_set(self, patch_sandbox):
+        Chat = patch_sandbox.Chat
+        harbor._CHAT_TOKEN_ANCHOR_PATCHED = True
+        original = Chat.chat
+        _patch_chat_token_anchor()
+        assert Chat.chat is original
+
+    def test_skips_when_chat_already_records(self, patch_sandbox):
+        Chat = patch_sandbox.Chat
+        Chat._records_api_token_anchor = True
+        original = Chat.chat
+        _patch_chat_token_anchor()
+        assert harbor._CHAT_TOKEN_ANCHOR_PATCHED is True
+        assert Chat.chat is original
+
+
+# ── _patch_terminus_api_token_anchor ─────────────────────────────────────
+
+
+class TestPatchApiTokenAnchor:
+    def test_apply(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        Chat = patch_sandbox.Chat
+        _patch_terminus_api_token_anchor()
+        assert harbor._TERMINUS_API_ANCHOR_PATCHED is True
+        assert terminus._count_total_tokens is _terminus2_count_total_tokens
+        assert harbor._CHAT_TOKEN_ANCHOR_PATCHED is True
+        assert getattr(Chat, "_records_api_token_anchor", False) is True
+
+    def test_idempotent_when_flag_set(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        harbor._TERMINUS_API_ANCHOR_PATCHED = True
+        original = terminus._count_total_tokens
+        _patch_terminus_api_token_anchor()
+        assert terminus._count_total_tokens is original
+
+    def test_diverged_source_raises(self, patch_sandbox):
+        patch_sandbox.terminus._count_total_tokens = _diverged_method
+        with pytest.raises(RuntimeError, match="diverged"):
+            _patch_terminus_api_token_anchor()
+
+
+# ── HarborSolver._create_agent gating ────────────────────────────────────
+
+
+class TestCreateAgentGating:
+    @staticmethod
+    def _solver(agent):
+        from unittest.mock import patch
+
+        with patch("nemo_evaluator.solvers.harbor._check_harbor_installed"):
+            from nemo_evaluator.solvers.harbor import HarborSolver
+
+            return HarborSolver(
+                harbor_agent=agent,
+                model_url="http://localhost:8000",
+                model_id="glm5",
+                api_key="test-key",
+            )
+
+    def test_terminus2_triggers_all_patches(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        solver = self._solver("terminus-2")
+        cle, unwind, anchor = MagicMock(), MagicMock(), MagicMock()
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_cle_reset", cle)
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_unwind_min_pairs", unwind)
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_api_token_anchor", anchor)
+
+        sentinel = object()
+        with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=sentinel):
+            result = solver._create_agent(tmp_path)
+
+        assert result is sentinel
+        cle.assert_called_once()
+        unwind.assert_called_once()
+        anchor.assert_called_once()
+
+    def test_non_terminus_agent_skips_patches(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock, patch
+
+        solver = self._solver("openhands")
+        cle, unwind, anchor = MagicMock(), MagicMock(), MagicMock()
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_cle_reset", cle)
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_unwind_min_pairs", unwind)
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_api_token_anchor", anchor)
+
+        with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=object()):
+            solver._create_agent(tmp_path)
+
+        cle.assert_not_called()
+        unwind.assert_not_called()
+        anchor.assert_not_called()

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -154,6 +154,57 @@ class TestCountTotalTokens:
         assert "shrank below the API anchor" not in caplog.text
 
 
+# ── anchored estimate + custom tokenizer integration ─────────────────────
+
+
+class TestAnchoredEstimateUsesCustomTokenizer:
+    """The anchored estimate routes its token_counter calls through the custom tokenizer."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_counter_patch(self, monkeypatch):
+        monkeypatch.setattr(harbor, "_TOKEN_COUNTER_PATCHED", False)
+        monkeypatch.setattr(harbor, "_TOKENIZER_REGISTRY", {})
+
+    @staticmethod
+    def _install_with_fake_original(monkeypatch):
+        def fake_original(*args, model=None, messages=None, custom_tokenizer=None, **kwargs):
+            per_msg = 100 if custom_tokenizer is not None else 10
+            return len(messages) * per_msg
+
+        monkeypatch.setattr("litellm.utils.token_counter", fake_original)
+        harbor._install_token_counter_patch()
+
+    @staticmethod
+    def _messages(n):
+        return [{"role": "user", "content": "x"} for _ in range(n)]
+
+    def test_remainder_estimate_uses_custom_tokenizer(self, monkeypatch):
+        self._install_with_fake_original(monkeypatch)
+        harbor._TOKENIZER_REGISTRY["M"] = {"sentinel": True}
+
+        agent = SimpleNamespace(_model_name="M")
+        chat = SimpleNamespace(messages=self._messages(5), _api_token_anchor=(2, 1000))
+        result = _terminus2_count_total_tokens(agent, chat)
+        assert result == 1000 + 3 * 100
+
+    def test_full_fallback_uses_custom_tokenizer(self, monkeypatch):
+        self._install_with_fake_original(monkeypatch)
+        harbor._TOKENIZER_REGISTRY["M"] = {"sentinel": True}
+
+        agent = SimpleNamespace(_model_name="M")
+        chat = SimpleNamespace(messages=self._messages(4))
+        result = _terminus2_count_total_tokens(agent, chat)
+        assert result == 4 * 100
+
+    def test_unregistered_model_uses_default_tokenizer(self, monkeypatch):
+        self._install_with_fake_original(monkeypatch)
+
+        agent = SimpleNamespace(_model_name="unregistered")
+        chat = SimpleNamespace(messages=self._messages(5), _api_token_anchor=(2, 1000))
+        result = _terminus2_count_total_tokens(agent, chat)
+        assert result == 1000 + 3 * 10
+
+
 # ── _terminus2_build_local_fallback_llm_content ──────────────────────────
 
 

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -41,7 +41,7 @@ def _query_llm_with_marker(self, *args, **kwargs):
 
 
 def _unwind_with_marker(self, chat, target_free_tokens=4000):
-    min_pairs_to_remove = 3
+    min_pairs_to_remove = 10
     return min_pairs_to_remove
 
 
@@ -227,7 +227,7 @@ class TestPatchUnwindMinPairs:
         assert harbor._TERMINUS_UNWIND_PATCHED is True
         assert terminus._unwind_messages_to_free_tokens is not original
 
-    def test_removes_at_least_three_pairs_even_when_target_met(self, patch_sandbox):
+    def test_removes_at_least_min_pairs_even_when_target_met(self, patch_sandbox):
         terminus = patch_sandbox.terminus
         _patch_terminus_unwind_min_pairs()
         unwind = terminus._unwind_messages_to_free_tokens
@@ -237,13 +237,15 @@ class TestPatchUnwindMinPairs:
             logger=SimpleNamespace(debug=lambda *a, **k: None),
             _count_total_tokens=lambda chat: 10,
         )
-        chat = _FakeChat(["system"] + [f"m{i}" for i in range(8)])  # 1 + 8 = 9 messages
+        min_pairs = harbor._TERMINUS_UNWIND_MIN_PAIRS
+        remainder = 4
+        chat = _FakeChat(["system"] + [f"m{i}" for i in range(2 * min_pairs + remainder)])
 
         unwind(fake_self, chat, target_free_tokens=4000)
 
-        # Free-token target is met from the start, but the minimum of 3 pairs
-        # (6 messages) must still be removed: 9 - 6 = 3 remain.
-        assert len(chat.messages) == 3
+        # Free-token target is met from the start, but the minimum of min_pairs
+        # pairs (2 * min_pairs messages) must still be removed.
+        assert len(chat.messages) == 1 + remainder
 
     def test_idempotent_when_flag_set(self, patch_sandbox):
         terminus = patch_sandbox.terminus


### PR DESCRIPTION
## Token miscounting

In terminus-2, litellm's token_counter falls back to the tiktoken/OpenAI tokenizer for models it doesn't recognize, miscounting tokens relative to the serving tokenizer. As a result terminus-2's internal token estimate can diverge from the model API, so proactive summarization might trigger too late and the API raises context-length-exceeded errors while the internal estimate still looks safe.

Monkeypatch litellm.utils.token_counter to anchor the token count estimate from model API's self-reported token usage, and use the OpenAI tokenizer only to estimate the token count of the latest observation (which is not included in the API's token count). This way, the internal token counts are a more accurate estimate of the real token usage.

Additionally, add an optional 'tokenizer' field to model service configs, thread it through the orchestrator into HarborSolver, and monkeypatch litellm.utils.token_counter to use a custom Hugging Face / local tokenizer (keyed per model) so internal token count estimates are a more accurate approximation of the serving tokenizer's token counts.

## Summarization fallback logic

When the context is already over the limit, terminus-2's reactive summarization could itself raise context-length-exceeded: the full-summary attempt fails and the fallbacks just append the summary prompt to an already-overflowing chat, so every retry hits the same error.

Require that the chat history unwind step before full summarization attempt always unwinds at least 10 pairs of chat messages to account for possible token count estimate inaccuracies. Additionally, patch Terminus2._query_llm to detect when full summarization fails specifically with a CLE, reset the chat history to the system message before retrying, and emit an XML/JSON-parseable local fallback response so the agent's parser can consume it instead of a plain string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminus-2 agents now apply improved recovery when summarization fails, using a local fallback to produce more reliable outputs.
  * More accurate token accounting across multi-message interactions via an API-usage “anchor” approach.
  * Added optional tokenizer configuration support, enabling custom token counting for Terminus-2 where configured.
  * Token optimization now ensures a minimum unwinding of message pairs.
* **Bug Fixes**
  * Improved consistency of total token estimates, with safer fallback when anchored data isn’t available.
* **Tests**
  * Expanded pytest coverage for patch application/idempotency, anchor behavior, fallback formatting, tokenizer/token-counter wiring, and Terminus-2 gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->