### PR TITLE
feat: add sandbox.scrub_git_history anti-cheat for SWE stateless evals

### DIFF
--- a/src/nemo_evaluator/config/sandboxes.py
+++ b/src/nemo_evaluator/config/sandboxes.py
@@ -47,6 +47,10 @@ class _SandboxBase(BaseModel):
     capture_cmd: str | None = None
     verify_timeout: float = 600.0
     stateful: bool = False
+    scrub_git_history: bool = False
+    """Run the git future-history scrub in the agent sandbox before the agent
+    starts (anti-cheat for SWE-style tasks whose gold fix / hidden tests live in
+    the repo's future commits). Only applies to StatelessSandbox tasks."""
 
     @model_validator(mode="after")
     def _warn_stateful_with_capture_cmd(self) -> "_SandboxBase":
@@ -54,6 +58,18 @@ class _SandboxBase(BaseModel):
             warnings.warn(
                 "sandbox.stateful=True ignores capture_cmd — the capture/transfer "
                 "workflow is skipped when stateful mode is enabled.",
+                UserWarning,
+                stacklevel=2,
+            )
+        return self
+
+    @model_validator(mode="after")
+    def _warn_stateful_with_scrub_git_history(self) -> "_SandboxBase":
+        if self.stateful and self.scrub_git_history:
+            warnings.warn(
+                "sandbox.stateful=True ignores scrub_git_history — the git-history "
+                "scrub only runs for StatelessSandbox tasks (solve and verify share "
+                "one container in stateful mode, so scrubbing could corrupt scoring).",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -347,6 +347,7 @@ async def run_evaluation(
                     config_capture_cmd=sandbox_cfg.capture_cmd if sandbox_cfg else None,
                     verify_timeout=sandbox_cfg.verify_timeout if sandbox_cfg else 600.0,
                     force_stateful=sandbox_cfg.stateful if sandbox_cfg else False,
+                    scrub_git_history=sandbox_cfg.scrub_git_history if sandbox_cfg else False,
                 )
 
                 try:

--- a/src/nemo_evaluator/environments/base.py
+++ b/src/nemo_evaluator/environments/base.py
@@ -36,6 +36,7 @@ class SeedResult:
     verify_sandbox_spec: SandboxSpec | None = None
     capture_cmd: str | None = None
     apply_cmd: str | None = None
+    pre_agent_cmd: str | None = None
 
 
 @dataclass

--- a/src/nemo_evaluator/sandbox/git_scrub.py
+++ b/src/nemo_evaluator/sandbox/git_scrub.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Git future-history scrub — anti-cheat pre-agent command for SWE-style evals.
+
+SWE-bench task images ship the repository with the *solution* present in the
+git history: the gold fix and hidden tests sit in commits that are descendants
+of the base commit. An agent can read them with ``git log --all`` /
+``git show <fix_sha>`` and copy the solution instead of solving the issue.
+
+:func:`build_git_history_scrub_cmd` returns a POSIX shell snippet, run once in
+the agent sandbox before the agent starts, that makes every commit which is not
+an ancestor of the base commit unreachable *and* physically deletes the objects
+(refs/tags/remotes/reflogs/packed-refs removed + ``git gc --prune=now``).
+
+The working tree is deliberately left untouched — SWE images carry env-patch
+edits and pre-built artifacts in the workdir, and verification runs in a fresh
+container with the agent's diff re-applied against the recorded base commit, so
+scrubbing the agent container's history cannot affect scoring.
+
+The snippet is self-enforcing: it emits a single ``NEL_GIT_CLEANUP`` audit line
+and exits non-zero if any non-ancestor commit survived, so a caller that only
+checks the return code still catches an incomplete scrub. Skip conditions
+(missing workdir, not a git repo, no HEAD) exit 0 — they are expected for
+non-git tasks and must not fail the rollout.
+"""
+
+from __future__ import annotations
+
+
+def build_git_history_scrub_cmd(workdir: str) -> str:
+    """Return the git-history scrub shell command for *workdir*.
+
+    ``workdir`` is the repository root inside the agent sandbox (the sandbox
+    spec's ``workdir``); it is trusted config, not model input.
+    """
+    return f"""
+_T0=$(date +%s 2>/dev/null || echo 0)
+if ! cd "{workdir}" 2>/dev/null; then echo "NEL_GIT_CLEANUP skipped reason=no_workdir wd={workdir}"; exit 0; fi
+git config --global --add safe.directory "{workdir}" 2>/dev/null
+if ! git rev-parse --git-dir >/dev/null 2>&1; then echo "NEL_GIT_CLEANUP skipped reason=not_a_git_repo wd={workdir}"; exit 0; fi
+_BASE=$(git rev-parse HEAD 2>/dev/null)
+if [ -z "$_BASE" ]; then echo "NEL_GIT_CLEANUP skipped reason=no_head wd={workdir}"; exit 0; fi
+_BEFORE=$(git rev-list --all --count 2>/dev/null || echo '?')
+mkdir -p .git/refs/heads
+echo "$_BASE" > .git/refs/heads/_nel_work
+git symbolic-ref HEAD refs/heads/_nel_work 2>/dev/null
+rm -f .git/packed-refs .git/ORIG_HEAD .git/FETCH_HEAD .git/MERGE_HEAD
+find .git/refs -type f ! -path '*/heads/_nel_work' -delete 2>/dev/null
+rm -rf .git/refs/tags .git/refs/remotes .git/logs
+for _r in $(git remote 2>/dev/null); do git remote remove "$_r" 2>/dev/null; done
+git reflog expire --expire=now --expire-unreachable=now --all 2>/dev/null
+git gc --prune=now --quiet 2>/dev/null
+_GC_RC=$?
+_AFTER=$(git rev-list --all --count 2>/dev/null || echo '?')
+_LEFT=$(git rev-list --all --not "$_BASE" --count 2>/dev/null || echo '?')
+_ELAPSED=$(( $(date +%s 2>/dev/null || echo 0) - _T0 ))
+echo "NEL_GIT_CLEANUP base=$_BASE commits_before=$_BEFORE commits_after=$_AFTER non_ancestor_left=$_LEFT gc_rc=$_GC_RC elapsed_s=$_ELAPSED"
+[ "$_LEFT" = 0 ] || exit 3
+""".strip()

--- a/src/nemo_evaluator/sandbox/strategies.py
+++ b/src/nemo_evaluator/sandbox/strategies.py
@@ -31,12 +31,38 @@ import logging
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol
 
+from nemo_evaluator.sandbox.git_scrub import build_git_history_scrub_cmd
+
 if TYPE_CHECKING:
     from nemo_evaluator.sandbox.base import OutsideEndpoint, Sandbox, SandboxSpec
     from nemo_evaluator.sandbox.manager import SandboxManager
     from nemo_evaluator.sandbox.transfer import WorkspaceTransfer
 
 logger = logging.getLogger(__name__)
+
+
+async def _run_pre_agent_cmd(sandbox: Sandbox, cmd: str) -> None:
+    """Run a pre-agent setup command in the agent sandbox, best-effort.
+
+    Failures are logged loudly but never raise: a broken setup step must not
+    abort the rollout. The command is expected to self-report via its exit
+    code (non-zero → failure) and to print its own audit line, so no
+    command-specific parsing lives here.
+    """
+    try:
+        result = await sandbox.exec(cmd, timeout_sec=900)
+        tail = (result.stdout or "").strip().splitlines()[-1:] or [""]
+        if result.return_code != 0:
+            logger.error(
+                "StatelessSandbox: pre_agent_cmd FAILED (rc=%d): %s | stderr=%s",
+                result.return_code,
+                tail[0][:500],
+                (result.stderr or "").strip()[:500],
+            )
+        else:
+            logger.info("StatelessSandbox: pre_agent_cmd OK — %s", tail[0][:500])
+    except Exception:
+        logger.error("StatelessSandbox: pre_agent_cmd errored", exc_info=True)
 
 
 # -- Context passed to lifecycle constructors --------------------------------
@@ -51,6 +77,7 @@ class LifecycleContext:
     apply_cmd: str | None
     verify_timeout: float = 600.0
     outside_endpoints: list[OutsideEndpoint] = field(default_factory=list)
+    pre_agent_cmd: str | None = None
 
 
 # -- Protocol ----------------------------------------------------------------
@@ -197,6 +224,8 @@ class StatelessSandbox:
             f"_h=$(cd {wd} 2>/dev/null && git rev-parse HEAD 2>/dev/null) && echo $_h > /tmp/_nel_base_commit || true",
             timeout_sec=10,
         )
+        if self._ctx.pre_agent_cmd:
+            await _run_pre_agent_cmd(self._agent_sandbox, self._ctx.pre_agent_cmd)
         return self._agent_sandbox
 
     async def transition_to_verify(
@@ -350,6 +379,7 @@ def pick_lifecycle(
     config_capture_cmd: str | None = None,
     verify_timeout: float = 600.0,
     force_stateful: bool = False,
+    scrub_git_history: bool = False,
 ) -> SandboxLifecycle:
     """Select the appropriate lifecycle strategy for *seed*.
 
@@ -371,6 +401,11 @@ def pick_lifecycle(
 
         transfer = sandbox_mgr.get_transfer_strategy()
 
+        if scrub_git_history and agent_spec is not None:
+            pre_agent_cmd = build_git_history_scrub_cmd(agent_spec.workdir)
+        else:
+            pre_agent_cmd = seed.pre_agent_cmd
+
         logger.debug("pick_lifecycle: selected StatelessSandbox")
         return StatelessSandbox(
             LifecycleContext(
@@ -381,6 +416,7 @@ def pick_lifecycle(
                 apply_cmd=seed.apply_cmd,
                 verify_timeout=verify_timeout,
                 outside_endpoints=eps,
+                pre_agent_cmd=pre_agent_cmd,
             ),
             transfer=transfer,
         )

--- a/tests/test_config/test_config_schema.py
+++ b/tests/test_config/test_config_schema.py
@@ -754,6 +754,40 @@ class TestStatefulSandboxFlag:
             )
         assert any("stateful" in str(w.message).lower() and issubclass(w.category, UserWarning) for w in caught)
 
+    def test_scrub_git_history_field_accepted_and_defaults_false(self):
+        """scrub_git_history parses and defaults off."""
+        from nemo_evaluator.config import EcsFargateSandbox
+
+        sb = EcsFargateSandbox(
+            type="ecs_fargate",
+            region="us-east-1",
+            ecr_repository="123.dkr.ecr.us-east-1.amazonaws.com/repo",
+        )
+        assert sb.scrub_git_history is False
+        sb2 = EcsFargateSandbox(
+            type="ecs_fargate",
+            region="us-east-1",
+            ecr_repository="123.dkr.ecr.us-east-1.amazonaws.com/repo",
+            scrub_git_history=True,
+        )
+        assert sb2.scrub_git_history is True
+
+    def test_stateful_with_scrub_git_history_warns(self):
+        """stateful=True alongside scrub_git_history emits a UserWarning — the
+        scrub is silently ignored in stateful mode."""
+        from nemo_evaluator.config import EcsFargateSandbox
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            EcsFargateSandbox(
+                type="ecs_fargate",
+                region="us-east-1",
+                ecr_repository="123.dkr.ecr.us-east-1.amazonaws.com/repo",
+                stateful=True,
+                scrub_git_history=True,
+            )
+        assert any("scrub_git_history" in str(w.message) and issubclass(w.category, UserWarning) for w in caught)
+
 
 class TestTerminalBenchPlaybook:
     def test_terminal_bench_playbook_loads(self):

--- a/tests/test_sandbox/test_git_scrub.py
+++ b/tests/test_sandbox/test_git_scrub.py
@@ -1,0 +1,143 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Behavioural tests for the git future-history scrub command builder.
+
+The builder returns a POSIX shell snippet run in the agent sandbox before the
+agent starts. These tests execute that snippet against real throwaway git
+repositories to prove the anti-cheat invariant: after the scrub, no commit that
+is not an ancestor of the base commit is reachable, and the future objects are
+physically gone. Skip cases (no repo / no HEAD) must exit 0.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from nemo_evaluator.sandbox.git_scrub import build_git_history_scrub_cmd
+
+
+def _git(cwd: Path, *args: str) -> str:
+    env = {
+        "GIT_AUTHOR_NAME": "t",
+        "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t",
+        "GIT_COMMITTER_EMAIL": "t@t",
+        "HOME": str(cwd),
+        "PATH": "/usr/bin:/bin:/usr/local/bin",
+    }
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _run_scrub(wd: Path):
+    return subprocess.run(
+        ["/bin/sh", "-c", build_git_history_scrub_cmd(str(wd))],
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_repo_with_future(tmp_path: Path) -> tuple[Path, str, str]:
+    """Repo whose HEAD is left at the *base* commit while a 'gold' fix commit
+    plus a hidden-tests tag live in the future history (reachable via
+    other refs), mimicking a SWE-bench task image."""
+    wd = tmp_path / "repo"
+    wd.mkdir()
+    _git(wd, "init", "-q")
+    (wd / "a.txt").write_text("base\n")
+    _git(wd, "add", "-A")
+    _git(wd, "commit", "-qm", "base")
+    base = _git(wd, "rev-parse", "HEAD")
+    (wd / "a.txt").write_text("fixed\n")
+    _git(wd, "add", "-A")
+    _git(wd, "commit", "-qm", "gold fix + hidden tests")
+    gold = _git(wd, "rev-parse", "HEAD")
+    _git(wd, "tag", "gold-fix")
+    _git(wd, "branch", "future")
+    # Leave the working tree checked out at base, as the task image would.
+    _git(wd, "checkout", "-q", base)
+    return wd, base, gold
+
+
+@pytest.mark.skipif(
+    subprocess.run(["which", "git"], capture_output=True).returncode != 0,
+    reason="git not available",
+)
+class TestGitHistoryScrub:
+    def test_future_commit_becomes_unreachable_and_deleted(self, tmp_path: Path):
+        wd, base, gold = _make_repo_with_future(tmp_path)
+
+        result = _run_scrub(wd)
+
+        assert result.returncode == 0, result.stderr
+        assert "NEL_GIT_CLEANUP" in result.stdout
+        assert "non_ancestor_left=0" in result.stdout
+        # git log --all must no longer reveal the gold fix.
+        log_all = _git(wd, "log", "--all", "--oneline")
+        assert gold[:8] not in log_all
+        assert "gold fix" not in log_all
+        # git show <gold_sha> must fail — object physically pruned.
+        shown = subprocess.run(
+            ["git", "-C", str(wd), "cat-file", "-e", gold],
+            capture_output=True,
+        )
+        assert shown.returncode != 0
+        # base history is intact.
+        assert _git(wd, "rev-parse", "HEAD") == base
+
+    def test_invariant_enforced_via_exit_code(self, tmp_path: Path):
+        """The snippet self-enforces: a generic runner that only checks the
+        exit code must see success (0) once the scrub completes cleanly."""
+        wd, _base, _gold = _make_repo_with_future(tmp_path)
+        assert _run_scrub(wd).returncode == 0
+
+    def test_workdir_with_space_does_not_fail_open(self, tmp_path: Path):
+        """A workdir path containing a space must still scrub — cd/safe.directory
+        are quoted, so it must not silently hit the no_workdir skip (fail-open)."""
+        spaced = tmp_path / "dir with space"
+        spaced.mkdir()
+        wd, _base, gold = _make_repo_with_future(spaced)
+        assert " " in str(wd)
+
+        result = _run_scrub(wd)
+
+        assert result.returncode == 0, result.stderr
+        assert "skipped" not in result.stdout  # did NOT fail open to no_workdir
+        assert "non_ancestor_left=0" in result.stdout
+        shown = subprocess.run(["git", "-C", str(wd), "cat-file", "-e", gold], capture_output=True)
+        assert shown.returncode != 0
+
+    def test_skips_non_git_dir_without_error(self, tmp_path: Path):
+        wd = tmp_path / "plain"
+        wd.mkdir()
+        result = _run_scrub(wd)
+        assert result.returncode == 0
+        assert "skipped" in result.stdout
+        assert "not_a_git_repo" in result.stdout
+
+    def test_skips_missing_workdir_without_error(self, tmp_path: Path):
+        result = _run_scrub(tmp_path / "does-not-exist")
+        assert result.returncode == 0
+        assert "skipped" in result.stdout
+        assert "no_workdir" in result.stdout

--- a/tests/test_sandbox/test_sandbox_lifecycle.py
+++ b/tests/test_sandbox/test_sandbox_lifecycle.py
@@ -118,7 +118,7 @@ class TestStatefulSandbox:
 
 
 class TestStatelessSandbox:
-    def _make_ctx(self, mgr=None, capture_cmd=None, apply_cmd=None):
+    def _make_ctx(self, mgr=None, capture_cmd=None, apply_cmd=None, pre_agent_cmd=None):
         mgr = mgr or MockSandboxManager()
         return LifecycleContext(
             sandbox_mgr=mgr,
@@ -126,6 +126,7 @@ class TestStatelessSandbox:
             verify_spec=SandboxSpec(image="verify:latest"),
             capture_cmd=capture_cmd,
             apply_cmd=apply_cmd,
+            pre_agent_cmd=pre_agent_cmd,
         ), mgr
 
     @pytest.mark.asyncio
@@ -170,6 +171,48 @@ class TestStatelessSandbox:
         verify_sb = await lc.get_verify_sandbox()
 
         assert any("git apply" in cmd for cmd in verify_sb._exec_log)
+        await lc.teardown()
+
+    @pytest.mark.asyncio
+    async def test_pre_agent_cmd_executed_after_acquire(self):
+        """pre_agent_cmd runs in the agent container before the agent starts."""
+        ctx, mgr = self._make_ctx(pre_agent_cmd="NEL_SCRUB_MARKER cleanup")
+        transfer = HostVolumeTransfer()
+        lc = StatelessSandbox(ctx, transfer)
+
+        await lc.setup()
+        agent_sb = await lc.get_agent_sandbox()
+
+        assert any("NEL_SCRUB_MARKER" in cmd for cmd in agent_sb._exec_log)
+        await lc.teardown()
+
+    @pytest.mark.asyncio
+    async def test_no_pre_agent_cmd_runs_nothing_extra(self):
+        """Without pre_agent_cmd, no scrub-like command is executed."""
+        ctx, mgr = self._make_ctx(pre_agent_cmd=None)
+        transfer = HostVolumeTransfer()
+        lc = StatelessSandbox(ctx, transfer)
+
+        await lc.setup()
+        agent_sb = await lc.get_agent_sandbox()
+
+        assert not any("NEL_GIT_CLEANUP" in cmd for cmd in agent_sb._exec_log)
+        await lc.teardown()
+
+    @pytest.mark.asyncio
+    async def test_pre_agent_cmd_failure_does_not_abort_rollout(self):
+        """A non-zero pre_agent_cmd is logged but must not raise."""
+        from tests.conftest import MockExecResult
+
+        mgr = MockSandboxManager(exec_results={"NEL_GIT_CLEANUP": MockExecResult(return_code=3)})
+        ctx, mgr = self._make_ctx(mgr=mgr, pre_agent_cmd="echo NEL_GIT_CLEANUP; exit 3")
+        transfer = HostVolumeTransfer()
+        lc = StatelessSandbox(ctx, transfer)
+
+        await lc.setup()
+        agent_sb = await lc.get_agent_sandbox()  # must not raise
+
+        assert agent_sb is not None
         await lc.teardown()
 
     @pytest.mark.asyncio
@@ -254,3 +297,38 @@ class TestPickLifecycle:
         mgr = MockSandboxManager()
         lc = pick_lifecycle(seed, sandbox_mgr=mgr, force_stateful=False)
         assert isinstance(lc, StatelessSandbox)
+
+    def test_scrub_git_history_injects_pre_agent_cmd(self):
+        """scrub_git_history=True builds the git-scrub command against the
+        resolved agent workdir and attaches it as the context pre_agent_cmd."""
+        seed = _make_seed(
+            sandbox_spec=SandboxSpec(image="agent:latest", workdir="/testbed"),
+            verify_sandbox_spec=SandboxSpec(image="verify:latest", workdir="/testbed"),
+        )
+        mgr = MockSandboxManager()
+        lc = pick_lifecycle(seed, sandbox_mgr=mgr, scrub_git_history=True)
+        assert isinstance(lc, StatelessSandbox)
+        assert "NEL_GIT_CLEANUP" in lc._ctx.pre_agent_cmd
+        assert "/testbed" in lc._ctx.pre_agent_cmd
+
+    def test_scrub_git_history_default_off(self):
+        """Without the flag, no pre_agent_cmd is injected (seed default wins)."""
+        seed = _make_seed(
+            sandbox_spec=SandboxSpec(image="agent:latest", workdir="/testbed"),
+            verify_sandbox_spec=SandboxSpec(image="verify:latest", workdir="/testbed"),
+        )
+        mgr = MockSandboxManager()
+        lc = pick_lifecycle(seed, sandbox_mgr=mgr)
+        assert isinstance(lc, StatelessSandbox)
+        assert lc._ctx.pre_agent_cmd is None
+
+    def test_seed_pre_agent_cmd_used_when_flag_off(self):
+        """An environment-supplied seed.pre_agent_cmd is honoured verbatim."""
+        seed = _make_seed(
+            sandbox_spec=SandboxSpec(image="agent:latest", workdir="/testbed"),
+            verify_sandbox_spec=SandboxSpec(image="verify:latest", workdir="/testbed"),
+            pre_agent_cmd="echo custom-setup",
+        )
+        mgr = MockSandboxManager()
+        lc = pick_lifecycle(seed, sandbox_mgr=mgr)
+        assert lc._ctx.pre_agent_cmd == "echo custom-setup"


### PR DESCRIPTION
## Summary
SWE-bench-style task images ship the repository with the gold fix and hidden tests present in the git history (as commits descending from the base commit). An agent can read them with `git log --all` / `git show <sha>` and copy the solution instead of solving the issue. This adds a config-toggled anti-cheat that scrubs the repo's future git history in the agent sandbox before the agent starts.

## How it works
- New sandbox config field `scrub_git_history` (default off).
- New module `sandbox/git_scrub.py`: `build_git_history_scrub_cmd(workdir)` returns a self-enforcing shell snippet that makes every non-ancestor commit unreachable, physically prunes the objects, emits a single `NEL_GIT_CLEANUP` audit line, and exits non-zero if any non-ancestor commit survived.
- Generic `SeedResult.pre_agent_cmd` / `LifecycleContext.pre_agent_cmd` seam: `StatelessSandbox` runs it in the agent container after acquire, best-effort (a broken step never aborts the rollout). Mirrors the existing `capture_cmd` / `apply_cmd` threading.
- `pick_lifecycle` builds the scrub command from the resolved agent workdir when the flag is set; otherwise honors an env-supplied `seed.pre_agent_cmd`.
- **StatelessSandbox only.** In stateful mode solve and verify share one container, so scrubbing could corrupt scoring; setting `stateful: true` together with `scrub_git_history: true` emits a warning and skips the scrub. The working tree is left untouched and verification runs in a fresh container, so scoring is unaffected.

## Usage
```yaml
benchmarks:
  - name: harbor://swebench_multilingual@1.0   # any harbor SWE benchmark
    sandbox:
      type: ecs_fargate
      scrub_git_history: true   # StatelessSandbox only
```
Note: `scrub_git_history` is validated at submit time (the sandbox config model is `extra="forbid"`), so the `nel` that submits the run must include this change in addition to the eval image.

## Testing
- `pytest tests/ -m "not network"` — new `test_git_scrub.py` runs the scrub against throwaway git repos and asserts the future commit becomes unreachable (`git log --all`) and is physically pruned (`git cat-file -e` fails), and that skip-cases (missing workdir / not a git repo / no HEAD) exit 0; lifecycle tests assert the command runs when flagged, is absent otherwise, and a non-zero scrub does not abort the rollout; a config test asserts that `stateful` + `scrub_git_history` warns.
- Validated end-to-end on a SWE-bench Multilingual oracle run: every rollout logged the scrub audit marker with `non_ancestor_left=0`, and grading was unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional sandbox setting to scrub Git “future history” before agent execution for supported stateless tasks.
  * Added support for a pre-agent command in sandbox lifecycles, including automatic Git history cleanup when enabled.
* **Bug Fixes**
  * Emit a warning when history cleanup is enabled in a mode where it’s ignored.
  * Improved failure behavior so pre-agent cleanup commands fail safely without aborting execution.
* **Tests**
  * Added integration-style coverage for Git history scrubbing, including skip behavior and paths with spaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->