### PR TITLE
fix(harbor): flush trajectory on timeout

### DIFF
--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -306,12 +306,14 @@ async def _patch_openhands_sdk(sandbox: Sandbox, *, cmd_timeout: float | None = 
     _runner_patch_script = (
         "p = '/installed-agent/run_agent.py'\n"
         "c = open(p).read()\n"
-        "old = 'conversation = Conversation(**conv_kwargs)'\n"
-        'new = \'conv_kwargs["stuck_detection"] = False\\n'
-        '    conv_kwargs["visualizer"] = None\\n'
-        "    conversation = Conversation(**conv_kwargs)'\n"
-        "if old in c:\n"
-        "    open(p, 'w').write(c.replace(old, new, 1))\n"
+        'old = \'    conv_kwargs: dict[str, Any] = {"agent": agent, "workspace": workspace}\\n\'\n'
+        'new = old + \'    conv_kwargs["stuck_detection"] = False\\n    conv_kwargs["visualizer"] = None\\n\'\n'
+        "already = 'conv_kwargs[\"visualizer\"] = None' in c\n"
+        "if old in c and not already:\n"
+        "    c = c.replace(old, new, 1)\n"
+        "    open(p, 'w').write(c)\n"
+        "    already = True\n"
+        "if already:\n"
         "    print('stuck_detection disabled, visualizer disabled')\n"
         "else:\n"
         "    print('pattern not found')\n"
@@ -641,10 +643,14 @@ print(f'cmd_timeout_{{_MAX}}s={{ok}} at {{p}}')
     else:
         logger.info("Cmd timeout patch: skipped (cmd_timeout not configured)")
 
-    # -- Patch 4: wrap conversation.run() so any crash still saves trajectory --
-    # Anchor 1: wrap `conversation.run()` in try/except BaseException so main()
-    # continues to the existing event-reconstruction + build_trajectory + save
-    # code on any failure — no duplication needed.
+    # -- Patch 4: flush trajectory when the runner is interrupted ----------
+    # Anchor 1: wrap `conversation.send_message()` + `conversation.run()` in
+    # try/except BaseException so main() continues to the existing
+    # event-reconstruction + build_trajectory + save code on timeout/crash.
+    # SIGTERM/SIGINT are converted to KeyboardInterrupt so evaluator timeout
+    # cancellation gets the same flush path.  On interruption, first write a
+    # cheap partial trajectory from already-received model events.  The normal
+    # full writer below overwrites it if post-run serialization completes.
     # Anchor 2: after the final print in main(), exit(0) cleanly so Harbor
     # treats the run as a normal completion and downloads the trajectory.
     _budget_flush_script = """\
@@ -652,11 +658,12 @@ import sys
 p = '/installed-agent/run_agent.py'
 c = open(p).read()
 
-old1 = ind = None
-for line in c.splitlines():
-    s = line.lstrip()
-    if s == 'conversation.run()':
-        old1 = line; ind = line[:len(line)-len(s)]; break
+old1 = (
+    '    # Send instruction and run\\n'
+    '    conversation.send_message(args.instruction)\\n'
+    '    conversation.run()'
+)
+ind = '    '
 
 old2 = None
 for line in c.splitlines():
@@ -664,15 +671,85 @@ for line in c.splitlines():
         old2 = line; break
 
 already = '_nel_run_exc' in c
-ok = old1 is not None and old2 is not None and not already
+ok = old1 in c and old2 is not None and not already
 print(f'anchor1={repr(old1)} anchor2={repr(old2)} already={already} ok={ok}')
 
 if ok:
-    wrap = (ind + '_nel_run_exc = None\\n' +
-            ind + 'try:\\n' +
-            ind + '    conversation.run()\\n' +
-            ind + 'except BaseException as _e:\\n' +
-            ind + '    _nel_run_exc = _e')
+    partial = (
+        ind + 'def _nel_text_from_event(_event):\\n' +
+        ind + '    _msg = getattr(_event, "llm_message", None)\\n' +
+        ind + '    _raw = getattr(_msg, "content", None) if _msg is not None else None\\n' +
+        ind + '    if isinstance(_raw, list):\\n' +
+        ind + '        return chr(10).join(getattr(_c, "text", str(_c)) for _c in _raw if getattr(_c, "text", None))\\n' +
+        ind + '    return str(_raw) if _raw else ""\\n' +
+        ind + 'def _nel_tool_args(_event):\\n' +
+        ind + '    if getattr(_event, "tool_call", None) and hasattr(_event.tool_call, "function"):\\n' +
+        ind + '        _raw_args = getattr(_event.tool_call.function, "arguments", None)\\n' +
+        ind + '        if isinstance(_raw_args, str):\\n' +
+        ind + '            try:\\n' +
+        ind + '                return json.loads(_raw_args)\\n' +
+        ind + '            except json.JSONDecodeError:\\n' +
+        ind + '                return {"raw": _raw_args}\\n' +
+        ind + '        if isinstance(_raw_args, dict):\\n' +
+        ind + '            return _raw_args\\n' +
+        ind + '    if getattr(_event, "action", None):\\n' +
+        ind + '        try:\\n' +
+        ind + '            _ad = _event.action.model_dump() if hasattr(_event.action, "model_dump") else vars(_event.action)\\n' +
+        ind + '            return {_k: _v for _k, _v in _ad.items() if _k != "kind" and _v is not None}\\n' +
+        ind + '        except Exception:\\n' +
+        ind + '            pass\\n' +
+        ind + '    return {}\\n' +
+        ind + 'def _nel_write_partial_trajectory(_reason):\\n' +
+        ind + '    try:\\n' +
+        ind + '        _metric_obj = getattr(llm, "metrics", None)\\n' +
+        ind + '        _usage = getattr(_metric_obj, "accumulated_token_usage", None)\\n' +
+        ind + '        _metrics = {\\n' +
+        ind + '            "prompt_tokens": int(getattr(_usage, "prompt_tokens", 0) or 0),\\n' +
+        ind + '            "completion_tokens": int(getattr(_usage, "completion_tokens", 0) or 0),\\n' +
+        ind + '            "cached_tokens": int(getattr(_usage, "cache_read_tokens", 0) or 0),\\n' +
+        ind + '            "cost_usd": float(getattr(_metric_obj, "accumulated_cost", 0.0) or 0.0),\\n' +
+        ind + '        }\\n' +
+        ind + '        _events_list = []\\n' +
+        ind + '        for _event in list(getattr(getattr(conversation, "state", None), "events", []) or []):\\n' +
+        ind + '            if isinstance(_event, MessageEvent):\\n' +
+        ind + '                if _event.source in ("user", "agent"):\\n' +
+        ind + '                    _entry_type = "assistant_message" if _event.source == "agent" else "user_message"\\n' +
+        ind + '                    _entry = {"type": _entry_type, "content": _nel_text_from_event(_event), "timestamp": _event.timestamp}\\n' +
+        ind + '                    _events_list.append(_entry)\\n' +
+        ind + '            elif isinstance(_event, ActionEvent):\\n' +
+        ind + '                _events_list.append({"type": "assistant_message", "content": "", "timestamp": _event.timestamp, "tool_calls": [{"id": _event.tool_call_id, "name": _event.tool_name, "arguments": _nel_tool_args(_event)}]})\\n' +
+        ind + '        _trajectory = build_trajectory(_events_list, _metrics, model)\\n' +
+        ind + '        _trajectory.setdefault("extra", {})["nel_partial_trajectory"] = {"reason": _reason, "events": len(_events_list)}\\n' +
+        ind + '        _path = Path(args.trajectory_path)\\n' +
+        ind + '        _path.parent.mkdir(parents=True, exist_ok=True)\\n' +
+        ind + '        _tmp = _path.with_suffix(_path.suffix + ".partial")\\n' +
+        ind + '        with open(_tmp, "w") as _f:\\n' +
+        ind + '            json.dump(_trajectory, _f, indent=2)\\n' +
+        ind + '        os.replace(_tmp, _path)\\n' +
+        ind + '        print(f"NEL: partial trajectory saved to {_path}", file=sys.stderr, flush=True)\\n' +
+        ind + '    except BaseException as _save_e:\\n' +
+        ind + '        print(f"NEL: partial trajectory save failed: {type(_save_e).__name__}: {_save_e}", file=sys.stderr, flush=True)\\n'
+    )
+    wrap = (
+        ind + '# Send instruction and run\\n' +
+        ind + '_nel_run_exc = None\\n' +
+        partial +
+        ind + 'def _nel_timeout_handler(_signum, _frame):\\n' +
+        ind + '    raise KeyboardInterrupt(f"NEL timeout signal {_signum}")\\n' +
+        ind + 'try:\\n' +
+        ind + '    import signal as _nel_signal\\n' +
+        ind + '    _nel_signal.signal(_nel_signal.SIGTERM, _nel_timeout_handler)\\n' +
+        ind + '    _nel_signal.signal(_nel_signal.SIGINT, _nel_timeout_handler)\\n' +
+        ind + 'except Exception:\\n' +
+        ind + '    pass\\n' +
+        ind + 'try:\\n' +
+        ind + '    conversation.send_message(args.instruction)\\n' +
+        ind + '    conversation.run()\\n' +
+        ind + 'except BaseException as _e:\\n' +
+        ind + '    _nel_run_exc = _e\\n' +
+        ind + '    print(f"NEL: flushing trajectory after {type(_e).__name__}: {_e}", file=sys.stderr, flush=True)\\n' +
+        ind + '    _nel_write_partial_trajectory(type(_e).__name__)'
+    )
     c = c.replace(old1, wrap, 1)
     exit_block = (
         ind + 'if _nel_run_exc is not None:\\n' +
@@ -801,6 +878,8 @@ def _error_from_crash_marker(agent_logs_dir: Path) -> str | None:
         crash = json.loads(crash_file.read_text())
         etype = crash.get("etype", "AgentCrash")
         emsg = crash.get("emsg", "")
+        if etype == "KeyboardInterrupt" and str(emsg).startswith("NEL timeout signal "):
+            return None
         if etype in _INFRA_ERROR_NAMES:
             raise InfraError(f"Agent infrastructure failure: {etype}: {emsg}")
         return f"Agent crashed: {etype}: {emsg}"
@@ -1558,9 +1637,39 @@ class HarborSolver:
                 jitter,
                 self._timeout_strategy,
             )
-            agent_task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
-                await agent_task
+            if sandbox.is_running:
+                try:
+                    await sandbox.exec(
+                        "python3 - <<'PY'\n"
+                        "import os, signal, subprocess\n"
+                        "me = os.getpid()\n"
+                        "try:\n"
+                        "    out = subprocess.check_output(['ps', '-eo', 'pid=,comm=,args='], text=True)\n"
+                        "except Exception:\n"
+                        "    out = ''\n"
+                        "for line in out.splitlines():\n"
+                        "    parts = line.strip().split(None, 2)\n"
+                        "    if len(parts) < 3:\n"
+                        "        continue\n"
+                        "    try:\n"
+                        "        pid = int(parts[0])\n"
+                        "    except ValueError:\n"
+                        "        continue\n"
+                        "    comm, args = parts[1], parts[2]\n"
+                        "    if pid != me and 'python' in comm and '/installed-agent/run_agent.py' in args:\n"
+                        "        os.kill(pid, signal.SIGTERM)\n"
+                        "PY",
+                        timeout_sec=10,
+                    )
+                    done_after_signal, _ = await asyncio.wait({agent_task}, timeout=30.0)
+                    if agent_task in done_after_signal:
+                        logger.info("HarborSolver: timed-out agent flushed after SIGTERM")
+                except Exception:
+                    logger.debug("HarborSolver: timed-out agent flush signal failed", exc_info=True)
+            if not agent_task.done():
+                agent_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await agent_task
 
         agent_error: Exception | None = None
         if agent_task.done() and not agent_task.cancelled():
@@ -1757,10 +1866,11 @@ class HarborSolver:
 
             prompt = await self._inject_skill(sandbox, task.prompt)
             agent_task = asyncio.create_task(agent.run(prompt, adapter, context))
+            agent_t0 = time.monotonic()
             agent_timed_out, agent_error = await self._wait_for_agent(
                 agent_task,
                 sandbox,
-                t0,
+                agent_t0,
                 effective_timeout,
                 jitter,
             )

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -333,8 +333,8 @@ if 'LLM_TIMEOUT' in c:
 else:
     old = '    llm = LLM(**llm_kwargs)'
     new = (
-        '    import os\\n'
-        '    timeout_raw = os.environ.get("LLM_TIMEOUT")\\n'
+        '    import os as _nel_os\\n'
+        '    timeout_raw = _nel_os.environ.get("LLM_TIMEOUT")\\n'
         '    if timeout_raw:\\n'
         '        llm_kwargs["timeout"] = int(timeout_raw)\\n'
         '    llm = LLM(**llm_kwargs)'

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -647,10 +647,10 @@ print(f'cmd_timeout_{{_MAX}}s={{ok}} at {{p}}')
     # Anchor 1: wrap `conversation.send_message()` + `conversation.run()` in
     # try/except BaseException so main() continues to the existing
     # event-reconstruction + build_trajectory + save code on timeout/crash.
-    # SIGTERM/SIGINT are converted to KeyboardInterrupt so evaluator timeout
-    # cancellation gets the same flush path.  On interruption, first write a
-    # cheap partial trajectory from already-received model events.  The normal
-    # full writer below overwrites it if post-run serialization completes.
+    # SIGTERM/SIGINT are converted to a catchable BaseException so evaluator
+    # timeout cancellation gets the same flush path.  On interruption, first
+    # write a cheap partial trajectory from already-received model events.  The
+    # normal full writer below overwrites it if post-run serialization completes.
     # Anchor 2: after the final print in main(), exit(0) cleanly so Harbor
     # treats the run as a normal completion and downloads the trajectory.
     _budget_flush_script = """\
@@ -735,8 +735,10 @@ if ok:
         ind + '# Send instruction and run\\n' +
         ind + '_trajectory_flush_exc = None\\n' +
         partial +
+        ind + 'class TrajectoryFlushRequested(BaseException):\\n' +
+        ind + '    pass\\n' +
         ind + 'def _trajectory_timeout_handler(_signum, _frame):\\n' +
-        ind + '    raise KeyboardInterrupt(f"trajectory flush signal {_signum}")\\n' +
+        ind + '    raise TrajectoryFlushRequested(f"signal {_signum}")\\n' +
         ind + 'try:\\n' +
         ind + '    import signal as _trajectory_signal\\n' +
         ind + '    _trajectory_signal.signal(_trajectory_signal.SIGTERM, _trajectory_timeout_handler)\\n' +
@@ -879,7 +881,7 @@ def _error_from_crash_marker(agent_logs_dir: Path) -> str | None:
         crash = json.loads(crash_file.read_text())
         etype = crash.get("etype", "AgentCrash")
         emsg = crash.get("emsg", "")
-        if etype == "KeyboardInterrupt" and str(emsg).startswith("trajectory flush signal "):
+        if etype == "TrajectoryFlushRequested":
             return None
         if etype in _INFRA_ERROR_NAMES:
             raise InfraError(f"Agent infrastructure failure: {etype}: {emsg}")

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -48,6 +48,12 @@ _INFRA_ERROR_NAMES = frozenset(
         "ConnectError",
         "ReadTimeout",
         "APIConnectionError",
+        # TODO: decide whether litellm request timeouts ("Timeout" / "APITimeoutError")
+        # belong here. Classifying them as infra makes them retryable, but it also
+        # raises InfraError ahead of the `agent_timed_out and workspace_diff` branch
+        # that submits a partial patch for verification — so a timeout that already
+        # produced a usable workspace diff would be discarded instead of scored.
+        # Deferred to a follow-up to keep this change from altering scoring.
     }
 )
 
@@ -701,6 +707,8 @@ if ok:
         ind + '            pass\\n' +
         ind + '    return {}\\n' +
         ind + 'def _write_partial_trajectory(_reason):\\n' +
+        ind + '    import json, os, sys\\n' +
+        ind + '    from pathlib import Path\\n' +
         ind + '    try:\\n' +
         ind + '        _metric_obj = getattr(llm, "metrics", None)\\n' +
         ind + '        _usage = getattr(_metric_obj, "accumulated_token_usage", None)\\n' +
@@ -728,8 +736,10 @@ if ok:
         ind + '            json.dump(_trajectory, _f, indent=2)\\n' +
         ind + '        os.replace(_tmp, _path)\\n' +
         ind + '        print(f"trajectory flush: partial trajectory saved to {_path}", file=sys.stderr, flush=True)\\n' +
-        ind + '    except BaseException as _save_e:\\n' +
-        ind + '        print(f"trajectory flush: partial trajectory save failed: {type(_save_e).__name__}: {_save_e}", file=sys.stderr, flush=True)\\n'
+        ind + '        return True\\n' +
+        ind + '    except Exception as _save_e:\\n' +
+        ind + '        print(f"trajectory flush: partial trajectory save failed: {type(_save_e).__name__}: {_save_e}", file=sys.stderr, flush=True)\\n' +
+        ind + '        return False\\n'
     )
     wrap = (
         ind + '# Send instruction and run\\n' +
@@ -748,6 +758,10 @@ if ok:
         ind + 'try:\\n' +
         ind + '    conversation.send_message(args.instruction)\\n' +
         ind + '    conversation.run()\\n' +
+        ind + 'except TrajectoryFlushRequested as _e:\\n' +
+        ind + '    _trajectory_flush_exc = _e\\n' +
+        ind + '    print(f"trajectory flush: flushing after NEL timeout signal: {_e}", file=sys.stderr, flush=True)\\n' +
+        ind + '    _write_partial_trajectory("timeout")\\n' +
         ind + 'except BaseException as _e:\\n' +
         ind + '    _trajectory_flush_exc = _e\\n' +
         ind + '    print(f"trajectory flush: flushing after {type(_e).__name__}: {_e}", file=sys.stderr, flush=True)\\n' +
@@ -756,13 +770,14 @@ if ok:
     c = c.replace(old1, wrap, 1)
     exit_block = (
         ind + 'if _trajectory_flush_exc is not None:\\n' +
-        ind + '    import json as _j, os as _os\\n' +
-        ind + '    _os.makedirs("/logs/agent", exist_ok=True)\\n' +
-        ind + '    _marker = "/logs/agent/agent_error.json"\\n' +
-        ind + '    _marker_tmp = _marker + ".tmp"\\n' +
-        ind + '    with open(_marker_tmp, "w") as _mf:\\n' +
-        ind + '        _mf.write(_j.dumps({"etype": type(_trajectory_flush_exc).__name__, "emsg": str(_trajectory_flush_exc)}))\\n' +
-        ind + '    _os.replace(_marker_tmp, _marker)\\n' +
+        ind + '    if not isinstance(_trajectory_flush_exc, TrajectoryFlushRequested):\\n' +
+        ind + '        import json as _j, os as _os\\n' +
+        ind + '        _os.makedirs("/logs/agent", exist_ok=True)\\n' +
+        ind + '        _marker = "/logs/agent/agent_error.json"\\n' +
+        ind + '        _marker_tmp = _marker + ".tmp"\\n' +
+        ind + '        with open(_marker_tmp, "w") as _mf:\\n' +
+        ind + '            _mf.write(_j.dumps({"etype": type(_trajectory_flush_exc).__name__, "emsg": str(_trajectory_flush_exc)}))\\n' +
+        ind + '        _os.replace(_marker_tmp, _marker)\\n' +
         ind + '    sys.exit(0)')
     c = c.replace(old2, old2 + '\\n' + exit_block, 1)
     open(p, 'w').write(c)
@@ -884,8 +899,6 @@ def _error_from_crash_marker(agent_logs_dir: Path) -> str | None:
         crash = json.loads(crash_file.read_text())
         etype = crash.get("etype", "AgentCrash")
         emsg = crash.get("emsg", "")
-        if etype == "TrajectoryFlushRequested":
-            return None
         if etype in _INFRA_ERROR_NAMES:
             raise InfraError(f"Agent infrastructure failure: {etype}: {emsg}")
         return f"Agent crashed: {etype}: {emsg}"
@@ -1977,6 +1990,11 @@ class HarborSolver:
                     "workspace changes — submitting for verification",
                     self._run_timeout,
                 )
