### PR TITLE
fix(traffic): persist request hashes in model traffic logs

### DIFF
--- a/src/nemo_evaluator/engine/model_traffic_log.py
+++ b/src/nemo_evaluator/engine/model_traffic_log.py
@@ -83,6 +83,7 @@ def format_model_traffic_log_records(
             "repeat": repeat,
             "session_id": record.get("session_id"),
             "adapter_request_id": record.get("request_id"),
+            "request_hash": record.get("request_hash") or "",
             "service": record.get("service"),
             "method": record.get("method"),
             "path": record.get("path"),

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -183,6 +183,7 @@ def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_
     rows = format_model_traffic_log_records(store.drain_session("cap-session"), benchmark="b", problem_idx=0, repeat=0)
     assert len(rows) == 1
     row = rows[0]
+    assert row["request_hash"]
     assert row["tool_calls"] == {"count": 1, "names": {"w": 1}}
     if expect_response_fields:
         assert row["tool_calls_full"] == [{"id": "c1", "name": "w", "arguments": "{}"}]
@@ -192,6 +193,36 @@ def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_
         assert "tool_calls_full" not in row
         assert "reasoning_content" not in row
         assert "message_content" not in row
+
+
+def test_duplicate_requests_persist_same_request_hash() -> None:
+    store = ModelTrafficStore(service_name="solver")
+    body = {"model": "m", "messages": [{"role": "user", "content": "same request"}], "temperature": 0}
+
+    for request_id in ("req-a", "req-b"):
+        ctx = InterceptorContext(request_id=request_id)
+        ctx.extra["session_id"] = "dup-session"
+        store.start_request(AdapterRequest(method="POST", path="/chat/completions", headers={}, body=body, ctx=ctx))
+        store.finish_response(
+            AdapterResponse(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                latency_ms=5.0,
+                ctx=ctx,
+                body=_capture_response_body(),
+            )
+        )
+
+    rows = format_model_traffic_log_records(
+        store.drain_session("dup-session"),
+        benchmark="b",
+        problem_idx=0,
+        repeat=0,
+    )
+
+    assert [row["adapter_request_id"] for row in rows] == ["req-a", "req-b"]
+    assert rows[0]["request_hash"]
+    assert rows[0]["request_hash"] == rows[1]["request_hash"]
 
 
 def test_non_success_response_forwards_compact_error_summary() -> None:
@@ -315,6 +346,7 @@ async def test_model_traffic_writes_compact_log_and_inference_stats(tmp_path: Pa
         assert traffic["session_id"]
         assert traffic["adapter_request_id"]
         assert traffic["model_traffic_request_id"] == f"{traffic['session_id']}:{traffic['adapter_request_id']}"
+        assert traffic["request_hash"]
         assert traffic["service"] == "solver"
         assert traffic["status_code"] == 200
         assert traffic["path"] == "/chat/completions"


### PR DESCRIPTION
Minimal duplicate-detection fix. ModelTrafficStore already computes request_hash, but model_traffic.jsonl formatting dropped it. This PR preserves request_hash and verifies it through model-traffic writer tests.

Testing:
- Ran a controlled local duplicate-request comparison with the same upstream request body sent twice through ModelTrafficStore, format_model_traffic_log_records, and generate_trajectories_report:
  - origin/main: in-memory hashes matched, but compact model_traffic.jsonl rows had no request_hash; report showed wire_total=2, wire_unique=2, problems_with_duplicates=0.
  - this PR (e7290ee): compact model_traffic.jsonl rows persisted the same request_hash twice; report showed wire_total=2, wire_unique=1, problems_with_duplicates=1.
- Ran `python -m pytest tests/test_engine/test_model_traffic_capture.py` -> 10 passed.
- Ran `python -m pytest tests/test_reports/test_trajectories_report.py::test_wire_dedup_via_request_hash` -> 1 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model traffic logs now include a `request_hash` value on every emitted row for improved request traceability.
  * When a request hash isn’t available, an empty value is written to keep the field consistent.
  * End-to-end compact log output now preserves `request_hash` consistently.
* **Tests**
  * Added assertions that formatted and persisted model-traffic records contain `request_hash`.
  * Added coverage to confirm identical requests produce the same `request_hash` even when request identifiers differ.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->