### PR TITLE
fix(triviaqa): update dataset loading path to use correct repository

### DIFF
--- a/src/nemo_evaluator/benchmarks/triviaqa.py
+++ b/src/nemo_evaluator/benchmarks/triviaqa.py
@@ -30,7 +30,7 @@ def _prepare(row, idx, rng):
 def _load_triviaqa():
     from datasets import load_dataset
 
-    ds = load_dataset("trivia_qa", "rc.nocontext", split="validation")
+    ds = load_dataset("mandarjoshi/trivia_qa", "rc.nocontext", split="validation")
     return [dict(row) for row in ds]
 
 


### PR DESCRIPTION
## Summary
Fix TriviaQA dataset loading by switching from the legacy dataset identifier to the current namespaced Hugging Face repository ID.

## Problem
The loader currently uses `load_dataset("trivia_qa", ...)`. Hugging Face Hub now enforces `namespace/name` repository IDs, so this fails with repository ID validation errors.

## Change
- Update dataset ID from `trivia_qa` to `mandarjoshi/trivia_qa`.

## Impact
- Restores TriviaQA data loading without changing evaluator semantics.
- Keeps existing seeding and verification behavior intact.

## Validation
- Verified dataset streaming and row access using `mandarjoshi/trivia_qa`.
- Verified expected fields remain compatible with current loader logic.
- Run standard checks:
  - `make test`
  - `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated TriviaQA benchmark loading to use a more reliable dataset source, helping ensure the benchmark loads correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->