### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nemo-evaluator"
-version = "0.3.1"
+version = "0.4.0"
 description = "NeMo Evaluator — benchmark environments, pluggable solvers, interceptor proxy, and decision-grade scoring for LLMs"
 readme = "README.md"
 requires-python = ">=3.12,<3.14"

--- a/src/nemo_evaluator/__init__.py
+++ b/src/nemo_evaluator/__init__.py
@@ -18,7 +18,7 @@
 # can safely back-reference ``nemo_evaluator.__version__`` without triggering
 # a circular import while ``__init__.py`` is partially loaded. ``package_info``
 # remains the canonical source for the FW-CI-templates wheel patcher.
-__version__ = "0.3.1"
+__version__ = "0.4.0"
 __package_name__ = "nemo_evaluator"
 
 from nemo_evaluator.engine.eval_loop import run_evaluation

--- a/src/nemo_evaluator/package_info.py
+++ b/src/nemo_evaluator/package_info.py
@@ -25,8 +25,8 @@ to keep them in sync.
 
 # Below is the _next_ version that will be published, not the currently published one.
 MAJOR = 0
-MINOR = 3
-PATCH = 1
+MINOR = 4
+PATCH = 0
 PRE_RELEASE = ""
 
 # Use the following formatting: (major, minor, patch, pre-release)


### PR DESCRIPTION
## What

Bumps `main` version `0.3.1` → `0.4.0` across `pyproject.toml`, `src/nemo_evaluator/__init__.py`, and `src/nemo_evaluator/package_info.py`.

## Why

The `v0.3.1` tag/version bump on `main` was a mistake — `main` should track the upcoming **minor** version, not a patch. Per the branching model (confirmed with @ko3n1g):

- `main` → tracks upcoming **0.4.0**
- `r0.3.0` → tracks v0.3.0 + its patches (a real v0.3.1 is cut from there)

The stray `v0.3.1` tag has already been deleted (no release/PyPI artifact existed). This PR completes the cleanup by lifting `main` to 0.4.0.

cc @ko3n1g

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.4.0 (minor release)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->