+                if not trajectory:
+                    logger.warning(
+                        "HarborSolver: timeout trajectory flush produced no events "
+                        "(empty trajectory); verifying on workspace patch only"
+                    )
                 error_kind = ErrorKind.SOLVE_TIMEOUT
             elif not response and prompt_tokens + completion_tokens == 0:
                 error = "Agent produced no output (0 tokens, empty response). Check agent logs for details."
@@ -1989,6 +2007,11 @@ class HarborSolver:
                     prompt_tokens,
                     completion_tokens,
                 )
+                if not trajectory:
+                    logger.warning(
+                        "HarborSolver: timeout trajectory flush produced no events "
+                        "(empty trajectory); verifying on workspace patch only"
+                    )
                 error_kind = ErrorKind.SOLVE_TIMEOUT
 
             return SolveResult(

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -672,6 +672,7 @@ for line in c.splitlines():
 
 already = '_nel_run_exc' in c
 ok = old1 in c and old2 is not None and not already
+success = already or ok
 print(f'anchor1={repr(old1)} anchor2={repr(old2)} already={already} ok={ok}')
 
 if ok:
@@ -760,7 +761,7 @@ if ok:
         ind + '    sys.exit(0)')
     c = c.replace(old2, old2 + '\\n' + exit_block, 1)
     open(p, 'w').write(c)
