### PR TITLE
fix(observability): demote empty final response to observational flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,7 +86,6 @@ Before committing, always:
 1. **Lint**: Run linter checks on all modified files. Fix any errors you introduced. Do not fix pre-existing lints unless they are in code you modified.
 2. **Test**: Run `python -m pytest tests/ -v --tb=short -m "not network" -x`. All tests must pass. If a test fails because of your change, fix it. If a test fails for an unrelated reason, note it but do not silently skip it.
 3. **Verify imports**: If you moved or renamed a module, grep for the old import path across the entire repo. Update all references.
-4. **CHANGELOG**: For user-visible changes, add an entry under the current version in `CHANGELOG.md`.
 
 Only after all checks pass, create the commit.
 

--- a/docs/deployment-patterns.mdx
+++ b/docs/deployment-patterns.mdx
@@ -330,7 +330,7 @@ Every evaluation run (all patterns) produces:
 | `results.jsonl` | Per-sample: problem_idx, repeat, reward, extracted answer, tokens, latency |
 | `trajectories.jsonl` | Per-step: full prompt, model response, token breakdown (prompt/completion/reasoning), latency breakdown (seed/model/verify ms), scoring method + details, SHA256 request hash, failure category |
 | `runtime_stats.json` | Latency percentiles (p50/p90/p99), token throughput, finish reason distribution, error count |
-| `failure_analysis.json` | Categorized failures (refusal, format_error, timeout, rate_limit, empty_response) with counts, percentages, exemplars |
+| `failure_analysis.json` | Categorized failures (refusal, format_error, timeout, rate_limit) with counts, percentages, exemplars |
 | `regression.json` | Score deltas, CI overlap, per-category and runtime deltas (when comparing two runs) |
 
 ---

--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -32,7 +32,11 @@ from nemo_evaluator.engine.step_log import (
     MODEL_TRAFFIC_LOG,
     VERIFIED_LOG,
     StepLog,
+    clear_capture_marker,
     config_hash,
+    has_capture_marker,
+    reset_checkpoint_sidecars,
+    write_capture_marker,
 )
 from nemo_evaluator.environments.base import EvalEnvironment, VerifyResult
 from nemo_evaluator.errors import GracefulError, InfraError
