### PR TITLE
fix(harbor): recognize vLLM "model's context length" phrasing

### DIFF
--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1295,6 +1295,7 @@ def _patch_terminus_unwind_min_pairs() -> None:
 
 _TERMINUS_API_ANCHOR_PATCHED = False
 _CHAT_TOKEN_ANCHOR_PATCHED = False
+_HARBOR_LITELLM_CTXLIM_PATCHED = False
 
 
 def _terminus2_count_total_tokens(self, chat) -> int:
@@ -1372,6 +1373,75 @@ def _patch_terminus_api_token_anchor() -> None:
     terminus2_mod.Terminus2._count_total_tokens = _terminus2_count_total_tokens
     _TERMINUS_API_ANCHOR_PATCHED = True
     logger.info("Patched Terminus2._count_total_tokens: anchor on API usage + litellm token remainder")
+
+
+# Matches the vLLM ``VLLMValidationError`` phrasing raised by self-hosted vLLM
+# deployments when a request exceeds the configured context length. The raw 400
+# body reads:
+#
+#   "You passed N input tokens and requested 0 output tokens. However, the
+#    model's context length is only M tokens..."
+#
+# Harbor 0.3.x's ``LiteLLM._is_context_length_error`` phrases tuple lists
+# ``"maximum context length"`` but NOT ``"model's context length"``, so this
+# text falls through to a plain ``LiteLLMBadRequestError``, Terminus-2's
+# ``except ContextLengthExceededError`` block never fires, and the agent
+# crashes instead of running its reactive-summarization fallback.
+#
+# Harbor v0.18.0 added exactly this substring upstream (see
+# ``harbor/llms/lite_llm.py`` with the comment ``# vllm 0.16.0 error
+# message``), so this patch becomes redundant the moment the ``harbor`` pin
+# in ``pyproject.toml`` is bumped to a release containing it.
+_VLLM_CTXLIM_PHRASES: tuple[str, ...] = (
+    "model's context length",  # vLLM VLLMValidationError; harbor >=0.18 catches this natively
+)
+
+# vLLM's ``VLLMValidationError`` is raised with ``parameter="input_tokens"`` as
+# a structured kwarg. On stringification, that appears verbatim in the wire
+# error body as ``parameter=input_tokens``. Grep of vLLM shows this kwarg is
+# emitted by a single call site — the context-overflow validator — so its
+# presence in an unclassified ``BadRequestError`` is a strong signal that the
+# free-text phrase list above has drifted behind a vLLM release. We do NOT
+# reclassify on this marker (a bad free-text detector should be fixed, not
+# silently papered over); instead we log loudly so the drift is visible.
+_VLLM_CTXLIM_DRIFT_MARKER = "parameter=input_tokens"
+
+
+def _patch_harbor_lite_llm_context_length_matcher() -> None:
+    global _HARBOR_LITELLM_CTXLIM_PATCHED
+    if _HARBOR_LITELLM_CTXLIM_PATCHED:
+        return
+
+    from harbor.llms import lite_llm as harbor_litellm
+
+    original = harbor_litellm.LiteLLM._is_context_length_error
+
+    def _patched(self: Any, error: Any) -> bool:
+        if original(self, error):
+            return True
+        parts = [
+            str(error),
+            str(getattr(error, "body", "") or ""),
+            str(getattr(error, "message", "") or ""),
+            str(getattr(error, "error", "") or ""),
+        ]
+        combined = " ".join(p for p in parts if p).lower()
+        if any(phrase in combined for phrase in _VLLM_CTXLIM_PHRASES):
+            return True
+        if _VLLM_CTXLIM_DRIFT_MARKER in combined:
+            logger.warning(
+                "BadRequestError body contains vLLM's stable ctx-overflow marker "
+                "'%s' but did not match any classifier phrase in "
+                "_VLLM_CTXLIM_PHRASES. vLLM's error phrasing has likely drifted "
+                "and _VLLM_CTXLIM_PHRASES needs an update. Body preview: %s",
+                _VLLM_CTXLIM_DRIFT_MARKER,
+                combined[:500],
+            )
+        return False
+
+    harbor_litellm.LiteLLM._is_context_length_error = _patched
+    _HARBOR_LITELLM_CTXLIM_PATCHED = True
+    logger.info('Patched Harbor LiteLLM._is_context_length_error to recognize vLLM "model\'s context length" phrasing')
 
 
 _TOKENIZER_REGISTRY: dict[str, dict] = {}
