### PR TITLE
fix(trajectory report): wire alignment, default set up

### DIFF
--- a/src/nemo_evaluator/config/output.py
+++ b/src/nemo_evaluator/config/output.py
@@ -26,15 +26,16 @@ class TrajectoriesConfig(BaseModel):
 
     The audit report (``trajectories_report.json``) is emitted unconditionally
     by the orchestrator finalize step when ``trajectories.jsonl`` exists.
-    When ``enrich=True``, also writes ``trajectories_enriched.jsonl``: per-trial
-    step metrics are backfilled 1:1 from matching ``model_traffic.jsonl`` wire
-    calls when counts align, otherwise all wire calls land in
+    Enrichment is enabled by default. Set ``enrich=False`` to opt out of
+    writing ``trajectories_enriched.jsonl``. When enabled, per-trial step
+    metrics are backfilled 1:1 from matching ``model_traffic.jsonl`` wire calls
+    when counts align, otherwise all wire calls land in
     ``trajectory[0].extra.captured_model_calls``.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    enrich: bool = False
+    enrich: bool = True
 
 
 class OutputConfig(BaseModel):

--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -62,18 +62,18 @@ class InterceptorConfig(BaseModel):
 
 
 class ModelTrafficCaptureConfig(BaseModel):
-    """Opt-in extras for what ``model_traffic.jsonl`` captures per call.
+    """Controls what ``model_traffic.jsonl`` captures per call.
 
-    By default the store records stats only (tokens, finish_reason, latency,
-    model, tool_calls.count). Set any of these flags to ``true`` to also
-    persist the corresponding fields from the upstream response.
+    By default the store records the assistant message, reasoning content, and
+    full tool-call payloads in addition to stats. Set these flags to ``false``
+    to opt out of the corresponding response fields.
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    capture_tool_calls: bool = False  # full {id, name, arguments} per call
-    capture_reasoning: bool = False  # message.reasoning_content (or SSE delta)
-    capture_messages: bool = False  # message.content
+    capture_tool_calls: bool = True  # full {id, name, arguments} per call
+    capture_reasoning: bool = True  # message.reasoning_content (or SSE delta)
+    capture_messages: bool = True  # message.content
     max_content_chars: int = 100_000  # truncation guard for the three above
 
 

--- a/src/nemo_evaluator/engine/model_traffic_log.py
+++ b/src/nemo_evaluator/engine/model_traffic_log.py
@@ -95,8 +95,9 @@ def format_model_traffic_log_records(
         }
         if row["usage"]:
             row["token_provenance"] = _PROVIDER
-        if record.get("error_type"):
-            row["error_type"] = record["error_type"]
+        for key in ("error_type", "error_message", "error_body", "error_code"):
+            if record.get(key):
+                row[key] = record[key]
         # Opt-in capture fields from ModelTrafficStore.finish_response: only
         # forwarded when present in the in-memory record (controlled by the
         # service's proxy.model_traffic.capture_{tool_calls,reasoning,messages}).

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -33,6 +33,7 @@ _REGISTRY: dict[str, "ModelTrafficStore"] = {}
 _REGISTRY_LOCK = threading.Lock()
 _USAGE_KEYS = ("prompt_tokens", "completion_tokens", "total_tokens", "reasoning_tokens", "cached_tokens")
 _PROVIDER = "provider_reported"
+_ERROR_SUMMARY_CHARS = 4000
 
 
 def register_store(store: "ModelTrafficStore") -> str:
@@ -132,6 +133,52 @@ def _truncate(value: Any, limit: int) -> Any:
     return value
 
 
+def _first_str(data: dict[str, Any], *keys: str) -> str:
+    for key in keys:
+        value = data.get(key)
+        if value is not None and value != "":
+            return str(value)
+    return ""
+
+
+def _error_summary(body: Any, max_content_chars: int) -> dict[str, Any]:
+    """Return a compact, non-request error summary for non-success responses."""
+    limit = min(max_content_chars, _ERROR_SUMMARY_CHARS)
+    out: dict[str, Any] = {}
+
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, dict):
+            message = _first_str(error, "message", "detail", "type", "code")
+            if message:
+                out["error_message"] = _truncate(message, limit)
+            if error.get("type") is not None:
+                out["error_type"] = str(error["type"])
+            if error.get("code") is not None:
+                out["error_code"] = str(error["code"])
+        elif error is not None:
+            out["error_message"] = _truncate(str(error), limit)
+
+        if "error_message" not in out:
+            message = _first_str(body, "message", "detail", "error_message")
+            if message:
+                out["error_message"] = _truncate(message, limit)
+        try:
+            out["error_body"] = _truncate(json.dumps(body, sort_keys=True, default=str), limit)
+        except (TypeError, ValueError):
+            pass
+        return out
+
+    if isinstance(body, bytes):
+        text = body.decode("utf-8", errors="replace")
+    else:
+        text = str(body) if body is not None else ""
+    if text:
+        out["error_message"] = _truncate(text, limit)
+        out["error_body"] = _truncate(text, limit)
+    return out
+
+
 def _full_tool_calls_from_message(message: dict[str, Any], limit: int) -> list[dict[str, Any]]:
     out: list[dict[str, Any]] = []
     for raw in message.get("tool_calls") or []:
@@ -159,9 +206,9 @@ def _full_tool_calls_from_message(message: dict[str, Any], limit: int) -> list[d
 def _summary_from_json(
     body: dict[str, Any],
     *,
-    capture_tool_calls: bool = False,
-    capture_reasoning: bool = False,
-    capture_messages: bool = False,
+    capture_tool_calls: bool = True,
+    capture_reasoning: bool = True,
+    capture_messages: bool = True,
     max_content_chars: int = 100_000,
 ) -> dict[str, Any]:
     tool_names: list[str] = []
@@ -241,9 +288,9 @@ def _iter_sse(body: Any) -> Iterator[dict[str, Any]]:
 def _summary_from_sse(
     body: Any,
     *,
-    capture_tool_calls: bool = False,
-    capture_reasoning: bool = False,
-    capture_messages: bool = False,
+    capture_tool_calls: bool = True,
+    capture_reasoning: bool = True,
+    capture_messages: bool = True,
     max_content_chars: int = 100_000,
 ) -> dict[str, Any]:
     model = ""
@@ -324,9 +371,9 @@ class ModelTrafficStore:
         self,
         *,
         service_name: str | None = None,
-        capture_tool_calls: bool = False,
-        capture_reasoning: bool = False,
-        capture_messages: bool = False,
+        capture_tool_calls: bool = True,
+        capture_reasoning: bool = True,
+        capture_messages: bool = True,
         max_content_chars: int = 100_000,
     ) -> None:
         self.store_id = uuid.uuid4().hex
@@ -334,7 +381,7 @@ class ModelTrafficStore:
         self._lock = threading.Lock()
         self._pending: dict[str, dict[str, Any]] = {}
         self._records_by_session: dict[str, list[dict[str, Any]]] = {}
-        # Opt-in capture: extra fields persisted to model_traffic.jsonl when set.
+        # Capture options for extra response fields persisted to model_traffic.jsonl.
         self._capture_opts = {
             "capture_tool_calls": capture_tool_calls,
             "capture_reasoning": capture_reasoning,
@@ -385,6 +432,8 @@ class ModelTrafficStore:
                 "tool_calls": summary["tool_calls"] if success else {"count": 0, "names": {}},
             }
         )
