### PR TITLE
fix(healthbench): update dataset loading URL to correct path

### DIFF
--- a/src/nemo_evaluator/benchmarks/healthbench.py
+++ b/src/nemo_evaluator/benchmarks/healthbench.py
@@ -31,7 +31,7 @@ def _load_healthbench():
     except Exception:
         pass
 
-    url = "https://huggingface.co/datasets/openai/HealthBench/resolve/main/data/test.jsonl"
+    url = "https://huggingface.co/datasets/openai/HealthBench/resolve/main/2025-05-07-06-14-12_oss_eval.jsonl"
     with urllib.request.urlopen(url, timeout=60) as resp:
         text = resp.read().decode()
     rows = [_json.loads(line) for line in text.strip().splitlines() if line.strip()]

--- a/src/nemo_evaluator/benchmarks/triviaqa.py
+++ b/src/nemo_evaluator/benchmarks/triviaqa.py
@@ -30,7 +30,7 @@ def _prepare(row, idx, rng):
 def _load_triviaqa():
     from datasets import load_dataset
 
-    ds = load_dataset("trivia_qa", "rc.nocontext", split="validation")
+    ds = load_dataset("mandarjoshi/trivia_qa", "rc.nocontext", split="validation")
     return [dict(row) for row in ds]
 
 


### PR DESCRIPTION
## Summary
Fix HealthBench ingestion by pointing the fallback data fetch to the valid JSONL artifact in the Hugging Face repository.

## Problem
HealthBench loading fails because:
- The configured `split="test"` path does not resolve for this dataset layout.
- The fallback URL points to `data/test.jsonl`, which is not present in the repo.

## Change
- Update fallback path to `resolve/main/2025-05-07-06-14-12_oss_eval.jsonl`.

## Impact
- Restores HealthBench fallback ingestion.
- Maintains existing seeding expectations (`prompt` messages and `rubrics`) without changing scoring behavior.

## Validation
- Verified the referenced JSONL exists and is readable.
- Verified row shape matches current seeder expectations.
- Run standard checks:
  - `make test`
  - `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated benchmark data sources for HealthBench and TriviaQA to use current, more reliable dataset locations.
  * Improved benchmark loading consistency so evaluation runs can fetch the expected test and validation data without changing scoring behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->