-print(f'budget_flush={ok}')
+print(f'budget_flush={success}')
 """
     encoded4 = base64.b64encode(_budget_flush_script.encode()).decode()
     r4 = await sandbox.exec(
@@ -769,7 +770,7 @@ print(f'budget_flush={ok}')
     )
     stdout4 = (r4.stdout or "").strip()
     logger.info("Budget-flush patch: %s", stdout4)
-    if r4.return_code != 0 or "False" in stdout4:
+    if r4.return_code != 0 or "budget_flush=True" not in stdout4:
         logger.warning(
             "Budget-flush patch problem (rc=%d): %s",
             r4.return_code,
@@ -1565,7 +1566,7 @@ class HarborSolver:
         self,
         agent_task: asyncio.Task[None],
         sandbox: "Sandbox",
-        t0: float,
+        agent_started_at: float,
         effective_timeout: float,
         jitter: float,
     ) -> tuple[bool, Exception | None]:
@@ -1620,7 +1621,7 @@ class HarborSolver:
                 )
 
             # Phase 2 — progress confirmed, wait remaining time
-            remaining = effective_timeout - (time.monotonic() - t0)
+            remaining = effective_timeout - (time.monotonic() - agent_started_at)
             done, _ = await asyncio.wait(
                 {agent_task},
                 timeout=max(0.0, remaining),
@@ -1632,7 +1633,7 @@ class HarborSolver:
             logger.warning(
                 "HarborSolver: agent.run() timed out after %.0fs "
                 "(effective=%.0fs+%.0fs jitter, strategy=%s) — collecting partial results",
-                time.monotonic() - t0,
+                time.monotonic() - agent_started_at,
                 effective_timeout - jitter,
                 jitter,
                 self._timeout_strategy,

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -758,8 +758,11 @@ if ok:
         ind + 'if _trajectory_flush_exc is not None:\\n' +
         ind + '    import json as _j, os as _os\\n' +
         ind + '    _os.makedirs("/logs/agent", exist_ok=True)\\n' +
-        ind + '    open("/logs/agent/agent_error.json", "w").write(\\n' +
-        ind + '        _j.dumps({"etype": type(_trajectory_flush_exc).__name__, "emsg": str(_trajectory_flush_exc)}))\\n' +
+        ind + '    _marker = "/logs/agent/agent_error.json"\\n' +
+        ind + '    _marker_tmp = _marker + ".tmp"\\n' +
+        ind + '    with open(_marker_tmp, "w") as _mf:\\n' +
+        ind + '        _mf.write(_j.dumps({"etype": type(_trajectory_flush_exc).__name__, "emsg": str(_trajectory_flush_exc)}))\\n' +
+        ind + '    _os.replace(_marker_tmp, _marker)\\n' +
         ind + '    sys.exit(0)')
     c = c.replace(old2, old2 + '\\n' + exit_block, 1)
     open(p, 'w').write(c)

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -333,8 +333,8 @@ if 'LLM_TIMEOUT' in c:
 else:
     old = '    llm = LLM(**llm_kwargs)'
     new = (
-        '    import os as _nel_os\\n'
-        '    timeout_raw = _nel_os.environ.get("LLM_TIMEOUT")\\n'
+        '    import os as _llm_timeout_os\\n'
+        '    timeout_raw = _llm_timeout_os.environ.get("LLM_TIMEOUT")\\n'
         '    if timeout_raw:\\n'
         '        llm_kwargs["timeout"] = int(timeout_raw)\\n'
         '    llm = LLM(**llm_kwargs)'
@@ -670,20 +670,20 @@ for line in c.splitlines():
     if 'Total cost:' in line and 'print' in line:
         old2 = line; break
 
-already = '_nel_run_exc' in c
+already = '_trajectory_flush_exc' in c
 ok = old1 in c and old2 is not None and not already
 success = already or ok
 print(f'anchor1={repr(old1)} anchor2={repr(old2)} already={already} ok={ok}')
 
 if ok:
     partial = (
-        ind + 'def _nel_text_from_event(_event):\\n' +
+        ind + 'def _trajectory_text_from_event(_event):\\n' +
         ind + '    _msg = getattr(_event, "llm_message", None)\\n' +
         ind + '    _raw = getattr(_msg, "content", None) if _msg is not None else None\\n' +
         ind + '    if isinstance(_raw, list):\\n' +
         ind + '        return chr(10).join(getattr(_c, "text", str(_c)) for _c in _raw if getattr(_c, "text", None))\\n' +
         ind + '    return str(_raw) if _raw else ""\\n' +
-        ind + 'def _nel_tool_args(_event):\\n' +
+        ind + 'def _trajectory_tool_args(_event):\\n' +
         ind + '    if getattr(_event, "tool_call", None) and hasattr(_event.tool_call, "function"):\\n' +
         ind + '        _raw_args = getattr(_event.tool_call.function, "arguments", None)\\n' +
         ind + '        if isinstance(_raw_args, str):\\n' +
@@ -700,7 +700,7 @@ if ok:
         ind + '        except Exception:\\n' +
         ind + '            pass\\n' +
         ind + '    return {}\\n' +
-        ind + 'def _nel_write_partial_trajectory(_reason):\\n' +
+        ind + 'def _write_partial_trajectory(_reason):\\n' +
         ind + '    try:\\n' +
         ind + '        _metric_obj = getattr(llm, "metrics", None)\\n' +
         ind + '        _usage = getattr(_metric_obj, "accumulated_token_usage", None)\\n' +
@@ -715,49 +715,49 @@ if ok:
         ind + '            if isinstance(_event, MessageEvent):\\n' +
         ind + '                if _event.source in ("user", "agent"):\\n' +
         ind + '                    _entry_type = "assistant_message" if _event.source == "agent" else "user_message"\\n' +
-        ind + '                    _entry = {"type": _entry_type, "content": _nel_text_from_event(_event), "timestamp": _event.timestamp}\\n' +
+        ind + '                    _entry = {"type": _entry_type, "content": _trajectory_text_from_event(_event), "timestamp": _event.timestamp}\\n' +
         ind + '                    _events_list.append(_entry)\\n' +
         ind + '            elif isinstance(_event, ActionEvent):\\n' +
-        ind + '                _events_list.append({"type": "assistant_message", "content": "", "timestamp": _event.timestamp, "tool_calls": [{"id": _event.tool_call_id, "name": _event.tool_name, "arguments": _nel_tool_args(_event)}]})\\n' +
+        ind + '                _events_list.append({"type": "assistant_message", "content": "", "timestamp": _event.timestamp, "tool_calls": [{"id": _event.tool_call_id, "name": _event.tool_name, "arguments": _trajectory_tool_args(_event)}]})\\n' +
         ind + '        _trajectory = build_trajectory(_events_list, _metrics, model)\\n' +
-        ind + '        _trajectory.setdefault("extra", {})["nel_partial_trajectory"] = {"reason": _reason, "events": len(_events_list)}\\n' +
+        ind + '        _trajectory.setdefault("extra", {})["partial_trajectory"] = {"reason": _reason, "events": len(_events_list)}\\n' +
         ind + '        _path = Path(args.trajectory_path)\\n' +
         ind + '        _path.parent.mkdir(parents=True, exist_ok=True)\\n' +
         ind + '        _tmp = _path.with_suffix(_path.suffix + ".partial")\\n' +
         ind + '        with open(_tmp, "w") as _f:\\n' +
         ind + '            json.dump(_trajectory, _f, indent=2)\\n' +
         ind + '        os.replace(_tmp, _path)\\n' +
-        ind + '        print(f"NEL: partial trajectory saved to {_path}", file=sys.stderr, flush=True)\\n' +
+        ind + '        print(f"trajectory flush: partial trajectory saved to {_path}", file=sys.stderr, flush=True)\\n' +
         ind + '    except BaseException as _save_e:\\n' +
-        ind + '        print(f"NEL: partial trajectory save failed: {type(_save_e).__name__}: {_save_e}", file=sys.stderr, flush=True)\\n'
+        ind + '        print(f"trajectory flush: partial trajectory save failed: {type(_save_e).__name__}: {_save_e}", file=sys.stderr, flush=True)\\n'
     )
     wrap = (
         ind + '# Send instruction and run\\n' +
-        ind + '_nel_run_exc = None\\n' +
+        ind + '_trajectory_flush_exc = None\\n' +
         partial +
-        ind + 'def _nel_timeout_handler(_signum, _frame):\\n' +
-        ind + '    raise KeyboardInterrupt(f"NEL timeout signal {_signum}")\\n' +
+        ind + 'def _trajectory_timeout_handler(_signum, _frame):\\n' +
+        ind + '    raise KeyboardInterrupt(f"trajectory flush signal {_signum}")\\n' +
         ind + 'try:\\n' +
-        ind + '    import signal as _nel_signal\\n' +
-        ind + '    _nel_signal.signal(_nel_signal.SIGTERM, _nel_timeout_handler)\\n' +
-        ind + '    _nel_signal.signal(_nel_signal.SIGINT, _nel_timeout_handler)\\n' +
+        ind + '    import signal as _trajectory_signal\\n' +
+        ind + '    _trajectory_signal.signal(_trajectory_signal.SIGTERM, _trajectory_timeout_handler)\\n' +
+        ind + '    _trajectory_signal.signal(_trajectory_signal.SIGINT, _trajectory_timeout_handler)\\n' +
         ind + 'except Exception:\\n' +
         ind + '    pass\\n' +
         ind + 'try:\\n' +
         ind + '    conversation.send_message(args.instruction)\\n' +
         ind + '    conversation.run()\\n' +
         ind + 'except BaseException as _e:\\n' +
-        ind + '    _nel_run_exc = _e\\n' +
-        ind + '    print(f"NEL: flushing trajectory after {type(_e).__name__}: {_e}", file=sys.stderr, flush=True)\\n' +
-        ind + '    _nel_write_partial_trajectory(type(_e).__name__)'
+        ind + '    _trajectory_flush_exc = _e\\n' +
+        ind + '    print(f"trajectory flush: flushing after {type(_e).__name__}: {_e}", file=sys.stderr, flush=True)\\n' +
+        ind + '    _write_partial_trajectory(type(_e).__name__)'
     )
     c = c.replace(old1, wrap, 1)
     exit_block = (
-        ind + 'if _nel_run_exc is not None:\\n' +
+        ind + 'if _trajectory_flush_exc is not None:\\n' +
         ind + '    import json as _j, os as _os\\n' +
         ind + '    _os.makedirs("/logs/agent", exist_ok=True)\\n' +
-        ind + '    open("/logs/agent/nel_agent_error.json", "w").write(\\n' +
-        ind + '        _j.dumps({"etype": type(_nel_run_exc).__name__, "emsg": str(_nel_run_exc)}))\\n' +
+        ind + '    open("/logs/agent/agent_error.json", "w").write(\\n' +
+        ind + '        _j.dumps({"etype": type(_trajectory_flush_exc).__name__, "emsg": str(_trajectory_flush_exc)}))\\n' +
         ind + '    sys.exit(0)')
     c = c.replace(old2, old2 + '\\n' + exit_block, 1)
     open(p, 'w').write(c)
@@ -871,7 +871,7 @@ def _recover_from_logs(agent_logs_dir: Path) -> dict[str, Any]:
 
 def _error_from_crash_marker(agent_logs_dir: Path) -> str | None:
     """Return a user-facing crash error from the agent sidecar, or raise infra errors."""
-    crash_file = agent_logs_dir / "nel_agent_error.json"
+    crash_file = agent_logs_dir / "agent_error.json"
     if not crash_file.is_file():
         return None
 
@@ -879,7 +879,7 @@ def _error_from_crash_marker(agent_logs_dir: Path) -> str | None:
         crash = json.loads(crash_file.read_text())
         etype = crash.get("etype", "AgentCrash")
         emsg = crash.get("emsg", "")
-        if etype == "KeyboardInterrupt" and str(emsg).startswith("NEL timeout signal "):
+        if etype == "KeyboardInterrupt" and str(emsg).startswith("trajectory flush signal "):
             return None
         if etype in _INFRA_ERROR_NAMES:
             raise InfraError(f"Agent infrastructure failure: {etype}: {emsg}")

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -287,9 +287,55 @@ class TestPatchOpenhandsSDK:
         exec(compile(timeout_patch, "llm_timeout_patch.py", "exec"), {})  # noqa: S102
 
         patched = runner.read_text()
-        assert "import os" in patched
-        assert 'os.environ.get("LLM_TIMEOUT")' in patched
+        assert "import os as _nel_os" in patched
+        assert '_nel_os.environ.get("LLM_TIMEOUT")' in patched
         assert 'llm_kwargs["timeout"] = int(timeout_raw)' in patched
+
+    async def test_runner_timeout_patch_does_not_shadow_os(self, tmp_path):
+        import base64
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            """\
+import os
+
+
+def main():
+    model = os.environ.get("LLM_MODEL", "m")
+    llm_kwargs = {"model": model}
+    llm = LLM(**llm_kwargs)
+"""
+        )
+
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = MagicMock(stdout="ok", stderr="", return_code=0)
+        await _patch_openhands_sdk(sandbox)
+
+        decoded_scripts = []
+        for call in sandbox.exec.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+            if "base64 -d" in cmd:
+                encoded = cmd.split("echo ", 1)[1].split(" ", 1)[0]
+                decoded_scripts.append(base64.b64decode(encoded).decode())
+
+        timeout_patch = next(
+            (s for s in decoded_scripts if "llm_timeout" in s and "LLM_TIMEOUT" in s),
+            None,
+        )
+        assert timeout_patch is not None, "LLM timeout patch script not emitted"
+
+        timeout_patch = timeout_patch.replace(
+            "p = '/installed-agent/run_agent.py'",
+            f"p = {str(runner)!r}",
+        )
+        exec(compile(timeout_patch, "llm_timeout_patch.py", "exec"), {})  # noqa: S102
+
+        patched = runner.read_text()
+        namespace = {"LLM": lambda **kwargs: kwargs}
+        exec(compile(patched, str(runner), "exec"), namespace)  # noqa: S102
+        namespace["main"]()
 
     async def test_runner_patch_preserves_tool_timing(self, tmp_path):
         import base64

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -184,19 +184,19 @@ class TestDownloadAgentLogs:
 
 class TestCrashMarker:
     def test_non_infra_marker_returns_agent_crash_error(self, tmp_path):
-        (tmp_path / "nel_agent_error.json").write_text(json.dumps({"etype": "ValueError", "emsg": "bad input"}))
+        (tmp_path / "agent_error.json").write_text(json.dumps({"etype": "ValueError", "emsg": "bad input"}))
 
         assert _error_from_crash_marker(tmp_path) == "Agent crashed: ValueError: bad input"
 
     def test_timeout_signal_marker_is_not_agent_crash(self, tmp_path):
-        (tmp_path / "nel_agent_error.json").write_text(
-            json.dumps({"etype": "KeyboardInterrupt", "emsg": "NEL timeout signal 15"})
+        (tmp_path / "agent_error.json").write_text(
+            json.dumps({"etype": "KeyboardInterrupt", "emsg": "trajectory flush signal 15"})
         )
 
         assert _error_from_crash_marker(tmp_path) is None
 
     def test_infra_marker_raises_infra_error(self, tmp_path):
-        (tmp_path / "nel_agent_error.json").write_text(
+        (tmp_path / "agent_error.json").write_text(
             json.dumps({"etype": "APIConnectionError", "emsg": "connection failed"})
         )
 
@@ -287,8 +287,8 @@ class TestPatchOpenhandsSDK:
         exec(compile(timeout_patch, "llm_timeout_patch.py", "exec"), {})  # noqa: S102
 
         patched = runner.read_text()
-        assert "import os as _nel_os" in patched
-        assert '_nel_os.environ.get("LLM_TIMEOUT")' in patched
+        assert "import os as _llm_timeout_os" in patched
+        assert '_llm_timeout_os.environ.get("LLM_TIMEOUT")' in patched
         assert 'llm_kwargs["timeout"] = int(timeout_raw)' in patched
 
     async def test_runner_timeout_patch_does_not_shadow_os(self, tmp_path):

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -556,7 +556,11 @@ def main():
         assert "_trajectory_flush_exc = None" in patched
         assert "def _write_partial_trajectory" in patched
         assert "class TrajectoryFlushRequested" in patched
-        assert 'open("/logs/agent/agent_error.json", "w")' in patched
+        # Crash marker is written atomically (tmp + os.replace), matching the
+        # partial-trajectory write, so a kill mid-write can't leave a truncated
+        # marker that _error_from_crash_marker would silently drop.
+        assert '_marker = "/logs/agent/agent_error.json"' in patched
+        assert "_os.replace(_marker_tmp, _marker)" in patched
         assert "sys.exit(0)" in patched
 
         # Execute the patched runner: run() raises, so the flush path writes a

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -10,14 +10,17 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import nemo_evaluator.solvers.harbor as harbor_mod
+from nemo_evaluator.environments.base import SeedResult
 from nemo_evaluator.errors import InfraError
 from nemo_evaluator.solvers.harbor import (
     _ensure_claude_host_env,
@@ -184,6 +187,13 @@ class TestCrashMarker:
         (tmp_path / "nel_agent_error.json").write_text(json.dumps({"etype": "ValueError", "emsg": "bad input"}))
 
         assert _error_from_crash_marker(tmp_path) == "Agent crashed: ValueError: bad input"
+
+    def test_timeout_signal_marker_is_not_agent_crash(self, tmp_path):
+        (tmp_path / "nel_agent_error.json").write_text(
+            json.dumps({"etype": "KeyboardInterrupt", "emsg": "NEL timeout signal 15"})
+        )
+
+        assert _error_from_crash_marker(tmp_path) is None
 
     def test_infra_marker_raises_infra_error(self, tmp_path):
         (tmp_path / "nel_agent_error.json").write_text(
@@ -646,6 +656,183 @@ class TestHarborSolverLlmTimeout:
                 container_env={"LLM_TIMEOUT": "7200"},
             )
             assert solver._container_env["LLM_TIMEOUT"] == "7200"
+
+
+class _TimeoutFlushSandbox:
+    is_running = True
+
+    def __init__(
+        self,
+        flush_event: asyncio.Event | None = None,
+        *,
+        signal_error: Exception | None = None,
+    ) -> None:
+        self.flush_event = flush_event
+        self.signal_error = signal_error
+        self.exec_calls: list[tuple[str, float | None]] = []
+
+    async def exec(self, command: str, timeout_sec: float | None = None):
+        self.exec_calls.append((command, timeout_sec))
+        if "find /logs/agent" in command:
+            return MagicMock(stdout="1\n", stderr="", return_code=0)
+        if "/installed-agent/run_agent.py" in command:
+            if self.signal_error is not None:
+                raise self.signal_error
+            if self.flush_event is not None:
+                self.flush_event.set()
+            return MagicMock(stdout="", stderr="", return_code=0)
+        return MagicMock(stdout="", stderr="", return_code=0)
+
+
+class TestWaitForAgentTimeout:
+    def _solver(self):
+        from nemo_evaluator.solvers.harbor import HarborSolver
+
+        solver = HarborSolver.__new__(HarborSolver)
+        solver._run_timeout = 0.05
+        solver._timeout_strategy = "override"
+        return solver
+
+    @pytest.mark.asyncio
+    async def test_timeout_sends_sigterm_and_waits_for_trajectory_flush(self):
+        solver = self._solver()
+        flush_event = asyncio.Event()
+        sandbox = _TimeoutFlushSandbox(flush_event)
+
+        async def agent_run():
+            await flush_event.wait()
+
+        agent_task = asyncio.create_task(agent_run())
+
+        timed_out, agent_error = await solver._wait_for_agent(
+            agent_task,
+            sandbox,
+            time.monotonic(),
+            effective_timeout=0.05,
+            jitter=0.0,
+        )
+
+        assert timed_out is True
+        assert agent_error is None
+        assert agent_task.done()
+        assert not agent_task.cancelled()
+        assert any("/installed-agent/run_agent.py" in command for command, _ in sandbox.exec_calls)
+
+    @pytest.mark.asyncio
+    async def test_timeout_cancels_agent_if_sigterm_flush_fails(self):
+        solver = self._solver()
+        sandbox = _TimeoutFlushSandbox(signal_error=RuntimeError("signal failed"))
+
+        async def agent_run():
+            await asyncio.Event().wait()
+
+        agent_task = asyncio.create_task(agent_run())
+
+        timed_out, agent_error = await solver._wait_for_agent(
+            agent_task,
+            sandbox,
+            time.monotonic(),
+            effective_timeout=0.05,
+            jitter=0.0,
+        )
+
+        assert timed_out is True
+        assert agent_error is None
+        assert agent_task.cancelled()
+        assert any("/installed-agent/run_agent.py" in command for command, _ in sandbox.exec_calls)
+
+
+class TestSolveTimeoutPlumbing:
+    @pytest.mark.asyncio
+    async def test_solve_starts_timeout_clock_at_agent_run(self, monkeypatch):
+        import nemo_evaluator.solvers.harbor as harbor_mod
+        from nemo_evaluator.solvers.harbor import HarborSolver
+
+        class FakeContext:
+            def __init__(self) -> None:
+                self.metadata = {}
+                self.rollout_details = []
+                self.n_input_tokens = 0
+                self.n_output_tokens = 0
+
+            def is_empty(self) -> bool:
+                return False
+
+        class FakeAdapter:
+            is_mounted = True
+
+            def __init__(self, *args, **kwargs) -> None:
+                pass
+
+        class FakeAgent:
+            async def setup(self, adapter) -> None:
+                pass
+
+            async def run(self, prompt, adapter, context) -> None:
+                context.metadata["response"] = "agent answer"
+                context.n_input_tokens = 3
+                context.n_output_tokens = 4
+
+        class FakeSandbox:
+            is_running = True
+
+            def resolved_endpoint_url(self, name):
+                return None
+
+            def resolve_outside_endpoint(self, url):
+                return url
+
+            async def exec(self, command: str, timeout_sec: float | None = None):
+                return MagicMock(stdout="", stderr="", return_code=0)
+
+        import harbor.models.agent.context as context_mod
+
+        import nemo_evaluator.solvers.harbor_adapter as harbor_adapter_mod
+
+        monkeypatch.setattr(context_mod, "AgentContext", FakeContext)
+        monkeypatch.setattr(harbor_adapter_mod, "SandboxEnvironmentAdapter", FakeAdapter)
+        monkeypatch.setattr(harbor_mod, "_capture_workspace_diff", AsyncMock(return_value=""))
+        monkeypatch.setattr(
+            harbor_mod,
+            "_recover_from_logs",
+            lambda logs_dir: {"trajectory": [], "prompt_tokens": 0, "completion_tokens": 0, "response": ""},
+        )
+        monkeypatch.setattr(harbor_mod.random, "uniform", lambda low, high: 0.0)
+
+        solver = HarborSolver.__new__(HarborSolver)
+        solver._model_url = "http://model"
+        solver._model_id = "model"
+        solver._timeout = 60.0
+        solver._run_timeout = 60.0
+        solver._timeout_strategy = "override"
+        solver._max_agent_timeout = None
+        solver._harbor_agent = "terminus-2"
+        solver._container_env = {}
+        solver._skill = None
+        solver._skill_dir = None
+        solver._create_agent = lambda logs_dir, model_url="": FakeAgent()
+
+        wait_args: dict[str, float] = {}
+
+        async def fake_wait_for_agent(agent_task, sandbox, agent_started_at, effective_timeout, jitter):
+            wait_args["agent_started_at"] = agent_started_at
+            wait_args["effective_timeout"] = effective_timeout
+            wait_args["jitter"] = jitter
+            await agent_task
+            return False, None
+
+        solver._wait_for_agent = fake_wait_for_agent
+
+        result = await solver.solve(
+            SeedResult(prompt="do task", expected_answer="", metadata={"task_id": "task-1"}),
+            sandbox=FakeSandbox(),
+        )
+
+        assert result.response == "agent answer"
+        assert result.model_response.total_tokens == 7
+        assert wait_args["agent_started_at"] > 0
+        assert wait_args["effective_timeout"] == 60.0
+        assert wait_args["jitter"] == 0.0
 
 
 class TestInjectSkill:

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -447,6 +447,139 @@ def build_trajectory(events, llm_metrics, model_name):
             "duration_ms": 1250.0,
         }
 
+    async def test_runner_patch_flushes_partial_trajectory_on_interrupt(self, tmp_path, monkeypatch):
+        """Patch 4 must wrap the run with a flush path that survives execution.
+
+        The injected block is the largest patch (helpers + signal handlers +
+        two anchors), so a stub run is the only thing that catches an
+        indentation slip or a closure-scope mistake before a live eval.  Drive
+        a stub whose ``conversation.run()`` raises and assert the partial
+        trajectory is serialized from the already-received events.
+        """
+        import base64
+        import contextlib
+        import signal
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
+
+        traj_path = tmp_path / "trajectory" / "out.json"
+        monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            '''\
+import json
+import os
+import sys
+from pathlib import Path
+
+
+class MessageEvent:
+    def __init__(self, source, content, timestamp):
+        self.source = source
+        self.timestamp = timestamp
+        self.llm_message = type("LM", (), {"content": content})()
+
+
+class ActionEvent:
+    def __init__(self, timestamp, tool_call_id, tool_name, arguments):
+        self.timestamp = timestamp
+        self.tool_call_id = tool_call_id
+        self.tool_name = tool_name
+        fn = type("Fn", (), {"arguments": arguments})()
+        self.tool_call = type("TC", (), {"function": fn})()
+
+
+def build_trajectory(events, metrics, model):
+    return {"steps": events, "final_metrics": metrics, "model_name": model}
+
+
+class _Args:
+    instruction = "solve it"
+
+
+class _Conversation:
+    def __init__(self, events):
+        self.state = type("S", (), {"events": events})()
+
+    def send_message(self, instruction):
+        self._sent = instruction
+
+    def run(self):
+        raise RuntimeError("simulated timeout interrupt")
+
+
+def main():
+    args = _Args()
+    args.trajectory_path = os.environ["NEL_TEST_TRAJECTORY_PATH"]
+    model = "test-model"
+    llm = type("LLM", (), {"metrics": None})()
+    conversation = _Conversation(
+        [
+            MessageEvent("agent", "partial reasoning", 1.0),
+            ActionEvent(2.0, "call-1", "bash", \'{"command": "ls"}\'),
+        ]
+    )
+
+    # Send instruction and run
+    conversation.send_message(args.instruction)
+    conversation.run()
+
+    print("Total cost: 0.0")
+'''
+        )
+
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = MagicMock(stdout="budget_flush=True", stderr="", return_code=0)
+        await _patch_openhands_sdk(sandbox)
+
+        decoded_scripts = []
+        for call in sandbox.exec.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+            if "base64 -d" in cmd:
+                encoded = cmd.split("echo ", 1)[1].split(" ", 1)[0]
+                decoded_scripts.append(base64.b64decode(encoded).decode())
+
+        flush_patch = next(
+            (s for s in decoded_scripts if "_trajectory_flush_exc" in s and "budget_flush" in s),
+            None,
+        )
+        assert flush_patch is not None, "trajectory-flush patch script not emitted"
+
+        flush_patch = flush_patch.replace(
+            "p = '/installed-agent/run_agent.py'",
+            f"p = {str(runner)!r}",
+        )
+        exec(compile(flush_patch, "flush_patch.py", "exec"), {})  # noqa: S102
+
+        patched = runner.read_text()
+        assert "_trajectory_flush_exc = None" in patched
+        assert "def _write_partial_trajectory" in patched
+        assert "class TrajectoryFlushRequested" in patched
+        assert 'open("/logs/agent/agent_error.json", "w")' in patched
+        assert "sys.exit(0)" in patched
+
+        # Execute the patched runner: run() raises, so the flush path writes a
+        # partial trajectory before main() exits.  The hardcoded /logs write in
+        # the exit block is not writable under test, so tolerate its OSError /
+        # the clean sys.exit(0) — the trajectory is serialized before either.
+        namespace = {}
+        exec(compile(patched, str(runner), "exec"), namespace)  # noqa: S102
+        old_term = signal.getsignal(signal.SIGTERM)
+        old_int = signal.getsignal(signal.SIGINT)
+        try:
+            with contextlib.suppress(SystemExit, OSError):
+                namespace["main"]()
+        finally:
+            signal.signal(signal.SIGTERM, old_term)
+            signal.signal(signal.SIGINT, old_int)
+
+        assert traj_path.is_file(), "partial trajectory was not flushed"
+        data = json.loads(traj_path.read_text())
+        assert data["extra"]["partial_trajectory"]["reason"] == "RuntimeError"
+        assert data["extra"]["partial_trajectory"]["events"] == 2
+        assert len(data["steps"]) == 2
+
 
 class TestSandboxEnvironmentAdapter:
     def test_exposes_all_base_environment_public_attrs(self, tmp_path):

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -188,12 +188,13 @@ class TestCrashMarker:
 
         assert _error_from_crash_marker(tmp_path) == "Agent crashed: ValueError: bad input"
 
-    def test_timeout_signal_marker_is_not_agent_crash(self, tmp_path):
-        (tmp_path / "agent_error.json").write_text(
-            json.dumps({"etype": "TrajectoryFlushRequested", "emsg": "signal 15"})
-        )
+    def test_litellm_timeout_marker_treated_as_crash_not_infra(self, tmp_path):
+        # TODO: litellm request timeouts (etype "Timeout") are currently surfaced as a
+        # generic crash, not infra. Whether they should be retryable infra is deferred —
+        # see the TODO on _INFRA_ERROR_NAMES. This test pins the current behavior.
+        (tmp_path / "agent_error.json").write_text(json.dumps({"etype": "Timeout", "emsg": "request timed out"}))
 
-        assert _error_from_crash_marker(tmp_path) is None
+        assert _error_from_crash_marker(tmp_path) == "Agent crashed: Timeout: request timed out"
 
     def test_infra_marker_raises_infra_error(self, tmp_path):
         (tmp_path / "agent_error.json").write_text(
@@ -447,31 +448,28 @@ def build_trajectory(events, llm_metrics, model_name):
             "duration_ms": 1250.0,
         }
 
-    async def test_runner_patch_flushes_partial_trajectory_on_interrupt(self, tmp_path, monkeypatch):
-        """Patch 4 must wrap the run with a flush path that survives execution.
+    _EVENTS_MSG_AND_ACTION = (
+        'MessageEvent("agent", "partial reasoning", 1.0), ActionEvent(2.0, "call-1", "bash", \'{"command": "ls"}\')'
+    )
+    _EVENTS_TWO_MESSAGES = (
+        'MessageEvent("agent", "partial reasoning", 1.0), MessageEvent("agent", "more reasoning", 2.0)'
+    )
 
