### PR TITLE
fix: use available HealthBench fallback dataset

### DIFF
--- a/src/nemo_evaluator/benchmarks/healthbench.py
+++ b/src/nemo_evaluator/benchmarks/healthbench.py
@@ -31,7 +31,7 @@ def _load_healthbench():
     except Exception:
         pass
 
-    url = "https://huggingface.co/datasets/openai/HealthBench/resolve/main/data/test.jsonl"
+    url = "https://huggingface.co/datasets/openai/HealthBench/resolve/main/2025-05-07-06-14-12_oss_eval.jsonl"
     with urllib.request.urlopen(url, timeout=60) as resp:
         text = resp.read().decode()
     rows = [_json.loads(line) for line in text.strip().splitlines() if line.strip()]

--- a/tests/test_scoring/test_benchmark_definitions.py
+++ b/tests/test_scoring/test_benchmark_definitions.py
@@ -14,6 +14,11 @@
 # limitations under the License.
 """Golden tests: verify benchmark scorers produce correct results on known data."""
 
+import importlib
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
 from nemo_evaluator.scoring import (
     ScorerInput,
     answer_line,
@@ -143,3 +148,41 @@ class TestBenchmarkScorerImport:
 
         s = ScorerInput(response="The result is 15", target="15")
         assert mgsm_scorer(s)["correct"] is True
+
+
+def test_healthbench_fallback_uses_available_evaluation_file(monkeypatch):
+    benchmark_package = ModuleType("nemo_evaluator.benchmarks")
+    benchmark_package.__path__ = [str(Path(__file__).parents[2] / "src" / "nemo_evaluator" / "benchmarks")]
+    monkeypatch.setitem(sys.modules, "nemo_evaluator.benchmarks", benchmark_package)
+    monkeypatch.delitem(sys.modules, "nemo_evaluator.benchmarks.healthbench", raising=False)
+    healthbench = importlib.import_module("nemo_evaluator.benchmarks.healthbench")
+
+    def fail_dataset_load(*args, **kwargs):
+        raise FileNotFoundError("test split unavailable")
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return b'{"prompt": [{"role": "user", "content": "Question"}]}\n'
+
+    requested = {}
+
+    def fake_urlopen(url, timeout):
+        requested.update(url=url, timeout=timeout)
+        return Response()
+
+    monkeypatch.setitem(sys.modules, "datasets", SimpleNamespace(load_dataset=fail_dataset_load))
+    monkeypatch.setattr("urllib.request.urlopen", fake_urlopen)
+
+    rows = healthbench._load_healthbench()
+
+    assert requested == {
+        "url": ("https://huggingface.co/datasets/openai/HealthBench/resolve/main/2025-05-07-06-14-12_oss_eval.jsonl"),
+        "timeout": 60,
+    }
+    assert rows == [{"prompt": [{"role": "user", "content": "Question"}]}]


### PR DESCRIPTION
## What changed

- update the HealthBench fallback URL to the available `2025-05-07-06-14-12_oss_eval.jsonl` dataset file
- add an offline regression test that forces the primary loader to fail and verifies the fallback URL, timeout, and JSONL parsing

## Why

The configured `test` split can be unavailable, and the previous fallback pointed to `data/test.jsonl`, which does not exist and returned HTTP 404. The fallback now resolves to the published evaluation file.

## Validation

- focused fallback test passes
- `ruff check` passes for both modified files
- `ruff format --check` passes for both modified files
- the required full offline suite collected 415 tests but is blocked on Windows during collection by the existing Unix-only `fcntl` import in `engine/checkpoint.py`

Closes #1109