+        if not success:
+            record.update(_error_summary(resp.body, self._capture_opts["max_content_chars"]))
         # Persist opt-in capture fields when present (and the call succeeded).
         if success:
             for key in ("tool_calls_full", "reasoning_content", "message_content"):

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -784,9 +784,9 @@ def _start_proxy(
     capture_cfg = getattr(proxy_cfg, "model_traffic", None) if proxy_cfg is not None else None
     traffic_store = ModelTrafficStore(
         service_name=service_name,
-        capture_tool_calls=getattr(capture_cfg, "capture_tool_calls", False),
-        capture_reasoning=getattr(capture_cfg, "capture_reasoning", False),
-        capture_messages=getattr(capture_cfg, "capture_messages", False),
+        capture_tool_calls=getattr(capture_cfg, "capture_tool_calls", True),
+        capture_reasoning=getattr(capture_cfg, "capture_reasoning", True),
+        capture_messages=getattr(capture_cfg, "capture_messages", True),
         max_content_chars=getattr(capture_cfg, "max_content_chars", 100_000),
     )
     register_store(traffic_store)

--- a/src/nemo_evaluator/reports/schemas.py
+++ b/src/nemo_evaluator/reports/schemas.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Pydantic schemas for trajectories.jsonl and model_traffic.jsonl rows.
+"""Pydantic schemas for trajectory report coverage checks.
 
 Required fields (no default) mark the minimum a writer must emit.
 Optional fields (``= None``) are expected but may be absent in older logs
@@ -98,52 +98,6 @@ class TrajectoryRow(BaseModel):
     reward: float
     model: str | None = None
     trajectory: list[TrajectoryEntry] | None = None
-
-
-# ---------------------------------------------------------------------------
-# Model-traffic row (model_traffic.jsonl)
-# ---------------------------------------------------------------------------
-
-
-class ModelTrafficUsage(BaseModel):
-    model_config = ConfigDict(extra="allow")
-
-    prompt_tokens: int = 0
-    completion_tokens: int = 0
-    total_tokens: int = 0
-    reasoning_tokens: int = 0
-    cached_tokens: int = 0
-
-
-class ModelTrafficRow(BaseModel):
-    """One row in ``model_traffic.jsonl``."""
-
-    model_config = ConfigDict(extra="allow")
-
-    model_traffic_request_id: str
-    timestamp: str
-    benchmark: str
-    problem_idx: int
-    repeat: int
-    model: str = ""
-    finish_reason: str = ""
-    session_id: str | None = None
-    adapter_request_id: str | None = None
-    service: str | None = None
-    method: str | None = None
-    path: str | None = None
-    status_code: int | None = None
-    latency_ms: float | None = None
-    usage: ModelTrafficUsage | None = None
-    token_provenance: str | None = None
-    error_type: str | None = None
-    error_message: str | None = None
-    error_body: str | None = None
-    error_code: str | None = None
-    request_hash: str | None = None
-    tool_calls_full: list | None = None
-    reasoning_content: str | None = None
-    message_content: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/nemo_evaluator/reports/schemas.py
+++ b/src/nemo_evaluator/reports/schemas.py
@@ -137,6 +137,9 @@ class ModelTrafficRow(BaseModel):
     usage: ModelTrafficUsage | None = None
     token_provenance: str | None = None
     error_type: str | None = None
+    error_message: str | None = None
+    error_body: str | None = None
+    error_code: str | None = None
     request_hash: str | None = None
     tool_calls_full: list | None = None
     reasoning_content: str | None = None

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -55,6 +55,9 @@ logger = logging.getLogger(__name__)
 # with the schema without manual duplication.
 _TRIAL_FIELDS = fields_as_coverage_paths(TrajectoryRow)
 _STEP_FIELDS = fields_as_coverage_paths(AgentStep)
+_EXAMPLE_TEXT_CHARS = 500
+_MAX_EXAMPLES_PER_ERROR_TYPE = 5
+_MAX_RETRY_EXAMPLES = 5
 
 
 def _is_successful_wire(record: dict[str, Any]) -> bool:
@@ -83,6 +86,30 @@ def _wire_dedup_key(record: dict[str, Any], fallback_id: int) -> Any:
     return record.get("request_hash") or ("_no_hash", fallback_id)
 
 
+def _wire_session_id(record: dict[str, Any]) -> str:
+    session_id = str(record.get("session_id") or "").strip()
+    if session_id:
+        return session_id
+    request_id = str(record.get("model_traffic_request_id") or "")
+    if ":" in request_id:
+        return request_id.split(":", 1)[0]
+    return ""
+
+
+def _wire_has_tool(record: dict[str, Any], name: str) -> bool:
+    names = ((record.get("tool_calls") or {}).get("names") or {}) if isinstance(record.get("tool_calls"), dict) else {}
+    if names.get(name):
+        return True
+    for tool_call in record.get("tool_calls_full") or []:
+        if not isinstance(tool_call, dict):
+            continue
+        fn = tool_call.get("function") if isinstance(tool_call.get("function"), dict) else {}
+        tool_name = tool_call.get("name") or tool_call.get("function_name") or fn.get("name")
+        if tool_name == name:
+            return True
+    return False
+
+
 def _agent_steps(row: dict[str, Any]) -> list[dict[str, Any]]:
     traj = row.get("trajectory") or []
     if not traj:
@@ -105,6 +132,215 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
             except json.JSONDecodeError:
                 logger.warning("trajectories_report: skipping invalid JSON line in %s", path)
     return rows
+
+
+def _truncate_text(value: Any, limit: int = _EXAMPLE_TEXT_CHARS) -> str:
+    text = "" if value is None else str(value)
+    text = " ".join(text.split())
+    if len(text) > limit:
+        return text[:limit] + f"...[truncated, {len(text) - limit} chars dropped]"
+    return text
+
+
+def _trajectory_doc(row: dict[str, Any]) -> dict[str, Any]:
+    traj = row.get("trajectory") or []
+    if not traj or not isinstance(traj[0], dict):
+        return {}
+    return traj[0]
+
+
+def _final_metrics(row: dict[str, Any]) -> dict[str, Any]:
+    return _trajectory_doc(row).get("final_metrics") or {}
+
+
+def _failure_category(row: dict[str, Any]) -> str:
+    return str((row.get("scoring_details") or {}).get("error_category") or row.get("failure_category") or "")
+
+
+def _failure_error(row: dict[str, Any]) -> str:
+    scoring_details = row.get("scoring_details") or {}
+    return _truncate_text(scoring_details.get("error") or row.get("model_error") or row.get("error") or "")
+
+
+def _has_final_metric_tokens(row: dict[str, Any]) -> bool:
+    fm = _final_metrics(row)
+    return fm.get("total_prompt_tokens") is not None or fm.get("total_completion_tokens") is not None
+
+
+def _wire_example(record: dict[str, Any], *, is_last_wire: bool) -> dict[str, Any]:
+    example = {
+        "problem_idx": record.get("problem_idx"),
+        "repeat": record.get("repeat"),
+        "status_code": record.get("status_code"),
+        "error_type": record.get("error_type") or "",
+        "error_code": record.get("error_code") or "",
+        "error_message": _truncate_text(record.get("error_message")),
+        "latency_ms": record.get("latency_ms"),
+        "finish_reason": record.get("finish_reason") or "",
+        "model": record.get("model") or "",
+        "path": record.get("path") or "",
+        "model_traffic_request_id": record.get("model_traffic_request_id") or "",
+        "session_id": record.get("session_id") or "",
+        "adapter_request_id": record.get("adapter_request_id") or "",
+        "request_hash": record.get("request_hash") or "",
+        "is_last_wire": is_last_wire,
+    }
+    if record.get("error_body"):
+        example["error_body"] = _truncate_text(record.get("error_body"))
+    return example
+
+
+def _wire_error_type_key(example: dict[str, Any]) -> str:
+    error_type = str(example.get("error_type") or "").strip()
+    if error_type:
+        return error_type
+    error_code = str(example.get("error_code") or "").strip()
+    if error_code:
+        return error_code
+    status_code = example.get("status_code")
+    if status_code is not None and status_code != "":
+        return f"http_{status_code}"
+    return "unknown_error_type"
+
+
+def _group_wire_examples_by_error_type(examples: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    grouped: dict[str, dict[str, Any]] = {}
+    for example in examples:
+        key = _wire_error_type_key(example)
+        bucket = grouped.setdefault(key, {"count": 0, "examples": []})
+        bucket["count"] += 1
+        if len(bucket["examples"]) < _MAX_EXAMPLES_PER_ERROR_TYPE:
+            bucket["examples"].append(example)
+        else:
+            bucket["omitted_examples"] = bucket.get("omitted_examples", 0) + 1
+    return grouped
+
+
+def _session_group_example(
+    trial_key: tuple[Any, Any],
+    sessions: dict[str, list[dict[str, Any]]],
+    *,
+    selected_session_id: str = "",
+) -> dict[str, Any]:
+    session_rows = []
+    for session_id, rows in sessions.items():
+        session_rows.append(
+            {
+                "session_id": session_id,
+                "selected": session_id == selected_session_id,
+                "wire_calls": len(rows),
+                "successful_wire_calls": sum(1 for row in rows if _is_successful_wire(row)),
+                "non_success_wire_calls": sum(1 for row in rows if not _is_successful_wire(row)),
+                "finish_calls": sum(1 for row in rows if _wire_has_tool(row, "finish")),
+                "wire_tokens": sum(_wire_tokens(row) for row in rows if _is_successful_wire(row)),
+                "first_timestamp": rows[0].get("timestamp") or "",
+                "last_timestamp": rows[-1].get("timestamp") or "",
+                "first_model_traffic_request_id": rows[0].get("model_traffic_request_id") or "",
+                "last_model_traffic_request_id": rows[-1].get("model_traffic_request_id") or "",
+            }
+        )
+    return {
+        "problem_idx": trial_key[0],
+        "repeat": trial_key[1],
+        "session_count": len(sessions),
+        "selected_session_id": selected_session_id,
+        "retry_session_count": max(0, len(sessions) - 1),
+        "total_wire_calls": sum(len(rows) for rows in sessions.values()),
+        "total_finish_calls": sum(row["finish_calls"] for row in session_rows),
+        "retry_successful_wire_calls": sum(
+            row["successful_wire_calls"] for row in session_rows if row["session_id"] != selected_session_id
+        ),
+        "retry_wire_tokens": sum(
+            row["wire_tokens"] for row in session_rows if row["session_id"] != selected_session_id
+        ),
+        "sessions": session_rows,
+    }
+
+
+def _retry_summary(
+    traffic_by_trial_all: dict[tuple[Any, Any], list[dict[str, Any]]],
+    selected_sessions_by_trial: dict[tuple[Any, Any], str],
+) -> dict[str, Any]:
+    examples: list[dict[str, Any]] = []
+    problems_with_retries = 0
+    problems_with_multiple_finish_calls = 0
+    retry_sessions = 0
+    retry_successful_wire_calls = 0
+    retry_wire_tokens = 0
+
+    for trial_key, rows in traffic_by_trial_all.items():
+        sessions: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            session_id = _wire_session_id(row)
+            if not session_id:
+                continue
+            sessions.setdefault(session_id, []).append(row)
+
+        if len(sessions) <= 1:
+            continue
+
+        problems_with_retries += 1
+        total_finish_calls = sum(
+            1 for session_rows in sessions.values() for row in session_rows if _wire_has_tool(row, "finish")
+        )
+        if total_finish_calls > 1:
+            problems_with_multiple_finish_calls += 1
+
+        selected_session_id = selected_sessions_by_trial.get(trial_key, "")
+        if selected_session_id:
+            extra_rows = [
+                row
+                for session_id, session_rows in sessions.items()
+                if session_id != selected_session_id
+                for row in session_rows
+            ]
+            retry_sessions += sum(1 for session_id in sessions if session_id != selected_session_id)
+            retry_successful_wire_calls += sum(1 for row in extra_rows if _is_successful_wire(row))
+            retry_wire_tokens += sum(_wire_tokens(row) for row in extra_rows if _is_successful_wire(row))
+
+        if len(examples) < _MAX_RETRY_EXAMPLES:
+            examples.append(_session_group_example(trial_key, sessions, selected_session_id=selected_session_id))
+
+    return {
+        "problems_with_retries": problems_with_retries,
+        "problems_with_multiple_finish_calls": problems_with_multiple_finish_calls,
+        "retry_sessions": retry_sessions,
+        "retry_successful_wire_calls": retry_successful_wire_calls,
+        "retry_wire_tokens": retry_wire_tokens,
+        "retry_examples": examples,
+    }
+
+
+def _trial_failure_example(
+    row: dict[str, Any],
+    *,
+    agent_step_count: int,
+    successful_wire_count: int,
+    all_wire_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    fm = _final_metrics(row)
+    last_wire = all_wire_rows[-1] if all_wire_rows else {}
+    return {
+        "problem_idx": row.get("problem_idx"),
+        "repeat": row.get("repeat"),
+        "reward": row.get("reward"),
+        "failure_category": _failure_category(row),
+        "error": _failure_error(row),
+        "agent_steps": agent_step_count,
+        "successful_wire_calls": successful_wire_count,
+        "all_wire_calls": len(all_wire_rows),
+        "last_wire_status_code": last_wire.get("status_code"),
+        "last_wire_error_type": last_wire.get("error_type") or "",
+        "last_wire_error_message": _truncate_text(last_wire.get("error_message")),
+        "last_wire_error_body": _truncate_text(last_wire.get("error_body")),
+        "missing_final_metrics_tokens": not _has_final_metric_tokens(row),
+        "workspace_diff_preview_present": bool(fm.get("workspace_diff_preview")),
+    }
+
+
+def _is_timeout_failure(example: dict[str, Any]) -> bool:
+    text = f"{example.get('failure_category', '')} {example.get('error', '')}".lower()
+    return "timeout" in text or "run_timeout" in text
 
 
 def _load_eval_summary(bench_dir: Path) -> dict[str, Any] | None:
@@ -196,6 +432,55 @@ def _index_traffic_by_trial(
     return bucket
 
 
+def _last_wire_session_id(rows: list[dict[str, Any]]) -> str:
+    for row in reversed(rows):
+        session_id = _wire_session_id(row)
+        if session_id:
+            return session_id
+    return ""
+
+
+def _select_wire_session_id(_row: dict[str, Any], wire_rows: list[dict[str, Any]]) -> str:
+    """Select the wire session that represents a trajectory row.
+
+    Model traffic can contain abandoned/replayed sessions for the same
+    ``(problem_idx, repeat)``. The saved trajectory corresponds to the final
+    attempt, so token/step alignment uses the last session in file order.
+    Rows with no session ids are left unfiltered by returning an empty string.
+    """
+    return _last_wire_session_id(wire_rows)
+
+
+def _selected_sessions_by_trial(
+    traj_rows: list[dict[str, Any]],
+    traffic_by_trial_all: dict[tuple[Any, Any], list[dict[str, Any]]],
+) -> dict[tuple[Any, Any], str]:
+    selected: dict[tuple[Any, Any], str] = {}
+    for row in traj_rows:
+        key = _trial_key(row)
+        selected[key] = _select_wire_session_id(row, traffic_by_trial_all.get(key, []))
+    return selected
+
+
+def _filter_traffic_to_selected_sessions(
+    traffic_by_trial_all: dict[tuple[Any, Any], list[dict[str, Any]]],
+    selected_sessions_by_trial: dict[tuple[Any, Any], str],
+    *,
+    only_successful: bool = True,
+) -> dict[tuple[Any, Any], list[dict[str, Any]]]:
+    selected_rows: dict[tuple[Any, Any], list[dict[str, Any]]] = {}
+    for key, rows in traffic_by_trial_all.items():
+        if key not in selected_sessions_by_trial:
+            continue
+        selected_session_id = selected_sessions_by_trial[key]
+        if selected_session_id:
+            rows = [row for row in rows if _wire_session_id(row) == selected_session_id]
+        if only_successful:
+            rows = [row for row in rows if _is_successful_wire(row)]
+        selected_rows[key] = rows
+    return selected_rows
+
+
 def _step_tokens(s: dict[str, Any]) -> int:
     m = s.get("metrics") or {}
     return int(m.get("prompt_tokens") or 0) + int(m.get("completion_tokens") or 0)
@@ -260,7 +545,17 @@ def _wire_error_summary(wire_rows: list[dict[str, Any]]) -> tuple[dict[str, int]
             if code not in examples:
                 examples[code] = {
                     k: r[k]
-                    for k in ("status_code", "error_type", "latency_ms", "model", "path")
+                    for k in (
+                        "status_code",
+                        "error_type",
+                        "error_code",
+                        "error_message",
+                        "error_body",
+                        "latency_ms",
+                        "model",
+                        "path",
+                        "model_traffic_request_id",
+                    )
                     if r.get(k) is not None
                 }
     return dict(by_status), examples
@@ -327,8 +622,14 @@ def _piotr_quality_aggregate(traj_rows: list[dict[str, Any]]) -> dict[str, int]:
 def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
     traj_rows = _read_jsonl(bench_dir / "trajectories.jsonl")
     traffic_rows = _read_jsonl(bench_dir / "model_traffic.jsonl")
-    traffic_by_trial = _index_traffic_by_trial(traffic_rows)
-    traffic_by_trial_all = _index_traffic_by_trial(traffic_rows, only_successful=False)
+    traffic_by_trial_all_raw = _index_traffic_by_trial(traffic_rows, only_successful=False)
+    selected_sessions = _selected_sessions_by_trial(traj_rows, traffic_by_trial_all_raw)
+    traffic_by_trial = _filter_traffic_to_selected_sessions(traffic_by_trial_all_raw, selected_sessions)
+    traffic_by_trial_all = _filter_traffic_to_selected_sessions(
+        traffic_by_trial_all_raw,
+        selected_sessions,
+        only_successful=False,
+    )
 
     n_problems = len({r.get("problem_idx") for r in traj_rows if r.get("problem_idx") is not None})
 
@@ -347,18 +648,22 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
     problems_missing_fm_tokens = 0
     final_metrics_token_sum = 0
     problems_with_last_wire_non_200 = 0
+    failure_examples: list[dict[str, Any]] = []
+    timeout_examples: list[dict[str, Any]] = []
+    no_agent_step_examples: list[dict[str, Any]] = []
 
     for r in traj_rows:
         steps = _agent_steps(r)
         all_agent_steps.extend(steps)
 
-        cat = (r.get("scoring_details") or {}).get("error_category") or r.get("failure_category")
+        cat = _failure_category(r)
         if cat:
             failures[cat] += 1
 
         step_n = len(steps)
         trial_wire_rows = traffic_by_trial.get(_trial_key(r), [])
         wire_n = len(trial_wire_rows)
+        all_trial_wire = traffic_by_trial_all.get(_trial_key(r), [])
         if wire_n > step_n:
             problems_more_wire += 1
         elif wire_n < step_n:
@@ -370,7 +675,7 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
         if step_n == 0 or wire_n == 0:
             problems_silent += 1
 
-        fm = ((r.get("trajectory") or [{}])[0]).get("final_metrics") or {}
+        fm = _final_metrics(r)
         fm_prompt = fm.get("total_prompt_tokens")
         fm_completion = fm.get("total_completion_tokens")
         fm_has_tokens = fm_prompt is not None or fm_completion is not None
@@ -390,22 +695,56 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
             wire_vs_fm_mismatch += 1
 
         # Last wire call: check if the chronologically last call ended with non-200
-        all_trial_wire = traffic_by_trial_all.get(_trial_key(r), [])
         if all_trial_wire and not _is_successful_wire(all_trial_wire[-1]):
             problems_with_last_wire_non_200 += 1
 
+        failure_signal = bool(
+            cat
+            or _failure_error(r)
+            or step_n == 0
+            or not fm_has_tokens
+            or any(not _is_successful_wire(w) for w in all_trial_wire)
+        )
+        if failure_signal:
+            example = _trial_failure_example(
+                r,
+                agent_step_count=step_n,
+                successful_wire_count=wire_n,
+                all_wire_rows=all_trial_wire,
+            )
+            failure_examples.append(example)
+            if example["agent_steps"] == 0:
+                no_agent_step_examples.append(example)
+            if _is_timeout_failure(example):
+                timeout_examples.append(example)
+
     per_step_token_sum = sum(_step_tokens(s) for s in all_agent_steps)
-    wire_token_sum = sum(_wire_tokens(r) for r in traffic_rows)
+    selected_all_traffic_rows = [row for rows in traffic_by_trial_all.values() for row in rows]
+    selected_successful_traffic_rows = [row for rows in traffic_by_trial.values() for row in rows]
+    wire_token_sum = sum(_wire_tokens(r) for r in selected_successful_traffic_rows)
+    wire_token_sum_all_sessions = sum(_wire_tokens(r) for r in traffic_rows if _is_successful_wire(r))
 
     # Wire dedup: how many trials had ≥1 dup, and the unique count overall.
     problems_with_dup_wire = 0
-    for recs in traffic_by_trial.values():
+    for recs in traffic_by_trial_all_raw.values():
         keys = Counter(_wire_dedup_key(r, i) for i, r in enumerate(recs))
         if any(v > 1 for v in keys.values()):
             problems_with_dup_wire += 1
     wire_unique = len({_wire_dedup_key(r, i) for i, r in enumerate(traffic_rows)})
 
-    non_200_by_status, non_200_examples = _wire_error_summary(traffic_rows)
+    non_200_by_status, non_200_examples = _wire_error_summary(selected_all_traffic_rows)
+    non_200_by_status_all_sessions, non_200_examples_all_sessions = _wire_error_summary(traffic_rows)
+    last_wire_by_trial = {key: rows[-1] for key, rows in traffic_by_trial_all_raw.items() if rows}
+    non_success_examples = [
+        _wire_example(r, is_last_wire=last_wire_by_trial.get(_trial_key(r)) is r)
+        for r in traffic_rows
+        if not _is_successful_wire(r)
+    ]
+    non_success_by_error_type = _group_wire_examples_by_error_type(non_success_examples)
+    last_non_success_by_error_type = _group_wire_examples_by_error_type(
+        [e for e in non_success_examples if e["is_last_wire"]]
+    )
+    retry_summary = _retry_summary(traffic_by_trial_all_raw, selected_sessions)
 
     all_sources_match = per_step_vs_fm_mismatch == 0 and wire_vs_fm_mismatch == 0 and problems_missing_fm_tokens == 0
 
@@ -417,6 +756,9 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
             "mean_reward": traj_mean,
             "reported_mean": reported_mean,
             "failures_by_category": dict(failures),
+            "failure_examples": failure_examples,
+            "timeout_examples": timeout_examples,
+            "no_agent_step_examples": no_agent_step_examples,
             "quality": _piotr_quality_aggregate(traj_rows),
             "field_coverage": {
                 "per_trial_missing": _missing_fields(traj_rows, _TRIAL_FIELDS),
@@ -426,6 +768,9 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
         "tokens_stats": {
             "per_step_sum": per_step_token_sum,
             "wire_total": wire_token_sum,
+            "wire_total_for_trajectory_comparison": wire_token_sum,
+            "wire_total_all_sessions": wire_token_sum_all_sessions,
+            "wire_total_earlier_retry_sessions": retry_summary["retry_wire_tokens"],
             "final_metrics_total": final_metrics_token_sum,
             "problems_with_missing_final_metrics_tokens": problems_missing_fm_tokens,
             "problems_with_per_step_vs_final_metrics_mismatch": per_step_vs_fm_mismatch,
@@ -433,13 +778,29 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
             "all_sources_match": all_sources_match,
         },
         "wire_calls": {
-            "total": len(traffic_rows),
-            "successful": sum(1 for r in traffic_rows if _is_successful_wire(r)),
-            "non_200": sum(1 for r in traffic_rows if not _is_successful_wire(r)),
+            "total": len(selected_all_traffic_rows),
+            "successful": len(selected_successful_traffic_rows),
+            "non_200": sum(1 for r in selected_all_traffic_rows if not _is_successful_wire(r)),
+            "total_for_trajectory_comparison": len(selected_all_traffic_rows),
+            "successful_for_trajectory_comparison": len(selected_successful_traffic_rows),
+            "total_all_sessions": len(traffic_rows),
+            "successful_all_sessions": sum(1 for r in traffic_rows if _is_successful_wire(r)),
+            "non_200_all_sessions": sum(1 for r in traffic_rows if not _is_successful_wire(r)),
             "non_200_by_status": non_200_by_status,
             "non_200_examples": non_200_examples,
+            "non_200_by_status_all_sessions": non_200_by_status_all_sessions,
+            "non_200_examples_all_sessions": non_200_examples_all_sessions,
+            "non_success_examples": non_success_by_error_type,
+            "last_non_success_examples": last_non_success_by_error_type,
             "unique": wire_unique,
             "problems_with_duplicates": problems_with_dup_wire,
+            "selected_session_policy": "last_wire_session",
+            "problems_with_retries": retry_summary["problems_with_retries"],
+            "retry_sessions": retry_summary["retry_sessions"],
+            "problems_with_multiple_finish_calls": retry_summary["problems_with_multiple_finish_calls"],
+            "retry_successful_wire_calls": retry_summary["retry_successful_wire_calls"],
+            "retry_wire_tokens": retry_summary["retry_wire_tokens"],
+            "retry_examples": retry_summary["retry_examples"],
             "problems_with_more_wire_than_steps": problems_more_wire,
             "problems_with_fewer_wire_than_steps": problems_fewer_wire,
             "problems_with_no_agent_steps": problems_no_steps,
@@ -476,7 +837,9 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
 
     traj_rows = _read_jsonl(traj_path)
     traffic_rows = _read_jsonl(traffic_path)
-    by_trial = _index_traffic_by_trial(traffic_rows)
+    all_by_trial = _index_traffic_by_trial(traffic_rows, only_successful=False)
+    selected_sessions = _selected_sessions_by_trial(traj_rows, all_by_trial)
+    by_trial = _filter_traffic_to_selected_sessions(all_by_trial, selected_sessions)
 
     counts = {
         "trials_spliced": 0,

--- a/tests/test_config/test_config_schema.py
+++ b/tests/test_config/test_config_schema.py
@@ -106,6 +106,75 @@ class TestParseEvalConfig:
         assert cfg.benchmarks[0].name == "gsm8k"
         assert isinstance(cfg.benchmarks[0].solver, SimpleSolver)
         assert cfg.benchmarks[0].solver.service == "solver"
+        assert cfg.output.trajectories.enrich is True
+
+    @pytest.mark.parametrize(
+        "service_overrides,output_overrides,expected_capture,expected_enrich",
+        [
+            pytest.param(
+                {"proxy": {}},
+                {},
+                {"messages": True, "reasoning": True, "tool_calls": True},
+                True,
+                id="model-traffic-defaults",
+            ),
+            pytest.param(
+                {
+                    "proxy": {
+                        "model_traffic": {
+                            "capture_messages": False,
+                            "capture_reasoning": False,
+                            "capture_tool_calls": False,
+                        }
+                    }
+                },
+                {},
+                {"messages": False, "reasoning": False, "tool_calls": False},
+                True,
+                id="model-traffic-disabled",
+            ),
+            pytest.param(
+                {"proxy": {}},
+                {"trajectories": {"enrich": False}},
+                {"messages": True, "reasoning": True, "tool_calls": True},
+                False,
+                id="trajectory-enrichment-disabled",
+            ),
+        ],
+    )
+    def test_output_and_model_traffic_capture_options(
+        self,
+        service_overrides,
+        output_overrides,
+        expected_capture,
+        expected_enrich,
+    ):
+        service = {
+            "type": "api",
+            "url": "http://localhost:8000/v1/chat/completions",
+            "protocol": "chat_completions",
+            "model": "gpt-4",
+            **service_overrides,
+        }
+        raw = {
+            "services": {"solver": service},
+            "benchmarks": [
+                {
+                    "name": "gsm8k",
+                    "solver": {"type": "simple", "service": "solver"},
+                },
+            ],
+        }
+        if output_overrides:
+            raw["output"] = output_overrides
+
+        cfg = parse_eval_config(raw)
+        capture = cfg.services["solver"].proxy.model_traffic
+        assert capture.capture_messages is expected_capture["messages"]
+        assert capture.capture_reasoning is expected_capture["reasoning"]
+        assert capture.capture_tool_calls is expected_capture["tool_calls"]
+        assert capture.max_content_chars == 100_000
+        assert cfg.output.trajectories.enrich is expected_enrich
 
     def test_vllm_service(self):
         raw = {

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -19,6 +19,8 @@ import json
 import threading
 from pathlib import Path
 
+import pytest
+
 from nemo_evaluator.adapters.proxy import start_adapter_proxy
 from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
 from nemo_evaluator.engine.eval_loop import run_evaluation
@@ -127,17 +129,45 @@ def _jsonl(path: Path):
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
 
 
-def test_format_log_record_forwards_opt_in_capture_fields() -> None:
-    """When the store captured tool_calls_full / reasoning_content / message_content,
-    they must land on the model_traffic.jsonl row (not be silently dropped)."""
+def _capture_response_body(
+    *,
+    content: str = "the answer is 42",
+    reasoning: str = "let me think",
+    tool_calls: list[dict] | None = None,
+) -> dict:
+    return {
+        "model": "m",
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                    "reasoning_content": reasoning,
+                    "tool_calls": tool_calls
+                    or [{"id": "c1", "type": "function", "function": {"name": "w", "arguments": "{}"}}],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+    }
+
+
+@pytest.mark.parametrize(
+    "capture_kwargs,expect_response_fields",
+    [
+        pytest.param({}, True, id="default-capture"),
+        pytest.param(
+            {"capture_tool_calls": False, "capture_reasoning": False, "capture_messages": False},
+            False,
+            id="capture-disabled",
+        ),
+    ],
+)
+def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_response_fields: bool) -> None:
     ctx = InterceptorContext()
     ctx.extra["session_id"] = "cap-session"
-    store = ModelTrafficStore(
-        service_name="solver",
-        capture_tool_calls=True,
-        capture_reasoning=True,
-        capture_messages=True,
-    )
+    store = ModelTrafficStore(service_name="solver", **capture_kwargs)
     store.start_request(
         AdapterRequest(method="POST", path="/chat/completions", headers={}, body={"model": "m"}, ctx=ctx)
     )
@@ -147,33 +177,62 @@ def test_format_log_record_forwards_opt_in_capture_fields() -> None:
             headers={"content-type": "application/json"},
             latency_ms=10.0,
             ctx=ctx,
-            body={
-                "model": "m",
-                "choices": [
-                    {
-                        "message": {
-                            "role": "assistant",
-                            "content": "the answer is 42",
-                            "reasoning_content": "let me think",
-                            "tool_calls": [
-                                {"id": "c1", "type": "function", "function": {"name": "w", "arguments": "{}"}}
-                            ],
-                        },
-                        "finish_reason": "tool_calls",
-                    }
-                ],
-                "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
-            },
+            body=_capture_response_body(),
         )
     )
     rows = format_model_traffic_log_records(store.drain_session("cap-session"), benchmark="b", problem_idx=0, repeat=0)
     assert len(rows) == 1
     row = rows[0]
     assert row["tool_calls"] == {"count": 1, "names": {"w": 1}}
-    assert "tool_calls_full" in row
-    assert row["tool_calls_full"][0]["name"] == "w"
-    assert row["reasoning_content"] == "let me think"
-    assert row["message_content"] == "the answer is 42"
+    if expect_response_fields:
+        assert row["tool_calls_full"] == [{"id": "c1", "name": "w", "arguments": "{}"}]
+        assert row["reasoning_content"] == "let me think"
+        assert row["message_content"] == "the answer is 42"
+    else:
+        assert "tool_calls_full" not in row
+        assert "reasoning_content" not in row
+        assert "message_content" not in row
+
+
+def test_non_success_response_forwards_compact_error_summary() -> None:
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = "bad-request-session"
+    store = ModelTrafficStore(service_name="solver")
+    store.start_request(
+        AdapterRequest(method="POST", path="/chat/completions", headers={}, body={"model": "m"}, ctx=ctx)
+    )
+    store.finish_response(
+        AdapterResponse(
+            status_code=400,
+            headers={"content-type": "application/json"},
+            latency_ms=5.0,
+            ctx=ctx,
+            body={
+                "error": {
+                    "message": "OpenAIException - Expecting ',' delimiter: line 1 column 237 (char 236)",
+                    "type": "invalid_request_error",
+                    "code": "bad_tool_json",
+                }
+            },
+        )
+    )
+
+    rows = format_model_traffic_log_records(
+        store.drain_session("bad-request-session"),
+        benchmark="b",
+        problem_idx=0,
+        repeat=0,
+    )
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["status_code"] == 400
+    assert row["usage"] == {}
+    assert "token_provenance" not in row
+    assert row["error_message"] == "OpenAIException - Expecting ',' delimiter: line 1 column 237 (char 236)"
+    assert row["error_type"] == "invalid_request_error"
+    assert row["error_code"] == "bad_tool_json"
+    assert "bad_tool_json" in row["error_body"]
 
 
 def test_model_traffic_parses_streaming_sse_usage_and_tool_calls() -> None:
@@ -267,6 +326,9 @@ async def test_model_traffic_writes_compact_log_and_inference_stats(tmp_path: Pa
             "cached_tokens": 3,
         }
         assert traffic["tool_calls"] == {"count": 1, "names": {"bash": 1}}
+        assert traffic["message_content"] == "answer"
+        assert traffic["reasoning_content"] == "I need to inspect the workspace."
+        assert traffic["tool_calls_full"] == [{"id": "call_1", "name": "bash", "arguments": '{"command":"ls"}'}]
         assert traffic["token_provenance"] == "provider_reported"
         assert "request" not in traffic
         assert "response" not in traffic
@@ -293,59 +355,51 @@ async def test_model_traffic_writes_compact_log_and_inference_stats(tmp_path: Pa
         upstream.shutdown()
 
 
-# ─── opt-in capture flags (this MR) ─────────────────────────────────
+# ─── response capture flags ──────────────────────────────────────────
 
 
-def test_summary_from_json_capture_flags_off_keeps_default_shape() -> None:
-    """Default behavior: stats only — no tool_calls_full / reasoning_content / message_content."""
+@pytest.mark.parametrize(
+    "capture_kwargs,expect_response_fields",
+    [
+        pytest.param({}, True, id="default-capture"),
+        pytest.param(
+            {"capture_tool_calls": False, "capture_reasoning": False, "capture_messages": False},
+            False,
+            id="capture-disabled",
+        ),
+        pytest.param(
+            {"capture_tool_calls": True, "capture_reasoning": True, "capture_messages": True},
+            True,
+            id="capture-explicit",
+        ),
+    ],
+)
+def test_summary_from_json_response_capture_fields(capture_kwargs: dict, expect_response_fields: bool) -> None:
     from nemo_evaluator.observability.model_traffic import _summary_from_json
 
-    body = {
-        "model": "qwen",
-        "choices": [
-            {
-                "finish_reason": "stop",
-                "message": {
-                    "content": "hello",
-                    "reasoning_content": "think",
-                    "tool_calls": [{"id": "t1", "function": {"name": "search", "arguments": '{"q":"x"}'}}],
-                },
-            }
+    body = _capture_response_body(
+        content="calling search",
+        reasoning="I need to look this up",
+        tool_calls=[
+            {"id": "t1", "function": {"name": "search", "arguments": '{"q":"x"}'}},
+            {"id": "t2", "function": {"name": "fetch", "arguments": '{"u":"y"}'}},
         ],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    }
-    out = _summary_from_json(body)
-    assert "tool_calls_full" not in out
-    assert "reasoning_content" not in out
-    assert "message_content" not in out
-    assert out["tool_calls"]["count"] == 1  # stats still there
-
-
-def test_summary_from_json_capture_flags_on_populate_fields() -> None:
-    from nemo_evaluator.observability.model_traffic import _summary_from_json
-
-    body = {
-        "model": "qwen",
-        "choices": [
-            {
-                "finish_reason": "tool_calls",
-                "message": {
-                    "content": "calling search",
-                    "reasoning_content": "I need to look this up",
-                    "tool_calls": [
-                        {"id": "t1", "function": {"name": "search", "arguments": '{"q":"x"}'}},
-                        {"id": "t2", "function": {"name": "fetch", "arguments": '{"u":"y"}'}},
-                    ],
-                },
-            }
-        ],
-        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
-    }
-    out = _summary_from_json(body, capture_tool_calls=True, capture_reasoning=True, capture_messages=True)
-    assert out["reasoning_content"] == "I need to look this up"
-    assert out["message_content"] == "calling search"
-    assert len(out["tool_calls_full"]) == 2
-    assert out["tool_calls_full"][0] == {"id": "t1", "name": "search", "arguments": '{"q":"x"}'}
+    )
+    body["model"] = "qwen"
+    body["usage"] = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    out = _summary_from_json(body, **capture_kwargs)
+    assert out["tool_calls"] == {"count": 2, "names": {"search": 1, "fetch": 1}}
+    if expect_response_fields:
+        assert out["reasoning_content"] == "I need to look this up"
+        assert out["message_content"] == "calling search"
+        assert out["tool_calls_full"] == [
+            {"id": "t1", "name": "search", "arguments": '{"q":"x"}'},
+            {"id": "t2", "name": "fetch", "arguments": '{"u":"y"}'},
+        ]
+    else:
+        assert "tool_calls_full" not in out
+        assert "reasoning_content" not in out
+        assert "message_content" not in out
 
 
 def test_summary_truncates_long_content() -> None:

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -126,6 +126,9 @@ def test_tokens_section(bundle: Path) -> None:
     # 2 trials × (pt+ct): trial0=15, trial1=20+10+30+8=68 → 83 across all
     assert t["per_step_sum"] == 83
     assert t["wire_total"] == 83
+    assert t["wire_total_for_trajectory_comparison"] == 83
+    assert t["wire_total_all_sessions"] == 83
+    assert t["wire_total_earlier_retry_sessions"] == 0
     assert t["final_metrics_total"] == 83
     assert t["problems_with_missing_final_metrics_tokens"] == 0
     assert t["problems_with_per_step_vs_final_metrics_mismatch"] == 0
@@ -140,6 +143,13 @@ def test_wire_calls_section(bundle: Path) -> None:
     assert wc["successful"] == 3
     assert wc["unique"] == 3
     assert wc["problems_with_duplicates"] == 0
+    assert wc["selected_session_policy"] == "last_wire_session"
+    assert wc["problems_with_retries"] == 0
+    assert wc["retry_sessions"] == 0
+    assert wc["problems_with_multiple_finish_calls"] == 0
+    assert wc["retry_successful_wire_calls"] == 0
+    assert wc["retry_wire_tokens"] == 0
+    assert wc["retry_examples"] == []
     assert wc["problems_with_more_wire_than_steps"] == 0
     assert wc["problems_with_fewer_wire_than_steps"] == 0
     assert wc["non_200"] == 0
@@ -238,6 +248,87 @@ def test_wire_dedup_via_request_hash(tmp_path: Path) -> None:
     assert wc["total"] == 2
     assert wc["unique"] == 1
     assert wc["problems_with_duplicates"] == 1
+
+
+def test_last_session_selected_for_wire_token_alignment(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [
+            _trial(
+                7,
+                0,
+                reward=1.0,
+                steps=[
+                    _agent_step(0, msg="x", pt=5, ct=3),
+                    _agent_step(1, msg="y", pt=7, ct=2),
+                ],
+            )
+        ],
+    )
+    _write_jsonl(
+        bench / "model_traffic.jsonl",
+        [
+            {
+                **_wire(7, 0, prompt=10, completion=1),
+                "session_id": "sess-old",
+                "request_hash": "old-a",
+                "model_traffic_request_id": "sess-old:req-a",
+            },
+            {
+                **_wire(7, 0, prompt=11, completion=1),
+                "session_id": "sess-old",
+                "request_hash": "old-b",
+                "model_traffic_request_id": "sess-old:req-b",
+                "tool_calls": {"names": {"finish": 1}},
+            },
+            {
+                **_wire(7, 0, prompt=5, completion=3),
+                "session_id": "sess-final",
+                "request_hash": "final-a",
+                "model_traffic_request_id": "sess-final:req-a",
+            },
+            {
+                **_wire(7, 0, prompt=7, completion=2),
+                "session_id": "sess-final",
+                "request_hash": "final-b",
+                "model_traffic_request_id": "sess-final:req-b",
+                "tool_calls": {"names": {"finish": 1}},
+            },
+        ],
+    )
+
+    report = json.loads(generate_trajectories_report(tmp_path, enrich=True).read_text())["benchmarks"][0]
+    tokens = report["tokens_stats"]
+    wc = report["wire_calls"]
+
+    assert tokens["per_step_sum"] == 17
+    assert tokens["wire_total"] == 17
+    assert tokens["wire_total_for_trajectory_comparison"] == 17
+    assert tokens["wire_total_all_sessions"] == 40
+    assert tokens["wire_total_earlier_retry_sessions"] == 23
+    assert tokens["final_metrics_total"] == 17
+    assert tokens["all_sources_match"] is True
+    assert wc["total"] == 2
+    assert wc["successful"] == 2
+    assert wc["total_all_sessions"] == 4
+    assert wc["successful_all_sessions"] == 4
+    assert wc["problems_with_more_wire_than_steps"] == 0
+    assert wc["problems_with_fewer_wire_than_steps"] == 0
+    assert wc["problems_with_retries"] == 1
+    assert wc["retry_sessions"] == 1
+    assert wc["problems_with_multiple_finish_calls"] == 1
+    assert wc["retry_successful_wire_calls"] == 2
+    assert wc["retry_wire_tokens"] == 23
+    assert wc["retry_examples"][0]["selected_session_id"] == "sess-final"
+    assert wc["retry_examples"][0]["retry_session_count"] == 1
+    assert report["enrichment"]["trials_spliced_1_to_1"] == 1
+    assert report["enrichment"]["trials_with_unmatched_calls_stashed"] == 0
+    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
+    steps = enriched["trajectory"][0]["steps"]
+    assert [s["metrics"]["prompt_tokens"] for s in steps] == [5, 7]
+    assert [s["metrics"]["completion_tokens"] for s in steps] == [3, 2]
+    assert "captured_model_calls" not in enriched["trajectory"][0].get("extra", {})
 
 
 def test_tokens_per_step_vs_wire_mismatch(tmp_path: Path) -> None:
@@ -482,6 +573,109 @@ def test_last_wire_non_200(tmp_path: Path) -> None:
     assert wc["non_200_by_status"] == {"429": 1}
     assert wc["non_200_examples"]["429"]["status_code"] == 429
     assert wc["non_200_examples"]["429"]["error_type"] == "rate_limit"
+    assert wc["non_success_examples"]["rate_limit"]["count"] == 1
+    assert wc["non_success_examples"]["rate_limit"]["examples"][0]["status_code"] == 429
+    assert wc["non_success_examples"]["rate_limit"]["examples"][0]["is_last_wire"] is True
+    assert wc["last_non_success_examples"]["rate_limit"]["examples"][0]["status_code"] == 429
+
+
+def test_non_success_wire_examples_include_invalid_response_details(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(7, 2, reward=0.0, steps=[_agent_step(0, msg="x", pt=5, ct=3)])],
+    )
+    _write_jsonl(
+        bench / "model_traffic.jsonl",
+        [
+            {**_wire(7, 2, prompt=5, completion=3, status_code=200), "model_traffic_request_id": "sess:req-ok"},
+            {
+                **_wire(7, 2, prompt=0, completion=0, status_code=400),
+                "model_traffic_request_id": "sess:req-bad",
+                "error_type": "invalid_request_error",
+                "error_code": "bad_tool_json",
+                "error_message": "OpenAIException - Expecting ',' delimiter: line 1 column 237 (char 236)",
+                "error_body": '{"error":{"code":"bad_tool_json"}}',
+            },
+        ],
+    )
+
+    report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
+    wc = report["wire_calls"]
+    assert wc["non_200"] == 1
+    assert wc["non_200_examples"]["400"]["error_message"].startswith("OpenAIException")
+    assert wc["non_200_examples"]["400"]["error_body"] == '{"error":{"code":"bad_tool_json"}}'
+    assert wc["non_success_examples"]["invalid_request_error"] == {
+        "count": 1,
+        "examples": [
+            {
+                "problem_idx": 7,
+                "repeat": 2,
+                "status_code": 400,
+                "error_type": "invalid_request_error",
+                "error_code": "bad_tool_json",
+                "error_message": "OpenAIException - Expecting ',' delimiter: line 1 column 237 (char 236)",
+                "latency_ms": 100.0,
+                "finish_reason": "stop",
+                "model": "test-model",
+                "path": "",
+                "model_traffic_request_id": "sess:req-bad",
+                "session_id": "sess-7-2",
+                "adapter_request_id": "",
+                "request_hash": "",
+                "is_last_wire": True,
+                "error_body": '{"error":{"code":"bad_tool_json"}}',
+            }
+        ],
+    }
+    failure = report["trajectories"]["failure_examples"][0]
+    assert failure["problem_idx"] == 7
+    assert failure["last_wire_status_code"] == 400
+    assert failure["last_wire_error_message"].startswith("OpenAIException")
+    assert failure["last_wire_error_body"] == '{"error":{"code":"bad_tool_json"}}'
+
+
+def test_timeout_no_step_examples_keep_wire_counts(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    row = _trial(3, 1, reward=0.0, steps=[])
+    row["failure_category"] = "infra_error"
+    row["scoring_details"] = {
+        "error_category": "infra_error",
+        "error": "Agent timed out with workspace changes but 0 completion tokens (run_timeout=5400s). Model may have died mid-solve.",
+    }
+    row["trajectory"][0]["final_metrics"] = {
+        "total_steps": 0,
+        "workspace_diff_preview": "diff --git a/file.py b/file.py",
+    }
+    _write_jsonl(bench / "trajectories.jsonl", [row])
+    _write_jsonl(
+        bench / "model_traffic.jsonl",
+        [
+            _wire(3, 1, prompt=10, completion=5, finish="tool_calls"),
+            _wire(3, 1, prompt=20, completion=7, finish="tool_calls"),
+        ],
+    )
+
+    report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
+    traj = report["trajectories"]
+    wc = report["wire_calls"]
+
+    assert wc["problems_with_no_agent_steps"] == 1
+    assert wc["problems_with_more_wire_than_steps"] == 1
+    assert report["tokens_stats"]["problems_with_missing_final_metrics_tokens"] == 1
+
+    assert len(traj["failure_examples"]) == 1
+    failure = traj["failure_examples"][0]
+    assert failure["problem_idx"] == 3
+    assert failure["repeat"] == 1
+    assert failure["agent_steps"] == 0
+    assert failure["successful_wire_calls"] == 2
+    assert failure["all_wire_calls"] == 2
+    assert failure["missing_final_metrics_tokens"] is True
+    assert failure["workspace_diff_preview_present"] is True
+    assert failure["error"].startswith("Agent timed out with workspace changes")
+    assert traj["timeout_examples"] == [failure]
+    assert traj["no_agent_step_examples"] == [failure]
 
 
 def test_non_200_by_status_empty_when_all_success(bundle: Path) -> None:
@@ -490,7 +684,33 @@ def test_non_200_by_status_empty_when_all_success(bundle: Path) -> None:
     wc = report["wire_calls"]
     assert wc["non_200_by_status"] == {}
     assert wc["non_200_examples"] == {}
+    assert wc["non_success_examples"] == {}
+    assert wc["last_non_success_examples"] == {}
     assert wc["problems_with_last_wire_non_200"] == 0
+
+
+def test_non_success_examples_are_bounded_by_error_type(tmp_path: Path) -> None:
+    bench = tmp_path / "pb"
+    _write_jsonl(
+        bench / "trajectories.jsonl",
+        [_trial(i, 0, reward=0.0, steps=[_agent_step(0, msg="x", pt=1, ct=1)]) for i in range(25)],
+    )
+    _write_jsonl(
+        bench / "model_traffic.jsonl",
+        [
+            {
+                **_wire(i, 0, prompt=0, completion=0, status_code=400),
+                "error_type": "invalid_request_error",
+            }
+            for i in range(25)
+        ],
+    )
+
+    wc = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]["wire_calls"]
+    bucket = wc["non_success_examples"]["invalid_request_error"]
+    assert bucket["count"] == 25
+    assert len(bucket["examples"]) == 5
+    assert bucket["omitted_examples"] == 20
 
 
 def test_missing_final_metrics_tokens(tmp_path: Path) -> None:


### PR DESCRIPTION
Summary:
- Compare trajectory wire metrics against the selected last session per problem/repeat.
- Keep all-session retry traffic as separate context.
- Preserve non-success model traffic error_type/error_message/error_code/error_body.
- Make output.trajectories.enrich default true, with enrich: false as opt-out.

Tests:
- uv run --extra dev python -m pytest tests/test_config/test_config_schema.py tests/test_engine/test_model_traffic_capture.py tests/test_reports/test_trajectories_report.py -q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trajectory enrichment now defaults to enabled (disable via `enrich=false`).
  * Model traffic capture now includes tool-call payloads, reasoning, and message content by default (opt-out available).
  * Trajectory reports expand token and wire-call breakdowns for both selected “last” sessions and all sessions, including retry/session summaries.

* **Bug Fixes**
  * Non-success responses now retain a compact, capped error summary in logs and reports, with new error fields (`error_message`, `error_body`, `error_code`).
  * Wire-session alignment now consistently uses the latest relevant session.

* **Tests**
  * Updated/added coverage for enrichment/capture defaults, error-summary forwarding, last-session selection, and report output expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->