-        The injected block is the largest patch (helpers + signal handlers +
-        two anchors), so a stub run is the only thing that catches an
-        indentation slip or a closure-scope mistake before a live eval.  Drive
-        a stub whose ``conversation.run()`` raises and assert the partial
-        trajectory is serialized from the already-received events.
+    @staticmethod
+    def _stub_runner(module_imports: str, run_body: str, events: str) -> str:
+        """Build a minimal run_agent.py stub for the flush patch to wrap.
+
+        ``module_imports`` controls which names exist at module scope (used to
+        prove ``_write_partial_trajectory`` self-imports its dependencies).
+        ``run_body`` is the indented body of ``_Conversation.run`` — raise to
+        exercise the crash path, ``raise_signal`` to exercise the timeout path.
+        ``events`` is the comma-separated event constructor list; use message-
+        only events to keep the flush off the ``_trajectory_tool_args`` sibling
+        helper (which is not in change #5's self-sufficiency scope).
         """
-        import base64
-        import contextlib
-        import signal
-
-        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
-
-        traj_path = tmp_path / "trajectory" / "out.json"
-        monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
-
-        runner = tmp_path / "run_agent.py"
-        runner.write_text(
-            '''\
-import json
-import os
-import sys
-from pathlib import Path
+        return (
+            module_imports
+            + """
 
 
 class MessageEvent:
@@ -506,28 +504,31 @@ class _Conversation:
         self._sent = instruction
 
     def run(self):
-        raise RuntimeError("simulated timeout interrupt")
-
+"""
+            + run_body
+            + """
 
 def main():
     args = _Args()
     args.trajectory_path = os.environ["NEL_TEST_TRAJECTORY_PATH"]
     model = "test-model"
     llm = type("LLM", (), {"metrics": None})()
-    conversation = _Conversation(
-        [
-            MessageEvent("agent", "partial reasoning", 1.0),
-            ActionEvent(2.0, "call-1", "bash", \'{"command": "ls"}\'),
-        ]
-    )
+    conversation = _Conversation([__EVENTS__])
 
     # Send instruction and run
     conversation.send_message(args.instruction)
     conversation.run()
 
     print("Total cost: 0.0")
-'''
+""".replace("__EVENTS__", events)
         )
+
+    @staticmethod
+    async def _apply_flush_patch(runner: Path) -> str:
+        """Emit the trajectory-flush patch and apply it to *runner* in place."""
+        import base64
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
 
         sandbox = AsyncMock()
         sandbox.exec.return_value = MagicMock(stdout="budget_flush=True", stderr="", return_code=0)
@@ -551,8 +552,60 @@ def main():
             f"p = {str(runner)!r}",
         )
         exec(compile(flush_patch, "flush_patch.py", "exec"), {})  # noqa: S102
+        return runner.read_text()
 
-        patched = runner.read_text()
+    @staticmethod
+    def _run_patched_main(patched: str, runner: Path, monkeypatch) -> list[str]:
+        """Execute the patched ``main()``, returning the marker dir creations.
+
+        The exit block's ``/logs/agent`` marker write is not writable under
+        test, so ``os.makedirs`` is spied to both record whether the marker
+        branch was taken and short-circuit the unwritable path.  Signal
+        handlers installed by the wrap are saved and restored.
+        """
+        import contextlib
+        import signal
+
+        makedirs_calls: list[str] = []
+
+        def _spy_makedirs(path, *a, **k):
+            makedirs_calls.append(path)
+            raise OSError("marker dir not writable under test")
+
+        monkeypatch.setattr(os, "makedirs", _spy_makedirs)
+
+        namespace: dict = {}
+        exec(compile(patched, str(runner), "exec"), namespace)  # noqa: S102
+        old_term = signal.getsignal(signal.SIGTERM)
+        old_int = signal.getsignal(signal.SIGINT)
+        try:
+            with contextlib.suppress(SystemExit, OSError):
+                namespace["main"]()
+        finally:
+            signal.signal(signal.SIGTERM, old_term)
+            signal.signal(signal.SIGINT, old_int)
+        return makedirs_calls
+
+    async def test_flush_patch_crash_writes_trajectory_and_marker(self, tmp_path, monkeypatch):
+        """Genuine crash → flush with reason=etype AND the marker branch is taken.
+
+        The injected block is the largest patch (helpers + signal handlers +
+        two anchors), so a stub run is the only thing that catches an
+        indentation slip or a closure-scope mistake before a live eval.
+        """
+        traj_path = tmp_path / "trajectory" / "out.json"
+        monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            self._stub_runner(
+                "import json\nimport os\nimport sys\nfrom pathlib import Path",
+                '        raise RuntimeError("simulated crash")\n',
+                self._EVENTS_MSG_AND_ACTION,
+            )
+        )
+        patched = await self._apply_flush_patch(runner)
+
         assert "_trajectory_flush_exc = None" in patched
         assert "def _write_partial_trajectory" in patched
         assert "class TrajectoryFlushRequested" in patched
@@ -563,24 +616,67 @@ def main():
         assert "_os.replace(_marker_tmp, _marker)" in patched
         assert "sys.exit(0)" in patched
 
-        # Execute the patched runner: run() raises, so the flush path writes a
-        # partial trajectory before main() exits.  The hardcoded /logs write in
-        # the exit block is not writable under test, so tolerate its OSError /
-        # the clean sys.exit(0) — the trajectory is serialized before either.
-        namespace = {}
-        exec(compile(patched, str(runner), "exec"), namespace)  # noqa: S102
-        old_term = signal.getsignal(signal.SIGTERM)
-        old_int = signal.getsignal(signal.SIGINT)
-        try:
-            with contextlib.suppress(SystemExit, OSError):
-                namespace["main"]()
-        finally:
-            signal.signal(signal.SIGTERM, old_term)
-            signal.signal(signal.SIGINT, old_int)
+        makedirs_calls = self._run_patched_main(patched, runner, monkeypatch)
 
         assert traj_path.is_file(), "partial trajectory was not flushed"
         data = json.loads(traj_path.read_text())
         assert data["extra"]["partial_trajectory"]["reason"] == "RuntimeError"
+        assert data["extra"]["partial_trajectory"]["events"] == 2
+        assert len(data["steps"]) == 2
+        assert "/logs/agent" in makedirs_calls, "a genuine crash must take the marker-write branch"
+
+    async def test_flush_patch_timeout_writes_trajectory_no_marker(self, tmp_path, monkeypatch):
+        """NEL timeout signal → flush with reason='timeout' and NO crash marker.
+
+        Raising SIGINT inside ``run()`` fires the installed handler, which
+        raises ``TrajectoryFlushRequested``; the guarded exit block must skip
+        the marker write so the host never sees a bogus crash.
+        """
+        traj_path = tmp_path / "trajectory" / "out.json"
+        monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            self._stub_runner(
+                "import json\nimport os\nimport sys\nfrom pathlib import Path",
+                "        import signal as _sig\n        _sig.raise_signal(_sig.SIGINT)\n",
+                self._EVENTS_MSG_AND_ACTION,
+            )
+        )
+        patched = await self._apply_flush_patch(runner)
+
+        makedirs_calls = self._run_patched_main(patched, runner, monkeypatch)
+
+        assert traj_path.is_file(), "partial trajectory was not flushed on timeout"
+        data = json.loads(traj_path.read_text())
+        assert data["extra"]["partial_trajectory"]["reason"] == "timeout"
+        assert data["extra"]["partial_trajectory"]["events"] == 2
+        assert "/logs/agent" not in makedirs_calls, "the timeout path must not write a crash marker"
+
+    async def test_flush_patch_self_sufficient_without_module_imports(self, tmp_path, monkeypatch):
+        """_write_partial_trajectory flushes even without module-scope json/Path.
+
+        Proves change #5: the function self-imports its dependencies.  ``os``
+        and ``sys`` remain at module scope because the wrap/exit blocks (out of
+        scope for #5) still reference them there.
+        """
+        traj_path = tmp_path / "trajectory" / "out.json"
+        monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            self._stub_runner(
+                "import os\nimport sys",
+                '        raise RuntimeError("simulated crash")\n',
+                self._EVENTS_TWO_MESSAGES,
+            )
+        )
+        patched = await self._apply_flush_patch(runner)
+
+        self._run_patched_main(patched, runner, monkeypatch)
+
+        assert traj_path.is_file(), "flush must not depend on module-scope json/Path"
+        data = json.loads(traj_path.read_text())
         assert data["extra"]["partial_trajectory"]["events"] == 2
         assert len(data["steps"]) == 2
 

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -190,7 +190,7 @@ class TestCrashMarker:
 
     def test_timeout_signal_marker_is_not_agent_crash(self, tmp_path):
         (tmp_path / "agent_error.json").write_text(
-            json.dumps({"etype": "KeyboardInterrupt", "emsg": "trajectory flush signal 15"})
+            json.dumps({"etype": "TrajectoryFlushRequested", "emsg": "signal 15"})
         )
 
         assert _error_from_crash_marker(tmp_path) is None


### PR DESCRIPTION
## Summary
- Send `SIGTERM` to the timed-out OpenHands runner before cancellation so the runner gets a chance to flush logs.
- Patch the injected OpenHands runner to persist a partial ATIF trajectory immediately from received model/action events when the run is interrupted.
- Ignore the expected NEL timeout `KeyboardInterrupt` marker so timed-out solves are reported as `solve_timeout` instead of agent crashes.
- Clean up timeout accounting/readability by naming the agent-run start timestamp explicitly and making the budget-flush patch success check idempotent.

## Validation
- `python -m py_compile src/nemo_evaluator/solvers/harbor.py`
- Generated patched OpenHands runner compiles.
- `python -m pytest tests/test_solvers/test_harbor_solver.py tests/test_environments/test_harbor_timeouts.py -q`
- Follow-up cleanup verified with `ruff check`, `ruff format --check`, `py_compile`, and the same focused pytest command.
- GitLab Harbor image built and manifest verified:
  - MR: https://gitlab-master.nvidia.com/dl/JoC/competitive_evaluation/nemo-evaluator-next/-/merge_requests/201
  - image: `gitlab-master.nvidia.com/dl/joc/competitive_evaluation/nemo-evaluator-next:dev-20260624-153457-96bf902e-harbor`
- Post-cleanup GitLab minimal validation:
  - GitLab commit: `9411cd655aec894dc3df77a0b3e5155f2ad6fe20`
  - Pipeline: https://gitlab-master.nvidia.com/dl/JoC/competitive_evaluation/nemo-evaluator-next/-/pipelines/55805190
  - `lint`: passed
  - `test-offline`: passed
  - `build-docs`: passed
  - Harbor amd64 build: passed
  - Harbor arm64 build: passed
  - Harbor multiarch manifest: passed
  - image: `gitlab-master.nvidia.com/dl/joc/competitive_evaluation/nemo-evaluator-next:dev-20260625-134044-9411cd65-harbor`
  - note: `sonarqube` still fails with the existing missing `sonar.projectKey` configuration issue seen before; this is not Harbor-change-specific.

## Kimi Timeout Experiment
Ran Kimi K2.6 SWE-bench Verified with the Harbor MR image, capped at 100 samples, with `timeout_strategy=override` and `run_timeout=120` to force real Harbor agent timeouts.

- Run: `20260625_082342_09550176`
- Result: `100/100` completed, `avg_reward=0.2700`
- Timeout rows: `94`
- Non-timeout rows: `6`
- Empty trajectory rows: `0`
- `model_traffic.jsonl` rows: `2363`
- `inference_log.jsonl` rows: `100`
- Timeout log markers: `94`
- Timeout with workspace changes: `24`
- Timeout without workspace changes: `70`

For the 94 timeout rows:

- Total trajectory steps: min `9`, p50 `26`, p90 `35`, max `44`
- Agent steps: min `7`, p50 `24`, p90 `33`, max `42`
- Observation steps: min `7`, p50 `23`, p90 `32`, max `42`

This confirms timed-out Harbor solves preserve non-empty model trajectories in final merged results.

## Kimi Default-Timeout Full Eval
Launched the full Kimi K2.6 SWE-bench Verified eval with the same Harbor MR image and default timeout behavior unchanged.

- Run: `20260625_090131_09550176`
- Shape: 5 shards, 500 problems x 3 repeats = 1500 trials
- Config verified: `timeout_strategy=max`, `run_timeout=5400`, no `max_problems` cap
- Status at PR update time: `767/1500` complete, `avg_reward=0.7692`, merge pending


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of agent timeouts and interruptions, reducing false failures during long-running runs.
  * Added more reliable partial result saving when a run stops unexpectedly, helping preserve progress.
  * Updated crash handling so timeout-related interruptions are treated as non-fatal in supported cases.
  * Improved cleanup of stalled background processes when a timeout occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->