### PR TITLE
fix(xstest): update CSV URL and rename ID field for consistency

### DIFF
--- a/src/nemo_evaluator/benchmarks/xstest.py
+++ b/src/nemo_evaluator/benchmarks/xstest.py
@@ -34,7 +34,7 @@ import urllib.request
 from nemo_evaluator.environments.custom import benchmark, scorer
 from nemo_evaluator.scoring import ScorerInput
 
-_XSTEST_CSV_URL = "https://raw.githubusercontent.com/paul-rottger/exaggerated-safety/main/xstest_v2_prompts.csv"
+_XSTEST_CSV_URL = "https://raw.githubusercontent.com/paul-rottger/exaggerated-safety/main/xstest_prompts.csv"
 
 _REFUSAL_PREFIXES = (
     "sorry",
@@ -70,7 +70,7 @@ def _load_xstest(**kwargs) -> list[dict]:
             "prompt": row["prompt"],
             "label": row["label"],
             "type": row["type"],
-            "id": int(row["id_v2"]),
+            "id": int(row["id"]),
             "focus": row.get("focus", ""),
             "note": row.get("note", ""),
         }


### PR DESCRIPTION
## Problem
The upstream dataset changed in two ways:
- File renamed from `xstest_v2_prompts.csv` to `xstest_prompts.csv`.
- Column renamed from `id_v2` to `id`.

Fixing only the file path still leaves a parser failure on the missing `id_v2` column.

## Change
- Replace `xstest_v2_prompts.csv` with `xstest_prompts.csv`.
- Replace `int(row["id_v2"])` with `int(row["id"])`.

## Impact
- Restores full XSTest ingestion.
- Preserves prompt content and safe/unsafe label handling.

## Validation
- Verified CSV loads successfully from the new path.
- Verified parser completes with the updated `id` column.
- Run standard checks:
  - `make test`
  - `make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default benchmark prompt source to a newer CSV, improving the accuracy of loaded prompts.
  * Fixed row parsing to use the correct prompt ID field, helping benchmark records normalize correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->