### PR TITLE
docs: enable multi-source publishing in Fern docs.yml

### DIFF
--- a/docs/fern/docs.yml
+++ b/docs/fern/docs.yml
@@ -1,6 +1,7 @@
 instances:
   - url: evaluator.docs.buildwithfern.com/nemo/evaluator
     custom-domain: docs.nvidia.com/nemo/evaluator
+    multi-source: true
 
 title: NVIDIA NeMo Evaluator
 


### PR DESCRIPTION
## Summary
- Adds `multi-source: true` to the Fern instance config in `docs/fern/docs.yml`.
- Enables basepath-aware publishing so NeMo Evaluator docs can coexist with other NeMo documentation under `docs.nvidia.com/nemo/evaluator`.

## Test plan
- [ ] Verify `fern generate --docs` succeeds with the updated config
- [ ] Confirm docs publish correctly to the shared custom domain without overwriting sibling paths


Made with [Cursor](https://cursor.com)