@@ -1544,6 +1614,7 @@ class HarborSolver:
             _patch_terminus_cle_reset()
             _patch_terminus_unwind_min_pairs()
             _patch_terminus_api_token_anchor()
+            _patch_harbor_lite_llm_context_length_matcher()
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
         _configure_terminus_tokenizer(

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -24,6 +24,7 @@ import pytest
 import nemo_evaluator.solvers.harbor as harbor
 from nemo_evaluator.solvers.harbor import (
     _patch_chat_token_anchor,
+    _patch_harbor_lite_llm_context_length_matcher,
     _patch_terminus_api_token_anchor,
     _patch_terminus_cle_reset,
     _patch_terminus_unwind_min_pairs,
@@ -432,10 +433,14 @@ class TestCreateAgentGating:
         from unittest.mock import MagicMock, patch
 
         solver = self._solver("terminus-2")
-        cle, unwind, anchor = MagicMock(), MagicMock(), MagicMock()
+        cle, unwind, anchor, ctxlim = MagicMock(), MagicMock(), MagicMock(), MagicMock()
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_cle_reset", cle)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_unwind_min_pairs", unwind)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_api_token_anchor", anchor)
+        monkeypatch.setattr(
+            "nemo_evaluator.solvers.harbor._patch_harbor_lite_llm_context_length_matcher",
+            ctxlim,
+        )
 
         sentinel = object()
         with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=sentinel):
@@ -445,15 +450,20 @@ class TestCreateAgentGating:
         cle.assert_called_once()
         unwind.assert_called_once()
         anchor.assert_called_once()
+        ctxlim.assert_called_once()
 
     def test_non_terminus_agent_skips_patches(self, tmp_path, monkeypatch):
         from unittest.mock import MagicMock, patch
 
         solver = self._solver("openhands")
-        cle, unwind, anchor = MagicMock(), MagicMock(), MagicMock()
+        cle, unwind, anchor, ctxlim = MagicMock(), MagicMock(), MagicMock(), MagicMock()
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_cle_reset", cle)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_unwind_min_pairs", unwind)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_api_token_anchor", anchor)
+        monkeypatch.setattr(
+            "nemo_evaluator.solvers.harbor._patch_harbor_lite_llm_context_length_matcher",
+            ctxlim,
+        )
 
         with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=object()):
             solver._create_agent(tmp_path)
@@ -461,3 +471,157 @@ class TestCreateAgentGating:
         cle.assert_not_called()
         unwind.assert_not_called()
         anchor.assert_not_called()
