### PR TITLE
feat(config): save composed run config snapshot to the run directory

### DIFF
--- a/docs/deployment-patterns.mdx
+++ b/docs/deployment-patterns.mdx
@@ -326,6 +326,7 @@ Every evaluation run (all patterns) produces:
 | File | Contents |
 |------|----------|
 | `eval-{id}.json` | Config, pass@k with CIs, per-category scores, runtime stats, failure report |
+| `full_config.yaml` | Write-once snapshot at the run root: the full composed run config (fragments merged, CLI overrides applied, `${ENV_VAR}` refs unexpanded) with a provenance header (version, command, overrides, run_id). Re-runnable via `nel eval run` |
 | `results.jsonl` | Per-sample: problem_idx, repeat, reward, extracted answer, tokens, latency |
 | `trajectories.jsonl` | Per-step: full prompt, model response, token breakdown (prompt/completion/reasoning), latency breakdown (seed/model/verify ms), scoring method + details, SHA256 request hash, failure category |
 | `runtime_stats.json` | Latency percentiles (p50/p90/p99), token throughput, finish reason distribution, error count |

--- a/src/nemo_evaluator/cli/eval.py
+++ b/src/nemo_evaluator/cli/eval.py
@@ -116,6 +116,10 @@ def eval_run(
         config = _load_config(config_file, overrides=override)
         if output_dir is not None:
             config.output.dir = output_dir
+
+            from nemo_evaluator.config.snapshot import record_output_dir_override
+
+            record_output_dir_override(config, output_dir)
     elif bench:
         config = _build_quick_config(
             bench,
@@ -152,14 +156,27 @@ def eval_run(
 
 
 def _load_config(config_file: str, overrides: tuple[str, ...] = ()):
+    import copy
+    from pathlib import Path
+
     from nemo_evaluator.config import parse_eval_config
     from nemo_evaluator.config.compose import _prune_nulls, compose_config
+    from nemo_evaluator.config.snapshot import build_provenance
 
     raw = compose_config(config_file)
     for ov in overrides:
         _apply_override(raw, ov)
     _prune_nulls(raw)
-    return parse_eval_config(raw)
+    config = parse_eval_config(raw)
+    # Reproducibility snapshot inputs: keep the composed dict
+    # with ${ENV_VAR} refs unexpanded so executors can persist it without
+    # writing secrets to disk.
+    config._composed_raw = copy.deepcopy(raw)
+    config._snapshot_provenance = build_provenance(
+        source_config=str(Path(config_file).resolve()),
+        overrides=overrides,
+    )
+    return config
 
 
 def _apply_override(data: dict, override: str) -> None:

--- a/src/nemo_evaluator/cli/eval.py
+++ b/src/nemo_evaluator/cli/eval.py
@@ -168,9 +168,7 @@ def _load_config(config_file: str, overrides: tuple[str, ...] = ()):
         _apply_override(raw, ov)
     _prune_nulls(raw)
     config = parse_eval_config(raw)
-    # Reproducibility snapshot inputs: keep the composed dict
-    # with ${ENV_VAR} refs unexpanded so executors can persist it without
-    # writing secrets to disk.
+    # Snapshot inputs: the composed dict, env refs unexpanded (no secrets on disk).
     config._composed_raw = copy.deepcopy(raw)
     config._snapshot_provenance = build_provenance(
         source_config=str(Path(config_file).resolve()),

--- a/src/nemo_evaluator/config/eval_config.py
+++ b/src/nemo_evaluator/config/eval_config.py
@@ -21,7 +21,7 @@ import re
 import warnings
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator, model_validator
 
 from .benchmarks import BenchmarkConfig
 from .clusters import ClusterConfig, LocalCluster, SlurmCluster, _parse_walltime
@@ -64,6 +64,12 @@ class EvalConfig(BaseModel):
     benchmarks: list[BenchmarkConfig] = Field(min_length=1)
     cluster: ClusterConfig = Field(default_factory=LocalCluster)
     output: OutputConfig = Field(default_factory=OutputConfig)
+
+    # Reproducibility snapshot inputs, attached by the CLI
+    # loader and persisted by executors via config.snapshot: the composed
+    # raw dict (env refs unexpanded) and its provenance metadata.
+    _composed_raw: dict[str, Any] | None = PrivateAttr(default=None)
+    _snapshot_provenance: dict[str, str] = PrivateAttr(default_factory=dict)
 
     @field_validator("services")
     @classmethod

--- a/src/nemo_evaluator/config/eval_config.py
+++ b/src/nemo_evaluator/config/eval_config.py
@@ -65,9 +65,8 @@ class EvalConfig(BaseModel):
     cluster: ClusterConfig = Field(default_factory=LocalCluster)
     output: OutputConfig = Field(default_factory=OutputConfig)
 
-    # Reproducibility snapshot inputs, attached by the CLI
-    # loader and persisted by executors via config.snapshot: the composed
-    # raw dict (env refs unexpanded) and its provenance metadata.
+    # Snapshot inputs set by the CLI loader: composed raw dict (env refs
+    # unexpanded) + provenance. Persisted by executors via config.snapshot.
     _composed_raw: dict[str, Any] | None = PrivateAttr(default=None)
     _snapshot_provenance: dict[str, str] = PrivateAttr(default_factory=dict)
 

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -48,8 +48,10 @@ SNAPSHOT_FILENAME = "full_config.yaml"
 _MASK = "<redacted>"
 
 # Field names whose literal (non-``${...}``) values are always masked.
+# Plural forms are matched too, except 'tokens': benign *_tokens params
+# (max_new_tokens, tokens_to_generate) must not be masked.
 _SECRET_KEY_RE = re.compile(
-    r"(api[_-]?key|token|secret|password|passwd|credential|authorization)(?![A-Za-z])", re.IGNORECASE
+    r"(api[_-]?keys?|token|secrets?|passwords?|passwd|credentials?|authorization)(?![A-Za-z])", re.IGNORECASE
 )
 
 # Backstop for secret-looking literals hardcoded anywhere (including
@@ -76,13 +78,13 @@ def package_version() -> str:
 
 # ``key=value`` tokens (CLI overrides, argv) whose key looks secret.
 _SECRET_KV_RE = re.compile(
-    r"(?P<key>[A-Za-z0-9_.\-]*(?:api[_-]?key|token|secret|password|passwd|credential|authorization)(?![A-Za-z])[A-Za-z0-9_.\-]*\s*=\s*)(?P<value>[^\s'\"]+)",
+    r"(?P<key>[A-Za-z0-9_.\-]*(?:api[_-]?keys?|token|secrets?|passwords?|passwd|credentials?|authorization)(?![A-Za-z])[A-Za-z0-9_.\-]*\s*=\s*)(?P<value>[^\s'\"]+)",
     re.IGNORECASE,
 )
 
 # Space-separated secret flags, e.g. quick mode's ``--api-key <value>``.
 _SECRET_FLAG_RE = re.compile(
-    r"(?P<key>--?[A-Za-z0-9\-]*(?:api[_-]?key|token|secret|password|passwd|credential|authorization)(?![A-Za-z])[A-Za-z0-9\-]*\s+)(?P<value>[^\s'\"-][^\s'\"]*)",
+    r"(?P<key>--?[A-Za-z0-9\-]*(?:api[_-]?keys?|token|secrets?|passwords?|passwd|credentials?|authorization)(?![A-Za-z])[A-Za-z0-9\-]*\s+)(?P<value>[^\s'\"-][^\s'\"]*)",
     re.IGNORECASE,
 )
 

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Write-once snapshot of the composed run config for reproducibility.
+
+Every generated artifact in a run directory (sbatch scripts, per-shard
+``config_*.yaml`` execution configs, secrets env) is a deterministic
+function of two inputs: the composed config and the nemo-evaluator
+version. The per-benchmark execution configs deliberately transform the
+config (managed deployments become ``${ENV_VAR}`` API stubs, cluster is
+forced to ``local``), so they cannot serve as a reproducibility record.
+This module persists the root of that derivation tree instead: the
+config as composed from fragments with CLI overrides applied, but with
+``${ENV_VAR}`` references intentionally NOT expanded — so secrets never
+reach disk by construction. A provenance header records the package
+version, which pins all schema defaults.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import shlex
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+SNAPSHOT_FILENAME = "full_config.yaml"
+
+_MASK = "<redacted>"
+
+# Field names whose literal (non-``${...}``) values are always masked.
+_SECRET_KEY_RE = re.compile(
+    r"(api[_-]?key|token|secret|password|passwd|credential|authorization)(?![A-Za-z])", re.IGNORECASE
+)
+
+# Backstop for secret-looking literals hardcoded anywhere (including
+# inside free-form strings such as ``extra.args``).
+_SECRET_VALUE_RES = [
+    re.compile(r"nvapi-[A-Za-z0-9_\-]{16,}"),
+    re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"),
+    re.compile(r"\bglpat-[A-Za-z0-9_\-]{16,}\b"),
+    re.compile(r"\b[Bb]earer\s+[A-Za-z0-9._\-]{16,}"),
+]
+
+
+def package_version() -> str:
+    """Best-effort nemo-evaluator package version."""
+    try:
+        from importlib.metadata import version
+
+        return version("nemo-evaluator")
+    except Exception:  # pragma: no cover - metadata missing in odd installs
+        return "unknown"
+
+
+# ``key=value`` tokens (CLI overrides, argv) whose key looks secret.
+_SECRET_KV_RE = re.compile(
+    r"(?P<key>[A-Za-z0-9_.\-]*(?:api[_-]?key|token|secret|password|passwd|credential|authorization)(?![A-Za-z])[A-Za-z0-9_.\-]*\s*=\s*)(?P<value>[^\s'\"]+)",
+    re.IGNORECASE,
+)
+
+# Space-separated secret flags, e.g. quick mode's ``--api-key <value>``.
+_SECRET_FLAG_RE = re.compile(
+    r"(?P<key>--?[A-Za-z0-9\-]*(?:api[_-]?key|token|secret|password|passwd|credential|authorization)(?![A-Za-z])[A-Za-z0-9\-]*\s+)(?P<value>[^\s'\"-][^\s'\"]*)",
+    re.IGNORECASE,
+)
+
+
+# Values that are references, not secrets: ${VAR} (anywhere), bare $VAR,
+# an env-var NAME (all-caps identifier — the EF convention for "read this
+# env var", e.g. ``api_key: JUDGE_API_KEY``), or a v1 ``host:VAR`` mapping.
+# Trade-off: an actual secret shaped exactly like an all-caps identifier
+# would be kept, but real keys (nvapi-.., mixed case, dashes) never are —
+# and the value-pattern backstop still applies.
+_REFERENCE_VALUE_RES = [
+    re.compile(r"^\$[A-Za-z_][A-Za-z0-9_]*$"),
+    re.compile(r"^(host:)?[A-Z][A-Z0-9_]*$"),
+]
+
+
+def _is_reference_value(value: str) -> bool:
+    return "${" in value or any(p.fullmatch(value) for p in _REFERENCE_VALUE_RES)
+
+
+def _maskable_secret_literal(value: str) -> bool:
+    """Whether a value under a secret-named key is plausibly a secret literal.
+
+    Empty strings and values with whitespace or ``<>|`` (template markers
+    like adapter ``start_reasoning_token: '<|channel>thought'``) are not
+    secrets; references (env names, ``$VAR``/``${VAR}``) are exempt too.
+    """
+    if not value or _is_reference_value(value):
+        return False
+    # Paths and AWS ARNs are pointers, not secret literals (tiktoken paths
+    # otherwise trip the 'token' key match; secret ARNs *reference* secrets).
+    if value.startswith(("/", "./", "~/", "arn:")):
+        return False
+    return not re.search(r"[\s<>|]", value)
+
+
+def _mask_string(value: str) -> str:
+    for pattern in _SECRET_VALUE_RES:
+        value = pattern.sub(_MASK, value)
+    return value
+
+
+def _mask_cli_text(text: str) -> str:
+    """Mask secret values in CLI-shaped text (``--api-key x``, ``-O a.api_key=x``).
+
+    ``${VAR}`` values are kept — they are the safe representation.
+    """
+
+    def _kv_sub(m: re.Match) -> str:
+        if _is_reference_value(m.group("value")):
+            return m.group(0)
+        return m.group("key") + _MASK
+
+    text = _SECRET_KV_RE.sub(_kv_sub, text)
+    text = _SECRET_FLAG_RE.sub(_kv_sub, text)
+    return _mask_string(text)
+
+
+def mask_secrets(obj: Any, *, key: str | None = None) -> Any:
+    """Return a copy of *obj* with secret literals masked.
+
+    ``${ENV_VAR}`` references are preserved untouched — they are the
+    safe, intended representation. Only literal values are masked:
+    any string under a secret-looking key, plus any string anywhere
+    matching a known key/token pattern.
+    """
+    if isinstance(obj, dict):
+        return {k: mask_secrets(v, key=str(k)) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [mask_secrets(v, key=key) for v in obj]
+    if isinstance(obj, str):
+        if key is not None and _SECRET_KEY_RE.search(key) and _maskable_secret_literal(obj):
+            return _MASK
+        return _mask_string(obj)
+    return obj
+
+
+def build_provenance(
+    source_config: str | None = None,
+    overrides: tuple[str, ...] | list[str] = (),
+    run_id: str | None = None,
+) -> dict[str, str]:
+    """Provenance metadata recorded in the snapshot header."""
+    prov: dict[str, str] = {
+        "nemo-evaluator version": package_version(),
+        "created": datetime.now(timezone.utc).isoformat(),
+        "command": _mask_cli_text(shlex.join(sys.argv)),
+    }
+    if source_config:
+        prov["source config"] = source_config
+    if overrides:
+        prov["overrides"] = _mask_cli_text(" ".join(overrides))
+    if run_id:
+        prov["run_id"] = run_id
+    return prov
+
+
+def build_snapshot_text(raw: dict[str, Any], provenance: dict[str, str]) -> str:
+    """Render the snapshot file: provenance header + masked config YAML."""
+    lines = [
+        "# Re-run with:  nel eval run <this file>",
+    ]
+    for k, v in provenance.items():
+        lines.append(f"# {k}: {v}")
+    header = "\n".join(lines) + "\n"
+    body = yaml.dump(mask_secrets(raw), default_flow_style=False, sort_keys=False)
+    return header + body
+
+
+def record_output_dir_override(config: Any, output_dir: str) -> None:
+    """Keep the composed snapshot consistent with a CLI ``-o`` override.
+
+    The override mutates ``config.output.dir`` after the raw composed dict
+    was captured; without this the snapshot would record the YAML's
+    original output dir and re-running it would write elsewhere.
+    """
+    raw = getattr(config, "_composed_raw", None)
+    if isinstance(raw, dict):
+        raw.setdefault("output", {})["dir"] = output_dir
+
+
+def write_config_snapshot(config: Any, output_dir: str | Path | None = None, *, force: bool = False) -> Path | None:
+    """Write the composed-config snapshot into *output_dir*.
+
+    An existing snapshot is preserved unless *force* is set: resumes must
+    keep the original submission record, while a fresh run into a reused
+    output directory (common for local runs without timestamped subdirs)
+    must overwrite it — a stale "full config" is worse than none.
+
+    Skipped inside shard/inner executions (``NEL_INNER_EXECUTION=1``) —
+    those load the machine-generated per-benchmark config, which must
+    not be recorded as the full run config. Never raises: snapshotting
+    is an observability feature and must not break a run.
+    """
+    if os.environ.get("NEL_INNER_EXECUTION") == "1":
+        return None
+    try:
+        out_dir = Path(output_dir or config.output.dir)
+        path = out_dir / SNAPSHOT_FILENAME
+        if path.exists() and not force:
+            logger.debug("Config snapshot already exists (kept, force=False): %s", path)
+            return path
+
+        raw = getattr(config, "_composed_raw", None)
+        provenance = dict(getattr(config, "_snapshot_provenance", None) or {})
+        if raw is None:
+            # Quick mode / programmatic configs: reconstruct from the
+            # validated model. Defaults are inlined; secrets are masked.
+            raw = config.model_dump(mode="json", exclude_none=True)
+            provenance.setdefault("note", "reconstructed from validated config (no source YAML)")
+        if not provenance:
+            provenance = build_provenance()
+
+        out_dir.mkdir(parents=True, exist_ok=True)
+        path.write_text(build_snapshot_text(raw, provenance), encoding="utf-8")
+        logger.info("Saved run config snapshot: %s", path)
+        return path
+    except Exception as exc:  # noqa: BLE001 - never break a run over the snapshot
+        logger.warning("Could not write run config snapshot: %s", exc)
+        return None

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -90,14 +90,15 @@ _SECRET_FLAG_RE = re.compile(
 
 
 # Values that are references, not secrets: ${VAR} (anywhere), bare $VAR,
-# an env-var NAME (all-caps identifier — the EF convention for "read this
-# env var", e.g. ``api_key: JUDGE_API_KEY``), or a v1 ``host:VAR`` mapping.
-# Trade-off: an actual secret shaped exactly like an all-caps identifier
-# would be kept, but real keys (nvapi-.., mixed case, dashes) never are —
-# and the value-pattern backstop still applies.
+# an env-var NAME (all-caps with at least one underscore — the EF
+# convention for "read this env var", e.g. ``api_key: JUDGE_API_KEY``),
+# or a v1 ``host:VAR`` mapping. Requiring the underscore keeps bare
+# uppercase blobs (plausible secrets) maskable. Deliberately NOT checked
+# against os.environ: runtime-only vars are unset on the submitting
+# machine, and the snapshot must not depend on the local environment.
 _REFERENCE_VALUE_RES = [
     re.compile(r"^\$[A-Za-z_][A-Za-z0-9_]*$"),
-    re.compile(r"^(host:)?[A-Z][A-Z0-9_]*$"),
+    re.compile(r"^(host:)?[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$"),
 ]
 
 

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -57,7 +57,6 @@ _SECRET_KEY_RE = re.compile(
 # Backstop for secret-looking literals hardcoded anywhere (including
 # inside free-form strings such as ``extra.args``).
 _SECRET_VALUE_RES = [
-    re.compile(r"nvapi-[A-Za-z0-9_\-]{16,}"),
     re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"),
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
     re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"),

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -230,13 +230,13 @@ def write_config_snapshot(config: Any, output_dir: str | Path | None = None, *, 
 
         raw = getattr(config, "_composed_raw", None)
         provenance = dict(getattr(config, "_snapshot_provenance", None) or {})
+        if not provenance:
+            provenance = build_provenance()
         if raw is None:
             # Quick mode / programmatic configs: reconstruct from the
             # validated model. Defaults are inlined; secrets are masked.
             raw = config.model_dump(mode="json", exclude_none=True)
             provenance.setdefault("note", "reconstructed from validated config (no source YAML)")
-        if not provenance:
-            provenance = build_provenance()
 
         out_dir.mkdir(parents=True, exist_ok=True)
         path.write_text(build_snapshot_text(raw, provenance), encoding="utf-8")

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -19,9 +19,7 @@ The per-shard ``config_*.yaml`` files are transformed for execution
 (model URL runtime-assigned, cluster forced to ``local``) and cannot
 serve as the run record. This module persists the composed config
 instead, with ``${ENV_VAR}`` references NOT expanded — so secrets never
-reach disk by construction — plus a provenance header. Configs without a
-pre-expansion source (quick mode, programmatic) get no snapshot: the
-validated config holds resolved secrets and must not be persisted.
+reach disk by construction — plus a provenance header.
 """
 
 from __future__ import annotations
@@ -105,8 +103,7 @@ def write_config_snapshot(config: Any, output_dir: str | Path | None = None, *, 
     try:
         raw = getattr(config, "_composed_raw", None)
         if raw is None:
-            # No pre-expansion source (quick mode / programmatic): the
-            # validated config holds resolved secrets, so write nothing.
+            # Quick mode / programmatic: no pre-expansion source, write nothing.
             return None
         out_dir = Path(output_dir or config.output.dir)
         path = out_dir / SNAPSHOT_FILENAME

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -19,14 +19,15 @@ The per-shard ``config_*.yaml`` files are transformed for execution
 (model URL runtime-assigned, cluster forced to ``local``) and cannot
 serve as the run record. This module persists the composed config
 instead, with ``${ENV_VAR}`` references NOT expanded — so secrets never
-reach disk by construction — plus a provenance header.
+reach disk by construction — plus a provenance header. Configs without a
+pre-expansion source (quick mode, programmatic) get no snapshot: the
+validated config holds resolved secrets and must not be persisted.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-import re
 import shlex
 import sys
 from datetime import datetime, timezone
@@ -39,23 +40,6 @@ logger = logging.getLogger(__name__)
 
 SNAPSHOT_FILENAME = "full_config.yaml"
 
-_MASK = "<redacted>"
-
-# Field names whose literal values are always masked. Plurals match too,
-# except 'tokens' (benign *_tokens params must survive).
-_SECRET_KEY_RE = re.compile(
-    r"(api[_-]?keys?|token|secrets?|passwords?|passwd|credentials?|authorization)(?![A-Za-z])", re.IGNORECASE
-)
-
-# Backstop for secret-shaped literals anywhere, incl. free-form strings.
-_SECRET_VALUE_RES = [
-    re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"),
-    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
-    re.compile(r"\bghp_[A-Za-z0-9]{20,}\b"),
-    re.compile(r"\bglpat-[A-Za-z0-9_\-]{16,}\b"),
-    re.compile(r"\b[Bb]earer\s+[A-Za-z0-9._\-]{16,}"),
-]
-
 
 def package_version() -> str:
     """Best-effort nemo-evaluator package version."""
@@ -67,76 +51,6 @@ def package_version() -> str:
         return "unknown"
 
 
-# ``key=value`` tokens (CLI overrides, argv) whose key looks secret.
-_SECRET_KV_RE = re.compile(
-    r"(?P<key>[A-Za-z0-9_.\-]*(?:api[_-]?keys?|token|secrets?|passwords?|passwd|credentials?|authorization)(?![A-Za-z])[A-Za-z0-9_.\-]*\s*=\s*)(?P<value>[^\s'\"]+)",
-    re.IGNORECASE,
-)
-
-# Space-separated secret flags, e.g. quick mode's ``--api-key <value>``.
-_SECRET_FLAG_RE = re.compile(
-    r"(?P<key>--?[A-Za-z0-9\-]*(?:api[_-]?keys?|token|secrets?|passwords?|passwd|credentials?|authorization)(?![A-Za-z])[A-Za-z0-9\-]*\s+)(?P<value>[^\s'\"-][^\s'\"]*)",
-    re.IGNORECASE,
-)
-
-
-# References, not secrets: ${VAR}, bare $VAR, an env-var NAME (all-caps
-# with an underscore, e.g. ``api_key: JUDGE_API_KEY``) or v1 ``host:VAR``.
-# The underscore requirement keeps bare uppercase blobs maskable;
-# intentionally shape-based, never environment-dependent.
-_REFERENCE_VALUE_RES = [
-    re.compile(r"^\$[A-Za-z_][A-Za-z0-9_]*$"),
-    re.compile(r"^(host:)?[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$"),
-]
-
-
-def _is_reference_value(value: str) -> bool:
-    return "${" in value or any(p.fullmatch(value) for p in _REFERENCE_VALUE_RES)
-
-
-def _maskable_secret_literal(value: str) -> bool:
-    """Whether a value under a secret-named key is plausibly a secret literal."""
-    if not value or _is_reference_value(value):
-        return False
-    # Paths/ARNs are pointers, not secrets (tiktoken paths otherwise trip the 'token' match).
-    if value.startswith(("/", "./", "~/", "arn:")):
-        return False
-    # whitespace / <>| = template markers (reasoning tokens), not secrets
-    return not re.search(r"[\s<>|]", value)
-
-
-def _mask_string(value: str) -> str:
-    for pattern in _SECRET_VALUE_RES:
-        value = pattern.sub(_MASK, value)
-    return value
-
-
-def _mask_cli_text(text: str) -> str:
-    """Mask secret values in CLI-shaped text; ``${VAR}`` refs are kept."""
-
-    def _kv_sub(m: re.Match) -> str:
-        if _is_reference_value(m.group("value")):
-            return m.group(0)
-        return m.group("key") + _MASK
-
-    text = _SECRET_KV_RE.sub(_kv_sub, text)
-    text = _SECRET_FLAG_RE.sub(_kv_sub, text)
-    return _mask_string(text)
-
-
-def mask_secrets(obj: Any, *, key: str | None = None) -> Any:
-    """Return a copy of *obj* with secret literals masked; env refs are preserved."""
-    if isinstance(obj, dict):
-        return {k: mask_secrets(v, key=str(k)) for k, v in obj.items()}
-    if isinstance(obj, list):
-        return [mask_secrets(v, key=key) for v in obj]
-    if isinstance(obj, str):
-        if key is not None and _SECRET_KEY_RE.search(key) and _maskable_secret_literal(obj):
-            return _MASK
-        return _mask_string(obj)
-    return obj
-
-
 def build_provenance(
     source_config: str | None = None,
     overrides: tuple[str, ...] | list[str] = (),
@@ -146,26 +60,26 @@ def build_provenance(
     prov: dict[str, str] = {
         "nemo-evaluator version": package_version(),
         "created": datetime.now(timezone.utc).isoformat(),
-        "command": _mask_cli_text(shlex.join(sys.argv)),
+        "command": shlex.join(sys.argv),
     }
     if source_config:
         prov["source config"] = source_config
     if overrides:
-        prov["overrides"] = _mask_cli_text(" ".join(overrides))
+        prov["overrides"] = " ".join(overrides)
     if run_id:
         prov["run_id"] = run_id
     return prov
 
 
 def build_snapshot_text(raw: dict[str, Any], provenance: dict[str, str]) -> str:
-    """Render the snapshot file: provenance header + masked config YAML."""
+    """Render the snapshot file: provenance header + config YAML."""
     lines = [
         "# Re-run with:  nel eval run <this file>",
     ]
     for k, v in provenance.items():
         lines.append(f"# {k}: {v}")
     header = "\n".join(lines) + "\n"
-    body = yaml.dump(mask_secrets(raw), default_flow_style=False, sort_keys=False)
+    body = yaml.dump(raw, default_flow_style=False, sort_keys=False)
     return header + body
 
 
@@ -180,27 +94,29 @@ def record_output_dir_override(config: Any, output_dir: str) -> None:
 def write_config_snapshot(config: Any, output_dir: str | Path | None = None, *, force: bool = False) -> Path | None:
     """Write the composed-config snapshot into *output_dir*.
 
-    Existing snapshots are kept unless *force*: resumes preserve the
-    original record, fresh runs into a reused dir overwrite it. Skipped
-    in inner shard executions. Never raises — must not break a run.
+    Only the pre-expansion composed dict is persisted (env refs intact,
+    no secrets by construction). Existing snapshots are kept unless
+    *force*: resumes preserve the original record, fresh runs into a
+    reused dir overwrite it. Skipped in inner shard executions. Never
+    raises — must not break a run.
     """
     if os.environ.get("NEL_INNER_EXECUTION") == "1":
         return None
     try:
+        raw = getattr(config, "_composed_raw", None)
+        if raw is None:
+            # No pre-expansion source (quick mode / programmatic): the
+            # validated config holds resolved secrets, so write nothing.
+            return None
         out_dir = Path(output_dir or config.output.dir)
         path = out_dir / SNAPSHOT_FILENAME
         if path.exists() and not force:
             logger.debug("Config snapshot already exists (kept, force=False): %s", path)
             return path
 
-        raw = getattr(config, "_composed_raw", None)
         provenance = dict(getattr(config, "_snapshot_provenance", None) or {})
         if not provenance:
             provenance = build_provenance()
-        if raw is None:
-            # Quick mode / programmatic configs: reconstruct from the validated model.
-            raw = config.model_dump(mode="json", exclude_none=True)
-            provenance.setdefault("note", "reconstructed from validated config (no source YAML)")
 
         out_dir.mkdir(parents=True, exist_ok=True)
         path.write_text(build_snapshot_text(raw, provenance), encoding="utf-8")

--- a/src/nemo_evaluator/config/snapshot.py
+++ b/src/nemo_evaluator/config/snapshot.py
@@ -15,17 +15,11 @@
 
 """Write-once snapshot of the composed run config for reproducibility.
 
-Every generated artifact in a run directory (sbatch scripts, per-shard
-``config_*.yaml`` execution configs, secrets env) is a deterministic
-function of two inputs: the composed config and the nemo-evaluator
-version. The per-benchmark execution configs deliberately transform the
-config (managed deployments become ``${ENV_VAR}`` API stubs, cluster is
-forced to ``local``), so they cannot serve as a reproducibility record.
-This module persists the root of that derivation tree instead: the
-config as composed from fragments with CLI overrides applied, but with
-``${ENV_VAR}`` references intentionally NOT expanded — so secrets never
-reach disk by construction. A provenance header records the package
-version, which pins all schema defaults.
+The per-shard ``config_*.yaml`` files are transformed for execution
+(model URL runtime-assigned, cluster forced to ``local``) and cannot
+serve as the run record. This module persists the composed config
+instead, with ``${ENV_VAR}`` references NOT expanded — so secrets never
+reach disk by construction — plus a provenance header.
 """
 
 from __future__ import annotations
@@ -47,15 +41,13 @@ SNAPSHOT_FILENAME = "full_config.yaml"
 
 _MASK = "<redacted>"
 
-# Field names whose literal (non-``${...}``) values are always masked.
-# Plural forms are matched too, except 'tokens': benign *_tokens params
-# (max_new_tokens, tokens_to_generate) must not be masked.
+# Field names whose literal values are always masked. Plurals match too,
+# except 'tokens' (benign *_tokens params must survive).
 _SECRET_KEY_RE = re.compile(
     r"(api[_-]?keys?|token|secrets?|passwords?|passwd|credentials?|authorization)(?![A-Za-z])", re.IGNORECASE
 )
 
-# Backstop for secret-looking literals hardcoded anywhere (including
-# inside free-form strings such as ``extra.args``).
+# Backstop for secret-shaped literals anywhere, incl. free-form strings.
 _SECRET_VALUE_RES = [
     re.compile(r"\bsk-[A-Za-z0-9_\-]{16,}"),
     re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
@@ -88,13 +80,10 @@ _SECRET_FLAG_RE = re.compile(
 )
 
 
-# Values that are references, not secrets: ${VAR} (anywhere), bare $VAR,
-# an env-var NAME (all-caps with at least one underscore — the EF
-# convention for "read this env var", e.g. ``api_key: JUDGE_API_KEY``),
-# or a v1 ``host:VAR`` mapping. Requiring the underscore keeps bare
-# uppercase blobs (plausible secrets) maskable. Deliberately NOT checked
-# against os.environ: runtime-only vars are unset on the submitting
-# machine, and the snapshot must not depend on the local environment.
+# References, not secrets: ${VAR}, bare $VAR, an env-var NAME (all-caps
+# with an underscore, e.g. ``api_key: JUDGE_API_KEY``) or v1 ``host:VAR``.
+# The underscore requirement keeps bare uppercase blobs maskable;
+# intentionally shape-based, never environment-dependent.
 _REFERENCE_VALUE_RES = [
     re.compile(r"^\$[A-Za-z_][A-Za-z0-9_]*$"),
     re.compile(r"^(host:)?[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)+$"),
@@ -106,18 +95,13 @@ def _is_reference_value(value: str) -> bool:
 
 
 def _maskable_secret_literal(value: str) -> bool:
-    """Whether a value under a secret-named key is plausibly a secret literal.
-
-    Empty strings and values with whitespace or ``<>|`` (template markers
-    like adapter ``start_reasoning_token: '<|channel>thought'``) are not
-    secrets; references (env names, ``$VAR``/``${VAR}``) are exempt too.
-    """
+    """Whether a value under a secret-named key is plausibly a secret literal."""
     if not value or _is_reference_value(value):
         return False
-    # Paths and AWS ARNs are pointers, not secret literals (tiktoken paths
-    # otherwise trip the 'token' key match; secret ARNs *reference* secrets).
+    # Paths/ARNs are pointers, not secrets (tiktoken paths otherwise trip the 'token' match).
     if value.startswith(("/", "./", "~/", "arn:")):
         return False
+    # whitespace / <>| = template markers (reasoning tokens), not secrets
     return not re.search(r"[\s<>|]", value)
 
 
@@ -128,10 +112,7 @@ def _mask_string(value: str) -> str:
 
 
 def _mask_cli_text(text: str) -> str:
-    """Mask secret values in CLI-shaped text (``--api-key x``, ``-O a.api_key=x``).
-
-    ``${VAR}`` values are kept — they are the safe representation.
-    """
+    """Mask secret values in CLI-shaped text; ``${VAR}`` refs are kept."""
 
     def _kv_sub(m: re.Match) -> str:
         if _is_reference_value(m.group("value")):
@@ -144,13 +125,7 @@ def _mask_cli_text(text: str) -> str:
 
 
 def mask_secrets(obj: Any, *, key: str | None = None) -> Any:
-    """Return a copy of *obj* with secret literals masked.
-
-    ``${ENV_VAR}`` references are preserved untouched — they are the
-    safe, intended representation. Only literal values are masked:
-    any string under a secret-looking key, plus any string anywhere
-    matching a known key/token pattern.
-    """
+    """Return a copy of *obj* with secret literals masked; env refs are preserved."""
     if isinstance(obj, dict):
         return {k: mask_secrets(v, key=str(k)) for k, v in obj.items()}
     if isinstance(obj, list):
@@ -195,12 +170,8 @@ def build_snapshot_text(raw: dict[str, Any], provenance: dict[str, str]) -> str:
 
 
 def record_output_dir_override(config: Any, output_dir: str) -> None:
-    """Keep the composed snapshot consistent with a CLI ``-o`` override.
-
-    The override mutates ``config.output.dir`` after the raw composed dict
-    was captured; without this the snapshot would record the YAML's
-    original output dir and re-running it would write elsewhere.
-    """
+    """Sync a CLI ``-o`` override into the captured dict so the snapshot
+    records where the run actually wrote."""
     raw = getattr(config, "_composed_raw", None)
     if isinstance(raw, dict):
         raw.setdefault("output", {})["dir"] = output_dir
@@ -209,15 +180,9 @@ def record_output_dir_override(config: Any, output_dir: str) -> None:
 def write_config_snapshot(config: Any, output_dir: str | Path | None = None, *, force: bool = False) -> Path | None:
     """Write the composed-config snapshot into *output_dir*.
 
-    An existing snapshot is preserved unless *force* is set: resumes must
-    keep the original submission record, while a fresh run into a reused
-    output directory (common for local runs without timestamped subdirs)
-    must overwrite it — a stale "full config" is worse than none.
-
-    Skipped inside shard/inner executions (``NEL_INNER_EXECUTION=1``) —
-    those load the machine-generated per-benchmark config, which must
-    not be recorded as the full run config. Never raises: snapshotting
-    is an observability feature and must not break a run.
+    Existing snapshots are kept unless *force*: resumes preserve the
+    original record, fresh runs into a reused dir overwrite it. Skipped
+    in inner shard executions. Never raises — must not break a run.
     """
     if os.environ.get("NEL_INNER_EXECUTION") == "1":
         return None
@@ -233,8 +198,7 @@ def write_config_snapshot(config: Any, output_dir: str | Path | None = None, *, 
         if not provenance:
             provenance = build_provenance()
         if raw is None:
-            # Quick mode / programmatic configs: reconstruct from the
-            # validated model. Defaults are inlined; secrets are masked.
+            # Quick mode / programmatic configs: reconstruct from the validated model.
             raw = config.model_dump(mode="json", exclude_none=True)
             provenance.setdefault("note", "reconstructed from validated config (no source YAML)")
 

--- a/src/nemo_evaluator/executors/docker_executor.py
+++ b/src/nemo_evaluator/executors/docker_executor.py
@@ -162,6 +162,10 @@ class DockerExecutor(Executor):
             encoding="utf-8",
         )
 
+        from nemo_evaluator.config.snapshot import write_config_snapshot
+
+        write_config_snapshot(config, output_dir, force=not resume)
+
         shm = getattr(config.cluster, "shm_size", None)
         if not shm:
             if any(s.type == "gym" for s in config.services.values()):

--- a/src/nemo_evaluator/executors/local_executor.py
+++ b/src/nemo_evaluator/executors/local_executor.py
@@ -63,6 +63,11 @@ class LocalExecutor(Executor):
                 click.echo(f"  - {b.name} (repeats={b.repeats})")
             click.echo(f"Output: {config.output.dir}")
             return
+
+        from nemo_evaluator.config.snapshot import write_config_snapshot
+
+        write_config_snapshot(config, force=not resume)
+
         if background:
             self._run_background(config, resume=resume)
         else:

--- a/src/nemo_evaluator/executors/slurm_executor.py
+++ b/src/nemo_evaluator/executors/slurm_executor.py
@@ -390,9 +390,6 @@ class SlurmExecutor(Executor):
         else:
             script_paths, extra_paths = write_sbatch(config, dry_run=dry_run)
 
-        # Reproducibility snapshot: the full composed config at
-        # the run root — the per-shard config_*.yaml files are transformed
-        # execution slices and cannot serve as the run record.
         from nemo_evaluator.config.snapshot import write_config_snapshot
 
         if stamped_run_id and isinstance(getattr(config, "_snapshot_provenance", None), dict):
@@ -444,8 +441,7 @@ class SlurmExecutor(Executor):
             snapshot_upload_failed = False
             try:
                 if snapshot_path is not None:
-                    # Best-effort: the snapshot is a reproducibility record;
-                    # its upload must never block the actual submission.
+                    # Best-effort: never block submission on the snapshot upload.
                     try:
                         copy_to_remote(
                             config.cluster.hostname,
@@ -488,9 +484,7 @@ class SlurmExecutor(Executor):
             finally:
                 if local_staging:
                     if snapshot_upload_failed and snapshot_path is not None:
-                        # Preserve only the (secret-free) snapshot for manual
-                        # upload; the staging dir also holds .secrets.env and
-                        # must not outlive the submission.
+                        # Keep only the secret-free snapshot; staging also holds .secrets.env.
                         try:
                             kept = shutil.move(str(snapshot_path), tempfile.mkdtemp(prefix="nel-snapshot-"))
                             click.echo("Config snapshot kept locally. To retry the upload:")

--- a/src/nemo_evaluator/executors/slurm_executor.py
+++ b/src/nemo_evaluator/executors/slurm_executor.py
@@ -441,6 +441,7 @@ class SlurmExecutor(Executor):
 
             job_ids: list[str] = []
             submission_error: Exception | None = None
+            snapshot_upload_failed = False
             try:
                 if snapshot_path is not None:
                     # Best-effort: the snapshot is a reproducibility record;
@@ -454,6 +455,7 @@ class SlurmExecutor(Executor):
                             local_base=staging_root,
                         )
                     except Exception as exc:  # noqa: BLE001
+                        snapshot_upload_failed = True
                         click.echo(f"Warning: could not upload config snapshot: {exc}")
                 for script_path in script_paths:
                     # Include all extras under the script's staging dir, not
@@ -485,7 +487,12 @@ class SlurmExecutor(Executor):
                 submission_error = exc
             finally:
                 if local_staging:
-                    shutil.rmtree(local_staging, ignore_errors=True)
+                    if snapshot_upload_failed:
+                        # The staging dir holds the only copy of the
+                        # reproducibility record — keep it for manual upload.
+                        click.echo(f"Config snapshot kept locally: {snapshot_path}")
+                    else:
+                        shutil.rmtree(local_staging, ignore_errors=True)
 
             from nemo_evaluator.run_store import (
                 RunMeta,

--- a/src/nemo_evaluator/executors/slurm_executor.py
+++ b/src/nemo_evaluator/executors/slurm_executor.py
@@ -487,13 +487,17 @@ class SlurmExecutor(Executor):
                 submission_error = exc
             finally:
                 if local_staging:
-                    if snapshot_upload_failed:
-                        # The staging dir holds the only copy of the
-                        # reproducibility record — keep it for manual upload.
-                        click.echo("Config snapshot kept locally. To retry the upload:")
-                        click.echo(f"  scp {snapshot_path} {config.cluster.hostname}:{resolved_dir}/")
-                    else:
-                        shutil.rmtree(local_staging, ignore_errors=True)
+                    if snapshot_upload_failed and snapshot_path is not None:
+                        # Preserve only the (secret-free) snapshot for manual
+                        # upload; the staging dir also holds .secrets.env and
+                        # must not outlive the submission.
+                        try:
+                            kept = shutil.move(str(snapshot_path), tempfile.mkdtemp(prefix="nel-snapshot-"))
+                            click.echo("Config snapshot kept locally. To retry the upload:")
+                            click.echo(f"  scp {kept} {config.cluster.hostname}:{resolved_dir}/")
+                        except OSError as exc:
+                            click.echo(f"Warning: could not preserve config snapshot: {exc}")
+                    shutil.rmtree(local_staging, ignore_errors=True)
 
             from nemo_evaluator.run_store import (
                 RunMeta,

--- a/src/nemo_evaluator/executors/slurm_executor.py
+++ b/src/nemo_evaluator/executors/slurm_executor.py
@@ -490,7 +490,8 @@ class SlurmExecutor(Executor):
                     if snapshot_upload_failed:
                         # The staging dir holds the only copy of the
                         # reproducibility record — keep it for manual upload.
-                        click.echo(f"Config snapshot kept locally: {snapshot_path}")
+                        click.echo("Config snapshot kept locally. To retry the upload:")
+                        click.echo(f"  scp {snapshot_path} {config.cluster.hostname}:{resolved_dir}/")
                     else:
                         shutil.rmtree(local_staging, ignore_errors=True)
 

--- a/src/nemo_evaluator/executors/slurm_executor.py
+++ b/src/nemo_evaluator/executors/slurm_executor.py
@@ -390,11 +390,23 @@ class SlurmExecutor(Executor):
         else:
             script_paths, extra_paths = write_sbatch(config, dry_run=dry_run)
 
+        # Reproducibility snapshot: the full composed config at
+        # the run root — the per-shard config_*.yaml files are transformed
+        # execution slices and cannot serve as the run record.
+        from nemo_evaluator.config.snapshot import write_config_snapshot
+
+        if stamped_run_id and isinstance(getattr(config, "_snapshot_provenance", None), dict):
+            config._snapshot_provenance.setdefault("run_id", stamped_run_id)
+        staging_root = local_staging if is_remote else Path(config.output.dir)
+        snapshot_path = write_config_snapshot(config, staging_root, force=not resume)
+
         is_sharded = len(script_paths) > 1 or (
             len(script_paths) == 1 and script_paths[0].parent.name.startswith("shard_")
         )
         for sp in script_paths:
             click.echo(f"Generated: {sp}")
+        if snapshot_path is not None:
+            click.echo(f"  snapshot: {snapshot_path}")
         for sp in extra_paths:
             if sp.name == ".secrets.env":
                 click.echo(f"  secrets: {sp}  (chmod 600)")
@@ -408,6 +420,8 @@ class SlurmExecutor(Executor):
                 click.echo(f"Remote target:   {target}:{resolved_dir}")
                 click.echo("\nTo submit manually:")
                 all_files = [str(p) for p in script_paths] + [str(p) for p in extra_paths]
+                if snapshot_path is not None:
+                    all_files.append(str(snapshot_path))
                 click.echo(f"  scp -r {' '.join(all_files)} {target}:{resolved_dir}/")
                 for sp in script_paths:
                     shard_dir = sp.parent.name if is_sharded else ""
@@ -423,11 +437,24 @@ class SlurmExecutor(Executor):
             return
 
         if is_remote:
-            from nemo_evaluator.executors.ssh import submit_eval
+            from nemo_evaluator.executors.ssh import copy_to_remote, submit_eval
 
             job_ids: list[str] = []
             submission_error: Exception | None = None
             try:
+                if snapshot_path is not None:
+                    # Best-effort: the snapshot is a reproducibility record;
+                    # its upload must never block the actual submission.
+                    try:
+                        copy_to_remote(
+                            config.cluster.hostname,
+                            [snapshot_path],
+                            resolved_dir,
+                            config.cluster.username,
+                            local_base=staging_root,
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        click.echo(f"Warning: could not upload config snapshot: {exc}")
                 for script_path in script_paths:
                     # Include all extras under the script's staging dir, not
                     # just direct siblings — legacy container:// benchmarks

--- a/src/nemo_evaluator/orchestration/slurm_gen.py
+++ b/src/nemo_evaluator/orchestration/slurm_gen.py
@@ -2005,18 +2005,29 @@ def _extract_bench_config(config: EvalConfig, bench_idx: int, svc_url_var: str, 
     if svc:
         proto = getattr(svc, "protocol", "chat_completions")
         url_suffix = _PROTO_SUFFIX.get(proto, "/chat/completions")
+        # Inline the model id when it is known at generation time so the
+        # sidecar records which model ran. The value written
+        # here must mirror what the sbatch exports into the env var; when
+        # in doubt (e.g. NAT services) keep the env-var reference.
+        literal_model: str | None = None
+        if getattr(svc, "type", "") == "api":
+            literal_model = getattr(svc, "model", None)
+        elif getattr(svc, "is_model_server", False):
+            literal_model = getattr(svc, "served_model_name", None)
         svc_dict: dict = {
             "type": "api",
             "url": f"${{{svc_url_var}}}{url_suffix}",
             "protocol": proto,
-            "model": f"${{{svc_model_var}}}",
+            "model": literal_model or f"${{{svc_model_var}}}",
         }
         api_key = getattr(svc, "api_key", None)
         if api_key:
             svc_dict["api_key"] = api_key
         proxy = getattr(svc, "proxy", None)
         if proxy is not None:
-            svc_dict["proxy"] = proxy.model_dump(exclude_none=True, exclude_defaults=True)
+            # exclude_none only: keep default-valued fields (timeouts,
+            # retries, ...) so the sidecar records the effective settings.
+            svc_dict["proxy"] = proxy.model_dump(exclude_none=True)
         if hasattr(svc, "generation"):
             gen = svc.generation.model_dump(exclude_none=True)
             if gen:
@@ -2805,6 +2816,15 @@ def _write_export_config(out: Path, export_config: dict) -> Path | None:
     return path
 
 
+_SIDECAR_HEADER = (
+    "# Machine-generated per-benchmark execution config (executed inside the\n"
+    "# sbatch job). NOT the full run config: the model URL may be an env-var\n"
+    "# placeholder filled at runtime, and cluster is forced to 'local'.\n"
+    "# The complete composed run config is saved as full_config.yaml in\n"
+    "# the run root directory (the parent directory for sharded runs).\n"
+)
+
+
 def _write_single_script(
     out: Path,
     script: str,
@@ -2847,7 +2867,10 @@ def _write_single_script(
 
     for safe_name, cfg_dict in sidecar_configs.items():
         cfg_path = out / f"config_{safe_name}.yaml"
-        cfg_path.write_text(yaml.dump(cfg_dict, default_flow_style=False, sort_keys=False), encoding="utf-8")
+        cfg_path.write_text(
+            _SIDECAR_HEADER + yaml.dump(cfg_dict, default_flow_style=False, sort_keys=False),
+            encoding="utf-8",
+        )
         if _sidecar_contains_secret(cfg_dict):
             cfg_path.chmod(0o600)
         else:

--- a/src/nemo_evaluator/orchestration/slurm_gen.py
+++ b/src/nemo_evaluator/orchestration/slurm_gen.py
@@ -2005,10 +2005,8 @@ def _extract_bench_config(config: EvalConfig, bench_idx: int, svc_url_var: str, 
     if svc:
         proto = getattr(svc, "protocol", "chat_completions")
         url_suffix = _PROTO_SUFFIX.get(proto, "/chat/completions")
-        # Inline the model id when it is known at generation time so the
-        # sidecar records which model ran. The value written
-        # here must mirror what the sbatch exports into the env var; when
-        # in doubt (e.g. NAT services) keep the env-var reference.
+        # Inline the model id when known at generation time; when in doubt
+        # (e.g. NAT services) keep the env-var reference the sbatch exports.
         literal_model: str | None = None
         if getattr(svc, "type", "") == "api":
             literal_model = getattr(svc, "model", None)
@@ -2025,8 +2023,7 @@ def _extract_bench_config(config: EvalConfig, bench_idx: int, svc_url_var: str, 
             svc_dict["api_key"] = api_key
         proxy = getattr(svc, "proxy", None)
         if proxy is not None:
-            # exclude_none only: keep default-valued fields (timeouts,
-            # retries, ...) so the sidecar records the effective settings.
+            # exclude_none only: keep defaults so the sidecar records effective settings.
             svc_dict["proxy"] = proxy.model_dump(exclude_none=True)
         if hasattr(svc, "generation"):
             gen = svc.generation.model_dump(exclude_none=True)
@@ -2817,11 +2814,8 @@ def _write_export_config(out: Path, export_config: dict) -> Path | None:
 
 
 _SIDECAR_HEADER = (
-    "# Machine-generated per-benchmark execution config (executed inside the\n"
-    "# sbatch job). NOT the full run config: the model URL may be an env-var\n"
-    "# placeholder filled at runtime, and cluster is forced to 'local'.\n"
-    "# The complete composed run config is saved as full_config.yaml in\n"
-    "# the run root directory (the parent directory for sharded runs).\n"
+    "# Machine-generated per-benchmark execution slice — not the full run config.\n"
+    "# The composed, re-runnable config is full_config.yaml at the run root.\n"
 )
 
 

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -131,7 +131,7 @@ class TestWriteConfigSnapshot:
         assert "nvapi-" not in text
         assert "<redacted>" in text
 
-    def test_never_raises(self, tmp_path):
+    def test_never_raises(self):
         """A broken config must not raise (snapshot is best-effort)."""
 
         class _Broken:

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the composed-config reproducibility snapshot."""
+
+import yaml
+
+from nemo_evaluator.config.snapshot import (
+    SNAPSHOT_FILENAME,
+    _mask_cli_text,
+    build_provenance,
+    build_snapshot_text,
+    mask_secrets,
+    record_output_dir_override,
+    write_config_snapshot,
+)
+
+
+class _StubConfig:
+    """Minimal stand-in for EvalConfig: private attrs + output.dir."""
+
+    def __init__(self, raw=None, provenance=None, output_dir="unused"):
+        self._composed_raw = raw
+        self._snapshot_provenance = provenance or {}
+
+        class _Out:
+            dir = output_dir
+
+        self.output = _Out()
+
+    def model_dump(self, **_kw):
+        return {"services": {"m": {"type": "api", "api_key": "nvapi-" + "x" * 20}}}
+
+
+class TestMaskSecrets:
+    def test_env_refs_preserved(self):
+        raw = {"services": {"m": {"api_key": "${NVIDIA_API_KEY}"}}}
+        assert mask_secrets(raw) == raw
+
+    def test_literal_secret_key_masked(self):
+        raw = {"services": {"m": {"api_key": "nvapi-not-a-real-key"}}}
+        assert mask_secrets(raw)["services"]["m"]["api_key"] == "<redacted>"
+
+    def test_env_var_names_masked_when_literal(self):
+        raw = {"env_vars": {"HF_TOKEN": "hf_literalvalue", "JUDGE_API_KEY": "${JUDGE_API_KEY}"}}
+        out = mask_secrets(raw)
+        assert out["env_vars"]["HF_TOKEN"] == "<redacted>"  # key matches token
+        assert out["env_vars"]["JUDGE_API_KEY"] == "${JUDGE_API_KEY}"
+
+    def test_pattern_backstop_inside_free_form_string(self):
+        raw = {"extra": {"args": "++server.key=nvapi-" + "a" * 24 + " ++x=1"}}
+        out = mask_secrets(raw)
+        assert "nvapi-" not in out["extra"]["args"]
+        assert "++x=1" in out["extra"]["args"]
+
+    def test_non_secret_values_untouched(self):
+        raw = {"model": "nvidia/nemotron", "temperature": 1.0, "flags": [1, "a"]}
+        assert mask_secrets(raw) == raw
+
+    def test_tokenizer_fields_untouched(self):
+        """'token' must not substring-match tokenizer/tokenizer_backend."""
+        raw = {"extra": {"tokenizer": "zai-org/GLM-4.7", "tokenizer_backend": "huggingface"}}
+        assert mask_secrets(raw) == raw
+
+    def test_template_markers_and_empty_untouched(self):
+        """Reasoning-token markers and empty strings under secret-named keys stay."""
+        raw = {
+            "adapter_config": {"start_reasoning_token": "<|channel>thought\n", "end_reasoning_token": "<channel|>"},
+            "model": {"api_key": ""},
+            "env": {"TIKTOKEN_ENCODINGS_DIR": "/cache/vllm/tiktoken_encodings"},
+            "sandbox": {"tunnel_secret_arn": "arn:aws:secretsmanager:us-west-2:123:secret:x"},
+        }
+        assert mask_secrets(raw) == raw
+
+    def test_reference_shaped_values_untouched(self):
+        """Env-var names, bare $VAR and host: mappings are references, not secrets."""
+        raw = {
+            "judge": {"api_key": "JUDGE_API_KEY"},
+            "env_vars": {"HF_TOKEN": "$HF_TOKEN", "NGC_API_KEY": "host:NGC_API_KEY"},
+        }
+        assert mask_secrets(raw) == raw
+
+
+class TestSnapshotText:
+    def test_header_and_reparseable_body(self):
+        raw = {"services": {"m": {"type": "api", "url": "${U}/v1", "model": "x"}}}
+        text = build_snapshot_text(raw, build_provenance(source_config="/tmp/c.yaml"))
+        assert text.startswith("#")
+        assert "nemo-evaluator version" in text
+        assert "source config: /tmp/c.yaml" in text
+        # Comments are ignored by YAML: the body must round-trip.
+        assert yaml.safe_load(text) == raw
+
+
+class TestWriteConfigSnapshot:
+    def test_writes_composed_raw(self, tmp_path):
+        raw = {"services": {"m": {"type": "api", "api_key": "${KEY}"}}}
+        cfg = _StubConfig(raw=raw, provenance={"run_id": "r1"})
+        path = write_config_snapshot(cfg, tmp_path)
+        assert path == tmp_path / SNAPSHOT_FILENAME
+        text = path.read_text()
+        assert "${KEY}" in text
+        assert "run_id: r1" in text
+
+    def test_skipped_in_inner_execution(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NEL_INNER_EXECUTION", "1")
+        cfg = _StubConfig(raw={"a": 1})
+        assert write_config_snapshot(cfg, tmp_path) is None
+        assert not (tmp_path / SNAPSHOT_FILENAME).exists()
+
+    def test_fallback_reconstruction_masks_secrets(self, tmp_path):
+        """Quick-mode configs (no composed raw) fall back to model_dump, masked."""
+        cfg = _StubConfig(raw=None)
+        path = write_config_snapshot(cfg, tmp_path)
+        text = path.read_text()
+        assert "nvapi-" not in text
+        assert "<redacted>" in text
+
+    def test_never_raises(self, tmp_path):
+        """A broken config must not raise (snapshot is best-effort)."""
+
+        class _Broken:
+            output = None  # config.output.dir access will fail
+
+        assert write_config_snapshot(_Broken(), None) is None
+
+
+class TestMaskCliText:
+    def test_override_kv_secret_masked(self):
+        out = _mask_cli_text("nel eval run c.yaml -O services.m.api_key=hunter2 -O benchmarks.0.repeats=2")
+        assert "hunter2" not in out
+        assert "api_key=<redacted>" in out
+        assert "repeats=2" in out  # non-secret override untouched
+
+    def test_override_env_ref_kept(self):
+        out = _mask_cli_text("-O services.m.api_key=${NVIDIA_API_KEY}")
+        assert "${NVIDIA_API_KEY}" in out
+
+
+class TestForceOverwrite:
+    def test_fresh_run_overwrites_stale_snapshot(self, tmp_path):
+        write_config_snapshot(_StubConfig(raw={"a": 1}), tmp_path, force=True)
+        path = write_config_snapshot(_StubConfig(raw={"a": 2}), tmp_path, force=True)
+        assert "a: 2" in path.read_text()
+
+    def test_resume_preserves_original(self, tmp_path):
+        first = write_config_snapshot(_StubConfig(raw={"a": 1}), tmp_path, force=True)
+        original = first.read_text()
+        write_config_snapshot(_StubConfig(raw={"a": 2}), tmp_path, force=False)
+        assert first.read_text() == original
+
+
+class TestProvenanceLeakRegression:
+    def test_secret_cli_forms_never_reach_snapshot_text(self, monkeypatch):
+        """argv/override secrets must not survive into the rendered snapshot."""
+        import sys
+
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["nel", "eval", "run", "c.yaml", "--api-key=nvapi-ARGVSECRET111111", "--token", "plainSecret123"],
+        )
+        prov = build_provenance(overrides=("services.x.api_key=overrideSecret99",))
+        text = build_snapshot_text({"services": {}}, prov)
+        assert "nvapi-" not in text
+        assert "plainSecret123" not in text
+        assert "overrideSecret99" not in text
+        assert "<redacted>" in text
+
+
+class TestOutputDirOverride:
+    def test_cli_override_reflected_in_snapshot(self, tmp_path):
+        """-o overrides config.output.dir after compose; the snapshot must match."""
+        cfg = _StubConfig(raw={"output": {"dir": "./from_yaml"}})
+        record_output_dir_override(cfg, "/actual/run/dir")
+        path = write_config_snapshot(cfg, tmp_path)
+        text = path.read_text()
+        assert "/actual/run/dir" in text
+        assert "from_yaml" not in text

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -19,7 +19,6 @@ import yaml
 from nemo_evaluator.config.snapshot import (
     SNAPSHOT_FILENAME,
     build_provenance,
-    build_snapshot_text,
     record_output_dir_override,
     write_config_snapshot,
 )
@@ -33,39 +32,25 @@ class _StubConfig:
         self._snapshot_provenance = provenance or {}
 
 
-class TestSnapshotText:
-    def test_header_and_reparseable_body(self):
-        raw = {"services": {"m": {"type": "api", "url": "${U}/v1", "model": "x", "api_key": "${KEY}"}}}
-        text = build_snapshot_text(raw, build_provenance(source_config="/tmp/c.yaml"))
+class TestWriteConfigSnapshot:
+    def test_snapshot_content(self, tmp_path):
+        """Header carries provenance; env refs survive; body round-trips."""
+        raw = {"services": {"m": {"type": "api", "url": "${U}/v1", "api_key": "${KEY}"}}}
+        prov = build_provenance(source_config="/tmp/c.yaml", run_id="r1")
+        path = write_config_snapshot(_StubConfig(raw=raw, provenance=prov), tmp_path)
+        assert path == tmp_path / SNAPSHOT_FILENAME
+        text = path.read_text()
         assert text.startswith("#")
         assert "nemo-evaluator version" in text
         assert "source config: /tmp/c.yaml" in text
-        # Env refs are the safe representation and must survive verbatim.
+        assert "run_id: r1" in text
         assert "${KEY}" in text
         # Comments are ignored by YAML: the body must round-trip.
         assert yaml.safe_load(text) == raw
 
-
-class TestWriteConfigSnapshot:
-    def test_writes_composed_raw(self, tmp_path):
-        raw = {"services": {"m": {"type": "api", "api_key": "${KEY}"}}}
-        cfg = _StubConfig(raw=raw, provenance={"run_id": "r1"})
-        path = write_config_snapshot(cfg, tmp_path)
-        assert path == tmp_path / SNAPSHOT_FILENAME
-        text = path.read_text()
-        assert "${KEY}" in text
-        assert "run_id: r1" in text
-
     def test_skipped_in_inner_execution(self, tmp_path, monkeypatch):
         monkeypatch.setenv("NEL_INNER_EXECUTION", "1")
-        cfg = _StubConfig(raw={"a": 1})
-        assert write_config_snapshot(cfg, tmp_path) is None
-        assert not (tmp_path / SNAPSHOT_FILENAME).exists()
-
-    def test_no_snapshot_without_composed_raw(self, tmp_path):
-        """Quick mode / programmatic configs hold resolved secrets — no snapshot."""
-        cfg = _StubConfig(raw=None)
-        assert write_config_snapshot(cfg, tmp_path) is None
+        assert write_config_snapshot(_StubConfig(raw={"a": 1}), tmp_path) is None
         assert not (tmp_path / SNAPSHOT_FILENAME).exists()
 
     def test_never_raises(self):
@@ -77,26 +62,19 @@ class TestWriteConfigSnapshot:
 
         assert write_config_snapshot(_Broken(), None) is None
 
-
-class TestForceOverwrite:
-    def test_fresh_run_overwrites_stale_snapshot(self, tmp_path):
+    def test_force_semantics(self, tmp_path):
+        """Fresh runs overwrite a stale snapshot; resumes keep the original."""
         write_config_snapshot(_StubConfig(raw={"a": 1}), tmp_path, force=True)
-        path = write_config_snapshot(_StubConfig(raw={"a": 2}), tmp_path, force=True)
-        assert "a: 2" in path.read_text()
+        write_config_snapshot(_StubConfig(raw={"a": 2}), tmp_path, force=False)  # resume: kept
+        path = tmp_path / SNAPSHOT_FILENAME
+        assert "a: 1" in path.read_text()
+        write_config_snapshot(_StubConfig(raw={"a": 3}), tmp_path, force=True)  # fresh run: overwritten
+        assert "a: 3" in path.read_text()
 
-    def test_resume_preserves_original(self, tmp_path):
-        first = write_config_snapshot(_StubConfig(raw={"a": 1}), tmp_path, force=True)
-        original = first.read_text()
-        write_config_snapshot(_StubConfig(raw={"a": 2}), tmp_path, force=False)
-        assert first.read_text() == original
-
-
-class TestOutputDirOverride:
-    def test_cli_override_reflected_in_snapshot(self, tmp_path):
+    def test_cli_output_dir_override_reflected(self, tmp_path):
         """-o overrides config.output.dir after compose; the snapshot must match."""
         cfg = _StubConfig(raw={"output": {"dir": "./from_yaml"}})
         record_output_dir_override(cfg, "/actual/run/dir")
-        path = write_config_snapshot(cfg, tmp_path)
-        text = path.read_text()
+        text = write_config_snapshot(cfg, tmp_path).read_text()
         assert "/actual/run/dir" in text
         assert "from_yaml" not in text

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -26,16 +26,11 @@ from nemo_evaluator.config.snapshot import (
 
 
 class _StubConfig:
-    """Minimal stand-in for EvalConfig: private attrs + output.dir."""
+    """Minimal stand-in for EvalConfig: just the snapshot private attrs."""
 
-    def __init__(self, raw=None, provenance=None, output_dir="unused"):
+    def __init__(self, raw=None, provenance=None):
         self._composed_raw = raw
         self._snapshot_provenance = provenance or {}
-
-        class _Out:
-            dir = output_dir
-
-        self.output = _Out()
 
 
 class TestSnapshotText:

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -14,15 +14,12 @@
 # limitations under the License.
 """Tests for the composed-config reproducibility snapshot."""
 
-import pytest
 import yaml
 
 from nemo_evaluator.config.snapshot import (
     SNAPSHOT_FILENAME,
-    _mask_cli_text,
     build_provenance,
     build_snapshot_text,
-    mask_secrets,
     record_output_dir_override,
     write_config_snapshot,
 )
@@ -40,78 +37,16 @@ class _StubConfig:
 
         self.output = _Out()
 
-    def model_dump(self, **_kw):
-        return {"services": {"m": {"type": "api", "api_key": "secret-" + "x" * 20}}}
-
-
-class TestMaskSecrets:
-    @pytest.mark.parametrize(
-        "raw",
-        [
-            pytest.param({"services": {"m": {"api_key": "${NVIDIA_API_KEY}"}}}, id="env_ref"),
-            pytest.param({"model": "nvidia/nemotron", "temperature": 1.0, "flags": [1, "a"]}, id="non_secret_values"),
-            pytest.param(
-                {"extra": {"tokenizer": "zai-org/GLM-4.7", "tokenizer_backend": "huggingface"}},
-                id="tokenizer_not_token",
-            ),
-            pytest.param(
-                {
-                    "adapter_config": {
-                        "start_reasoning_token": "<|channel>thought\n",
-                        "end_reasoning_token": "<channel|>",
-                    },
-                    "model": {"api_key": ""},
-                    "env": {"TIKTOKEN_ENCODINGS_DIR": "/cache/vllm/tiktoken_encodings"},
-                    "sandbox": {"tunnel_secret_arn": "arn:aws:secretsmanager:us-west-2:123:secret:x"},
-                },
-                id="template_markers_empty_path_arn",
-            ),
-            pytest.param(
-                {
-                    "judge": {"api_key": "JUDGE_API_KEY"},
-                    "env_vars": {"HF_TOKEN": "$HF_TOKEN", "NGC_API_KEY": "host:NGC_API_KEY"},
-                },
-                id="reference_shaped_values",
-            ),
-        ],
-    )
-    def test_untouched(self, raw):
-        """References, template markers, paths and non-secrets pass through as-is."""
-        assert mask_secrets(raw) == raw
-
-    def test_literal_secret_key_masked(self):
-        raw = {"services": {"m": {"api_key": "not-a-real-key-literal"}}}
-        assert mask_secrets(raw)["services"]["m"]["api_key"] == "<redacted>"
-
-    def test_env_var_names_masked_when_literal(self):
-        raw = {"env_vars": {"HF_TOKEN": "hf_literalvalue", "JUDGE_API_KEY": "${JUDGE_API_KEY}"}}
-        out = mask_secrets(raw)
-        assert out["env_vars"]["HF_TOKEN"] == "<redacted>"  # key matches token
-        assert out["env_vars"]["JUDGE_API_KEY"] == "${JUDGE_API_KEY}"
-
-    def test_pattern_backstop_inside_free_form_string(self):
-        raw = {"extra": {"args": "++server.key=sk-" + "a" * 24 + " ++x=1"}}
-        out = mask_secrets(raw)
-        assert "sk-" not in out["extra"]["args"]
-        assert "++x=1" in out["extra"]["args"]
-
-    def test_plural_secret_keys_masked(self):
-        raw = {"credentials": "some-literal-cred", "secrets": "another-literal"}
-        assert mask_secrets(raw) == {"credentials": "<redacted>", "secrets": "<redacted>"}
-
-    def test_all_caps_blob_masked(self):
-        """Uppercase alnum without underscores is not an env-var name."""
-        raw = {"m": {"api_key": "ABCDEF123456XYZ"}}
-        assert mask_secrets(raw)["m"]["api_key"] == "<redacted>"
-
 
 class TestSnapshotText:
     def test_header_and_reparseable_body(self):
-        raw = {"services": {"m": {"type": "api", "url": "${U}/v1", "model": "x"}}}
+        raw = {"services": {"m": {"type": "api", "url": "${U}/v1", "model": "x", "api_key": "${KEY}"}}}
         text = build_snapshot_text(raw, build_provenance(source_config="/tmp/c.yaml"))
         assert text.startswith("#")
         assert "nemo-evaluator version" in text
         assert "source config: /tmp/c.yaml" in text
+        # Env refs are the safe representation and must survive verbatim.
+        assert "${KEY}" in text
         # Comments are ignored by YAML: the body must round-trip.
         assert yaml.safe_load(text) == raw
 
@@ -132,38 +67,20 @@ class TestWriteConfigSnapshot:
         assert write_config_snapshot(cfg, tmp_path) is None
         assert not (tmp_path / SNAPSHOT_FILENAME).exists()
 
-    def test_fallback_reconstruction_masks_secrets(self, tmp_path):
-        """Quick-mode configs (no composed raw) fall back to model_dump, masked."""
+    def test_no_snapshot_without_composed_raw(self, tmp_path):
+        """Quick mode / programmatic configs hold resolved secrets — no snapshot."""
         cfg = _StubConfig(raw=None)
-        path = write_config_snapshot(cfg, tmp_path)
-        text = path.read_text()
-        assert "x" * 20 not in text
-        assert "<redacted>" in text
+        assert write_config_snapshot(cfg, tmp_path) is None
+        assert not (tmp_path / SNAPSHOT_FILENAME).exists()
 
     def test_never_raises(self):
         """A broken config must not raise (snapshot is best-effort)."""
 
         class _Broken:
+            _composed_raw = {"a": 1}
             output = None  # config.output.dir access will fail
 
         assert write_config_snapshot(_Broken(), None) is None
-
-
-class TestMaskCliText:
-    def test_override_kv_secret_masked(self):
-        out = _mask_cli_text("nel eval run c.yaml -O services.m.api_key=hunter2 -O benchmarks.0.repeats=2")
-        assert "hunter2" not in out
-        assert "api_key=<redacted>" in out
-        assert "repeats=2" in out  # non-secret override untouched
-
-    def test_override_env_ref_kept(self):
-        out = _mask_cli_text("-O services.m.api_key=${NVIDIA_API_KEY}")
-        assert "${NVIDIA_API_KEY}" in out
-
-    def test_tokens_param_not_masked(self):
-        """'tokens' plural is deliberately excluded: *_tokens params are benign."""
-        out = _mask_cli_text("-O benchmarks.0.params.max_new_tokens=2048")
-        assert "max_new_tokens=2048" in out
 
 
 class TestForceOverwrite:
@@ -177,24 +94,6 @@ class TestForceOverwrite:
         original = first.read_text()
         write_config_snapshot(_StubConfig(raw={"a": 2}), tmp_path, force=False)
         assert first.read_text() == original
-
-
-class TestProvenanceLeakRegression:
-    def test_secret_cli_forms_never_reach_snapshot_text(self, monkeypatch):
-        """argv/override secrets must not survive into the rendered snapshot."""
-        import sys
-
-        monkeypatch.setattr(
-            sys,
-            "argv",
-            ["nel", "eval", "run", "c.yaml", "--api-key=ARGVSECRET111111", "--token", "plainSecret123"],
-        )
-        prov = build_provenance(overrides=("services.x.api_key=overrideSecret99",))
-        text = build_snapshot_text({"services": {}}, prov)
-        assert "ARGVSECRET111111" not in text
-        assert "plainSecret123" not in text
-        assert "overrideSecret99" not in text
-        assert "<redacted>" in text
 
 
 class TestOutputDirOverride:

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -91,6 +91,10 @@ class TestMaskSecrets:
         }
         assert mask_secrets(raw) == raw
 
+    def test_plural_secret_keys_masked(self):
+        raw = {"credentials": "some-literal-cred", "secrets": "another-literal"}
+        assert mask_secrets(raw) == {"credentials": "<redacted>", "secrets": "<redacted>"}
+
 
 class TestSnapshotText:
     def test_header_and_reparseable_body(self):
@@ -146,6 +150,11 @@ class TestMaskCliText:
     def test_override_env_ref_kept(self):
         out = _mask_cli_text("-O services.m.api_key=${NVIDIA_API_KEY}")
         assert "${NVIDIA_API_KEY}" in out
+
+    def test_tokens_param_not_masked(self):
+        """'tokens' plural is deliberately excluded: *_tokens params are benign."""
+        out = _mask_cli_text("-O benchmarks.0.params.max_new_tokens=2048")
+        assert "max_new_tokens=2048" in out
 
 
 class TestForceOverwrite:

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -95,6 +95,11 @@ class TestMaskSecrets:
         raw = {"credentials": "some-literal-cred", "secrets": "another-literal"}
         assert mask_secrets(raw) == {"credentials": "<redacted>", "secrets": "<redacted>"}
 
+    def test_all_caps_blob_masked(self):
+        """Uppercase alnum without underscores is not an env-var name."""
+        raw = {"m": {"api_key": "ABCDEF123456XYZ"}}
+        assert mask_secrets(raw)["m"]["api_key"] == "<redacted>"
+
 
 class TestSnapshotText:
     def test_header_and_reparseable_body(self):

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests for the composed-config reproducibility snapshot."""
 
+import pytest
 import yaml
 
 from nemo_evaluator.config.snapshot import (
@@ -44,8 +45,38 @@ class _StubConfig:
 
 
 class TestMaskSecrets:
-    def test_env_refs_preserved(self):
-        raw = {"services": {"m": {"api_key": "${NVIDIA_API_KEY}"}}}
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            pytest.param({"services": {"m": {"api_key": "${NVIDIA_API_KEY}"}}}, id="env_ref"),
+            pytest.param({"model": "nvidia/nemotron", "temperature": 1.0, "flags": [1, "a"]}, id="non_secret_values"),
+            pytest.param(
+                {"extra": {"tokenizer": "zai-org/GLM-4.7", "tokenizer_backend": "huggingface"}},
+                id="tokenizer_not_token",
+            ),
+            pytest.param(
+                {
+                    "adapter_config": {
+                        "start_reasoning_token": "<|channel>thought\n",
+                        "end_reasoning_token": "<channel|>",
+                    },
+                    "model": {"api_key": ""},
+                    "env": {"TIKTOKEN_ENCODINGS_DIR": "/cache/vllm/tiktoken_encodings"},
+                    "sandbox": {"tunnel_secret_arn": "arn:aws:secretsmanager:us-west-2:123:secret:x"},
+                },
+                id="template_markers_empty_path_arn",
+            ),
+            pytest.param(
+                {
+                    "judge": {"api_key": "JUDGE_API_KEY"},
+                    "env_vars": {"HF_TOKEN": "$HF_TOKEN", "NGC_API_KEY": "host:NGC_API_KEY"},
+                },
+                id="reference_shaped_values",
+            ),
+        ],
+    )
+    def test_untouched(self, raw):
+        """References, template markers, paths and non-secrets pass through as-is."""
         assert mask_secrets(raw) == raw
 
     def test_literal_secret_key_masked(self):
@@ -63,33 +94,6 @@ class TestMaskSecrets:
         out = mask_secrets(raw)
         assert "sk-" not in out["extra"]["args"]
         assert "++x=1" in out["extra"]["args"]
-
-    def test_non_secret_values_untouched(self):
-        raw = {"model": "nvidia/nemotron", "temperature": 1.0, "flags": [1, "a"]}
-        assert mask_secrets(raw) == raw
-
-    def test_tokenizer_fields_untouched(self):
-        """'token' must not substring-match tokenizer/tokenizer_backend."""
-        raw = {"extra": {"tokenizer": "zai-org/GLM-4.7", "tokenizer_backend": "huggingface"}}
-        assert mask_secrets(raw) == raw
-
-    def test_template_markers_and_empty_untouched(self):
-        """Reasoning-token markers and empty strings under secret-named keys stay."""
-        raw = {
-            "adapter_config": {"start_reasoning_token": "<|channel>thought\n", "end_reasoning_token": "<channel|>"},
-            "model": {"api_key": ""},
-            "env": {"TIKTOKEN_ENCODINGS_DIR": "/cache/vllm/tiktoken_encodings"},
-            "sandbox": {"tunnel_secret_arn": "arn:aws:secretsmanager:us-west-2:123:secret:x"},
-        }
-        assert mask_secrets(raw) == raw
-
-    def test_reference_shaped_values_untouched(self):
-        """Env-var names, bare $VAR and host: mappings are references, not secrets."""
-        raw = {
-            "judge": {"api_key": "JUDGE_API_KEY"},
-            "env_vars": {"HF_TOKEN": "$HF_TOKEN", "NGC_API_KEY": "host:NGC_API_KEY"},
-        }
-        assert mask_secrets(raw) == raw
 
     def test_plural_secret_keys_masked(self):
         raw = {"credentials": "some-literal-cred", "secrets": "another-literal"}

--- a/tests/test_config/test_snapshot.py
+++ b/tests/test_config/test_snapshot.py
@@ -40,7 +40,7 @@ class _StubConfig:
         self.output = _Out()
 
     def model_dump(self, **_kw):
-        return {"services": {"m": {"type": "api", "api_key": "nvapi-" + "x" * 20}}}
+        return {"services": {"m": {"type": "api", "api_key": "secret-" + "x" * 20}}}
 
 
 class TestMaskSecrets:
@@ -49,7 +49,7 @@ class TestMaskSecrets:
         assert mask_secrets(raw) == raw
 
     def test_literal_secret_key_masked(self):
-        raw = {"services": {"m": {"api_key": "nvapi-not-a-real-key"}}}
+        raw = {"services": {"m": {"api_key": "not-a-real-key-literal"}}}
         assert mask_secrets(raw)["services"]["m"]["api_key"] == "<redacted>"
 
     def test_env_var_names_masked_when_literal(self):
@@ -59,9 +59,9 @@ class TestMaskSecrets:
         assert out["env_vars"]["JUDGE_API_KEY"] == "${JUDGE_API_KEY}"
 
     def test_pattern_backstop_inside_free_form_string(self):
-        raw = {"extra": {"args": "++server.key=nvapi-" + "a" * 24 + " ++x=1"}}
+        raw = {"extra": {"args": "++server.key=sk-" + "a" * 24 + " ++x=1"}}
         out = mask_secrets(raw)
-        assert "nvapi-" not in out["extra"]["args"]
+        assert "sk-" not in out["extra"]["args"]
         assert "++x=1" in out["extra"]["args"]
 
     def test_non_secret_values_untouched(self):
@@ -133,7 +133,7 @@ class TestWriteConfigSnapshot:
         cfg = _StubConfig(raw=None)
         path = write_config_snapshot(cfg, tmp_path)
         text = path.read_text()
-        assert "nvapi-" not in text
+        assert "x" * 20 not in text
         assert "<redacted>" in text
 
     def test_never_raises(self):
@@ -183,11 +183,11 @@ class TestProvenanceLeakRegression:
         monkeypatch.setattr(
             sys,
             "argv",
-            ["nel", "eval", "run", "c.yaml", "--api-key=nvapi-ARGVSECRET111111", "--token", "plainSecret123"],
+            ["nel", "eval", "run", "c.yaml", "--api-key=ARGVSECRET111111", "--token", "plainSecret123"],
         )
         prov = build_provenance(overrides=("services.x.api_key=overrideSecret99",))
         text = build_snapshot_text({"services": {}}, prov)
-        assert "nvapi-" not in text
+        assert "ARGVSECRET111111" not in text
         assert "plainSecret123" not in text
         assert "overrideSecret99" not in text
         assert "<redacted>" in text

--- a/tests/test_docker_executor_snapshot.py
+++ b/tests/test_docker_executor_snapshot.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DockerExecutor must write the full_config.yaml snapshot to the output dir."""
+
+from nemo_evaluator.config import EvalConfig
+from nemo_evaluator.executors.docker_executor import DockerExecutor
+
+
+def test_dry_run_writes_config_snapshot(tmp_path, monkeypatch):
+    monkeypatch.delenv("NEL_INNER_EXECUTION", raising=False)
+    out_dir = tmp_path / "out"
+    config = EvalConfig.model_validate(
+        {
+            "services": {
+                "m": {
+                    "type": "api",
+                    "url": "https://example.com/v1/chat/completions",
+                    "protocol": "chat_completions",
+                    "model": "test-model",
+                    "api_key": "${TEST_API_KEY}",
+                }
+            },
+            "benchmarks": [{"name": "gsm8k", "max_problems": 1, "solver": {"type": "simple", "service": "m"}}],
+            "cluster": {"type": "docker"},
+            "output": {"dir": str(out_dir)},
+        }
+    )
+    # dry_run writes .docker.env, _docker_config.json and the snapshot,
+    # then stops before `docker run`.
+    DockerExecutor().run(config, dry_run=True)
+
+    text = (out_dir / "full_config.yaml").read_text()
+    assert "nemo-evaluator version" in text  # provenance header present
+    assert "${TEST_API_KEY}" in text  # env ref survives unexpanded

--- a/tests/test_docker_executor_snapshot.py
+++ b/tests/test_docker_executor_snapshot.py
@@ -18,25 +18,31 @@ from nemo_evaluator.config import EvalConfig
 from nemo_evaluator.executors.docker_executor import DockerExecutor
 
 
+def _raw_config(out_dir):
+    return {
+        "services": {
+            "m": {
+                "type": "api",
+                "url": "https://example.com/v1/chat/completions",
+                "protocol": "chat_completions",
+                "model": "test-model",
+                "api_key": "${TEST_API_KEY}",
+            }
+        },
+        "benchmarks": [{"name": "gsm8k", "max_problems": 1, "solver": {"type": "simple", "service": "m"}}],
+        "cluster": {"type": "docker"},
+        "output": {"dir": str(out_dir)},
+    }
+
+
 def test_dry_run_writes_config_snapshot(tmp_path, monkeypatch):
     monkeypatch.delenv("NEL_INNER_EXECUTION", raising=False)
     out_dir = tmp_path / "out"
-    config = EvalConfig.model_validate(
-        {
-            "services": {
-                "m": {
-                    "type": "api",
-                    "url": "https://example.com/v1/chat/completions",
-                    "protocol": "chat_completions",
-                    "model": "test-model",
-                    "api_key": "${TEST_API_KEY}",
-                }
-            },
-            "benchmarks": [{"name": "gsm8k", "max_problems": 1, "solver": {"type": "simple", "service": "m"}}],
-            "cluster": {"type": "docker"},
-            "output": {"dir": str(out_dir)},
-        }
-    )
+    raw = _raw_config(out_dir)
+    config = EvalConfig.model_validate(raw)
+    # The CLI loader attaches the pre-expansion composed dict; simulate it.
+    config._composed_raw = raw
+
     # dry_run writes .docker.env, _docker_config.json and the snapshot,
     # then stops before `docker run`.
     DockerExecutor().run(config, dry_run=True)
@@ -44,3 +50,14 @@ def test_dry_run_writes_config_snapshot(tmp_path, monkeypatch):
     text = (out_dir / "full_config.yaml").read_text()
     assert "nemo-evaluator version" in text  # provenance header present
     assert "${TEST_API_KEY}" in text  # env ref survives unexpanded
+
+
+def test_dry_run_no_snapshot_without_composed_raw(tmp_path, monkeypatch):
+    """Programmatic configs hold resolved secrets — the executor writes no snapshot."""
+    monkeypatch.delenv("NEL_INNER_EXECUTION", raising=False)
+    out_dir = tmp_path / "out"
+    config = EvalConfig.model_validate(_raw_config(out_dir))
+
+    DockerExecutor().run(config, dry_run=True)
+
+    assert not (out_dir / "full_config.yaml").exists()

--- a/tests/test_orchestration/test_sidecar_reproducibility.py
+++ b/tests/test_orchestration/test_sidecar_reproducibility.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Sidecar reproducibility: literal model id, proxy defaults, header."""
+
+import pytest
+
+from nemo_evaluator.config import EvalConfig
+from nemo_evaluator.orchestration.slurm_gen import generate_sbatch, write_sbatch
+
+
+def _make_slurm_config(services, benchmarks):
+    return EvalConfig.model_validate(
+        {
+            "services": services,
+            "benchmarks": benchmarks,
+            "cluster": {
+                "type": "slurm",
+                "walltime": "02:00:00",
+                "node_pools": {"gpu": {"partition": "batch", "nodes": 1, "gres": "gpu:4"}},
+            },
+        }
+    )
+
+
+_BENCH = [
+    {
+        "name": "swebench-multilingual",
+        "solver": {
+            "type": "gym_delegation",
+            "service": "model",
+            "gym_service": "gym",
+            "gym_agent": "openhands",
+        },
+    }
+]
+
+_GYM = {"type": "gym", "port": 9090}
+
+
+def _vllm(**extra):
+    return {
+        "type": "vllm",
+        "model": "/ckpt/some-checkpoint",
+        "protocol": "chat_completions",
+        "tensor_parallel_size": 4,
+        "port": 8000,
+        "node_pool": "gpu",
+        **extra,
+    }
+
+
+_EXTERNAL_API = {
+    "type": "api",
+    "url": "https://integrate.api.nvidia.com/v1/chat/completions",
+    "protocol": "chat_completions",
+    "model": "nvidia/nemotron-3-ultra-550b-a55b",
+}
+
+
+class TestSidecarModelLiteral:
+    @pytest.mark.parametrize(
+        ("model_service", "expected_literal"),
+        [
+            pytest.param(
+                _vllm(served_model_name="nvidia/nemotron-test"),
+                "nvidia/nemotron-test",
+                id="served_name_inlined",
+            ),
+            pytest.param(_vllm(), None, id="env_ref_kept"),
+            pytest.param(_EXTERNAL_API, "nvidia/nemotron-3-ultra-550b-a55b", id="external_api_inlined"),
+        ],
+    )
+    def test_model_id_in_sidecar(self, model_service, expected_literal):
+        cfg = _make_slurm_config(
+            services={"model": model_service, "gym": _GYM},
+            benchmarks=_BENCH,
+        )
+        _, sidecars, _ = generate_sbatch(cfg)
+        svc = list(sidecars.values())[0]["services"]["model"]
+        if expected_literal is None:
+            assert svc["model"].startswith("${")
+        else:
+            assert svc["model"] == expected_literal
+        if model_service.get("type") != "api":
+            # URL is runtime-assigned for deployments: must stay an env ref.
+            assert svc["url"].startswith("${")
+
+
+class TestSidecarProxyDefaults:
+    def test_proxy_defaults_recorded(self):
+        """exclude_defaults must NOT strip effective proxy settings."""
+        cfg = _make_slurm_config(
+            services={
+                "model": _vllm(proxy={"interceptors": [{"name": "reasoning"}]}),
+                "gym": _GYM,
+            },
+            benchmarks=_BENCH,
+        )
+        _, sidecars, _ = generate_sbatch(cfg)
+        proxy = list(sidecars.values())[0]["services"]["model"]["proxy"]
+        # Default-valued fields must be present so the sidecar records the
+        # effective configuration (request_timeout=120.0, max_retries=0, ...).
+        assert "request_timeout" in proxy
+        assert "max_retries" in proxy
+        assert proxy["interceptors"][0]["name"] == "reasoning"
+
+
+class TestSidecarHeader:
+    def test_written_sidecar_has_provenance_header(self, tmp_path):
+        cfg = _make_slurm_config(
+            services={"model": _vllm(served_model_name="m"), "gym": _GYM},
+            benchmarks=_BENCH,
+        )
+        write_sbatch(cfg, output_dir=tmp_path)
+        sidecar_files = list(tmp_path.glob("config_*.yaml"))
+        assert sidecar_files, "no sidecar config written"
+        for sidecar in sidecar_files:
+            text = sidecar.read_text()
+            assert "full_config.yaml" in text, sidecar

--- a/tests/test_slurm_executor_snapshot.py
+++ b/tests/test_slurm_executor_snapshot.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Remote SLURM submission: snapshot upload and staging cleanup semantics."""
+
+from unittest.mock import patch
+
+import nemo_evaluator.executors.slurm_executor as slurm_executor_module
+from nemo_evaluator.config import (
+    BenchmarkConfig,
+    EvalConfig,
+    ExternalApiService,
+    NodePool,
+    OutputConfig,
+    SimpleSolver,
+    SlurmCluster,
+)
+from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+
+
+def _remote_config(tmp_path):
+    config = EvalConfig(
+        services={
+            "m": ExternalApiService(
+                type="api",
+                url="http://localhost:8000/v1/chat/completions",
+                protocol="chat_completions",
+                model="test-model",
+            )
+        },
+        benchmarks=[BenchmarkConfig(name="gsm8k", solver=SimpleSolver(type="simple", service="m"))],
+        cluster=SlurmCluster(
+            type="slurm",
+            hostname="login.example.com",
+            node_pools={"compute": NodePool(partition="batch")},
+        ),
+        output=OutputConfig(dir=str(tmp_path / "remote_out")),
+    )
+    # The CLI loader attaches the pre-expansion composed dict; simulate it.
+    config._composed_raw = {"services": {"m": {"api_key": "${KEY}"}}}
+    return config
+
+
+def _run_remote(config, tmp_path, monkeypatch, copy_side_effect=None):
+    """Run the executor with SSH mocked; track every mkdtemp'd directory."""
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    made = []
+
+    def fake_mkdtemp(prefix=""):
+        d = tmp_path / f"{prefix}{len(made)}"
+        d.mkdir(parents=True)
+        made.append(d)
+        return str(d)
+
+    monkeypatch.setattr(slurm_executor_module.tempfile, "mkdtemp", fake_mkdtemp)
+    with (
+        patch("nemo_evaluator.executors.ssh.copy_to_remote", side_effect=copy_side_effect) as copy_mock,
+        patch("nemo_evaluator.executors.ssh.submit_eval", return_value={"job_id": "42"}) as submit_mock,
+        patch("nemo_evaluator.run_store.RunMeta.save"),
+    ):
+        SlurmExecutor().run(config)
+    return made, copy_mock, submit_mock
+
+
+def test_remote_submission_uploads_snapshot_and_cleans_staging(tmp_path, monkeypatch, capsys):
+    config = _remote_config(tmp_path)
+    made, copy_mock, submit_mock = _run_remote(config, tmp_path, monkeypatch)
+
+    # snapshot was uploaded to the resolved remote run dir
+    copy_mock.assert_called_once()
+    assert [p.name for p in copy_mock.call_args.args[1]] == ["full_config.yaml"]
+    assert copy_mock.call_args.args[2] == config.output.dir
+
+    submit_mock.assert_called_once()
+    assert "SLURM job submitted: 42" in capsys.readouterr().out
+    # staging dir (holding .secrets.env etc.) must not outlive the submission
+    staging = next(d for d in made if "nel-slurm-" in d.name)
+    assert not staging.exists()
+
+
+def test_failed_upload_keeps_only_snapshot(tmp_path, monkeypatch, capsys):
+    config = _remote_config(tmp_path)
+    made, _, submit_mock = _run_remote(config, tmp_path, monkeypatch, copy_side_effect=RuntimeError("scp broke"))
+    out = capsys.readouterr().out
+
+    # the failed upload must not block the actual submission
+    submit_mock.assert_called_once()
+    assert "could not upload config snapshot" in out
+
+    # staging purged; only the secret-free snapshot survives, with a retry hint
+    staging = next(d for d in made if "nel-slurm-" in d.name)
+    assert not staging.exists()
+    kept = next(d for d in made if "nel-snapshot-" in d.name) / "full_config.yaml"
+    assert kept.exists()
+    assert "${KEY}" in kept.read_text()
+    assert f"scp {kept} login.example.com:{config.output.dir}/" in out


### PR DESCRIPTION
Adds a write-once `full_config.yaml` at each run root: the composed config (fragments merged, CLI overrides applied), directly re-runnable with `nel eval run` — a reproducibility record the transformed per-shard `config_*.yaml` can't provide.

- **Secret-safe by construction:** the snapshot is the pre-expansion composed config, so `${ENV_VAR}` refs stay unexpanded and no secrets reach disk. Configs without a pre-expansion source (quick mode / programmatic) get no snapshot. Provenance header records version, command, source config.
- Wired into the local, docker, and slurm executors; skipped in inner shard executions.
- Per-shard `config_*.yaml` inline the model id when known, keep default proxy settings, and point to `full_config.yaml`.
