### PR TITLE
fix(harbor): let NEL timeout flush OpenHands

### DIFF
--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -40,6 +40,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_SANDBOX_AGENT_TIMEOUT_GRACE_SECONDS = 30.0
+
 _INFRA_ERROR_NAMES = frozenset(
     {
         "ServiceUnavailableError",
@@ -86,6 +88,17 @@ def _resolve_agent_timeout(
     if max_cap is not None:
         result = min(result, max_cap)
     return result
+
+
+def _sandbox_agent_exec_timeout(agent_timeout: float) -> float:
+    """Return sandbox command timeout for the Harbor agent process.
+
+    The sandbox-level command timeout must exceed NEL's agent timeout so
+    ``_wait_for_agent`` can send SIGTERM and let OpenHands flush its partial
+    trajectory before any inner ``timeout(1)`` wrapper kills the process.
+    """
+
+    return agent_timeout + _SANDBOX_AGENT_TIMEOUT_GRACE_SECONDS
 
 
 def _extract_response(context: Any) -> str:
@@ -1794,11 +1807,39 @@ class HarborSolver:
             if resolved_url:
                 override["LLM_BASE_URL"] = resolved_url
 
+            task_timeout = task.metadata.get("agent_timeout_sec")
+            if task_timeout is not None and not isinstance(task_timeout, (int, float)):
+                logger.warning("agent_timeout_sec in metadata is not numeric: %r, ignoring", task_timeout)
+                task_timeout = None
+            run_timeout = _resolve_agent_timeout(
+                self._timeout_strategy,
+                self._run_timeout,
+                task_timeout,
+                self._max_agent_timeout,
+            )
+            logger.info(
+                "HarborSolver: timeout resolved: strategy=%s nel=%.0fs task=%s cap=%s → effective=%.0fs",
+                self._timeout_strategy,
+                self._run_timeout,
+                f"{task_timeout:.0f}s" if task_timeout is not None else "n/a",
+                f"{self._max_agent_timeout:.0f}s" if self._max_agent_timeout is not None else "n/a",
+                run_timeout,
+            )
+            jitter = random.uniform(0, min(120.0, run_timeout * 0.02))
+            effective_timeout = run_timeout + jitter
+            agent_exec_timeout = max(self._timeout, _sandbox_agent_exec_timeout(effective_timeout))
+            logger.info(
+                "HarborSolver: sandbox agent command timeout %.0fs (effective %.0fs + %.0fs jitter)",
+                agent_exec_timeout,
+                run_timeout,
+                jitter,
+            )
+
             adapter = SandboxEnvironmentAdapter(
                 sandbox,
                 session_id=task.metadata["task_id"],
                 logs_dir=logs_dir,
-                default_timeout=self._timeout,
+                default_timeout=agent_exec_timeout,
                 persistent_env=self._container_env,
                 override_env=override,
             )
@@ -1862,26 +1903,6 @@ class HarborSolver:
 
             agent_error: Exception | None = None
             agent_timed_out = False
-            task_timeout = task.metadata.get("agent_timeout_sec")
-            if task_timeout is not None and not isinstance(task_timeout, (int, float)):
-                logger.warning("agent_timeout_sec in metadata is not numeric: %r, ignoring", task_timeout)
-                task_timeout = None
-            run_timeout = _resolve_agent_timeout(
-                self._timeout_strategy,
-                self._run_timeout,
-                task_timeout,
-                self._max_agent_timeout,
-            )
-            logger.info(
-                "HarborSolver: timeout resolved: strategy=%s nel=%.0fs task=%s cap=%s → effective=%.0fs",
-                self._timeout_strategy,
-                self._run_timeout,
-                f"{task_timeout:.0f}s" if task_timeout is not None else "n/a",
-                f"{self._max_agent_timeout:.0f}s" if self._max_agent_timeout is not None else "n/a",
-                run_timeout,
-            )
-            jitter = random.uniform(0, min(120.0, run_timeout * 0.02))
-            effective_timeout = run_timeout + jitter
 
             prompt = await self._inject_skill(sandbox, task.prompt)
             agent_task = asyncio.create_task(agent.run(prompt, adapter, context))

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -30,6 +30,7 @@ from nemo_evaluator.solvers.harbor import (
     _model_id_for_openai,
     _resolve_agent_timeout,
     _resolve_api_key,
+    _sandbox_agent_exec_timeout,
 )
 
 # ── Pure helpers ─────────────────────────────────────────────────────────
@@ -903,6 +904,9 @@ class TestResolveAgentTimeout:
     def test_effective_timeout(self, strategy, config, task, cap, expected):
         assert _resolve_agent_timeout(strategy, config, task, cap) == expected
 
+    def test_sandbox_agent_exec_timeout_adds_flush_grace(self):
+        assert _sandbox_agent_exec_timeout(10800.0) > 10800.0
+
 
 class TestHarborSolverLlmTimeout:
     def test_llm_kwargs_timeout_maps_to_container_env(self):
@@ -1020,6 +1024,30 @@ class TestWaitForAgentTimeout:
         assert agent_task.cancelled()
         assert any("/installed-agent/run_agent.py" in command for command, _ in sandbox.exec_calls)
 
+    @pytest.mark.asyncio
+    async def test_inner_command_timeout_finishes_first_and_skips_nel_sigterm(self):
+        solver = self._solver()
+        sandbox = _TimeoutFlushSandbox()
+
+        async def agent_run():
+            await asyncio.sleep(0.001)
+            raise RuntimeError("Command failed (exit 124): stderr: timed out after 10800s")
+
+        agent_task = asyncio.create_task(agent_run())
+
+        timed_out, agent_error = await solver._wait_for_agent(
+            agent_task,
+            sandbox,
+            time.monotonic(),
+            effective_timeout=0.05,
+            jitter=0.0,
+        )
+
+        assert timed_out is False
+        assert agent_error is not None
+        assert "timed out after 10800s" in str(agent_error)
+        assert not any("/installed-agent/run_agent.py" in command for command, _ in sandbox.exec_calls)
+
 
 class TestSolveTimeoutPlumbing:
     @pytest.mark.asyncio
@@ -1037,11 +1065,13 @@ class TestSolveTimeoutPlumbing:
             def is_empty(self) -> bool:
                 return False
 
+        adapter_kwargs: dict[str, object] = {}
+
         class FakeAdapter:
             is_mounted = True
 
             def __init__(self, *args, **kwargs) -> None:
-                pass
+                adapter_kwargs.update(kwargs)
 
         class FakeAgent:
             async def setup(self, adapter) -> None:
@@ -1112,6 +1142,96 @@ class TestSolveTimeoutPlumbing:
         assert wait_args["agent_started_at"] > 0
         assert wait_args["effective_timeout"] == 60.0
         assert wait_args["jitter"] == 0.0
+        assert adapter_kwargs["default_timeout"] == _sandbox_agent_exec_timeout(60.0)
+
+    @pytest.mark.asyncio
+    async def test_solve_sets_command_timeout_after_10800s_effective_timeout_with_jitter(self, monkeypatch):
+        import nemo_evaluator.solvers.harbor as harbor_mod
+        from nemo_evaluator.solvers.harbor import HarborSolver
+
+        class FakeContext:
+            def __init__(self) -> None:
+                self.metadata = {"response": "agent answer"}
+                self.rollout_details = []
+                self.n_input_tokens = 3
+                self.n_output_tokens = 4
+
+            def is_empty(self) -> bool:
+                return False
+
+        adapter_kwargs: dict[str, object] = {}
+
+        class FakeAdapter:
+            is_mounted = True
+
+            def __init__(self, *args, **kwargs) -> None:
+                adapter_kwargs.update(kwargs)
+
+        class FakeAgent:
+            async def setup(self, adapter) -> None:
+                pass
+
+            async def run(self, prompt, adapter, context) -> None:
+                pass
+
+        class FakeSandbox:
+            is_running = True
+
+            def resolved_endpoint_url(self, name):
+                return None
+
+            def resolve_outside_endpoint(self, url):
+                return url
+
+            async def exec(self, command: str, timeout_sec: float | None = None):
+                return MagicMock(stdout="", stderr="", return_code=0)
+
+        import harbor.models.agent.context as context_mod
+
+        import nemo_evaluator.solvers.harbor_adapter as harbor_adapter_mod
+
+        monkeypatch.setattr(context_mod, "AgentContext", FakeContext)
+        monkeypatch.setattr(harbor_adapter_mod, "SandboxEnvironmentAdapter", FakeAdapter)
+        monkeypatch.setattr(harbor_mod, "_capture_workspace_diff", AsyncMock(return_value=""))
+        monkeypatch.setattr(
+            harbor_mod,
+            "_recover_from_logs",
+            lambda logs_dir: {"trajectory": [], "prompt_tokens": 0, "completion_tokens": 0, "response": ""},
+        )
+        monkeypatch.setattr(harbor_mod.random, "uniform", lambda low, high: high)
+
+        solver = HarborSolver.__new__(HarborSolver)
+        solver._model_url = "http://model"
+        solver._model_id = "model"
+        solver._timeout = 10800.0
+        solver._run_timeout = 10800.0
+        solver._timeout_strategy = "override"
+        solver._max_agent_timeout = None
+        solver._harbor_agent = "terminus-2"
+        solver._container_env = {}
+        solver._skill = None
+        solver._skill_dir = None
+        solver._create_agent = lambda logs_dir, model_url="": FakeAgent()
+
+        wait_args: dict[str, float] = {}
+
+        async def fake_wait_for_agent(agent_task, sandbox, agent_started_at, effective_timeout, jitter):
+            wait_args["effective_timeout"] = effective_timeout
+            wait_args["jitter"] = jitter
+            await agent_task
+            return False, None
+
+        solver._wait_for_agent = fake_wait_for_agent
+
+        await solver.solve(
+            SeedResult(prompt="do task", expected_answer="", metadata={"task_id": "task-1"}),
+            sandbox=FakeSandbox(),
+        )
+
+        assert wait_args["jitter"] == 120.0
+        assert wait_args["effective_timeout"] == 10920.0
+        assert adapter_kwargs["default_timeout"] == _sandbox_agent_exec_timeout(10920.0)
+        assert adapter_kwargs["default_timeout"] == 10950.0
 
 
 class TestInjectSkill:


### PR DESCRIPTION
## Why

In the Kimi SWE compaction run, two report-level wire-vs-final total-token mismatches were dirty timeout cases with missing final metrics:

- `problem_idx=331 repeat=1`
- `problem_idx=112 repeat=2`

Both had successful wire traffic but no `trajectory.json`; Harbor fell back to `openhands_sdk.txt`. The solve error was `NonZeroAgentExitCodeError: Command failed (exit 124)` with stderr `timed out after 10800s`.

Root cause: there were two independent clocks:

1. NEL/OpenHands outer agent runtime: `run_timeout + jitter`.
2. Sandbox command timeout around the process running OpenHands.

In the VPR config, `benchmark.timeout == solver.run_timeout == 10800s`. The sandbox command timeout therefore fired at exactly `10800s`, before NEL's `run_timeout + jitter`. `_wait_for_agent()` saw the agent task already finished with exit 124, so it skipped the `timed_out` branch that sends SIGTERM and lets OpenHands flush the partial trajectory.

## Change

- Resolve the effective Harbor agent timeout before constructing `SandboxEnvironmentAdapter`.
- Set the adapter default command timeout to `max(benchmark_timeout, effective_timeout + 30s)`.
- Keep the agent runtime clock starting immediately before `agent.run()`; setup/install time is not charged to `run_timeout`.

## Real SWE Local Validation

This was validated with a real local SWE run, not only a unit test:

- benchmark: `harbor://swebench-verified@1.0`
- agent: `openhands-sdk`, version `1.17.0`
- sandbox: Docker, `network: host`
- sample count: `max_problems: 1`, `max_concurrent: 1`
- timeout shape: `benchmark.timeout == solver.run_timeout == 120s`
- model request timeout: `300s`
- fake OpenAI-compatible endpoint: first `/v1/chat/completions` request returns a tool call with usage, second request sleeps `300s`

I used `120s` rather than `30s` or `60s` because this local Docker SWE image installs OpenHands SDK on the fly; shorter benchmark timeouts can fail during setup before the agent process starts. This still reproduces the Kimi shape: the benchmark command timeout and agent runtime are equal, while NEL adds jitter to the outer agent timeout.

### Repro Commands

Create the minimal fake endpoint:

```bash
cat > /tmp/swe_fake_endpoint.py <<'PY'
from __future__ import annotations

import argparse
import json
import time
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
from pathlib import Path


class State:
    def __init__(self, mode: str, sleep_seconds: float, log_path: Path) -> None:
        self.mode = mode
        self.sleep_seconds = sleep_seconds
        self.log_path = log_path
        self.calls = 0


def chat_response(call_no: int) -> dict:
    return {
        "id": f"chatcmpl-fake-{call_no}",
        "object": "chat.completion",
        "created": int(time.time()),
        "model": "fake-swe-model",
        "choices": [
            {
                "index": 0,
                "message": {"role": "assistant", "content": "local timeout validation"},
                "finish_reason": "stop",
            }
        ],
        "usage": {
            "prompt_tokens": 12,
            "completion_tokens": 7,
            "total_tokens": 19,
            "prompt_tokens_details": {"cached_tokens": 0},
        },
    }


def tool_response(call_no: int) -> dict:
    return {
        "id": f"chatcmpl-fake-{call_no}",
        "object": "chat.completion",
        "created": int(time.time()),
        "model": "fake-swe-model",
        "choices": [
            {
                "index": 0,
                "message": {
                    "role": "assistant",
                    "content": None,
                    "tool_calls": [
                        {
                            "id": "call_fake_terminal_1",
                            "type": "function",
                            "function": {
                                "name": "terminal",
                                "arguments": json.dumps(
                                    {
                                        "command": "echo timeout ordering repro",
                                        "timeout": 5,
                                        "summary": "Print timeout ordering marker",
                                    }
                                ),
                            },
                        }
                    ],
                },
                "finish_reason": "tool_calls",
            }
        ],
        "usage": {
            "prompt_tokens": 12,
            "completion_tokens": 5,
            "total_tokens": 17,
            "prompt_tokens_details": {"cached_tokens": 0},
        },
    }


class Handler(BaseHTTPRequestHandler):
    server: ThreadingHTTPServer

    def write_json(self, status: int, body: dict) -> None:
        payload = json.dumps(body).encode("utf-8")
        self.send_response(status)
        self.send_header("Content-Type", "application/json")
        self.send_header("Content-Length", str(len(payload)))
        self.end_headers()
        self.wfile.write(payload)

    def do_GET(self) -> None:
        self.write_json(200 if self.path == "/health" else 404, {"status": "ok"})

    def do_POST(self) -> None:
        state: State = self.server.state  # type: ignore[attr-defined]
        raw = self.rfile.read(int(self.headers.get("Content-Length", "0") or "0"))
        body = json.loads(raw or b"{}")
        state.calls += 1
        with state.log_path.open("a", encoding="utf-8") as f:
            f.write(
                json.dumps(
                    {
                        "call": state.calls,
                        "path": self.path,
                        "mode": state.mode,
                        "model": body.get("model"),
                        "stream": body.get("stream"),
                        "tools": len(body.get("tools") or []),
                        "messages": len(body.get("messages") or []),
                    },
                    sort_keys=True,
                )
                + "\n"
            )
        if state.mode == "tool_then_timeout" and state.calls == 1:
            self.write_json(200, tool_response(state.calls))
            return
        if state.mode in {"always_timeout", "tool_then_timeout"}:
            time.sleep(state.sleep_seconds)
        self.write_json(200, chat_response(state.calls))

    def log_message(self, fmt: str, *args: object) -> None:
        return


parser = argparse.ArgumentParser()
parser.add_argument("--host", default="127.0.0.1")
parser.add_argument("--port", type=int, required=True)
parser.add_argument("--mode", required=True)
parser.add_argument("--sleep-seconds", type=float, default=300.0)
parser.add_argument("--log-path", type=Path, required=True)
args = parser.parse_args()

args.log_path.parent.mkdir(parents=True, exist_ok=True)
args.log_path.write_text("", encoding="utf-8")
server = ThreadingHTTPServer((args.host, args.port), Handler)
server.state = State(args.mode, args.sleep_seconds, args.log_path)  # type: ignore[attr-defined]
server.serve_forever()
PY
```

Start a hanging fake endpoint:

```bash
python3 /tmp/swe_fake_endpoint.py \
  --port 18092 \
  --mode tool_then_timeout \
  --sleep-seconds 300 \
  --log-path /tmp/swe-timeout-order-wire-before-endpoint.jsonl &
before_ep_pid=$!
```

Run BEFORE on `origin/main` (`963c8eb2`):

```bash
cd /tmp/nel-next-main-reqhash
uv run --extra dev nel eval run /tmp/swe_local_timeout_order_wire_before.yaml -v \
  2>&1 | tee /tmp/nel-swe-timeout-order-wire-before.run.log
```

Run AFTER on this branch (`78753ba6`), with the same config except port/output path:

```bash
python3 /tmp/swe_fake_endpoint.py \
  --port 18093 \
  --mode tool_then_timeout \
  --sleep-seconds 300 \
  --log-path /tmp/swe-timeout-order-wire-after-endpoint.jsonl &
after_ep_pid=$!

cd /tmp/nel-next-timeout-fix
uv run --extra dev nel eval run /tmp/swe_local_timeout_order_wire_after.yaml -v \
  2>&1 | tee /tmp/nel-swe-timeout-order-wire-after.run.log
```

The full YAML template below is what I used. Save it as `/tmp/swe_local_timeout_order_wire_before.yaml` with `<port>=18092` and `<before-or-after>=before`, and as `/tmp/swe_local_timeout_order_wire_after.yaml` with `<port>=18093` and `<before-or-after>=after`.

```yaml
services:
  fake:
    type: api
    url: http://127.0.0.1:<port>/v1/chat/completions
    protocol: chat_completions
    model: fake-swe-model
    api_key: fake-key
    generation:
      temperature: 0.0
    proxy:
      verbose: true
      request_timeout: 300
      max_retries: 0

output:
  dir: /tmp/nel-swe-timeout-order-wire-<before-or-after>
  timestamped: false
  progress_interval: 5
  report: [json]
  trajectories:
    enrich: true

benchmarks:
  - name: harbor://swebench-verified@1.0
    repeats: 1
    max_problems: 1
    max_concurrent: 1
    max_system_retries: 1
    shuffle_seed: null
    timeout: 120.0
    solver:
      type: harbor
      service: fake
      agent: openhands-sdk
      run_timeout: 120.0
      cmd_timeout: 30.0
      timeout_strategy: override
      agent_kwargs:
        max_iterations: 2
        version: "1.17.0"
        temperature: 0.0
    sandbox:
      type: docker
      network: host
      memory: 8g
      cpus: 2.0
      timeout: 900.0
      concurrency: 1

cluster:
  type: local
```

### BEFORE: `main` lets the command timeout win

Artifacts:

- run root: `/tmp/nel-swe-timeout-order-wire-before`
- artifact dir: `/tmp/nel-swe-timeout-order-wire-before/swebench-verified_1.0`
- run log: `/tmp/nel-swe-timeout-order-wire-before.run.log`
- endpoint log: `/tmp/swe-timeout-order-wire-before-endpoint.jsonl`

Observed evidence:

```text
/tmp/nel-swe-timeout-order-wire-before.run.log:102
HarborSolver: timeout resolved: strategy=override nel=120s task=3000s cap=n/a → effective=120s

/tmp/nel-swe-timeout-order-wire-before.run.log:173
INFO:     127.0.0.1:45876 - "POST /s/cbfd3eab30c144bf/chat/completions HTTP/1.1" 200 OK

/tmp/nel-swe-timeout-order-wire-before.run.log:245
stderr: timeout

/tmp/nel-swe-timeout-order-wire-before.run.log:249
No trajectory file found at /tmp/eval_harbor_fczd4hpi/agent/trajectory.json
```

There is no `agent.run() timed out ... collecting partial results` line and no `timed-out agent flushed after SIGTERM` line. The sandbox command wrapper killed OpenHands first, so Harbor fell back to `openhands_sdk.txt` instead of loading a real `trajectory.json`.

Artifact checks:

```text
endpoint log: 2 chat/completions requests reached the fake endpoint
model_traffic.jsonl: 1 successful row, status=200, finish_reason=tool_calls
model_traffic usage: prompt_tokens=12 completion_tokens=5 total_tokens=17 cached_tokens=0
results.jsonl tokens: 0
trajectories_report.tokens_stats.wire_total: 17
trajectories_report.tokens_stats.per_step_sum: 0
trajectories_report.tokens_stats.final_metrics_total: 0
trajectories_report.tokens_stats.all_sources_match: false
trajectories_report.tokens_stats.problems_with_missing_final_metrics_tokens: 1
trajectories_report.tokens_stats.problems_with_wire_vs_final_metrics_mismatch: 1
trajectories_report.wire_calls.problems_with_more_wire_than_steps: 1
trajectories_report.wire_calls.problems_with_no_agent_steps: 1
trajectories_report.benchmarks[0].trajectories.failures_by_category: {"graceful": 1}
trajectories_enriched final_metrics: {"total_steps": 1}
```

This is the local equivalent of the dirty Kimi rows: there is completed successful wire traffic, the next model request is in flight, the command timeout fires first, and the fallback trajectory loses the agent/model steps and final token metrics.

### AFTER: this branch lets NEL timeout first and flush

Artifacts:

- run root: `/tmp/nel-swe-timeout-order-wire-after`
- artifact dir: `/tmp/nel-swe-timeout-order-wire-after/swebench-verified_1.0`
- run log: `/tmp/nel-swe-timeout-order-wire-after.run.log`
- endpoint log: `/tmp/swe-timeout-order-wire-after-endpoint.jsonl`

Observed evidence:

```text
/tmp/nel-swe-timeout-order-wire-after.run.log:75
HarborSolver: timeout resolved: strategy=override nel=120s task=3000s cap=n/a → effective=120s

/tmp/nel-swe-timeout-order-wire-after.run.log:76
HarborSolver: sandbox agent command timeout 151s (effective 120s + 1s jitter)

/tmp/nel-swe-timeout-order-wire-after.run.log:174
INFO:     127.0.0.1:42440 - "POST /s/801fef7c8c4449bd/chat/completions HTTP/1.1" 200 OK

/tmp/nel-swe-timeout-order-wire-after.run.log:175
HarborSolver: agent.run() timed out after 121s (effective=120s+1s jitter, strategy=override) — collecting partial results

/tmp/nel-swe-timeout-order-wire-after.run.log:177
HarborSolver: timed-out agent flushed after SIGTERM

/tmp/nel-swe-timeout-order-wire-after.run.log:182
Trajectory loaded from trajectory.json

/tmp/nel-swe-timeout-order-wire-after.run.log:183
HarborSolver: agent timed out after 120s without workspace changes (prompt_tokens=12 completion_tokens=5) — submitting for verification
```

Artifact checks:

```text
endpoint log: 2 chat/completions requests reached the fake endpoint
model_traffic.jsonl: 1 successful row, status=200, finish_reason=tool_calls
model_traffic usage: prompt_tokens=12 completion_tokens=5 total_tokens=17 cached_tokens=0
results.jsonl tokens: 17
trajectories_report.tokens_stats.wire_total: 17
trajectories_report.tokens_stats.per_step_sum: 17
trajectories_report.tokens_stats.final_metrics_total: 17
trajectories_report.tokens_stats.all_sources_match: true
trajectories_report.tokens_stats.problems_with_missing_final_metrics_tokens: 0
trajectories_report.tokens_stats.problems_with_wire_vs_final_metrics_mismatch: 0
trajectories_report.wire_calls.problems_with_more_wire_than_steps: 0
trajectories_report.wire_calls.problems_with_no_agent_steps: 0
trajectories_report.benchmarks[0].trajectories.failures_by_category: {"solve_timeout": 1}
trajectories_enriched final_metrics:
  {"total_prompt_tokens": 12, "total_completion_tokens": 5, "total_cached_tokens": 0, "total_cost_usd": 0.0}
```

The endpoint and traffic counts are intentionally the same before and after: one successful tool-call response completed and the next request hung. The behavioral difference is timeout ownership. After this change, NEL owns the timeout, sends SIGTERM, OpenHands flushes `trajectory.json`, and wire/per-step/final metric totals all agree at `17`.

## Repro: two timeout clocks

Create the standalone repro script:

```bash
cat > /tmp/repro_timeout_race.py <<'PY'
import asyncio
import time
from unittest.mock import MagicMock

from nemo_evaluator.solvers.harbor import HarborSolver


class Sandbox:
    is_running = True

    def __init__(self, flush_event=None):
        self.flush_event = flush_event
        self.exec_calls = []

    async def exec(self, command, timeout_sec=None):
        self.exec_calls.append((command, timeout_sec))
        if "find /logs/agent" in command:
            return MagicMock(stdout="1\n", stderr="", return_code=0)
        if "/installed-agent/run_agent.py" in command and self.flush_event:
            self.flush_event.set()
        return MagicMock(stdout="", stderr="", return_code=0)


def solver():
    s = HarborSolver.__new__(HarborSolver)
    s._run_timeout = 10800.0
    s._timeout_strategy = "override"
    return s


async def inner_timeout_wins():
    s = solver()
    sandbox = Sandbox()

    async def agent_run():
        await asyncio.sleep(0.01)
        raise RuntimeError("Command failed (exit 124): stderr: timed out after 10800s")

    task = asyncio.create_task(agent_run())
    timed_out, agent_error = await s._wait_for_agent(
        task,
        sandbox,
        time.monotonic(),
        effective_timeout=0.20,
        jitter=0.0,
    )
    sigterms = sum(1 for command, _ in sandbox.exec_calls if "/installed-agent/run_agent.py" in command)
    print("CASE inner_command_timeout_wins")
    print(f"  timed_out={timed_out}")
    print(f"  agent_error_type={type(agent_error).__name__ if agent_error else None}")
    print(f"  agent_error={agent_error}")
    print(f"  nel_sigterm_calls={sigterms}")


async def nel_timeout_wins():
    s = solver()
    flush_event = asyncio.Event()
    sandbox = Sandbox(flush_event)

    async def agent_run():
        await flush_event.wait()

    task = asyncio.create_task(agent_run())
    timed_out, agent_error = await s._wait_for_agent(
        task,
        sandbox,
        time.monotonic(),
        effective_timeout=0.05,
        jitter=0.0,
    )
    sigterms = sum(1 for command, _ in sandbox.exec_calls if "/installed-agent/run_agent.py" in command)
    print("CASE nel_outer_timeout_wins")
    print(f"  timed_out={timed_out}")
    print(f"  agent_error={agent_error}")
    print(f"  nel_sigterm_calls={sigterms}")
    print(f"  agent_done={task.done()} cancelled={task.cancelled()}")


async def main():
    await inner_timeout_wins()
    await nel_timeout_wins()


asyncio.run(main())
PY
```

### BEFORE: run on `origin/main`

```bash
git worktree add /tmp/nel-timeout-before origin/main
cd /tmp/nel-timeout-before
uv run --extra dev python /tmp/repro_timeout_race.py
```

Observed BEFORE output:

```text
CASE inner_command_timeout_wins
  timed_out=False
  agent_error_type=RuntimeError
  agent_error=Command failed (exit 124): stderr: timed out after 10800s
  nel_sigterm_calls=0
CASE nel_outer_timeout_wins
  timed_out=True
  agent_error=None
  nel_sigterm_calls=1
  agent_done=True cancelled=False
```

The first case is the real bad branch: the inner command timeout finishes first, so `_wait_for_agent()` returns `timed_out=False`, records an agent error, and sends no SIGTERM. That is why no graceful OpenHands trajectory flush happened in the dirty 10800s rows.

### AFTER: run on this branch

```bash
git fetch origin awarno/fix-harbor-timeout-ordering
git worktree add /tmp/nel-timeout-after origin/awarno/fix-harbor-timeout-ordering
cd /tmp/nel-timeout-after
uv run --extra dev python /tmp/repro_timeout_race.py
uv run --extra dev python - <<'PY'
from nemo_evaluator.solvers.harbor import _sandbox_agent_exec_timeout
run_timeout = 10800.0
jitter = min(120.0, run_timeout * 0.02)
effective_timeout = run_timeout + jitter
command_timeout = max(10800.0, _sandbox_agent_exec_timeout(effective_timeout))
print(f"run_timeout={run_timeout:.0f}s")
print(f"jitter={jitter:.0f}s")
print(f"effective_timeout={effective_timeout:.0f}s")
print(f"sandbox_command_timeout={command_timeout:.0f}s")
print(f"command_after_effective_by={command_timeout - effective_timeout:.0f}s")
PY
uv run --extra dev pytest tests/test_solvers/test_harbor_solver.py -q -k 'inner_command_timeout_finishes_first_and_skips_nel_sigterm or timeout_sends_sigterm_and_waits_for_trajectory_flush or solve_sets_command_timeout_after_10800s_effective_timeout_with_jitter'
```

Observed AFTER output for the fixed solve plumbing:

```text
run_timeout=10800s
jitter=120s
effective_timeout=10920s
sandbox_command_timeout=10950s
command_after_effective_by=30s
...                                                                      [100%]
3 passed, 66 deselected
```

The standalone script still demonstrates why the inner-timeout-first branch is bad, but the fixed `solve()` plumbing no longer schedules that branch for the 10800s config: the command timeout is after NEL's effective timeout plus 30s grace, so NEL's `timed_out=True` branch wins and sends SIGTERM for trajectory flush.

## Full Testing

```bash
uv run --extra dev pytest tests/test_solvers/test_harbor_solver.py -q
# 69 passed

uv run --extra dev ruff check src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_solver.py
# All checks passed

uv run --extra dev ruff format --check src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_solver.py
# 2 files already formatted
```

## CI Evidence

Pipeline `56728656` is for this branch head `78753ba6bcd243dfef9e172583b83ad29b995d61`.

Relevant jobs:

- `lint` job `354277145`: success.
- `test-offline` job `354277146`: success.
- Harbor amd64 image job `354277149`: success.
- Harbor arm64 image job `354277154`: success.

Produced Harbor image:

```text
gitlab-master.nvidia.com:5005/dl/joc/competitive_evaluation/nemo-evaluator-next:dev-20260703-151645-78753ba6-harbor-amd64
digest: sha256:4d05a892db9c31dca7daa252dacf90ea6cdda8669d5da536807916bcf15008cf
```

The same pipeline's `sonarqube` job `354277165` failed before analysis with:

```text
You must define the following mandatory properties for 'Unknown': sonar.projectKey
```

That failure is independent of this change; lint, offline tests, and the Harbor image build all completed successfully for the MR head commit.


---

This PR was created by an AI agent on behalf of the user.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout handling so the agent run timeout and the sandbox command timeout are calculated separately.
  * Added a small grace period to help preserve output when a timeout is reached.
  * Supported per-task timeout overrides when provided as valid numeric values.
  * Corrected timeout behavior so inner-command timeout failures surface as errors rather than being treated as an overall wait timeout.
* **Tests**
  * Expanded Harbor solver timeout coverage to validate grace timing and timeout plumbing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->