### PR TITLE
fix(judge): don't let an unparseable judge reply silently score 0

### DIFF
--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -633,7 +633,7 @@ async def run_evaluation(
                                     step.reward = float(reward)
                                     vr.reward = float(reward)
                             else:
-                                from nemo_evaluator.scoring.judge import judge_score
+                                from nemo_evaluator.scoring.judge import is_parse_error, judge_score
 
                                 judge_result = await judge_score(
                                     instruction=seed_result.prompt,
@@ -642,7 +642,10 @@ async def run_evaluation(
                                     client=judge_client,
                                 )
                                 step.scoring_details["judge"] = judge_result
-                                if "normalized" in judge_result:
+                                if is_parse_error(judge_result):
+                                    # Unparseable judge reply: a judge failure, not a real 0.
+                                    judge_result["error"] = "unparseable_judge_response"
+                                elif "normalized" in judge_result:
                                     step.reward = judge_result["normalized"]
                                     vr.reward = judge_result["normalized"]
                         except (KeyboardInterrupt, asyncio.CancelledError):

--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -311,10 +311,11 @@ async def run_evaluation(
                 async with lock:
                     collector.record(cached_step)
                     results.append(result_dict)
-                    if reward > 0:
-                        cum_correct += 1
-                    cum_total += 1
-                    problem_correct.setdefault(idx, []).append(reward)
+                    if not is_unscored_result(result_dict):
+                        if reward > 0:
+                            cum_correct += 1
+                        cum_total += 1
+                        problem_correct.setdefault(idx, []).append(reward)
                 pg.on_step(slot, rep, n_problems, n_repeats, reward, tokens, 0)
                 return
 

--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -67,6 +67,18 @@ def _get_error_category(entry: dict) -> str | None:
     return sd.get("error_category")
 
 
+# error_category for a sample the judge could not score (e.g. an unparseable
+# reply). Its reward is a placeholder 0, not a real score.
+JUDGE_PARSE_ERROR_CATEGORY = "judge_parse_error"
+
+
+def is_unscored_result(entry: dict) -> bool:
+    """Whether a result's reward is a non-score placeholder that must be excluded
+    from reward aggregation rather than counted as a real value. Today this is the
+    unparseable-judge-reply case; counting its 0 would silently drag scores down."""
+    return _get_error_category(entry) == JUDGE_PARSE_ERROR_CATEGORY
+
+
 async def run_evaluation(
     env: EvalEnvironment,
     solver: Solver,
@@ -643,8 +655,12 @@ async def run_evaluation(
                                 )
                                 step.scoring_details["judge"] = judge_result
                                 if is_parse_error(judge_result):
-                                    # Unparseable judge reply: a judge failure, not a real 0.
+                                    # Unparseable judge reply: a judge failure, not a
+                                    # real 0. Flag it so the placeholder reward is
+                                    # excluded from metrics (see is_unscored_result)
+                                    # instead of quietly dragging the score down.
                                     judge_result["error"] = "unparseable_judge_response"
+                                    step.scoring_details["error_category"] = JUDGE_PARSE_ERROR_CATEGORY
                                 elif "normalized" in judge_result:
                                     step.reward = judge_result["normalized"]
                                     vr.reward = judge_result["normalized"]
@@ -698,10 +714,11 @@ async def run_evaluation(
                 async with lock:
                     collector.record(step)
                     results.append(result_dict)
-                    if vr.reward > 0:
-                        cum_correct += 1
-                    cum_total += 1
-                    problem_correct.setdefault(idx, []).append(vr.reward)
+                    if not is_unscored_result(result_dict):
+                        if vr.reward > 0:
+                            cum_correct += 1
+                        cum_total += 1
+                        problem_correct.setdefault(idx, []).append(vr.reward)
 
                 pg.on_step(slot, rep, n_problems, n_repeats, vr.reward, tokens, step.total_ms)
 
@@ -804,7 +821,10 @@ async def run_evaluation(
     if first_error is not None:
         raise RuntimeError(f"Evaluation aborted (skip_failed=False): {first_error}") from first_error
 
-    all_rewards = [r["reward"] for r in results]
+    # Samples the judge could not score carry a placeholder reward; exclude them
+    # from reward aggregation so a judge glitch is not counted as a real 0.
+    scored_results = [r for r in results if not is_unscored_result(r)]
+    all_rewards = [r["reward"] for r in scored_results]
 
     # Fractional-vs-binary metric selection lives in
     # :mod:`nemo_evaluator.metrics.headline` so the single-shard path and
@@ -823,14 +843,14 @@ async def run_evaluation(
     metrics["summary"] = summary_stats(all_rewards)
 
     cats = None
-    if results and "category" in results[0].get("metadata", {}):
-        cat_results = category_breakdown(results, "category")
+    if scored_results and "category" in scored_results[0].get("metadata", {}):
+        cat_results = category_breakdown(scored_results, "category")
         cats = [
             {"category": c.category, "n_samples": c.n_samples, "mean_reward": round(c.mean_reward, 4)}
             for c in cat_results
         ]
 
-    sd_breakdowns = scoring_details_breakdown(results)
+    sd_breakdowns = scoring_details_breakdown(scored_results)
     if sd_breakdowns:
         metrics["breakdowns"] = {
             field: [

--- a/src/nemo_evaluator/engine/sharding.py
+++ b/src/nemo_evaluator/engine/sharding.py
@@ -86,17 +86,24 @@ def merge_results(shard_dirs: list[str | Path], output_dir: str | Path, n_repeat
         logger.warning("No results found in %d shard dirs", len(shard_dirs))
         return {}
 
+    # Samples the judge could not score carry a placeholder reward; exclude them
+    # from reward aggregation so a judge glitch is not counted as a real 0. Mirrors
+    # the single-shard path in ``run_evaluation``.
+    from nemo_evaluator.engine.eval_loop import is_unscored_result
+
+    scored_results = [r for r in all_results if not is_unscored_result(r)]
+
     # Group rewards by problem_idx, using ACTUAL per-problem repeat counts
     # (partial shards may produce fewer rows for some problems than
     # ``n_repeats``). ``headline_score_metrics`` handles both the binary
     # ``pass@k`` and fractional ``mean_reward`` cases.
     per_problem_rewards: dict[int, list[float]] = {}
-    for r in all_results:
+    for r in scored_results:
         per_problem_rewards.setdefault(r["problem_idx"], []).append(float(r.get("reward", 0.0)))
 
     metrics: dict[str, Any] = dict(headline_score_metrics(per_problem_rewards, n_repeats))
 
-    all_rewards = [r.get("reward", 0) for r in all_results]
+    all_rewards = [r.get("reward", 0) for r in scored_results]
     metrics["summary"] = summary_stats(all_rewards)
 
     if all_runtime_stats:
@@ -127,8 +134,8 @@ def merge_results(shard_dirs: list[str | Path], output_dir: str | Path, n_repeat
         metrics["runtime"] = merged_rt
 
     cats = None
-    if all_results and "category" in all_results[0].get("metadata", {}):
-        cr = category_breakdown(all_results, "category")
+    if scored_results and "category" in scored_results[0].get("metadata", {}):
+        cr = category_breakdown(scored_results, "category")
         cats = [{"category": c.category, "n_samples": c.n_samples, "mean_reward": round(c.mean_reward, 4)} for c in cr]
 
     from nemo_evaluator.engine.artifacts import build_artifact_bundle

--- a/src/nemo_evaluator/scoring/judge.py
+++ b/src/nemo_evaluator/scoring/judge.py
@@ -113,6 +113,12 @@ def parse_judge_response(text: str, max_score: int = 5) -> dict[str, Any]:
     return {"score": 0, "normalized": 0.0, "reasoning": text, "raw": text, "parse_error": True}
 
 
+def is_parse_error(judge_result: dict[str, Any]) -> bool:
+    """Whether a judge result came from an unparseable reply. Its 0 means
+    "judge unreadable", not "scored 0", so callers must not treat it as a reward."""
+    return bool(judge_result.get("parse_error"))
+
+
 def needs_judge(sample: ScorerInput) -> dict:
     """Signals that this sample needs LLM-as-judge post-processing in the eval loop."""
     return {"correct": False, "needs_judge": True, "extracted": sample.response[:500]}

--- a/tests/test_integration/test_eval_loop_integration.py
+++ b/tests/test_integration/test_eval_loop_integration.py
@@ -524,3 +524,34 @@ class TestUnparseableJudgeNotScoredZero:
         assert len(bundle["_results"]) == 2
         flagged = [r for r in bundle["_results"] if r["scoring_details"].get("error_category") == "judge_parse_error"]
         assert len(flagged) == 1
+
+    def test_resumed_run_excludes_cached_parse_error(self, tmp_path):
+        # A judge_parse_error sample is persisted to the verified cache, so a
+        # resumed run replays it through the cached-result branch. Its placeholder
+        # must be excluded there too, or fresh and resumed runs would disagree.
+        log_dir = tmp_path / "logs"
+        fresh = asyncio.run(
+            run_evaluation(
+                _JudgeScoreEnv(2),
+                _ScriptedSolver(["good", "bad"]),
+                n_repeats=1,
+                judge_client=_ScriptedJudgeClient(),
+                step_log_dir=log_dir,
+            )
+        )
+        resumed = asyncio.run(
+            run_evaluation(
+                _JudgeScoreEnv(2),
+                _ScriptedSolver(["good", "bad"]),
+                n_repeats=1,
+                judge_client=_ScriptedJudgeClient(),
+                step_log_dir=log_dir,
+                resume=True,
+            )
+        )
+
+        resumed_scores = resumed["benchmark"]["scores"]
+        assert resumed_scores["mean_reward"]["value"] == 0.8
+        assert resumed_scores["summary"]["n"] == 1
+        # Resumed metrics match the fresh run rather than counting the placeholder 0.
+        assert resumed_scores["mean_reward"]["value"] == fresh["benchmark"]["scores"]["mean_reward"]["value"]

--- a/tests/test_integration/test_eval_loop_integration.py
+++ b/tests/test_integration/test_eval_loop_integration.py
@@ -439,3 +439,88 @@ class TestJudgeFnSerialization:
         judge = result["scoring_details"]["judge"]
         assert judge["total"] is None
         assert "judge exploded" in judge["error"]
+
+
+class _JudgeScoreEnv(EvalEnvironment):
+    """Env whose verify() requests the built-in judge_score path (no _judge_fn)."""
+
+    name = "mock_judge_score"
+
+    def __init__(self, n):
+        super().__init__()
+        self._dataset = [{"idx": i} for i in range(n)]
+
+    async def seed(self, idx):
+        return SeedResult(prompt=f"q{idx}", expected_answer="a", metadata={"idx": idx})
+
+    async def verify(self, response, expected, **meta):  # noqa: ARG002
+        return VerifyResult(reward=0.0, extracted_answer=response, scoring_details={"needs_judge": True})
+
+
+class _ScriptedSolver:
+    """Echoes the response it is told to emit per problem index."""
+
+    def __init__(self, responses):
+        self._responses = responses
+
+    async def solve(self, task):
+        return SolveResult(response=self._responses[task.metadata["idx"]])
+
+    async def close(self):
+        pass
+
+
+class _ScriptedJudgeClient:
+    """Returns a valid score for a 'good' response and an unparseable reply otherwise."""
+
+    model = "mock-judge"
+
+    async def chat(self, prompt, system):  # noqa: ARG002
+        if "good" in prompt:
+            return ModelResponse(content='{"score": 4, "reasoning": "ok"}', model=self.model)
+        return ModelResponse(content="No score here, just vibes.", model=self.model)
+
+
+class TestUnparseableJudgeNotScoredZero:
+    """Regression: an unparseable judge reply is recorded as a judge error and
+    excluded from reward metrics rather than counted as a real 0 (PR #1094)."""
+
+    def test_unparseable_reply_recorded_as_judge_error(self, tmp_path):
+        env = _JudgeScoreEnv(1)
+        bundle = asyncio.run(
+            run_evaluation(
+                env,
+                _ScriptedSolver(["bad"]),
+                n_repeats=1,
+                judge_client=_ScriptedJudgeClient(),
+                step_log_dir=tmp_path,
+            )
+        )
+
+        (result,) = bundle["_results"]
+        judge = result["scoring_details"]["judge"]
+        assert judge["error"] == "unparseable_judge_response"
+        assert result["scoring_details"]["error_category"] == "judge_parse_error"
+
+    def test_unparseable_reply_excluded_from_reward_metrics(self, tmp_path):
+        # Problem 0 gets a clean 4/5 (normalized 0.8); problem 1's judge reply is
+        # unparseable. The unparseable sample must not pull the mean down to 0.4.
+        env = _JudgeScoreEnv(2)
+        bundle = asyncio.run(
+            run_evaluation(
+                env,
+                _ScriptedSolver(["good", "bad"]),
+                n_repeats=1,
+                judge_client=_ScriptedJudgeClient(),
+                step_log_dir=tmp_path,
+            )
+        )
+
+        scores = bundle["benchmark"]["scores"]
+        # Only the parseable sample contributes — mean reflects 0.8, not (0.8+0)/2.
+        assert scores["mean_reward"]["value"] == 0.8
+        assert scores["summary"]["n"] == 1
+        # Both samples are still recorded; the unparseable one is flagged, not dropped.
+        assert len(bundle["_results"]) == 2
+        flagged = [r for r in bundle["_results"] if r["scoring_details"].get("error_category") == "judge_parse_error"]
+        assert len(flagged) == 1

--- a/tests/test_scoring/test_judge.py
+++ b/tests/test_scoring/test_judge.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 """Tests for LLM-as-judge scoring primitives."""
 
-from nemo_evaluator.scoring.judge import build_judge_prompt, parse_judge_response
+from nemo_evaluator.scoring.judge import build_judge_prompt, is_parse_error, parse_judge_response
 
 
 class TestParseJudgeResponse:
@@ -43,6 +43,14 @@ class TestParseJudgeResponse:
         result = parse_judge_response('{"score": 10, "reasoning": "perfect"}', max_score=5)
         assert result["score"] == 5
         assert result["normalized"] == 1.0
+
+
+class TestIsParseError:
+    def test_true_for_unparseable(self):
+        assert is_parse_error(parse_judge_response("This is great!")) is True
+
+    def test_false_for_valid(self):
+        assert is_parse_error(parse_judge_response('{"score": 4, "reasoning": "ok"}')) is False
 
 
 class TestBuildJudgePrompt:


### PR DESCRIPTION
For open-ended benchmarks, NeMo scores answers with an LLM judge. When that judge's reply can't be parsed, parse_judge_response hands back a score of 0 with a `parse_error` flag attached. The eval loop reads the score straight through and does not consider the flag, so a judge that generated mis-formatted output and another judge that actually scored a sample as 0 due to an underperforming model were not resolved from each other. Due to this every parse glitch would silently pulled the benchmark number down.

The fix adds a small `is_parse_error()` check and has the eval loop treat a parse failure as a judge error: it flags the result and withholds the score. The parsing logic itself doesn't change, so the existing behavior and tests still hold.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unparseable judge replies are now tagged as explicit judge errors using a dedicated error category.
  * These unscored samples are excluded from reward and headline metric calculations, while still appearing in evaluation results as flagged judge failures.
  * Sharded/merged evaluation metrics now also aggregate only scored samples for consistent behavior.
* **Tests**
  * Added unit tests for parse-error detection.
  * Added integration tests covering unparseable judge replies, metric exclusion, and consistent results across resumed runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->