+        ctxlim.assert_not_called()
+
+
+# ── _patch_harbor_lite_llm_context_length_matcher ────────────────────────
+
+
+@pytest.fixture
+def ctxlim_patch_sandbox():
+    """Snapshot harbor.llms.lite_llm.LiteLLM._is_context_length_error and the
+    module-level idempotency guard; restore after the test."""
+    from harbor.llms import lite_llm as harbor_litellm
+
+    saved_method = harbor_litellm.LiteLLM._is_context_length_error
+    saved_flag = harbor._HARBOR_LITELLM_CTXLIM_PATCHED
+    harbor._HARBOR_LITELLM_CTXLIM_PATCHED = False
+    try:
+        yield harbor_litellm
+    finally:
+        harbor_litellm.LiteLLM._is_context_length_error = saved_method
+        harbor._HARBOR_LITELLM_CTXLIM_PATCHED = saved_flag
+
+
+_VLLM_ACTUAL_BODY = (
+    "You passed 262145 input tokens and requested 0 output tokens. "
+    "However, the model's context length is only 262144 tokens, "
+    "resulting in a maximum input length of 262144 tokens. Please "
+    "reduce the length of the input prompt. "
+    "(parameter=input_tokens, value=262145)"
+)
+
+
+class _CtxlimFakeError(Exception):
+    """Exception subclass whose ``str(err)`` carries the phrase under test."""
+
+
+class TestHarborLiteLLMContextLengthMatcher:
+    """The patch widens Harbor's substring matcher to recognize vLLM's actual
+    ``VLLMValidationError`` phrasing (``"You passed N input tokens... However,
+    the model's context length is only M tokens..."``) raised by self-hosted
+    vLLM deployments when a request exceeds the configured context length.
+    Without this, the wire error stays a plain ``BadRequestError`` and
+    Terminus-2's reactive summarization (``terminus_2.py::_query_llm``
+    ``except ContextLengthExceededError`` block) never triggers."""
+
+    @staticmethod
+    def _install():
+        _patch_harbor_lite_llm_context_length_matcher()
+        from harbor.llms.lite_llm import LiteLLM
+
+        return LiteLLM.__new__(LiteLLM)
+
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            pytest.param(
+                SimpleNamespace(body="", message=_VLLM_ACTUAL_BODY, error=""),
+                True,
+                id="vllm_body_in_message_attr",
+            ),
+            pytest.param(
+                _CtxlimFakeError("litellm.BadRequestError: " + _VLLM_ACTUAL_BODY),
+                True,
+                id="vllm_body_only_in_str_of_exception",
+            ),
+            pytest.param(
+                SimpleNamespace(body=_VLLM_ACTUAL_BODY, message="", error=""),
+                True,
+                id="vllm_body_in_body_attr",
+            ),
+            pytest.param(
+                SimpleNamespace(
+                    body="",
+                    message="Error code: 400 - context length exceeded (see docs)",
+                    error="",
+                ),
+                True,
+                id="original_openai_phrasing_still_matches",
+            ),
+            pytest.param(
+                SimpleNamespace(
+                    body="",
+                    message="Invalid tool call format: expected JSON object",
+                    error="",
+                ),
+                False,
+                id="unrelated_error_does_not_match",
+            ),
+            pytest.param(
+                SimpleNamespace(
+                    body="",
+                    message="You asked about the context limit; here is the answer.",
+                    error="",
+                ),
+                False,
+                id="similar_but_non_overflow_phrase_does_not_match",
+            ),
+        ],
+    )
+    def test_is_context_length_error(self, ctxlim_patch_sandbox, error, expected):
+        instance = self._install()
+        assert instance._is_context_length_error(error) is expected
+
+    def test_idempotent(self, ctxlim_patch_sandbox):
+        _patch_harbor_lite_llm_context_length_matcher()
+        first = ctxlim_patch_sandbox.LiteLLM._is_context_length_error
+        _patch_harbor_lite_llm_context_length_matcher()
+        assert ctxlim_patch_sandbox.LiteLLM._is_context_length_error is first
+
+    def test_drift_marker_present_but_phrase_missing_logs_warning(self, ctxlim_patch_sandbox, caplog):
+        """If vLLM's `parameter=input_tokens` marker is in the body but no
+        classifier phrase matches, the patched matcher must still return False
+        (agent still crashes) but log a WARNING so the drift is visible."""
+        instance = self._install()
+        drifted = SimpleNamespace(
+            body="SomeFutureVLLMPhrasing: 262145 tokens is over the limit. (parameter=input_tokens, value=262145)",
+            message="",
+            error="",
+        )
+        with caplog.at_level(logging.WARNING, logger="nemo_evaluator.solvers.harbor"):
+            result = instance._is_context_length_error(drifted)
+        assert result is False, "drift alarm must NOT reclassify — fix the classifier instead"
+        assert any("stable ctx-overflow marker" in rec.getMessage() for rec in caplog.records), (
+            "expected drift-alarm WARNING when the marker is present but no phrase matches"
+        )
+
+    def test_no_drift_warning_when_phrase_matches(self, ctxlim_patch_sandbox, caplog):
+        """When a classifier phrase DOES match, the drift alarm must stay quiet
+        even if the marker is also present — otherwise every real overflow
+        would trigger a spurious warning."""
+        instance = self._install()
+        real_body = SimpleNamespace(
+            body=_VLLM_ACTUAL_BODY,  # contains BOTH "model's context length" AND parameter=input_tokens
+            message="",
+            error="",
+        )
+        with caplog.at_level(logging.WARNING, logger="nemo_evaluator.solvers.harbor"):
+            result = instance._is_context_length_error(real_body)
+        assert result is True
+        assert not any("stable ctx-overflow marker" in rec.getMessage() for rec in caplog.records), (
+            "drift alarm fired even though the classifier caught the overflow"
+        )
+
+    def test_no_drift_warning_when_neither_marker_nor_phrase(self, ctxlim_patch_sandbox, caplog):
+        """Unrelated BadRequestErrors must not trigger the drift alarm."""
+        instance = self._install()
+        err = SimpleNamespace(
+            body="",
+            message="Invalid tool call format: expected JSON object",
+            error="",
+        )
+        with caplog.at_level(logging.WARNING, logger="nemo_evaluator.solvers.harbor"):
+            result = instance._is_context_length_error(err)
+        assert result is False
+        assert not any("stable ctx-overflow marker" in rec.getMessage() for rec in caplog.records)


