### PR TITLE
fix(xstest): update CSV URL and rename ID field for consistency

### DIFF
--- a/src/nemo_evaluator/benchmarks/healthbench.py
+++ b/src/nemo_evaluator/benchmarks/healthbench.py
@@ -31,7 +31,7 @@ def _load_healthbench():
     except Exception:
         pass
 
-    url = "https://huggingface.co/datasets/openai/HealthBench/resolve/main/data/test.jsonl"
+    url = "https://huggingface.co/datasets/openai/HealthBench/resolve/main/2025-05-07-06-14-12_oss_eval.jsonl"
     with urllib.request.urlopen(url, timeout=60) as resp:
         text = resp.read().decode()
     rows = [_json.loads(line) for line in text.strip().splitlines() if line.strip()]

--- a/src/nemo_evaluator/benchmarks/triviaqa.py
+++ b/src/nemo_evaluator/benchmarks/triviaqa.py
@@ -30,7 +30,7 @@ def _prepare(row, idx, rng):
 def _load_triviaqa():
     from datasets import load_dataset
 
-    ds = load_dataset("trivia_qa", "rc.nocontext", split="validation")
+    ds = load_dataset("mandarjoshi/trivia_qa", "rc.nocontext", split="validation")
     return [dict(row) for row in ds]
 
 

--- a/src/nemo_evaluator/benchmarks/xstest.py
+++ b/src/nemo_evaluator/benchmarks/xstest.py
@@ -34,7 +34,7 @@ import urllib.request
 from nemo_evaluator.environments.custom import benchmark, scorer
 from nemo_evaluator.scoring import ScorerInput
 
-_XSTEST_CSV_URL = "https://raw.githubusercontent.com/paul-rottger/exaggerated-safety/main/xstest_v2_prompts.csv"
+_XSTEST_CSV_URL = "https://raw.githubusercontent.com/paul-rottger/exaggerated-safety/main/xstest_prompts.csv"
 
 _REFUSAL_PREFIXES = (
     "sorry",
@@ -70,7 +70,7 @@ def _load_xstest(**kwargs) -> list[dict]:
             "prompt": row["prompt"],
             "label": row["label"],
             "type": row["type"],
-            "id": int(row["id_v2"]),
+            "id": int(row["id"]),
             "focus": row.get("focus", ""),
             "note": row.get("note", ""),
         }


### PR DESCRIPTION
## Summary
Fix XSTest loading after upstream dataset reorganization by updating both the CSV filename and the row ID column key.

## Problem
The upstream dataset changed in two ways:
- File renamed from `xstest_v2_prompts.csv` to `xstest_prompts.csv`.
- Column renamed from `id_v2` to `id`.

Fixing only the file path still leaves a parser failure on the missing `id_v2` column.

## Change
- Replace `xstest_v2_prompts.csv` with `xstest_prompts.csv`.
- Replace `int(row["id_v2"])` with `int(row["id"])`.

## Impact
- Restores full XSTest ingestion.
- Preserves prompt content and safe/unsafe label handling.

## Validation
- Verified CSV loads successfully from the new path.
- Verified parser completes with the updated `id` column.
- Run standard checks:
  - `make test`
  - `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated benchmark data sources so HealthBench, TriviaQA, and XSTest load the correct latest published datasets.
  * Improved XSTest prompt parsing to match the current dataset format, helping evaluation run more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->