@@ -190,6 +194,7 @@ async def run_evaluation(
                 if verified_cache:
                     verified_log.compact(verified_cache)
                 verified_log.open()
+                reset_checkpoint_sidecars(step_log_dir)
                 inference_log.open(truncate=True)
                 model_traffic_log.open(truncate=True)
                 inference_log.write_meta({"config_hash": cfg_hash})
@@ -201,6 +206,16 @@ async def run_evaluation(
                 inferred_cache = {k: v for k, v in inferred_cache_raw.items() if k not in infra_keys}
                 if infra_keys:
                     logger.info("resume: %d infra-error entries will be retried", len(infra_keys))
+                infra_inferred = {
+                    k
+                    for k, v in inferred_cache.items()
+                    if k not in verified_cache and v.get("error_kind") == ErrorKind.INFRA.value
+                }
+                inferred_cache = {k: v for k, v in inferred_cache.items() if k not in infra_inferred}
+                if infra_inferred:
+                    logger.info(
+                        "resume: %d unverified infra-error inference entries will be re-solved", len(infra_inferred)
+                    )
                 if inferred_cache:
                     meta = old_meta or {"config_hash": cfg_hash}
                     inference_log.compact(inferred_cache, meta=meta)
@@ -215,6 +230,7 @@ async def run_evaluation(
             if n_from_cache or n_verify_only:
                 logger.info("resume: %d fully cached, %d verify-only, rest from scratch", n_from_cache, n_verify_only)
         else:
+            reset_checkpoint_sidecars(step_log_dir)
             inference_log.open(truncate=True)
             inference_log.write_meta({"config_hash": cfg_hash})
             verified_log.open(truncate=True)
@@ -292,8 +308,9 @@ async def run_evaluation(
                 )
                 cached_inf = inferred_cache.get(key)
                 if cached_inf:
-                    if cached_inf.get("trajectory"):
-                        cached_step.trajectory = cached_inf["trajectory"]
+                    cached_traj = inference_log.resolve_trajectory(cached_inf)
+                    if cached_traj:
+                        cached_step.trajectory = cached_traj
                     cached_step.model_response = ModelResponse(
                         content=cached_inf.get("response", ""),
                         model=cached_inf.get("model", ""),
@@ -340,6 +357,9 @@ async def run_evaluation(
                 step.model_error = None
                 vr = None
                 _is_solve_timeout = False
+                _is_infra = False
+                _resume_capture_missing = False
+                _cached_solve_scoring_details: dict[str, Any] = {}
 
                 outside_eps: list[OutsideEndpoint] = []
                 step_session_id = uuid4().hex[:16] if model_url else None
@@ -368,12 +388,21 @@ async def run_evaluation(
                         response_text = cached_inferred.get("response", "")
                         tokens = cached_inferred.get("tokens", 0)
                         latency_ms = cached_inferred.get("latency_ms", 0)
-                        if cached_inferred.get("trajectory"):
-                            step.trajectory = cached_inferred["trajectory"]
+                        cached_traj = inference_log.resolve_trajectory(cached_inferred)
+                        if cached_traj:
+                            step.trajectory = cached_traj
+                        step.model_error = cached_inferred.get("error") or None
+                        cached_error_kind = cached_inferred.get("error_kind")
+                        _is_solve_timeout = cached_error_kind == ErrorKind.SOLVE_TIMEOUT.value
+                        _is_infra = cached_error_kind == ErrorKind.INFRA.value
+                        _cached_solve_scoring_details = cached_inferred.get("solve_scoring_details") or {}
+                        if step.model_error:
+                            logger.warning(
+                                "resume p%d r%d: replaying cached solve failure: %s", idx, rep, step.model_error
+                            )
                         logger.debug("resume p%d r%d: using cached inference", idx, rep)
                     else:
                         pg.on_phase(slot, rep, n_problems, n_repeats, "solving")
-                        _is_infra = False
                         try:
                             if _solver_accepts_sandbox(solver):
                                 sandbox = await lifecycle.get_agent_sandbox()
@@ -431,6 +460,10 @@ async def run_evaluation(
 
                         if inference_log is not None:
                             mr = solve_result.model_response if solve_result else None
+                            if solve_result:
+                                error_kind = solve_result.error_kind.value
+                            else:
+                                error_kind = ErrorKind.GRACEFUL.value if step.model_error else ErrorKind.NONE.value
                             inf_record = {
                                 "problem_idx": idx,
                                 "repeat": rep,
@@ -446,13 +479,34 @@ async def run_evaluation(
                                 "expected_answer": seed_result.expected_answer,
                                 "seed_metadata": seed_result.metadata,
                                 "trajectory": solve_result.trajectory if solve_result else None,
+                                "error": step.model_error,
+                                "error_kind": error_kind,
+                                "sandbox_used": sandbox is not None,
                             }
+                            if solve_result and solve_result.scoring_details:
+                                inf_record["solve_scoring_details"] = solve_result.scoring_details
                             if model_stats is not None:
                                 inf_record["model_stats"] = model_stats
+                            if step_log_dir is not None:
+                                clear_capture_marker(step_log_dir, idx, rep)
                             await inference_log.append(inf_record)
 
                     # ── Verify ───────────────────────────────────────
                     _solve_failed = step.model_error is not None
+                    if (
+                        cached_inferred is not None
+                        and not _solve_failed
+                        and cached_inferred.get("sandbox_used")
+                        and step_log_dir is not None
+                        and not has_capture_marker(step_log_dir, idx, rep)
+                    ):
+                        logger.warning(
+                            "resume p%d r%d: no workspace capture marker — the previous run may have died "
+                            "before capturing the agent workspace; verify may see an unmodified workspace",
+                            idx,
+                            rep,
+                        )
+                        _resume_capture_missing = True
                     if _solve_failed:
                         error_cat = _solve_failed_error_category(
                             step.model_error or "",
@@ -477,6 +531,12 @@ async def run_evaluation(
                             response_text,
                             solver_modified=(sandbox is not None),
                         )
+                        if (
+                            step_log_dir is not None
+                            and sandbox is not None
+                            and getattr(lifecycle, "captures_workspace", False)
+                        ):
+                            write_capture_marker(step_log_dir, idx, rep)
                         pg.on_phase(slot, rep, n_problems, n_repeats, "verifying")
                     tv = time.monotonic()
                     if not _solve_failed and solve_result and solve_result.reward is not None:
@@ -598,12 +658,15 @@ async def run_evaluation(
                 step.reward = vr.reward
                 step.extracted_answer = vr.extracted_answer
                 step.scoring_details = vr.scoring_details
-                if solve_result and solve_result.scoring_details:
-                    for detail_key, detail_value in solve_result.scoring_details.items():
+                solve_sd = solve_result.scoring_details if solve_result else _cached_solve_scoring_details
+                if solve_sd:
+                    for detail_key, detail_value in solve_sd.items():
                         step.scoring_details.setdefault(detail_key, detail_value)
                 step.scoring_method = vr.scoring_details.get("method", "")
                 if _is_solve_timeout and not step.scoring_details.get("error_category"):
                     step.scoring_details["error_category"] = "solve_timeout"
+                if _resume_capture_missing:
+                    step.scoring_details["resume_workspace_capture"] = "missing"
 
                 extra_scorers = (config or {}).get("scorers", [])
                 if extra_scorers:

--- a/src/nemo_evaluator/engine/step_log.py
+++ b/src/nemo_evaluator/engine/step_log.py
@@ -25,10 +25,12 @@ pairs can be skipped or need only partial re-execution.
 from __future__ import annotations
 
 import asyncio
+import gzip
 import hashlib
 import json
 import logging
 import os
+import shutil
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +41,8 @@ MODEL_TRAFFIC_LOG = "model_traffic.jsonl"
 VERIFIED_LOG = "verified_log.jsonl"
 META_TYPE = "meta"
 MAX_TRAJECTORY_BYTES = 5 * 1024 * 1024
+TRAJECTORY_OVERFLOW_DIR = "trajectory_overflow"
+CAPTURE_MARKER_DIR = "capture_markers"
 
 
 def config_hash(config: dict[str, Any]) -> str:
@@ -58,6 +62,52 @@ def config_hash(config: dict[str, Any]) -> str:
     return f"sha256:{hashlib.sha256(raw.encode()).hexdigest()}"
 
 
+def _env_trajectory_cap() -> int:
+    raw = os.environ.get("NEL_MAX_TRAJECTORY_BYTES")
+    if not raw:
+        return MAX_TRAJECTORY_BYTES
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("step_log: invalid NEL_MAX_TRAJECTORY_BYTES=%r, using default %d", raw, MAX_TRAJECTORY_BYTES)
+        return MAX_TRAJECTORY_BYTES
+
+
+def _capture_marker_path(step_log_dir: Path, problem_idx: int, repeat: int) -> Path:
+    return Path(step_log_dir) / CAPTURE_MARKER_DIR / f"p{problem_idx}_r{repeat}.captured"
+
+
+def write_capture_marker(step_log_dir: Path, problem_idx: int, repeat: int) -> None:
+    """Record that transition_to_verify completed for a workspace-capturing lifecycle.
+
+    Best-effort: a marker write failure must never abort the rollout.
+    """
+    try:
+        marker = _capture_marker_path(step_log_dir, problem_idx, repeat)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        marker.touch()
+    except OSError:
+        logger.debug("step_log: failed to write capture marker p%d r%d", problem_idx, repeat, exc_info=True)
+
+
+def clear_capture_marker(step_log_dir: Path, problem_idx: int, repeat: int) -> None:
+    """Invalidate a marker from an earlier attempt so it cannot outlive a newer inference record."""
+    try:
+        _capture_marker_path(step_log_dir, problem_idx, repeat).unlink(missing_ok=True)
+    except OSError:
+        logger.debug("step_log: failed to clear capture marker p%d r%d", problem_idx, repeat, exc_info=True)
+
+
+def has_capture_marker(step_log_dir: Path, problem_idx: int, repeat: int) -> bool:
+    return _capture_marker_path(step_log_dir, problem_idx, repeat).exists()
+
+
+def reset_checkpoint_sidecars(step_log_dir: Path) -> None:
+    """Remove overflow trajectories and capture markers when the checkpoint is truncated."""
+    for subdir in (TRAJECTORY_OVERFLOW_DIR, CAPTURE_MARKER_DIR):
+        shutil.rmtree(Path(step_log_dir) / subdir, ignore_errors=True)
+
+
 class StepLog:
     """Async-safe append-only JSONL log with fsync-on-write.
 
@@ -69,9 +119,10 @@ class StepLog:
     throughput on local disks.
     """
 
-    def __init__(self, path: Path, *, fsync_interval: int = 1) -> None:
+    def __init__(self, path: Path, *, fsync_interval: int = 1, max_trajectory_bytes: int | None = None) -> None:
         self._path = path
         self._fsync_interval = fsync_interval
+        self._max_trajectory_bytes = max_trajectory_bytes if max_trajectory_bytes is not None else _env_trajectory_cap()
         self._lock = asyncio.Lock()
         self._fd: Any = None
         self._append_count = 0
@@ -150,8 +201,8 @@ class StepLog:
 
             if "trajectory" in record and record["trajectory"]:
                 traj_str = json.dumps(record["trajectory"], default=str)
-                if len(traj_str) > MAX_TRAJECTORY_BYTES:
-                    record = {**record, "trajectory": None, "_truncated": True}
+                if len(traj_str) > self._max_trajectory_bytes:
+                    record = self._spill_trajectory(record, traj_str)
 
             self._fd.write(json.dumps(record, default=str) + "\n")
             self._fd.flush()
@@ -159,6 +210,68 @@ class StepLog:
 
             if self._fsync_interval > 0 and self._append_count % self._fsync_interval == 0:
                 os.fsync(self._fd.fileno())
+
+    def _spill_trajectory(self, record: dict[str, Any], traj_str: str) -> dict[str, Any]:
+        """Move an oversized trajectory to a gzip sidecar so resume can still recover it."""
+        idx = record.get("problem_idx", -1)
+        rep = record.get("repeat", -1)
+        ref = f"{TRAJECTORY_OVERFLOW_DIR}/p{idx}_r{rep}.json.gz"
+        target = self._path.parent / ref
+        data = traj_str.encode("utf-8")
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            tmp = target.with_name(target.name + ".tmp")
+            with open(tmp, "wb") as f:
+                with gzip.GzipFile(fileobj=f, mode="wb", compresslevel=1) as gz:
+                    gz.write(data)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp, target)
+        except Exception:
+            logger.error(
+                "step_log: failed to spill oversized trajectory (%d bytes) for p%s r%s; dropping it",
+                len(data),
+                idx,
+                rep,
+                exc_info=True,
+            )
+            return {**record, "trajectory": None, "_truncated": True}
+        logger.warning(
+            "step_log: trajectory for p%s r%s exceeds %d bytes (%d); spilled to %s",
+            idx,
+            rep,
+            self._max_trajectory_bytes,
+            len(data),
+            ref,
+        )
+        return {**record, "trajectory": None, "trajectory_ref": ref, "trajectory_bytes": len(data)}
+
+    def resolve_trajectory(self, record: dict[str, Any]) -> Any | None:
+        """Return the record's trajectory, dereferencing an overflow sidecar if needed."""
+        if record.get("trajectory"):
+            return record["trajectory"]
+        ref = record.get("trajectory_ref")
+        if ref:
+            path = self._path.parent / ref
+            try:
+                with gzip.open(path, "rt", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception:
+                logger.warning(
+                    "step_log: failed to read trajectory sidecar %s for p%s r%s",
+                    path,
+                    record.get("problem_idx"),
+                    record.get("repeat"),
+                    exc_info=True,
+                )
+                return None
+        if record.get("_truncated"):
+            logger.warning(
+                "step_log: trajectory for p%s r%s was dropped by the legacy size cap and cannot be restored",
+                record.get("problem_idx"),
+                record.get("repeat"),
+            )
+        return None
 
     def write_meta(self, meta: dict[str, Any]) -> None:
         """Write the metadata header as the first line. Call before any appends."""

--- a/src/nemo_evaluator/observability/collector.py
+++ b/src/nemo_evaluator/observability/collector.py
@@ -24,7 +24,6 @@ import numpy as np
 from nemo_evaluator.observability.failure_classification import (
     MODEL_FAILURE_CATEGORIES,
     classify_model_failure,
-    completed_harbor_verification_with_workspace_change,
 )
 from nemo_evaluator.observability.types import (
     FailureRecord,
@@ -81,15 +80,12 @@ class ArtifactCollector:
         elif step.model_response:
             content = step.model_response.content
             if not content.strip():
-                if completed_harbor_verification_with_workspace_change(
-                    sd,
-                    error=step.model_error,
-                    response=content,
-                    trajectory=step.trajectory,
-                ):
-                    return
-                step.failure_category = "empty_response"
-            elif self._refusal_re.search(content):
+                # Empty final content is an output-shape observation (surfaced
+                # as `empty_final_response` in the trajectories report), not a
+                # failure attribution (FEP-1132). Terminate here so it cannot
+                # fall through and mislabel as refusal or format_error.
+                return
+            if self._refusal_re.search(content):
                 step.failure_category = "refusal"
             elif step.reward == 0 and step.extracted_answer is None:
                 step.failure_category = "format_error"

--- a/src/nemo_evaluator/observability/failure_classification.py
+++ b/src/nemo_evaluator/observability/failure_classification.py
@@ -54,37 +54,6 @@ def _has_any(text: str, *markers: str) -> bool:
     return any(marker in text for marker in markers)
 
 
-def completed_harbor_verification_with_workspace_change(
-    scoring_details: object,
-    *,
-    error: object = None,
-    response: object = None,
-    trajectory: object = None,
-) -> bool:
-    if not isinstance(scoring_details, dict):
-        return False
-    if error or scoring_details.get("error") or scoring_details.get("error_category"):
-        return False
-    if scoring_details.get("method") != "harbor":
-        return False
-    if "test_exit_code" not in scoring_details and "test_summary" not in scoring_details:
-        return False
-
-    report = scoring_details.get("report")
-    if isinstance(report, dict) and report.get("patch_exists") is True:
-        return True
-    if str(response or "").strip() == "[workspace modified]":
-        return True
-    if not isinstance(trajectory, list):
-        return False
-    return any(
-        isinstance(document, dict)
-        and isinstance(document.get("final_metrics"), dict)
-        and bool(document["final_metrics"].get("workspace_diff_preview"))
-        for document in trajectory
-    )
-
-
 def classify_model_failure(error: str = "", *, status_code: Any = None) -> str | None:
     text = str(error or "").lower()
     status = _status_int(status_code)

--- a/src/nemo_evaluator/reports/trajectories.py
+++ b/src/nemo_evaluator/reports/trajectories.py
@@ -47,10 +47,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-from nemo_evaluator.observability.failure_classification import (
-    classify_model_failure,
-    completed_harbor_verification_with_workspace_change,
-)
+from nemo_evaluator.observability.failure_classification import classify_model_failure
 from nemo_evaluator.reports.schemas import AgentStep, TrajectoryRow, fields_as_coverage_paths
 
 logger = logging.getLogger(__name__)
@@ -166,18 +163,21 @@ def _failure_error(row: dict[str, Any]) -> str:
     return _truncate_text(scoring_details.get("error") or row.get("model_error") or row.get("error") or "")
 
 
-def _harbor_verification_suppresses_empty_response(row: dict[str, Any]) -> bool:
-    scoring_details = row.get("scoring_details")
-    model = row.get("model")
+def _empty_final_response(row: dict[str, Any]) -> bool:
+    """Observational (FEP-1132): a final model payload exists but strips to empty.
+
+    An empty final message describes output shape, not failure attribution --
+    it is never a failure category. Rows without any captured content are not
+    flagged.
+    """
     response = row.get("model_response")
-    if response is None and isinstance(model, dict):
-        response = model.get("content")
-    return completed_harbor_verification_with_workspace_change(
-        scoring_details,
-        error=row.get("model_error") or row.get("error"),
-        response=response,
-        trajectory=row.get("trajectory"),
-    )
+    if response is None:
+        model = row.get("model")
+        if isinstance(model, dict):
+            response = model.get("content")
+    if response is None:
+        return False
+    return not str(response).strip()
 
 
 def _wire_failure_text(record: dict[str, Any]) -> str:
@@ -209,14 +209,14 @@ def _trial_wire_failure(row: dict[str, Any], all_wire_rows: list[dict[str, Any]]
 
 def _trial_failure_category(row: dict[str, Any], all_wire_rows: list[dict[str, Any]]) -> str:
     category = _failure_category(row)
-    suppresses_empty_response = _harbor_verification_suppresses_empty_response(row)
     reward = row.get("reward")
     successful_verified_outcome = isinstance(reward, (int, float)) and reward > 0
     wire_category, _ = _trial_wire_failure(row, all_wire_rows)
+    # "empty_response" stays in the override set only for rows persisted by
+    # pre-FEP-1132 runs: this report audits any run directory, and that legacy
+    # label must still yield to the wire-derived category.
     if wire_category and not successful_verified_outcome and category in {"", "empty_response", "model_error"}:
         return wire_category
-    if category == "empty_response" and suppresses_empty_response:
-        return ""
     return category
 
 
@@ -400,6 +400,7 @@ def _trial_failure_example(
         "last_wire_error_body": _truncate_text(last_wire.get("error_body")),
         "missing_final_metrics_tokens": not _has_final_metric_tokens(row),
         "workspace_diff_preview_present": bool(fm.get("workspace_diff_preview")),
+        "empty_final_response": _empty_final_response(row),
     }
 
 
@@ -713,6 +714,7 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
     problems_missing_fm_tokens = 0
     final_metrics_token_sum = 0
     problems_with_last_wire_non_200 = 0
+    problems_with_empty_final_response = 0
     failure_examples: list[dict[str, Any]] = []
     timeout_examples: list[dict[str, Any]] = []
     no_agent_step_examples: list[dict[str, Any]] = []
@@ -763,9 +765,14 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
         if all_trial_wire and not _is_successful_wire(all_trial_wire[-1]):
             problems_with_last_wire_non_200 += 1
 
+        empty_final = _empty_final_response(r)
+        if empty_final:
+            problems_with_empty_final_response += 1
+
         failure_signal = bool(
             cat
             or _failure_error(r)
+            or empty_final
             or step_n == 0
             or not fm_has_tokens
             or any(not _is_successful_wire(w) for w in all_trial_wire)
@@ -821,6 +828,7 @@ def _build_bench_report(bench_name: str, bench_dir: Path) -> dict[str, Any]:
             "mean_reward": traj_mean,
             "reported_mean": reported_mean,
             "failures_by_category": dict(failures),
+            "problems_with_empty_final_response": problems_with_empty_final_response,
             "failure_examples": failure_examples,
             "timeout_examples": timeout_examples,
             "no_agent_step_examples": no_agent_step_examples,
@@ -925,7 +933,6 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
         "steps_backfilled_message": 0,
         "steps_backfilled_tool_calls": 0,
         "rows_reclassified_from_wire_failure": 0,
-        "rows_cleared_empty_response_after_verification": 0,
         "rows_written": 0,
     }
 
@@ -950,14 +957,9 @@ def _enrich_bench(bench_dir: Path) -> dict[str, int]:
             wire = by_trial.get(_trial_key(r), [])
             all_wire = by_trial_all.get(_trial_key(r), [])
             category = _trial_failure_category(r, all_wire)
-            original_category = _failure_category(r)
-            if category != original_category:
-                if category:
-                    r["failure_category"] = category
-                    counts["rows_reclassified_from_wire_failure"] += 1
-                elif original_category == "empty_response" and _harbor_verification_suppresses_empty_response(r):
-                    r.pop("failure_category", None)
-                    counts["rows_cleared_empty_response_after_verification"] += 1
+            if category != _failure_category(r):
+                r["failure_category"] = category
+                counts["rows_reclassified_from_wire_failure"] += 1
             if not wire:
                 counts["trials_no_wire_data"] += 1
             elif len(steps) == len(wire):
@@ -1070,9 +1072,6 @@ def generate_trajectories_report(
                     "tool_calls": counts["steps_backfilled_tool_calls"],
                 },
                 "rows_reclassified_from_wire_failure": counts["rows_reclassified_from_wire_failure"],
-                "rows_cleared_empty_response_after_verification": counts[
-                    "rows_cleared_empty_response_after_verification"
-                ],
                 "quality": _piotr_quality_aggregate(enriched_rows),
                 "per_step_sum_after_enrichment": sum(_step_tokens(s) for s in enriched_steps),
                 "step_field_coverage_after_enrichment_missing": _missing_fields(

--- a/src/nemo_evaluator/sandbox/strategies.py
+++ b/src/nemo_evaluator/sandbox/strategies.py
@@ -107,6 +107,8 @@ class SandboxLifecycle(Protocol):
 class NoSandbox:
     """No container needed (text-only benchmarks)."""
 
+    captures_workspace = False
+
     async def setup(self) -> None:
         pass
 
@@ -135,6 +137,8 @@ class StatefulSandbox:
     ``get_verify_sandbox``, so external solvers that skip the agent phase
     still get a sandbox for verification (e.g. HumanEval + ChatSolver).
     """
+
+    captures_workspace = False
 
     def __init__(
         self,
@@ -195,6 +199,8 @@ class StatelessSandbox:
        calls ``transfer.pre_restore()``, runs ``apply_cmd``, and returns
        the sandbox to the scorer.
     """
+
+    captures_workspace = True
 
     def __init__(self, ctx: LifecycleContext, transfer: WorkspaceTransfer) -> None:
         self._ctx = ctx

--- a/tests/test_engine/test_observability.py
+++ b/tests/test_engine/test_observability.py
@@ -257,54 +257,30 @@ class TestArtifactCollector:
             ({"error": "504 Gateway Timeout", "error_category": "model_timeout"}, "model_timeout"),
         ],
     )
-    def test_scoring_error_preempts_empty_response(self, scoring_details, expected_category):
+    def test_scoring_error_classified_even_when_content_empty(self, scoring_details, expected_category):
         c = ArtifactCollector()
         step = StepRecord(model_response=ModelResponse(content="  "), scoring_details=scoring_details)
         c.record(step)
         assert step.failure_category == expected_category
 
-    def test_empty_response_detected(self):
+    def test_empty_content_yields_no_failure_category(self):
         c = ArtifactCollector()
         step = StepRecord(model_response=ModelResponse(content="  "))
-        c.record(step)
-        assert step.failure_category == "empty_response"
-
-    def test_harbor_verification_failure_with_patch_is_not_empty_response(self):
-        c = ArtifactCollector()
-        step = StepRecord(
-            model_response=ModelResponse(content="  "),
-            reward=0.0,
-            scoring_details={
-                "method": "harbor",
-                "test_exit_code": 1,
-                "test_summary": "FAILED",
-                "report": {"patch_exists": True},
-            },
-        )
-        c.record(step)
-        assert step.failure_category is None
-
-    def test_harbor_verification_without_patch_keeps_empty_response(self):
-        c = ArtifactCollector()
-        step = StepRecord(
-            model_response=ModelResponse(content="  "),
-            reward=0.0,
-            scoring_details={
-                "method": "harbor",
-                "test_exit_code": 1,
-                "test_summary": "FAILED",
-                "report": {"patch_exists": False},
-            },
-        )
 
         c.record(step)
         artifacts = c.build(elapsed=1.0)
 
-        assert (
-            step.failure_category,
-            artifacts.failures.total_failures,
-            set(artifacts.failures.categories),
-        ) == ("empty_response", 1, {"empty_response"})
+        assert step.failure_category is None
+        assert artifacts.failures.total_failures == 0
+
+    def test_empty_content_with_zero_reward_is_not_format_error(self):
+        # Regression guard (FEP-1132): empty content must terminate
+        # classification, not fall through to the reward==0 +
+        # extracted_answer-is-None format_error check.
+        c = ArtifactCollector()
+        step = StepRecord(model_response=ModelResponse(content="  "), reward=0.0)
+        c.record(step)
+        assert step.failure_category is None
 
     def test_refusal_detected(self):
         c = ArtifactCollector()

--- a/tests/test_engine/test_step_log.py
+++ b/tests/test_engine/test_step_log.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for StepLog trajectory overflow sidecars and capture markers (FEP-1295).
+
+Before the fix, StepLog.append() rewrote any record whose trajectory JSON
+exceeded the cap as ``{"trajectory": None, "_truncated": True}`` — silently
+dropping the only copy of the trajectory a resumed run could recover.
+"""
+
+import logging
+
+from nemo_evaluator.engine.step_log import (
+    CAPTURE_MARKER_DIR,
+    INFERENCE_LOG,
+    TRAJECTORY_OVERFLOW_DIR,
+    StepLog,
+    clear_capture_marker,
+    has_capture_marker,
+    reset_checkpoint_sidecars,
+    write_capture_marker,
+)
+
+LOGGER_NAME = "nemo_evaluator.engine.step_log"
+
+BIG_TRAJECTORY = [{"step": 1, "action": "think", "output": "x" * 4096}]
+
+
+def _record(problem_idx=0, repeat=0, **extra):
+    return {"problem_idx": problem_idx, "repeat": repeat, "response": "ok", **extra}
+
+
+def _open_log(tmp_path, **kwargs) -> StepLog:
+    log = StepLog(tmp_path / INFERENCE_LOG, **kwargs)
+    log.open(truncate=True)
+    return log
+
+
+class TestTrajectoryOverflow:
+    async def test_small_trajectory_kept_inline(self, tmp_path):
+        log = _open_log(tmp_path)
+        await log.append(_record(trajectory=[{"step": 1}]))
+        log.close()
+
+        rec = log.load()[(0, 0)]
+        assert rec["trajectory"] == [{"step": 1}]
+        assert "trajectory_ref" not in rec
+        assert not (tmp_path / TRAJECTORY_OVERFLOW_DIR).exists()
+
+    async def test_oversized_trajectory_spilled_to_sidecar(self, tmp_path, caplog):
+        log = _open_log(tmp_path, max_trajectory_bytes=100)
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            await log.append(_record(problem_idx=2, repeat=1, trajectory=BIG_TRAJECTORY))
+        log.close()
+
+        rec = log.load()[(2, 1)]
+        assert rec["trajectory"] is None
+        assert rec["trajectory_ref"] == f"{TRAJECTORY_OVERFLOW_DIR}/p2_r1.json.gz"
+        assert rec["trajectory_bytes"] > 100
+        assert (tmp_path / TRAJECTORY_OVERFLOW_DIR / "p2_r1.json.gz").is_file()
+        assert log.resolve_trajectory(rec) == BIG_TRAJECTORY
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    async def test_env_var_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NEL_MAX_TRAJECTORY_BYTES", "100")
+        log = _open_log(tmp_path)
+        await log.append(_record(trajectory=BIG_TRAJECTORY))
+        log.close()
+
+        rec = log.load()[(0, 0)]
+        assert rec["trajectory"] is None
+        assert rec["trajectory_ref"] == f"{TRAJECTORY_OVERFLOW_DIR}/p0_r0.json.gz"
+
+    async def test_ctor_cap_beats_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NEL_MAX_TRAJECTORY_BYTES", "100")
+        log = _open_log(tmp_path, max_trajectory_bytes=10_000_000)
+        await log.append(_record(trajectory=BIG_TRAJECTORY))
+        log.close()
+
+        rec = log.load()[(0, 0)]
+        assert rec["trajectory"] == BIG_TRAJECTORY
+        assert "trajectory_ref" not in rec
+
+    async def test_spill_failure_falls_back_to_truncation(self, tmp_path, caplog):
+        (tmp_path / TRAJECTORY_OVERFLOW_DIR).write_text("not a directory")
+        log = _open_log(tmp_path, max_trajectory_bytes=100)
+        with caplog.at_level(logging.ERROR, logger=LOGGER_NAME):
+            await log.append(_record(trajectory=BIG_TRAJECTORY))
+        log.close()
+
+        rec = log.load()[(0, 0)]
+        assert rec["trajectory"] is None
+        assert rec["_truncated"] is True
+        assert "trajectory_ref" not in rec
+        assert any(r.levelno == logging.ERROR for r in caplog.records)
+
+    def test_resolve_legacy_truncated_warns_and_returns_none(self, tmp_path, caplog):
+        log = StepLog(tmp_path / INFERENCE_LOG)
+        rec = _record(trajectory=None, _truncated=True)
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            assert log.resolve_trajectory(rec) is None
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_resolve_missing_sidecar_warns_and_returns_none(self, tmp_path, caplog):
+        log = StepLog(tmp_path / INFERENCE_LOG)
+        rec = _record(trajectory=None, trajectory_ref=f"{TRAJECTORY_OVERFLOW_DIR}/p9_r9.json.gz")
+        with caplog.at_level(logging.WARNING, logger=LOGGER_NAME):
+            assert log.resolve_trajectory(rec) is None
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_resolve_inline_trajectory_passthrough(self, tmp_path):
+        log = StepLog(tmp_path / INFERENCE_LOG)
+        assert log.resolve_trajectory(_record(trajectory=[{"step": 1}])) == [{"step": 1}]
+        assert log.resolve_trajectory(_record()) is None
+
+    async def test_compact_preserves_trajectory_ref(self, tmp_path):
+        log = _open_log(tmp_path, max_trajectory_bytes=100)
+        await log.append(_record(trajectory=BIG_TRAJECTORY))
+        log.close()
+
+        cache = log.load()
+        log.compact(cache, meta={"config_hash": "sha256:abc"})
+
+        rec = log.load()[(0, 0)]
+        assert rec["trajectory_ref"] == f"{TRAJECTORY_OVERFLOW_DIR}/p0_r0.json.gz"
+        assert log.resolve_trajectory(rec) == BIG_TRAJECTORY
+
+    async def test_reappend_overwrites_sidecar(self, tmp_path):
+        log = _open_log(tmp_path, max_trajectory_bytes=100)
+        await log.append(_record(trajectory=BIG_TRAJECTORY))
+        new_trajectory = [{"step": 2, "action": "revise", "output": "y" * 4096}]
+        await log.append(_record(trajectory=new_trajectory))
+        log.close()
+
+        rec = log.load()[(0, 0)]
+        assert log.resolve_trajectory(rec) == new_trajectory
+        assert len(list((tmp_path / TRAJECTORY_OVERFLOW_DIR).iterdir())) == 1
+
+
+class TestCaptureMarkers:
+    def test_write_and_has(self, tmp_path):
+        assert not has_capture_marker(tmp_path, 3, 1)
+        write_capture_marker(tmp_path, 3, 1)
+        assert has_capture_marker(tmp_path, 3, 1)
+        assert not has_capture_marker(tmp_path, 3, 2)
+        assert (tmp_path / CAPTURE_MARKER_DIR / "p3_r1.captured").is_file()
+
+    def test_write_swallows_oserror(self, tmp_path):
+        (tmp_path / CAPTURE_MARKER_DIR).write_text("not a directory")
+        write_capture_marker(tmp_path, 0, 0)
+        assert not has_capture_marker(tmp_path, 0, 0)
+
+    def test_clear_removes_marker(self, tmp_path):
+        write_capture_marker(tmp_path, 3, 1)
+        clear_capture_marker(tmp_path, 3, 1)
+        assert not has_capture_marker(tmp_path, 3, 1)
+
+    def test_clear_noop_when_absent(self, tmp_path):
+        clear_capture_marker(tmp_path, 0, 0)
+
+    def test_reset_checkpoint_sidecars(self, tmp_path):
+        write_capture_marker(tmp_path, 0, 0)
+        (tmp_path / TRAJECTORY_OVERFLOW_DIR).mkdir()
+        (tmp_path / TRAJECTORY_OVERFLOW_DIR / "p0_r0.json.gz").write_bytes(b"x")
+
+        reset_checkpoint_sidecars(tmp_path)
+
+        assert not (tmp_path / CAPTURE_MARKER_DIR).exists()
+        assert not (tmp_path / TRAJECTORY_OVERFLOW_DIR).exists()
+
+    def test_reset_noop_when_absent(self, tmp_path):
+        reset_checkpoint_sidecars(tmp_path)

--- a/tests/test_integration/test_eval_loop_integration.py
+++ b/tests/test_integration/test_eval_loop_integration.py
@@ -15,11 +15,15 @@
 """Integration tests: run_evaluation end-to-end with mock solver."""
 
 import asyncio
+import logging
 
 from nemo_evaluator.engine.eval_loop import run_evaluation
 from nemo_evaluator.environments.base import EvalEnvironment, SeedResult, VerifyResult
 from nemo_evaluator.observability.types import ModelResponse
 from nemo_evaluator.solvers import SolveResult
+from nemo_evaluator.solvers.base import ErrorKind
+
+EVAL_LOOP_LOGGER = "nemo_evaluator.engine.eval_loop"
 
 
 class _MockEnv(EvalEnvironment):
@@ -439,3 +443,397 @@ class TestJudgeFnSerialization:
         judge = result["scoring_details"]["judge"]
         assert judge["total"] is None
         assert "judge exploded" in judge["error"]
+
+
+BIG_TRAJECTORY = [{"step": 1, "action": "think", "output": "x" * 4096}]
+
+
+class _BigTrajectorySolver:
+    """Trajectory JSON far exceeds the tiny NEL_MAX_TRAJECTORY_BYTES cap set in tests."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def solve(self, task):
+        self.calls += 1
+        return SolveResult(response=task.expected_answer, trajectory=BIG_TRAJECTORY)
+
+    async def close(self):
+        pass
+
+
+class TestResumeOversizedTrajectory:
+    """FEP-1295: trajectories over the checkpoint cap used to be rewritten as
+    ``{"trajectory": None, "_truncated": True}``, so after a walltime kill the
+    resumed run produced zero-step trajectories. They now spill to a gzip
+    sidecar and are dereferenced on resume."""
+
+    def _first_run(self, tmp_path, monkeypatch, solver):
+        monkeypatch.setenv("NEL_MAX_TRAJECTORY_BYTES", "100")
+        env = _MockEnv()
+        log_dir = tmp_path / "logs"
+        asyncio.run(run_evaluation(env, solver, n_repeats=1, step_log_dir=log_dir))
+        assert "trajectory_ref" in (log_dir / "inference_log.jsonl").read_text()
+        return env, log_dir
+
+    def test_survives_fully_cached_resume(self, tmp_path, monkeypatch):
+        solver = _BigTrajectorySolver()
+        env, log_dir = self._first_run(tmp_path, monkeypatch, solver)
+
+        bundle = asyncio.run(run_evaluation(env, solver, n_repeats=1, step_log_dir=log_dir, resume=True))
+
+        assert solver.calls == 3
+        steps = bundle["_artifacts"].steps
+        assert len(steps) == 3
+        for step in steps:
+            assert step.trajectory == BIG_TRAJECTORY, f"lost trajectory p{step.problem_idx} r{step.repeat}"
+
+    def test_survives_verify_only_resume(self, tmp_path, monkeypatch):
+        solver = _BigTrajectorySolver()
+        env, log_dir = self._first_run(tmp_path, monkeypatch, solver)
+        (log_dir / "verified_log.jsonl").unlink()
+
+        bundle = asyncio.run(run_evaluation(env, solver, n_repeats=1, step_log_dir=log_dir, resume=True))
+
+        assert solver.calls == 3
+        steps = bundle["_artifacts"].steps
+        assert len(steps) == 3
+        for step in steps:
+            assert step.trajectory == BIG_TRAJECTORY, f"lost trajectory p{step.problem_idx} r{step.repeat}"
+
+
+class _CountingEnv(_MockEnv):
+    def __init__(self):
+        super().__init__()
+        self.verify_calls = 0
+
+    async def verify(self, response, expected, **meta):
+        self.verify_calls += 1
+        return await super().verify(response, expected, **meta)
+
+
+class _TimeoutShapedSolver:
+    """Harbor timeout with workspace diff: error=None, error_kind=SOLVE_TIMEOUT."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def solve(self, task):
+        self.calls += 1
+        return SolveResult(response="partial work", error_kind=ErrorKind.SOLVE_TIMEOUT)
+
+    async def close(self):
+        pass
+
+
+class _CrashedSolver:
+    """Graceful solve failure whose message classifies as turn_budget_exhausted."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def solve(self, task):
+        self.calls += 1
+        return SolveResult(response="", error="Turn budget exhausted after 50 turns")
+
+    async def close(self):
+        pass
+
+
+class _TurnBudgetDetailsSolver:
+    """Succeeds but flags a failure label via scoring_details (Harbor workspace classification)."""
+
+    async def solve(self, task):
+        return SolveResult(
+            response=task.expected_answer,
+            scoring_details={"error": "turn budget exhausted", "error_category": "turn_budget_exhausted"},
+        )
+
+    async def close(self):
+        pass
+
+
+class _FlakyInfraSolver:
+    """First call fails with an infra-kind error; subsequent calls succeed."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def solve(self, task):
+        self.calls += 1
+        if self.calls == 1:
+            return SolveResult(response="", error="connection refused", error_kind=ErrorKind.INFRA)
+        return SolveResult(response=task.expected_answer)
+
+    async def close(self):
+        pass
+
+
+class TestResumeFailureLabels:
+    """FEP-1295: the inference checkpoint stored no error/error_kind/solver
+    scoring_details, so verify-only resume re-verified solve failures and lost
+    failure labels like solve_timeout and turn_budget_exhausted."""
+
+    def test_solve_timeout_label_survives_verify_only_resume(self, tmp_path):
+        env = _CountingEnv()
+        solver = _TimeoutShapedSolver()
+        log_dir = tmp_path / "logs"
+        asyncio.run(run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir))
+        (log_dir / "verified_log.jsonl").unlink()
+
+        bundle = asyncio.run(
+            run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir, resume=True)
+        )
+
+        assert solver.calls == 1, "verify-only resume must not re-solve"
+        (result,) = bundle["_results"]
+        assert result["scoring_details"]["error_category"] == "solve_timeout"
+
+    def test_solve_failure_replayed_without_reverify(self, tmp_path, caplog):
+        env = _CountingEnv()
+        solver = _CrashedSolver()
+        log_dir = tmp_path / "logs"
+        asyncio.run(run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir))
+        assert env.verify_calls == 0
+        (log_dir / "verified_log.jsonl").unlink()
+
+        with caplog.at_level(logging.WARNING, logger=EVAL_LOOP_LOGGER):
+            bundle = asyncio.run(
+                run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir, resume=True)
+            )
+
+        assert solver.calls == 1
+        assert env.verify_calls == 0, "cached solve failure must be replayed, not re-verified"
+        (result,) = bundle["_results"]
+        assert result["reward"] == 0.0
+        assert result["scoring_details"]["error_category"] == "turn_budget_exhausted"
+        assert result["scoring_details"]["method"] == "solve_failed"
+        assert any("replaying cached solve failure" in rec.message for rec in caplog.records)
+
+    def test_solver_scoring_details_survive_verify_only_resume(self, tmp_path):
+        env = _CountingEnv()
+        solver = _TurnBudgetDetailsSolver()
+        log_dir = tmp_path / "logs"
+        asyncio.run(run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir))
+        (log_dir / "verified_log.jsonl").unlink()
+
+        bundle = asyncio.run(
+            run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir, resume=True)
+        )
+
+        assert env.verify_calls == 2
+        (result,) = bundle["_results"]
+        assert result["scoring_details"]["error_category"] == "turn_budget_exhausted"
+        assert result["reward"] == 1.0
+
+    def test_unverified_infra_inference_is_retried(self, tmp_path):
+        env = _CountingEnv()
+        solver = _FlakyInfraSolver()
+        log_dir = tmp_path / "logs"
+        asyncio.run(run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir))
+        (log_dir / "verified_log.jsonl").unlink()
+
+        bundle = asyncio.run(
+            run_evaluation(env, solver, n_repeats=1, max_problems=1, step_log_dir=log_dir, resume=True)
+        )
+
+        assert solver.calls == 2, "infra-kind unverified inference must be re-solved on resume"
+        (result,) = bundle["_results"]
+        assert result["reward"] == 1.0
+
+
+class _DummySandboxLifecycle:
+    """Stub lifecycle handing out a bare object as the agent sandbox."""
+
+    captures_workspace = True
+
+    async def setup(self):
+        pass
+
+    async def get_agent_sandbox(self):
+        return object()
+
+    async def transition_to_verify(self, response_text, solver_modified):
+        pass
+
+    async def get_verify_sandbox(self):
+        return None
+
+    async def teardown(self):
+        pass
+
+
+class _SandboxAcceptingSolver:
+    async def solve(self, task, sandbox=None):
+        return SolveResult(response=task.expected_answer)
+
+    async def close(self):
+        pass
+
+
+class TestResumeCaptureMarkers:
+    """FEP-1295: a kill landing before/during workspace capture leaves verify-only
+    resume scoring an unmodified workspace with no trace. Markers written after
+    transition_to_verify() make that observable via scoring_details."""
+
+    def _patch_lifecycle(self, monkeypatch):
+        monkeypatch.setattr(
+            "nemo_evaluator.engine.eval_loop.pick_lifecycle",
+            lambda *args, **kwargs: _DummySandboxLifecycle(),
+        )
+
+    def test_first_run_writes_markers(self, tmp_path, monkeypatch):
+        self._patch_lifecycle(monkeypatch)
+        log_dir = tmp_path / "logs"
+        asyncio.run(run_evaluation(_MockEnv(), _SandboxAcceptingSolver(), n_repeats=1, step_log_dir=log_dir))
+
+        for idx in range(3):
+            assert (log_dir / "capture_markers" / f"p{idx}_r0.captured").is_file()
+
+    def test_resume_with_marker_not_flagged(self, tmp_path, monkeypatch):
+        self._patch_lifecycle(monkeypatch)
+        log_dir = tmp_path / "logs"
+        asyncio.run(
+            run_evaluation(_MockEnv(), _SandboxAcceptingSolver(), n_repeats=1, max_problems=1, step_log_dir=log_dir)
+        )
+        (log_dir / "verified_log.jsonl").unlink()
+
+        bundle = asyncio.run(
+            run_evaluation(
+                _MockEnv(),
+                _SandboxAcceptingSolver(),
+                n_repeats=1,
+                max_problems=1,
+                step_log_dir=log_dir,
+                resume=True,
+            )
+        )
+
+        (result,) = bundle["_results"]
+        assert "resume_workspace_capture" not in result["scoring_details"]
+
+    def test_resume_without_marker_flagged(self, tmp_path, monkeypatch, caplog):
+        self._patch_lifecycle(monkeypatch)
+        log_dir = tmp_path / "logs"
+        asyncio.run(
+            run_evaluation(_MockEnv(), _SandboxAcceptingSolver(), n_repeats=1, max_problems=1, step_log_dir=log_dir)
+        )
+        (log_dir / "verified_log.jsonl").unlink()
+        (log_dir / "capture_markers" / "p0_r0.captured").unlink()
+
+        with caplog.at_level(logging.WARNING, logger=EVAL_LOOP_LOGGER):
+            bundle = asyncio.run(
+                run_evaluation(
+                    _MockEnv(),
+                    _SandboxAcceptingSolver(),
+                    n_repeats=1,
+                    max_problems=1,
+                    step_log_dir=log_dir,
+                    resume=True,
+                )
+            )
+
+        (result,) = bundle["_results"]
+        assert result["scoring_details"]["resume_workspace_capture"] == "missing"
+        assert any("capture marker" in rec.message for rec in caplog.records)
+
+    def test_stale_marker_invalidated_by_retry_inference(self, tmp_path, monkeypatch):
+        """A verify retry re-solves and re-appends; a kill before the retry's capture
+        must not be masked by the marker left over from the first attempt."""
+
+        transitions = {"count": 0}
+
+        class _KilledOnRetryLifecycle(_DummySandboxLifecycle):
+            async def transition_to_verify(self, response_text, solver_modified):
+                transitions["count"] += 1
+                if transitions["count"] == 2:
+                    raise RuntimeError("killed before workspace capture")
+
+        monkeypatch.setattr(
+            "nemo_evaluator.engine.eval_loop.pick_lifecycle",
+            lambda *args, **kwargs: _KilledOnRetryLifecycle(),
+        )
+
+        class _FlakyVerifyEnv(_MockEnv):
+            def __init__(self):
+                super().__init__()
+                self.verify_calls = 0
+
+            async def verify(self, response, expected, **meta):
+                self.verify_calls += 1
+                if self.verify_calls == 1:
+                    raise RuntimeError("verify hiccup, triggers system retry")
+                return await super().verify(response, expected, **meta)
+
+        env = _FlakyVerifyEnv()
+        log_dir = tmp_path / "logs"
+        asyncio.run(
+            run_evaluation(
+                env,
+                _SandboxAcceptingSolver(),
+                n_repeats=1,
+                max_problems=1,
+                step_log_dir=log_dir,
+                max_system_retries=2,
+                skip_failed=True,
+            )
+        )
+
+        assert transitions["count"] == 2
+        assert not (log_dir / "capture_markers" / "p0_r0.captured").exists(), (
+            "marker from attempt 1 must be invalidated by attempt 2's inference append"
+        )
+
+        (log_dir / "verified_log.jsonl").unlink()
+        self._patch_lifecycle(monkeypatch)
+        bundle = asyncio.run(
+            run_evaluation(
+                env,
+                _SandboxAcceptingSolver(),
+                n_repeats=1,
+                max_problems=1,
+                step_log_dir=log_dir,
+                resume=True,
+            )
+        )
+
+        (result,) = bundle["_results"]
+        assert result["scoring_details"]["resume_workspace_capture"] == "missing"
+
+
+class TestSidecarReset:
+    def _plant_leftover_sidecars(self, log_dir):
+        (log_dir / "trajectory_overflow").mkdir(parents=True, exist_ok=True)
+        (log_dir / "trajectory_overflow" / "p0_r0.json.gz").write_bytes(b"junk")
+        (log_dir / "capture_markers").mkdir(exist_ok=True)
+        (log_dir / "capture_markers" / "p0_r0.captured").touch()
+
+    def test_fresh_run_clears_leftover_sidecars(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        self._plant_leftover_sidecars(log_dir)
+
+        asyncio.run(run_evaluation(_MockEnv(), _MockSolver(), n_repeats=1, step_log_dir=log_dir))
+
+        assert not (log_dir / "trajectory_overflow").exists()
+        assert not (log_dir / "capture_markers").exists()
+
+    def test_config_changed_resume_clears_leftover_sidecars(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        asyncio.run(
+            run_evaluation(_MockEnv(), _MockSolver(), n_repeats=1, step_log_dir=log_dir, config={"temperature": 0.1})
+        )
+        self._plant_leftover_sidecars(log_dir)
+
+        asyncio.run(
+            run_evaluation(
+                _MockEnv(),
+                _MockSolver(),
+                n_repeats=1,
+                step_log_dir=log_dir,
+                resume=True,
+                config={"temperature": 0.9},
+            )
+        )
+
+        assert not (log_dir / "trajectory_overflow").exists()
+        assert not (log_dir / "capture_markers").exists()

--- a/tests/test_reports/test_trajectories_report.py
+++ b/tests/test_reports/test_trajectories_report.py
@@ -665,16 +665,30 @@ def test_non_success_wire_examples_include_invalid_response_details(tmp_path: Pa
         (504, "timeout", "Upstream timed out after 5s", "server_error"),
     ],
 )
-def test_last_wire_non_200_reclassifies_empty_response(
+@pytest.mark.parametrize(
+    "persisted_category",
+    [None, "empty_response"],
+    ids=["uncategorized-post-fep-1132", "legacy-empty-response-label"],
+)
+def test_last_wire_non_200_reclassifies_uncategorized_and_legacy_rows(
     tmp_path: Path,
+    persisted_category: str | None,
     status_code: int,
     error_type: str,
     error_message: str,
     expected_category: str,
 ) -> None:
+    """Empty-final rows yield to the wire-derived category.
+
+    Covers both persisted shapes: no category at all (the collector persists
+    none for empty finals since FEP-1132) and the legacy ``empty_response``
+    label written by older runs.
+    """
     bench = tmp_path / "pb"
     row = _trial(7, 2, reward=0.0, steps=[_agent_step(0, msg="", pt=0, ct=0)])
-    row["failure_category"] = "empty_response"
+    row["model"]["content"] = ""
+    if persisted_category is not None:
+        row["failure_category"] = persisted_category
     _write_jsonl(bench / "trajectories.jsonl", [row])
     _write_jsonl(
         bench / "model_traffic.jsonl",
@@ -706,6 +720,7 @@ def test_last_wire_non_200_reclassifies_empty_response(
 def test_prior_504_then_final_200_does_not_reclassify_as_timeout(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
     row = _trial(7, 2, reward=0.0, steps=[_agent_step(0, msg="", pt=0, ct=0)])
+    # Legacy persisted category from a pre-FEP-1132 run; passes through untouched.
     row["failure_category"] = "empty_response"
     _write_jsonl(bench / "trajectories.jsonl", [row])
     _write_jsonl(
@@ -824,53 +839,54 @@ def test_failed_duplicate_wire_twin_reclassifies_unsuccessful_trial(tmp_path: Pa
     assert report["enrichment"]["rows_reclassified_from_wire_failure"] == 1
 
 
-def test_harbor_verification_failure_clears_false_empty_response(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "set_empty_content",
+    [lambda row: row["model"].__setitem__("content", "   "), lambda row: row.__setitem__("model_response", "")],
+    ids=["model-content", "model_response"],
+)
+def test_empty_final_response_is_observational_flag_not_failure(tmp_path: Path, set_empty_content) -> None:
+    """FEP-1132: emptiness surfaces as a per-trial flag + aggregate, never a category."""
+    bench = tmp_path / "pb"
+    empty_row = _trial(7, 2, reward=0.0, steps=[_agent_step(0, msg="", pt=7, ct=3)])
+    set_empty_content(empty_row)
+    nonempty_row = _trial(8, 2, reward=0.0, steps=[_agent_step(0, msg="answer", pt=7, ct=3)])
+    nonempty_row["model"]["content"] = "answer"
+    nonempty_row["scoring_details"] = {"error": "scoring exploded"}
+    _write_jsonl(bench / "trajectories.jsonl", [empty_row, nonempty_row])
+    _write_jsonl(
+        bench / "model_traffic.jsonl",
+        [
+            {**_wire(7, 2, prompt=7, completion=3, status_code=200), "model_traffic_request_id": "sess:req-ok"},
+            {**_wire(8, 2, prompt=7, completion=3, status_code=200), "model_traffic_request_id": "sess:req-ok2"},
+        ],
+    )
+
+    report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
+    traj = report["trajectories"]
+
+    assert traj["failures_by_category"] == {}
+    assert traj["problems_with_empty_final_response"] == 1
+    examples = {example["problem_idx"]: example for example in traj["failure_examples"]}
+    assert examples[7]["failure_category"] == ""
+    assert examples[7]["empty_final_response"] is True
+    assert examples[8]["empty_final_response"] is False
+
+
+def test_uncaptured_final_content_is_not_flagged_empty(tmp_path: Path) -> None:
     bench = tmp_path / "pb"
     row = _trial(7, 2, reward=0.0, steps=[_agent_step(0, msg="", pt=7, ct=3)])
-    row["failure_category"] = "empty_response"
-    row["scoring_details"] = {"method": "harbor", "test_exit_code": 1, "test_summary": "FAILED"}
-    row["trajectory"][0]["final_metrics"]["workspace_diff_preview"] = "diff --git a/file.py b/file.py"
+    row["scoring_details"] = {"error": "scoring exploded"}
     _write_jsonl(bench / "trajectories.jsonl", [row])
     _write_jsonl(
         bench / "model_traffic.jsonl",
         [{**_wire(7, 2, prompt=7, completion=3, status_code=200), "model_traffic_request_id": "sess:req-ok"}],
     )
 
-    report = json.loads(generate_trajectories_report(tmp_path, enrich=True).read_text())["benchmarks"][0]
+    report = json.loads(generate_trajectories_report(tmp_path).read_text())["benchmarks"][0]
+    traj = report["trajectories"]
 
-    assert report["trajectories"]["failures_by_category"] == {}
-    assert report["trajectories"]["failure_examples"] == []
-    assert report["enrichment"]["rows_reclassified_from_wire_failure"] == 0
-    assert report["enrichment"]["rows_cleared_empty_response_after_verification"] == 1
-
-    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
-    assert "failure_category" not in enriched
-
-
-def test_harbor_verification_without_patch_keeps_empty_response(tmp_path: Path) -> None:
-    bench = tmp_path / "pb"
-    row = _trial(7, 2, reward=0.0, steps=[_agent_step(0, msg="", pt=7, ct=3)])
-    row["failure_category"] = "empty_response"
-    row["scoring_details"] = {
-        "method": "harbor",
-        "test_exit_code": 1,
-        "test_summary": "FAILED",
-        "report": {"patch_exists": False},
-    }
-    _write_jsonl(bench / "trajectories.jsonl", [row])
-    _write_jsonl(
-        bench / "model_traffic.jsonl",
-        [{**_wire(7, 2, prompt=7, completion=3, status_code=200), "model_traffic_request_id": "sess:req-ok"}],
-    )
-
-    report = json.loads(generate_trajectories_report(tmp_path, enrich=True).read_text())["benchmarks"][0]
-    enriched = json.loads((bench / "trajectories_enriched.jsonl").read_text().splitlines()[0])
-
-    assert (
-        report["trajectories"]["failures_by_category"],
-        report["enrichment"]["rows_cleared_empty_response_after_verification"],
-        enriched.get("failure_category"),
-    ) == ({"empty_response": 1}, 0, "empty_response")
+    assert traj["problems_with_empty_final_response"] == 0
+    assert traj["failure_examples"][0]["empty_final_response"] is False
 
 
 def test_timeout_no_step_examples_keep_wire_counts(tmp_path: Path) -> None:


### PR DESCRIPTION
Stacked on #1099 (base: `awarno/fix-harbor-error-classification`) — review only the top commit here.

## Problem

`empty_response` fires as a failure *category* whenever the final assistant message is empty. Pre-merge verification of #1099 ([FEP-1132](https://linear.app/nvidia/issue/FEP-1132/empty-response-over-fires-on-harbor-swe-bench-labels-verified-task)) showed this is an observation about output shape, not a failure attribution: it conflates (1) rollouts killed mid-tool-call, (2) answers delivered inside tool-call arguments, and (3) genuine degenerate output — and it has fired on ordinary verified task failures and even a passing rollout (reward 1.0). The harbor `patch_exists` suppression added in #1099 also never fires on SWE-bench: harbor nests `patch_exists` per instance id, so the top-level lookup finds nothing.

## Change

- `_classify_failure`: an empty final message now terminates classification with **no category**. The empty-content guard is kept deliberately — without it, empty content would fall through to `refusal`/`format_error` (a worse mislabel). Regression-tested.
- Emptiness is preserved as an **observational flag** in the trajectories report: per-trial `empty_final_response` boolean (derived from the persisted `model_response`/`model.content`; only flagged when a payload was captured and strips to empty) plus a `problems_with_empty_final_response` aggregate next to `failures_by_category`. No row-schema or `StepRecord` change.
- The harbor suppression machinery is deleted entirely: `completed_harbor_verification_with_workspace_change`, `_harbor_verification_suppresses_empty_response`, the suppression branch, and the `rows_cleared_empty_response_after_verification` counter (replaced by the new aggregate).
- `docs/deployment-patterns.mdx` failure-category list updated.

## Behavior notes

- **Legacy rows**: rows persisted by older code may still carry `failure_category="empty_response"`; the report path passes them through and they still yield to the wire-derived category (the reports module runs offline against any run directory — data compatibility, not a code shim). New runs never emit the label.
- **Interplay kept**: a trial with an empty final message and a failed last wire call still receives the wire-derived category; turn-budget precedence unchanged. Both are covered by tests, including the post-taxonomy row shape (no persisted category).
- **Deliberately untouched**: `refusal` and `format_error` sit in the same no-error observational branch and arguably deserve the same treatment — out of scope here; the campaign evidence covers only `empty_response`.

## Verification

- Full offline suite green (`pytest tests/ -m "not network"`), `ruff check` / `ruff format --check` clean on touched files.
- Follow-ups outside this repo (tracked in FEP-1132): `audit_failures.py` category buckets and the evalpipeline glossary *Failure label* entry in the benchmarking repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