### PR DESCRIPTION
## What

Extend `harbor.llms.lite_llm.LiteLLM._is_context_length_error` at `HarborSolver._create_agent`-time so that the `VLLMValidationError` body raised by self-hosted vLLM deployments — literally:

> `"You passed N input tokens and requested 0 output tokens. However, the model's context length is only M tokens..."`

— is classified as a context-length overflow, which lets Harbor's existing `_handle_litellm_error` translate the wire error to `harbor.llms.base.ContextLengthExceededError` instead of leaving it as a plain `LiteLLMBadRequestError`. Terminus-2's `_query_llm::except ContextLengthExceededError` block then fires its three-tier reactive-summarization fallback and the agent continues, instead of hard-crashing with `Agent crashed`.

## Why

Harbor 0.3.x's `_is_context_length_error` phrases tuple lists `"maximum context length"` but not `"model's context length"`, so the vLLM body currently falls through unrecognized. Chain:

- vLLM (self-hosted) raises `VLLMValidationError` with the body above.
- LiteLLM classifies as a plain `BadRequestError` (its own `is_error_str_context_window_exceeded` substring list does not include this phrasing either).
- Harbor's own catch-net misses it too.
- `terminus_2.py::_query_llm` only catches `ContextLengthExceededError`; the `BadRequestError` retries 3× and then propagates → OpenHands reports `Agent crashed` → task hard-zeros.

The three-tier summarization fallback in Terminus-2 (`_summarize` → short summary → screen-only prompt at `terminus_2.py:1017-1094`) already exists and is correct — it just never triggers because the exception type never converts.

## How

- New module-level tuple `_VLLM_CTXLIM_PHRASES = ("model's context length",)`.
- New `_patch_harbor_lite_llm_context_length_matcher()` runtime patch, structured like the existing `_patch_terminus_cle_reset` / `_patch_terminus_unwind_min_pairs` / `_patch_terminus_api_token_anchor` functions. Wraps Harbor's original matcher additively (`if original(self, error): return True`) so existing coverage is unchanged.
- Wired into `HarborSolver._create_agent` alongside the other Terminus-2 patches, gated on `is_terminus2`. Idempotent via `_HARBOR_LITELLM_CTXLIM_PATCHED`.
- No new dependencies. No harbor pin bump. No behavior change for non-Terminus-2 agents or for non-vLLM overflows.

## Relationship to a harbor pin bump

Harbor v0.18.0 already ships this exact substring in its own phrases tuple upstream (with the comment `# vllm 0.16.0 error message`). This runtime patch is a **bridge** that becomes a strict no-op the moment the `harbor>=0.3.0,<0.4.0` pin in `pyproject.toml` is bumped to a release containing it. That pin bump is a separate change and can delete this patch cleanly once it lands.

## Testing

```bash
uv run pytest tests/test_solvers/test_harbor_terminus_patches.py -q
# 36 passed
```

New `TestHarborLiteLLMContextLengthMatcher` covers the actual vLLM body attribute layout (message / body / plain str), continued support of the original OpenAI-style `"context length exceeded"` phrasing, non-matches on unrelated errors and near-miss phrasings, and patch idempotency. `TestCreateAgentGating` extended to assert the new patch fires on Terminus-2 and does not fire on non-Terminus-2 agents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “context length exceeded” error classification for Terminus-2 across different vLLM/LiteLLM error shapes and message fields.
  * Applied the enhancement safely during agent setup with idempotent one-time installation.
  * Added warning behavior when a related token-length drift is detected without a matching classifier phrase.
* **Tests**
  * Strengthened Harbor/Terminus-2 patch gating coverage to verify correct conditional installation.
  * Added matcher tests for multiple error representations, log assertions, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->