### PR TITLE
feat: forward tools to model and harden managed Gym lifecycle

### DIFF
--- a/src/nemo_evaluator/engine/model_client.py
+++ b/src/nemo_evaluator/engine/model_client.py
@@ -147,7 +147,11 @@ class ModelClient:
         return params
 
     async def chat(
-        self, prompt: str | None = None, system: str | None = None, messages: list[dict[str, str]] | None = None
+        self,
+        prompt: str | None = None,
+        system: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> ModelResponse:
         if messages is not None:
             msgs = list(messages)
@@ -160,7 +164,9 @@ class ModelClient:
         cache_prompt = prompt or (msgs[-1]["content"] if msgs else "")
         cache_msgs = messages if messages is not None else None
 
-        if self._cache:
+        # ``tools`` is not part of the cache key, so skip the cache when present
+        # to avoid serving a tool-unaware response for a tool-aware request.
+        if self._cache and not tools:
             cached = self._cache.get(
                 self.model,
                 cache_prompt,
@@ -182,13 +188,15 @@ class ModelClient:
             "messages": msgs,
             **self._build_generation_payload(),
         }
+        if tools:
+            payload["tools"] = tools
 
         url = f"{self.base_url}/chat/completions"
         t0 = time.monotonic()
         data = await self._post_with_retry(url, payload)
         latency = (time.monotonic() - t0) * 1000
 
-        if self._cache:
+        if self._cache and not tools:
             self._cache.put(
                 self.model,
                 cache_prompt,
@@ -393,7 +401,7 @@ class ModelClient:
         return delay
 
     def _parse_response(self, data: dict, latency: float, prompt: str, system: str | None) -> ModelResponse:
-        choices = data.get("choices", [])
+        choices = data.get("choices", []) if data else []
         if not choices:
             raise InfraError("Model returned HTTP 200 but empty choices. Possible KV-cache exhaustion or model crash.")
 

--- a/src/nemo_evaluator/engine/model_client.py
+++ b/src/nemo_evaluator/engine/model_client.py
@@ -362,8 +362,16 @@ class ModelClient:
                             continue
 
                         resp.raise_for_status()
-                        return await resp.json()
+                        data = await resp.json()
+                        if not isinstance(data, dict):
+                            raise InfraError(
+                                f"Model returned non-object JSON response ({type(data).__name__}); "
+                                "expected a JSON object."
+                            )
+                        return data
 
+                except InfraError:
+                    raise
                 except asyncio.TimeoutError as e:
                     last_exc = e
                     if attempt < self.retry.max_retries:

--- a/src/nemo_evaluator/environments/gym.py
+++ b/src/nemo_evaluator/environments/gym.py
@@ -366,7 +366,7 @@ class ManagedGymEnvironment(EvalEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=env,
-            start_new_session=True,  # new session → new process group so killpg reaches all descendants
+            start_new_session=True,
         )
         self._wait_for_health()
         self._inner = GymEnvironment(
@@ -408,17 +408,12 @@ class ManagedGymEnvironment(EvalEnvironment):
         raise ValueError("ManagedGymEnvironment requires one of: server_cmd, server_module, or nel_benchmark")
 
     def _wait_for_health(self) -> None:
-        """Wait for the server to become responsive.
-
-        A 200 from ``/health`` (evaluator servers) or ``/openapi.json``
-        (native Gym servers, which lack ``/health`` but always serve the
-        FastAPI schema) means ready.  Every other outcome -- connection
-        refused, timeout, or any non-200 status -- means "not ready yet",
-        so we keep polling until the deadline.  ``HTTPError`` is a subclass
-        of ``URLError``, so a single handler covers all of them.
-        """
+        """Wait for the server to become responsive."""
         deadline = time.monotonic() + self._startup_timeout
-        while time.monotonic() < deadline:
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
             if self._process.poll() is not None:
                 output = ""
                 if self._process.stdout:
@@ -426,14 +421,15 @@ class ManagedGymEnvironment(EvalEnvironment):
                 raise RuntimeError(
                     f"Server exited with code {self._process.returncode} during startup.\nOutput:\n{output}"
                 )
+            probe_timeout = min(2.0, remaining)
             for probe in ("/health", "/openapi.json"):
                 try:
-                    with urllib.request.urlopen(f"{self.endpoint}{probe}", timeout=2.0) as r:
+                    with urllib.request.urlopen(f"{self.endpoint}{probe}", timeout=probe_timeout) as r:
                         if r.status == 200:
                             return
                 except (urllib.error.URLError, OSError):
                     pass
-            time.sleep(0.5)
+            time.sleep(min(0.5, max(0.0, deadline - time.monotonic())))
         self.stop()
         raise TimeoutError(f"Server at {self.endpoint} not healthy within {self._startup_timeout}s")
 
@@ -459,7 +455,9 @@ class ManagedGymEnvironment(EvalEnvironment):
         if not self._wait_for_group_exit(pgid, timeout=15.0):
             logger.warning("Gym process group %d survived SIGTERM; sending SIGKILL", pgid)
             self._signal_group(pgid, signal.SIGKILL)
-            self._wait_for_group_exit(pgid, timeout=5.0)
+            if not self._wait_for_group_exit(pgid, timeout=5.0):
+                logger.error("Gym process group %d survived SIGKILL; leaving handle for retry", pgid)
+                return
 
         with contextlib.suppress(subprocess.TimeoutExpired):
             self._process.wait(timeout=5)

--- a/src/nemo_evaluator/environments/gym.py
+++ b/src/nemo_evaluator/environments/gym.py
@@ -31,6 +31,7 @@ One helper:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -365,7 +366,7 @@ class ManagedGymEnvironment(EvalEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=env,
-            preexec_fn=os.setsid,  # new session → new process group so killpg reaches all descendants
+            start_new_session=True,  # new session → new process group so killpg reaches all descendants
         )
         self._wait_for_health()
         self._inner = GymEnvironment(
@@ -460,18 +461,14 @@ class ManagedGymEnvironment(EvalEnvironment):
             self._signal_group(pgid, signal.SIGKILL)
             self._wait_for_group_exit(pgid, timeout=5.0)
 
-        try:
+        with contextlib.suppress(subprocess.TimeoutExpired):
             self._process.wait(timeout=5)
-        except subprocess.TimeoutExpired:
-            pass
         self._process = None
 
     @staticmethod
     def _signal_group(pgid: int, sig: int) -> None:
-        try:
+        with contextlib.suppress(ProcessLookupError, OSError):
             os.killpg(pgid, sig)
-        except (ProcessLookupError, OSError):
-            pass
 
     @staticmethod
     def _wait_for_group_exit(pgid: int, timeout: float) -> bool:

--- a/src/nemo_evaluator/environments/gym.py
+++ b/src/nemo_evaluator/environments/gym.py
@@ -130,6 +130,7 @@ class GymEnvironment(EvalEnvironment):
         protocol: Literal["evaluator", "native"] = "evaluator",
         dataset: GymDataset | None = None,
         timeout: float = 60.0,
+        label: str | None = None,
     ) -> None:
         super().__init__()
         self.endpoint = endpoint.rstrip("/")
@@ -138,8 +139,11 @@ class GymEnvironment(EvalEnvironment):
         self.timeout = timeout
         self._client: aiohttp.ClientSession | None = None
 
-        ds_label = dataset.name if dataset else self.endpoint
-        self.name = f"gym@{ds_label}" if protocol == "evaluator" else f"gym-native@{ds_label}"
+        if label:
+            self.name = label
+        else:
+            ds_label = dataset.name if dataset else self.endpoint
+            self.name = f"gym@{ds_label}" if protocol == "evaluator" else f"gym-native@{ds_label}"
 
     async def _get_client(self) -> aiohttp.ClientSession:
         if self._client is None or self._client.closed:
@@ -255,11 +259,14 @@ class GymEnvironment(EvalEnvironment):
                 continue
             body[k] = v
 
-        # When no dataset row provided verifier_metadata, synthesize it
-        # from the eval-loop metadata so gym servers can read their fields.
+        # When no dataset row provided verifier_metadata, use it directly from meta
+        # if the seed populated it, or synthesize from other eval-loop metadata fields.
         if "verifier_metadata" not in body:
-            _INTERNAL = {"source", "benchmark", "problem_idx", "prompt", "verifier_metadata"}
-            body["verifier_metadata"] = {k: v for k, v in meta.items() if k not in _INTERNAL}
+            if "verifier_metadata" in meta:
+                body["verifier_metadata"] = meta["verifier_metadata"]
+            else:
+                _INTERNAL = {"source", "benchmark", "problem_idx", "prompt", "verifier_metadata"}
+                body["verifier_metadata"] = {k: v for k, v in meta.items() if k not in _INTERNAL}
 
         # Also forward any metadata the eval loop passed that isn't already set
         for k, v in meta.items():
@@ -325,6 +332,7 @@ class ManagedGymEnvironment(EvalEnvironment):
         request_timeout: float = 120.0,
         protocol: Literal["evaluator", "native"] = "evaluator",
         dataset: GymDataset | None = None,
+        label: str | None = None,
     ) -> None:
         super().__init__()
         self._server_cmd = server_cmd
@@ -336,9 +344,10 @@ class ManagedGymEnvironment(EvalEnvironment):
         self._request_timeout = request_timeout
         self._protocol = protocol
         self._dataset_obj = dataset
+        self._label = label
         self._process: subprocess.Popen | None = None
         self._inner: GymEnvironment | None = None
-        self.name = f"managed-gym@{host}:{self._port}"
+        self.name = label or f"managed-gym@{host}:{self._port}"
 
     @property
     def endpoint(self) -> str:
@@ -356,6 +365,7 @@ class ManagedGymEnvironment(EvalEnvironment):
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             env=env,
+            preexec_fn=os.setsid,  # new session → new process group so killpg reaches all descendants
         )
         self._wait_for_health()
         self._inner = GymEnvironment(
@@ -363,6 +373,7 @@ class ManagedGymEnvironment(EvalEnvironment):
             protocol=self._protocol,
             dataset=self._dataset_obj,
             timeout=self._request_timeout,
+            label=self._label,
         )
         logger.info("Managed Gym server ready at %s (pid=%d)", self.endpoint, self._process.pid)
 
@@ -398,9 +409,12 @@ class ManagedGymEnvironment(EvalEnvironment):
     def _wait_for_health(self) -> None:
         """Wait for the server to become responsive.
 
-        Tries ``/health`` first (evaluator servers).  Falls back to
-        ``/openapi.json`` which every FastAPI app serves by default
-        (native Gym resource servers don't expose ``/health``).
+        A 200 from ``/health`` (evaluator servers) or ``/openapi.json``
+        (native Gym servers, which lack ``/health`` but always serve the
+        FastAPI schema) means ready.  Every other outcome -- connection
+        refused, timeout, or any non-200 status -- means "not ready yet",
+        so we keep polling until the deadline.  ``HTTPError`` is a subclass
+        of ``URLError``, so a single handler covers all of them.
         """
         deadline = time.monotonic() + self._startup_timeout
         while time.monotonic() < deadline:
@@ -411,22 +425,10 @@ class ManagedGymEnvironment(EvalEnvironment):
                 raise RuntimeError(
                     f"Server exited with code {self._process.returncode} during startup.\nOutput:\n{output}"
                 )
-            try:
-                with urllib.request.urlopen(
-                    f"{self.endpoint}/health",
-                    timeout=2.0,
-                ) as r:
-                    if r.status == 200:
-                        return
-            except (urllib.error.URLError, OSError):
-                pass
-            else:
+            for probe in ("/health", "/openapi.json"):
                 try:
-                    with urllib.request.urlopen(
-                        f"{self.endpoint}/openapi.json",
-                        timeout=2.0,
-                    ) as r2:
-                        if r2.status == 200:
+                    with urllib.request.urlopen(f"{self.endpoint}{probe}", timeout=2.0) as r:
+                        if r.status == 200:
                             return
                 except (urllib.error.URLError, OSError):
                     pass
@@ -437,14 +439,56 @@ class ManagedGymEnvironment(EvalEnvironment):
     def stop(self) -> None:
         if self._process is None:
             return
-        logger.info("Stopping managed Gym server (pid=%d)", self._process.pid)
+        pid = self._process.pid
+        logger.info("Stopping managed Gym server (pid=%d)", pid)
+        # os.setsid made the child the leader of a new process group, so its
+        # pgid equals its pid. Cache it: once the leader exits, os.getpgid(pid)
+        # fails, but the group (and its still-running members) lives on.
         try:
-            self._process.send_signal(signal.SIGTERM)
-            self._process.wait(timeout=10)
-        except (subprocess.TimeoutExpired, OSError):
-            self._process.kill()
+            pgid = os.getpgid(pid)
+        except (ProcessLookupError, OSError):
+            pgid = pid
+
+        self._signal_group(pgid, signal.SIGTERM)
+        # Wait on the whole process group, not just the direct child. The shell
+        # that launched `ng_run` exits as soon as ng_run dies, but the gym
+        # app.py servers it spawned may still be handling SIGTERM. If we return
+        # when only the shell is gone, those servers are orphaned with no one
+        # left to reap them.
+        if not self._wait_for_group_exit(pgid, timeout=15.0):
+            logger.warning("Gym process group %d survived SIGTERM; sending SIGKILL", pgid)
+            self._signal_group(pgid, signal.SIGKILL)
+            self._wait_for_group_exit(pgid, timeout=5.0)
+
+        try:
             self._process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
         self._process = None
+
+    @staticmethod
+    def _signal_group(pgid: int, sig: int) -> None:
+        try:
+            os.killpg(pgid, sig)
+        except (ProcessLookupError, OSError):
+            pass
+
+    @staticmethod
+    def _wait_for_group_exit(pgid: int, timeout: float) -> bool:
+        """Poll until no process remains in ``pgid``. Returns True if the group
+        is fully gone within ``timeout``, False otherwise."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                os.killpg(pgid, 0)  # signal 0: liveness probe, kills nothing
+            except (ProcessLookupError, OSError):
+                return True
+            time.sleep(0.2)
+        try:
+            os.killpg(pgid, 0)
+        except (ProcessLookupError, OSError):
+            return True
+        return False
 
     async def seed(self, idx: int) -> SeedResult:
         if self._inner is None:

--- a/src/nemo_evaluator/environments/gym.py
+++ b/src/nemo_evaluator/environments/gym.py
@@ -418,8 +418,16 @@ class ManagedGymEnvironment(EvalEnvironment):
                 output = ""
                 if self._process.stdout:
                     output = self._process.stdout.read().decode(errors="replace")
+                rc = self._process.returncode
+                # start_new_session=True makes the child the process-group leader,
+                # so pgid == pid. Kill any surviving children before clearing state
+                # so a subsequent start() can retry cleanly.
+                pgid = self._process.pid
+                self._signal_group(pgid, signal.SIGTERM)
+                self._wait_for_group_exit(pgid, timeout=5.0)
+                self._process = None
                 raise RuntimeError(
-                    f"Server exited with code {self._process.returncode} during startup.\nOutput:\n{output}"
+                    f"Server exited with code {rc} during startup.\nOutput:\n{output}"
                 )
             probe_timeout = min(2.0, remaining)
             for probe in ("/health", "/openapi.json"):
@@ -452,10 +460,10 @@ class ManagedGymEnvironment(EvalEnvironment):
         # app.py servers it spawned may still be handling SIGTERM. If we return
         # when only the shell is gone, those servers are orphaned with no one
         # left to reap them.
-        if not self._wait_for_group_exit(pgid, timeout=15.0):
+        if not self._wait_for_group_exit(pgid, timeout=15.0, process=self._process):
             logger.warning("Gym process group %d survived SIGTERM; sending SIGKILL", pgid)
             self._signal_group(pgid, signal.SIGKILL)
-            if not self._wait_for_group_exit(pgid, timeout=5.0):
+            if not self._wait_for_group_exit(pgid, timeout=5.0, process=self._process):
                 logger.error("Gym process group %d survived SIGKILL; leaving handle for retry", pgid)
                 return
 
@@ -469,16 +477,28 @@ class ManagedGymEnvironment(EvalEnvironment):
             os.killpg(pgid, sig)
 
     @staticmethod
-    def _wait_for_group_exit(pgid: int, timeout: float) -> bool:
+    def _wait_for_group_exit(
+        pgid: int, timeout: float, process: subprocess.Popen | None = None
+    ) -> bool:
         """Poll until no process remains in ``pgid``. Returns True if the group
-        is fully gone within ``timeout``, False otherwise."""
+        is fully gone within ``timeout``, False otherwise.
+
+        ``process`` is the direct child (group leader). Polling it with
+        ``poll()`` reaps it if it has exited, preventing it from lingering as a
+        zombie that keeps ``os.killpg(pgid, 0)`` returning success even when no
+        real processes remain.
+        """
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
+            if process is not None:
+                process.poll()
             try:
                 os.killpg(pgid, 0)  # signal 0: liveness probe, kills nothing
             except (ProcessLookupError, OSError):
                 return True
             time.sleep(0.2)
+        if process is not None:
+            process.poll()
         try:
             os.killpg(pgid, 0)
         except (ProcessLookupError, OSError):

--- a/src/nemo_evaluator/environments/gym.py
+++ b/src/nemo_evaluator/environments/gym.py
@@ -429,10 +429,14 @@ class ManagedGymEnvironment(EvalEnvironment):
                 raise RuntimeError(
                     f"Server exited with code {rc} during startup.\nOutput:\n{output}"
                 )
-            probe_timeout = min(2.0, remaining)
             for probe in ("/health", "/openapi.json"):
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
                 try:
-                    with urllib.request.urlopen(f"{self.endpoint}{probe}", timeout=probe_timeout) as r:
+                    with urllib.request.urlopen(
+                        f"{self.endpoint}{probe}", timeout=min(2.0, remaining)
+                    ) as r:
                         if r.status == 200:
                             return
                 except (urllib.error.URLError, OSError):

--- a/src/nemo_evaluator/environments/gym_protocol.py
+++ b/src/nemo_evaluator/environments/gym_protocol.py
@@ -63,6 +63,9 @@ def wrap_text_as_gym_response(text: str) -> dict[str, Any]:
         "created_at": 0,
         "status": "completed",
         "model": "evaluator",
+        "parallel_tool_calls": True,
+        "tool_choice": "auto",
+        "tools": [],
         "output": [
             {
                 "id": "msg-eval-synthetic",
@@ -106,16 +109,54 @@ def extract_prompt_from_rcp(rcp: dict[str, Any]) -> str:
     return ""
 
 
-def messages_from_rcp(rcp: dict[str, Any]) -> list[dict[str, str]]:
-    """Build a messages list from responses_create_params.input."""
+def _as_text(content: Any) -> str:
+    """Coerce a Responses/chat ``content`` value to a plain string."""
+    return content if isinstance(content, str) else str(content) if content is not None else ""
+
+
+def messages_from_rcp(rcp: dict[str, Any]) -> list[dict[str, Any]]:
+    """Build a chat-completions messages list from responses_create_params.input.
+
+    Tool-call structure is preserved so tool-use trajectories survive:
+
+    * role-based messages keep any ``tool_calls`` / ``tool_call_id`` / ``name``
+      fields (an assistant tool-call turn or a ``role: "tool"`` result stays
+      intact instead of collapsing to an empty ``content``);
+    * Responses-API typed items are translated to the equivalent messages —
+      ``function_call`` -> an assistant message with ``tool_calls``,
+      ``function_call_output`` -> a ``role: "tool"`` message whose ``content``
+      carries the tool output (which otherwise rode in ``output``, not
+      ``content``, and was silently dropped).
+    """
     inp = rcp.get("input", [])
     if not isinstance(inp, list):
         return []
-    return [
-        {
-            "role": m.get("role", "user"),
-            "content": m.get("content", "") if isinstance(m.get("content"), str) else str(m.get("content", "")),
-        }
-        for m in inp
-        if isinstance(m, dict)
-    ]
+    messages: list[dict[str, Any]] = []
+    for m in inp:
+        if not isinstance(m, dict):
+            continue
+        item_type = m.get("type")
+        if item_type == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": m.get("call_id", ""),
+                            "type": "function",
+                            "function": {"name": m.get("name", ""), "arguments": _as_text(m.get("arguments", ""))},
+                        }
+                    ],
+                }
+            )
+            continue
+        if item_type == "function_call_output":
+            messages.append({"role": "tool", "tool_call_id": m.get("call_id", ""), "content": _as_text(m.get("output"))})
+            continue
+        msg: dict[str, Any] = {"role": m.get("role", "user"), "content": _as_text(m.get("content", ""))}
+        for key in ("tool_calls", "tool_call_id", "name"):
+            if m.get(key) is not None:
+                msg[key] = m[key]
+        messages.append(msg)
+    return messages

--- a/src/nemo_evaluator/environments/gym_protocol.py
+++ b/src/nemo_evaluator/environments/gym_protocol.py
@@ -109,7 +109,7 @@ def extract_prompt_from_rcp(rcp: dict[str, Any]) -> str:
     return ""
 
 
-def _as_text(content: Any) -> str:
+def _as_text(content: object) -> str:
     """Coerce a Responses/chat ``content`` value to a plain string."""
     return content if isinstance(content, str) else str(content) if content is not None else ""
 
@@ -132,25 +132,28 @@ def messages_from_rcp(rcp: dict[str, Any]) -> list[dict[str, Any]]:
     if not isinstance(inp, list):
         return []
     messages: list[dict[str, Any]] = []
+    pending_tool_calls: list[dict[str, Any]] = []
+
+    def flush_tool_calls() -> None:
+        if pending_tool_calls:
+            messages.append({"role": "assistant", "content": "", "tool_calls": list(pending_tool_calls)})
+            pending_tool_calls.clear()
+
     for m in inp:
         if not isinstance(m, dict):
             continue
         item_type = m.get("type")
         if item_type == "function_call":
-            messages.append(
+            # Consecutive function_call items form one assistant turn (parallel calls).
+            pending_tool_calls.append(
                 {
-                    "role": "assistant",
-                    "content": "",
-                    "tool_calls": [
-                        {
-                            "id": m.get("call_id", ""),
-                            "type": "function",
-                            "function": {"name": m.get("name", ""), "arguments": _as_text(m.get("arguments", ""))},
-                        }
-                    ],
+                    "id": m.get("call_id", ""),
+                    "type": "function",
+                    "function": {"name": m.get("name", ""), "arguments": _as_text(m.get("arguments", ""))},
                 }
             )
             continue
+        flush_tool_calls()
         if item_type == "function_call_output":
             messages.append({"role": "tool", "tool_call_id": m.get("call_id", ""), "content": _as_text(m.get("output"))})
             continue
@@ -159,4 +162,5 @@ def messages_from_rcp(rcp: dict[str, Any]) -> list[dict[str, Any]]:
             if m.get(key) is not None:
                 msg[key] = m[key]
         messages.append(msg)
+    flush_tool_calls()
     return messages

--- a/src/nemo_evaluator/environments/registry.py
+++ b/src/nemo_evaluator/environments/registry.py
@@ -100,8 +100,9 @@ def _make_gym(rest: str, **kwargs: Any) -> "EvalEnvironment":
     data_path = kwargs.get("data")
     dataset = GymDataset(data_path) if data_path else None
     label: str | None = None
+    timeout: float | None = None
 
-    # Parse inline query params: gym://host:port?protocol=native&data=/foo.jsonl&label=rolemrc
+    # Parse inline query params: gym://host:port?protocol=native&data=/foo.jsonl&label=rolemrc&timeout=600
     if "?" in rest:
         rest_base, qs = rest.split("?", 1)
         for kv in qs.split("&"):
@@ -114,15 +115,24 @@ def _make_gym(rest: str, **kwargs: Any) -> "EvalEnvironment":
                 dataset = GymDataset(v)
             elif k == "label":
                 label = v
+            elif k == "timeout":
+                # /verify (and /seed) HTTP total timeout in seconds. Raise it for
+                # judge-based verifiers whose slowest rows exceed the 60s default.
+                timeout = float(v)
         rest = rest_base
 
+    gym_kw: dict[str, Any] = {} if timeout is None else {"timeout": timeout}
+    managed_kw: dict[str, Any] = {} if timeout is None else {"request_timeout": timeout}
+
     if _HOST_PORT_RE.match(rest):
-        return GymEnvironment(f"http://{rest}", protocol=protocol, dataset=dataset, label=label)
+        return GymEnvironment(f"http://{rest}", protocol=protocol, dataset=dataset, label=label, **gym_kw)
     if rest.startswith("cmd:"):
-        return ManagedGymEnvironment(server_cmd=rest[4:], protocol=protocol, dataset=dataset, label=label)
+        return ManagedGymEnvironment(server_cmd=rest[4:], protocol=protocol, dataset=dataset, label=label, **managed_kw)
     if rest.startswith("module:"):
-        return ManagedGymEnvironment(server_module=rest[7:], protocol=protocol, dataset=dataset, label=label)
-    return ManagedGymEnvironment(nel_benchmark=rest, protocol=protocol, dataset=dataset, label=label)
+        return ManagedGymEnvironment(
+            server_module=rest[7:], protocol=protocol, dataset=dataset, label=label, **managed_kw
+        )
+    return ManagedGymEnvironment(nel_benchmark=rest, protocol=protocol, dataset=dataset, label=label, **managed_kw)
 
 
 def _make_skills(rest: str, **kwargs: Any) -> "EvalEnvironment":

--- a/src/nemo_evaluator/environments/registry.py
+++ b/src/nemo_evaluator/environments/registry.py
@@ -99,8 +99,9 @@ def _make_gym(rest: str, **kwargs: Any) -> "EvalEnvironment":
     protocol = kwargs.get("protocol", "evaluator")
     data_path = kwargs.get("data")
     dataset = GymDataset(data_path) if data_path else None
+    label: str | None = None
 
-    # Parse inline query params: gym://host:port?protocol=native&data=/foo.jsonl
+    # Parse inline query params: gym://host:port?protocol=native&data=/foo.jsonl&label=rolemrc
     if "?" in rest:
         rest_base, qs = rest.split("?", 1)
         for kv in qs.split("&"):
@@ -111,15 +112,17 @@ def _make_gym(rest: str, **kwargs: Any) -> "EvalEnvironment":
                 protocol = v
             elif k == "data":
                 dataset = GymDataset(v)
+            elif k == "label":
+                label = v
         rest = rest_base
 
     if _HOST_PORT_RE.match(rest):
-        return GymEnvironment(f"http://{rest}", protocol=protocol, dataset=dataset)
+        return GymEnvironment(f"http://{rest}", protocol=protocol, dataset=dataset, label=label)
     if rest.startswith("cmd:"):
-        return ManagedGymEnvironment(server_cmd=rest[4:], protocol=protocol, dataset=dataset)
+        return ManagedGymEnvironment(server_cmd=rest[4:], protocol=protocol, dataset=dataset, label=label)
     if rest.startswith("module:"):
-        return ManagedGymEnvironment(server_module=rest[7:], protocol=protocol, dataset=dataset)
-    return ManagedGymEnvironment(nel_benchmark=rest, protocol=protocol, dataset=dataset)
+        return ManagedGymEnvironment(server_module=rest[7:], protocol=protocol, dataset=dataset, label=label)
+    return ManagedGymEnvironment(nel_benchmark=rest, protocol=protocol, dataset=dataset, label=label)
 
 
 def _make_skills(rest: str, **kwargs: Any) -> "EvalEnvironment":

--- a/src/nemo_evaluator/environments/registry.py
+++ b/src/nemo_evaluator/environments/registry.py
@@ -23,6 +23,7 @@ import re
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
+from urllib.parse import parse_qs
 
 if TYPE_CHECKING:
     from nemo_evaluator.environments.base import EvalEnvironment
@@ -105,20 +106,17 @@ def _make_gym(rest: str, **kwargs: Any) -> "EvalEnvironment":
     # Parse inline query params: gym://host:port?protocol=native&data=/foo.jsonl&label=rolemrc&timeout=600
     if "?" in rest:
         rest_base, qs = rest.split("?", 1)
-        for kv in qs.split("&"):
-            if "=" not in kv:
-                continue
-            k, v = kv.split("=", 1)
-            if k == "protocol":
-                protocol = v
-            elif k == "data":
-                dataset = GymDataset(v)
-            elif k == "label":
-                label = v
-            elif k == "timeout":
-                # /verify (and /seed) HTTP total timeout in seconds. Raise it for
-                # judge-based verifiers whose slowest rows exceed the 60s default.
-                timeout = float(v)
+        parsed = parse_qs(qs, keep_blank_values=True)
+        if "protocol" in parsed:
+            protocol = parsed["protocol"][0]
+        if "data" in parsed:
+            dataset = GymDataset(parsed["data"][0])
+        if "label" in parsed:
+            label = parsed["label"][0]
+        if "timeout" in parsed:
+            # /verify (and /seed) HTTP total timeout in seconds. Raise it for
+            # judge-based verifiers whose slowest rows exceed the 60s default.
+            timeout = float(parsed["timeout"][0])
         rest = rest_base
 
     gym_kw: dict[str, Any] = {} if timeout is None else {"timeout": timeout}

--- a/src/nemo_evaluator/orchestration/slurm_gen.py
+++ b/src/nemo_evaluator/orchestration/slurm_gen.py
@@ -2316,7 +2316,28 @@ def generate_sbatch(
     if has_secrets:
         parts.append(_SECRETS_SOURCE)
 
-    if _any_multinode_service(config):
+    if is_shard_script:
+        parts.append(_SHARD_ENV.format(shard_idx=shard_idx, total_shards=total_shards))
+
+    _any_service_has_image = any(getattr(s, "image", None) for s in config.services.values())
+    use_containers = (
+        cluster.container_mounts
+        or cluster.container_env
+        or _any_service_has_image
+        or any(getattr(s, "container_mounts", []) for s in config.services.values())
+        or getattr(cluster, "eval_image", None)
+    )
+
+    # Emit MASTER_IP discovery whenever it will be referenced in srun flags.
+    # Two cases:
+    # 1. A service requests multiple nodes (existing multi-node case).
+    # 2. Single-pool container jobs: _pin=True causes gym sruns to get
+    #    -w $MASTER_IP even on single-node allocations. Without this block,
+    #    set -u aborts the script with "MASTER_IP: unbound variable".
+    #    For single-node jobs SLURM_JOB_NODELIST contains exactly one
+    #    hostname, so scontrol returns it and -w $MASTER_IP is a no-op.
+    _needs_master_ip = _has_multinode_service or (not use_het and bool(use_containers))
+    if _needs_master_ip:
         nodelist_var = "SLURM_JOB_NODELIST"
         if use_het:
             for svc in config.services.values():
@@ -2335,18 +2356,6 @@ def generate_sbatch(
                     nodelist_var = f"SLURM_JOB_NODELIST_HET_GROUP_{pool_to_het[prefill_pool]}"
                     break
         parts.append(_MULTINODE_IP_DISCOVERY.format(nodelist_var=nodelist_var))
-
-    if is_shard_script:
-        parts.append(_SHARD_ENV.format(shard_idx=shard_idx, total_shards=total_shards))
-
-    _any_service_has_image = any(getattr(s, "image", None) for s in config.services.values())
-    use_containers = (
-        cluster.container_mounts
-        or cluster.container_env
-        or _any_service_has_image
-        or any(getattr(s, "container_mounts", []) for s in config.services.values())
-        or getattr(cluster, "eval_image", None)
-    )
 
     if use_containers:
         parts.append(_preflight_image_checks(config, cluster))

--- a/src/nemo_evaluator/solvers/chat.py
+++ b/src/nemo_evaluator/solvers/chat.py
@@ -33,10 +33,11 @@ class ChatSolver:
 
     async def solve(self, task: SeedResult) -> SolveResult:
         effective_system = self._system or task.system
+        tools = (task.metadata or {}).get("tools") or None
         if task.messages:
-            resp = await self._client.chat(messages=task.messages)
+            resp = await self._client.chat(messages=task.messages, tools=tools)
         else:
-            resp = await self._client.chat(task.prompt, system=effective_system)
+            resp = await self._client.chat(task.prompt, system=effective_system, tools=tools)
         trajectory = build_single_turn_atif(
             task.prompt,
             resp.content,

--- a/tests/test_engine/test_model_client.py
+++ b/tests/test_engine/test_model_client.py
@@ -97,6 +97,28 @@ class TestModelClient:
             c._parse_response({"choices": []}, 100.0, "test", None)
 
     @pytest.mark.asyncio
+    async def test_post_with_retry_rejects_non_object_json(self):
+        from nemo_evaluator.errors import InfraError
+
+        c = ModelClient(base_url="https://api.example.com/v1", model="test")
+
+        resp = MagicMock()
+        resp.status = 200
+        resp.raise_for_status = MagicMock()
+        resp.json = AsyncMock(return_value=None)
+
+        post_cm = MagicMock()
+        post_cm.__aenter__ = AsyncMock(return_value=resp)
+        post_cm.__aexit__ = AsyncMock(return_value=False)
+        fake_client = MagicMock()
+        fake_client.post = MagicMock(return_value=post_cm)
+
+        with patch.object(c, "_get_client", return_value=fake_client):
+            with pytest.raises(InfraError, match="non-object JSON"):
+                await c.chat(prompt="hello")
+        await c.close()
+
+    @pytest.mark.asyncio
     async def test_chat_payload_includes_all_generation_fields(self):
         c = ModelClient(
             base_url="https://api.example.com/v1",

--- a/tests/test_engine/test_model_client.py
+++ b/tests/test_engine/test_model_client.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -129,6 +129,19 @@ class TestModelClient:
             await c.chat(messages=[{"role": "user", "content": "hi"}], tools=tools)
             payload = mock_post.call_args[0][1]
             assert payload["tools"] == tools
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_chat_with_tools_skips_cache(self):
+        c = ModelClient(base_url="https://api.example.com/v1", model="test")
+        c._cache = MagicMock()
+        tools = [{"type": "function", "function": {"name": "get_page"}}]
+        with patch.object(c, "_post_with_retry", new_callable=AsyncMock, return_value=MOCK_TOOL_RESPONSE) as mock_post:
+            await c.chat(messages=[{"role": "user", "content": "hi"}], tools=tools)
+            payload = mock_post.call_args[0][1]
+            assert payload["tools"] == tools
+        c._cache.get.assert_not_called()
+        c._cache.put.assert_not_called()
         await c.close()
 
     @pytest.mark.asyncio

--- a/tests/test_engine/test_model_client.py
+++ b/tests/test_engine/test_model_client.py
@@ -122,6 +122,25 @@ class TestModelClient:
         await c.close()
 
     @pytest.mark.asyncio
+    async def test_chat_payload_includes_tools_when_provided(self):
+        c = ModelClient(base_url="https://api.example.com/v1", model="test")
+        tools = [{"type": "function", "function": {"name": "get_page"}}]
+        with patch.object(c, "_post_with_retry", new_callable=AsyncMock, return_value=MOCK_CHAT_RESPONSE) as mock_post:
+            await c.chat(messages=[{"role": "user", "content": "hi"}], tools=tools)
+            payload = mock_post.call_args[0][1]
+            assert payload["tools"] == tools
+        await c.close()
+
+    @pytest.mark.asyncio
+    async def test_chat_payload_omits_tools_when_absent(self):
+        c = ModelClient(base_url="https://api.example.com/v1", model="test")
+        with patch.object(c, "_post_with_retry", new_callable=AsyncMock, return_value=MOCK_CHAT_RESPONSE) as mock_post:
+            await c.chat(prompt="hello")
+            payload = mock_post.call_args[0][1]
+            assert "tools" not in payload
+        await c.close()
+
+    @pytest.mark.asyncio
     async def test_chat_payload_omits_none_fields(self):
         c = ModelClient(base_url="https://api.example.com/v1", model="test")
         with patch.object(c, "_post_with_retry", new_callable=AsyncMock, return_value=MOCK_CHAT_RESPONSE) as mock_post:

--- a/tests/test_engine/test_model_client.py
+++ b/tests/test_engine/test_model_client.py
@@ -113,9 +113,11 @@ class TestModelClient:
         fake_client = MagicMock()
         fake_client.post = MagicMock(return_value=post_cm)
 
-        with patch.object(c, "_get_client", return_value=fake_client):
-            with pytest.raises(InfraError, match="non-object JSON"):
-                await c.chat(prompt="hello")
+        with (
+            patch.object(c, "_get_client", return_value=fake_client),
+            pytest.raises(InfraError, match="non-object JSON"),
+        ):
+            await c.chat(prompt="hello")
         await c.close()
 
     @pytest.mark.asyncio

--- a/tests/test_environments/test_gym_integration.py
+++ b/tests/test_environments/test_gym_integration.py
@@ -26,10 +26,12 @@ Tests are grouped by component.
 
 from __future__ import annotations
 
+import itertools
 import json
+import signal
 from contextlib import asynccontextmanager
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -130,6 +132,42 @@ class TestGymProtocol:
         )
         assert len(msgs) == 2
         assert msgs[0] == {"role": "user", "content": "q"}
+
+    def test_messages_from_rcp_translates_typed_tool_items(self):
+        """function_call / function_call_output items become a proper tool turn."""
+        from nemo_evaluator.environments.gym_protocol import messages_from_rcp
+
+        msgs = messages_from_rcp(
+            {
+                "input": [
+                    {"role": "user", "content": "fetch and translate"},
+                    {"type": "function_call", "call_id": "c0", "name": "get_page", "arguments": '{"url": "x"}'},
+                    {"type": "function_call_output", "call_id": "c0", "output": "página en español"},
+                ]
+            }
+        )
+        assert [m["role"] for m in msgs] == ["user", "assistant", "tool"]
+        assert msgs[1]["tool_calls"] == [
+            {"id": "c0", "type": "function", "function": {"name": "get_page", "arguments": '{"url": "x"}'}}
+        ]
+        # The tool output — which rode in `output`, not `content` — is preserved.
+        assert msgs[2] == {"role": "tool", "tool_call_id": "c0", "content": "página en español"}
+
+    def test_messages_from_rcp_preserves_chat_tool_fields(self):
+        """Role-based messages keep their tool_calls / tool_call_id / name fields."""
+        from nemo_evaluator.environments.gym_protocol import messages_from_rcp
+
+        tool_calls = [{"id": "c1", "type": "function", "function": {"name": "f", "arguments": "{}"}}]
+        msgs = messages_from_rcp(
+            {
+                "input": [
+                    {"role": "assistant", "content": "", "tool_calls": tool_calls},
+                    {"role": "tool", "tool_call_id": "c1", "name": "f", "content": "result"},
+                ]
+            }
+        )
+        assert msgs[0]["tool_calls"] == tool_calls
+        assert msgs[1] == {"role": "tool", "content": "result", "tool_call_id": "c1", "name": "f"}
 
     def test_extract_assistant_text_plain_string(self):
         from nemo_evaluator.environments.gym_protocol import extract_assistant_text
@@ -420,6 +458,75 @@ class TestManagedGymEnvironment:
         with patch("nemo_evaluator.environments.gym._find_free_port", return_value=12345):
             env = ManagedGymEnvironment(nel_benchmark="test")
         assert env._port == 12345
+
+    def test_stop_noop_when_not_started(self):
+        from nemo_evaluator.environments.gym import ManagedGymEnvironment
+
+        env = ManagedGymEnvironment(server_cmd="x", port=9999)
+        env.stop()  # no process → must not raise
+        assert env._process is None
+
+    def _make_env_with_fake_process(self):
+        from nemo_evaluator.environments.gym import ManagedGymEnvironment
+
+        env = ManagedGymEnvironment(server_cmd="x", port=9999)
+        proc = MagicMock()
+        proc.pid = 4242
+        proc.wait.return_value = 0
+        env._process = proc
+        return env
+
+    def test_stop_kills_whole_group_gracefully(self):
+        """When the group exits after SIGTERM, no SIGKILL is needed."""
+        from nemo_evaluator.environments import gym as gym_mod
+
+        env = self._make_env_with_fake_process()
+        sent: list[int] = []
+
+        def fake_killpg(pgid, sig):
+            sent.append(sig)
+            if sig == 0:  # liveness probe: group already gone
+                raise ProcessLookupError
+
+        with (
+            patch.object(gym_mod.os, "getpgid", return_value=4242),
+            patch.object(gym_mod.os, "killpg", side_effect=fake_killpg),
+            patch.object(gym_mod.time, "sleep"),
+            patch.object(gym_mod.time, "monotonic", side_effect=itertools.count(0, 1)),
+        ):
+            env.stop()
+
+        assert signal.SIGTERM in sent
+        assert signal.SIGKILL not in sent
+        assert env._process is None
+
+    def test_stop_escalates_to_sigkill_when_group_survives_sigterm(self):
+        """The direct child may exit while the app.py servers it spawned linger;
+        stop() must SIGKILL the whole group so nothing is orphaned."""
+        from nemo_evaluator.environments import gym as gym_mod
+
+        env = self._make_env_with_fake_process()
+        sent: list[int] = []
+        alive = {"v": True}
+
+        def fake_killpg(pgid, sig):
+            sent.append(sig)
+            if sig == signal.SIGKILL:
+                alive["v"] = False
+            elif sig == 0 and not alive["v"]:
+                raise ProcessLookupError
+
+        with (
+            patch.object(gym_mod.os, "getpgid", return_value=4242),
+            patch.object(gym_mod.os, "killpg", side_effect=fake_killpg),
+            patch.object(gym_mod.time, "sleep"),
+            patch.object(gym_mod.time, "monotonic", side_effect=itertools.count(0, 1)),
+        ):
+            env.stop()
+
+        assert signal.SIGTERM in sent
+        assert signal.SIGKILL in sent
+        assert env._process is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_environments/test_gym_integration.py
+++ b/tests/test_environments/test_gym_integration.py
@@ -90,6 +90,9 @@ class TestGymProtocol:
 
         assert result["output_text"] == "SELECT * FROM users;"
         assert result["status"] == "completed"
+        assert result["parallel_tool_calls"] is True
+        assert result["tool_choice"] == "auto"
+        assert result["tools"] == []
         msg = result["output"][0]
         assert msg["type"] == "message"
         assert msg["role"] == "assistant"
@@ -152,6 +155,30 @@ class TestGymProtocol:
         ]
         # The tool output — which rode in `output`, not `content` — is preserved.
         assert msgs[2] == {"role": "tool", "tool_call_id": "c0", "content": "página en español"}
+
+    def test_messages_from_rcp_groups_parallel_function_calls(self):
+        """Consecutive function_call items collapse into one assistant message."""
+        from nemo_evaluator.environments.gym_protocol import messages_from_rcp
+
+        msgs = messages_from_rcp(
+            {
+                "input": [
+                    {"role": "user", "content": "do both"},
+                    {"type": "function_call", "call_id": "c0", "name": "get_page", "arguments": '{"url": "x"}'},
+                    {"type": "function_call", "call_id": "c1", "name": "get_page", "arguments": '{"url": "y"}'},
+                    {"type": "function_call_output", "call_id": "c0", "output": "first"},
+                    {"type": "function_call_output", "call_id": "c1", "output": "second"},
+                ]
+            }
+        )
+        assert [m["role"] for m in msgs] == ["user", "assistant", "tool", "tool"]
+        # Both parallel calls live in a single assistant message.
+        assert msgs[1]["tool_calls"] == [
+            {"id": "c0", "type": "function", "function": {"name": "get_page", "arguments": '{"url": "x"}'}},
+            {"id": "c1", "type": "function", "function": {"name": "get_page", "arguments": '{"url": "y"}'}},
+        ]
+        assert msgs[2] == {"role": "tool", "tool_call_id": "c0", "content": "first"}
+        assert msgs[3] == {"role": "tool", "tool_call_id": "c1", "content": "second"}
 
     def test_messages_from_rcp_preserves_chat_tool_fields(self):
         """Role-based messages keep their tool_calls / tool_call_id / name fields."""
@@ -595,6 +622,29 @@ class TestGymUriResolution:
 
         env = _make_gym("localhost:8080", protocol="native")
         assert env.protocol == "native"
+
+    def test_label_query_param_host_port(self, _mock_port):
+        from nemo_evaluator.environments.gym import GymEnvironment
+        from nemo_evaluator.environments.registry import _make_gym
+
+        env = _make_gym("localhost:8080?label=rolemrc")
+        assert isinstance(env, GymEnvironment)
+        assert env.name == "rolemrc"
+
+    def test_timeout_query_param_host_port(self, _mock_port):
+        from nemo_evaluator.environments.gym import GymEnvironment
+        from nemo_evaluator.environments.registry import _make_gym
+
+        env = _make_gym("localhost:8080?timeout=600")
+        assert isinstance(env, GymEnvironment)
+        assert env.timeout == 600.0
+
+    def test_label_and_timeout_query_params_managed(self, _mock_port):
+        from nemo_evaluator.environments.registry import _make_gym
+
+        env = _make_gym("spider2_lite?label=spider&timeout=300")
+        assert env._label == "spider"
+        assert env._request_timeout == 300.0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_environments/test_gym_integration.py
+++ b/tests/test_environments/test_gym_integration.py
@@ -493,6 +493,37 @@ class TestManagedGymEnvironment:
         env.stop()  # no process → must not raise
         assert env._process is None
 
+    def test_wait_for_health_caps_probe_timeout_to_deadline(self):
+        """A startup_timeout shorter than the probe/sleep intervals must not
+        let a single urlopen call overrun the deadline."""
+        from nemo_evaluator.environments import gym as gym_mod
+        from nemo_evaluator.environments.gym import ManagedGymEnvironment
+
+        env = ManagedGymEnvironment(server_cmd="x", port=9999, startup_timeout=0.3)
+        proc = MagicMock()
+        proc.poll.return_value = None  # still running
+        env._process = proc
+
+        timeouts: list[float] = []
+
+        def fake_urlopen(url, timeout):
+            timeouts.append(timeout)
+            raise gym_mod.urllib.error.URLError("refused")
+
+        with (
+            patch.object(gym_mod.urllib.request, "urlopen", side_effect=fake_urlopen),
+            patch.object(gym_mod.time, "sleep"),
+            patch.object(gym_mod.time, "monotonic", side_effect=itertools.count(0.0, 0.1)),
+            patch.object(env, "stop"),
+            pytest.raises(TimeoutError),
+        ):
+            env._wait_for_health()
+
+        assert timeouts, "expected at least one probe"
+        # Probe timeout is capped by the remaining deadline (0.3s), never the 2.0s default.
+        assert max(timeouts) <= 0.3
+        env._process = None  # prevent __del__ -> stop() from signalling a real process group
+
     def _make_env_with_fake_process(self):
         from nemo_evaluator.environments.gym import ManagedGymEnvironment
 
@@ -502,6 +533,23 @@ class TestManagedGymEnvironment:
         proc.wait.return_value = 0
         env._process = proc
         return env
+
+    def test_stop_keeps_handle_when_group_survives_sigkill(self):
+        """If the group outlives SIGKILL, stop() must not drop the process handle."""
+        from nemo_evaluator.environments import gym as gym_mod
+
+        env = self._make_env_with_fake_process()
+
+        with (
+            patch.object(gym_mod.os, "getpgid", return_value=4242),
+            patch.object(gym_mod.os, "killpg"),  # never raises → group always "alive"
+            patch.object(gym_mod.time, "sleep"),
+            patch.object(gym_mod.time, "monotonic", side_effect=itertools.count(0, 1)),
+        ):
+            env.stop()
+
+        assert env._process is not None
+        env._process = None  # prevent __del__ -> stop() from signalling a real process group
 
     def test_stop_kills_whole_group_gracefully(self):
         """When the group exits after SIGTERM, no SIGKILL is needed."""

--- a/tests/test_environments/test_gym_integration.py
+++ b/tests/test_environments/test_gym_integration.py
@@ -506,7 +506,7 @@ class TestManagedGymEnvironment:
 
         timeouts: list[float] = []
 
-        def fake_urlopen(url, timeout):
+        def fake_urlopen(_url: str, timeout: float) -> None:
             timeouts.append(timeout)
             raise gym_mod.urllib.error.URLError("refused")
 

--- a/tests/test_orchestration/test_slurm_sharding.py
+++ b/tests/test_orchestration/test_slurm_sharding.py
@@ -56,6 +56,37 @@ def _mode(path):
     return path.stat().st_mode & 0o777
 
 
+def _make_single_node_container_config():
+    """Single node pool (use_het disabled) with a containerized eval (use_containers)."""
+    return EvalConfig.model_validate(
+        {
+            "services": {
+                "model": {"type": "api", "url": "http://x/v1/chat/completions", "protocol": "chat_completions"},
+            },
+            "benchmarks": [
+                {"name": "gsm8k", "repeats": 1, "solver": {"type": "simple", "service": "model"}},
+            ],
+            "cluster": {
+                "type": "slurm",
+                "walltime": "02:00:00",
+                "eval_image": "nvcr.io/nvidia/eval:latest",
+                "node_pools": {
+                    "compute": {"partition": "batch", "nodes": 1, "gres": "gpu:4"},
+                },
+            },
+        }
+    )
+
+
+class TestSbatchMasterIp:
+    def test_single_node_container_emits_master_ip(self):
+        """Single-pool containerized jobs still need MASTER_IP for pinned gym sruns."""
+        cfg = _make_single_node_container_config()
+        script, _, _ = generate_sbatch(cfg)
+        assert 'MASTER_IP=$(scontrol show hostname "$SLURM_JOB_NODELIST"' in script
+        assert "export MASTER_IP" in script
+
+
 class TestSbatchShardGeneration:
     def test_no_shards_no_shard_env(self):
         cfg = _make_slurm_config(shards=None)

--- a/tests/test_orchestration/test_slurm_sharding.py
+++ b/tests/test_orchestration/test_slurm_sharding.py
@@ -57,11 +57,17 @@ def _mode(path):
 
 
 def _make_single_node_container_config():
-    """Single node pool (use_het disabled) with a containerized eval (use_containers)."""
+    """Single node pool (use_het disabled) with a containerized eval and gym service.
+
+    The gym service has an image so its srun gets ``-w $MASTER_IP`` (single-pool
+    container jobs pin gym sruns to the master node). This exercises the invariant
+    that MASTER_IP is initialised before it is first referenced.
+    """
     return EvalConfig.model_validate(
         {
             "services": {
                 "model": {"type": "api", "url": "http://x/v1/chat/completions", "protocol": "chat_completions"},
+                "gym": {"type": "gym", "port": 9090, "image": "nvcr.io/nvidia/gym:latest", "server_cmd": "ng_run +config_paths=[gsm8k.yaml]"},
             },
             "benchmarks": [
                 {"name": "gsm8k", "repeats": 1, "solver": {"type": "simple", "service": "model"}},
@@ -85,6 +91,10 @@ class TestSbatchMasterIp:
         script, _, _ = generate_sbatch(cfg)
         assert 'MASTER_IP=$(scontrol show hostname "$SLURM_JOB_NODELIST"' in script
         assert "export MASTER_IP" in script
+        # Discovery block must precede the first srun that references $MASTER_IP.
+        init_pos = script.index("MASTER_IP=$(scontrol show hostname")
+        first_use_pos = script.index("-w $MASTER_IP")
+        assert init_pos < first_use_pos
 
 
 class TestSbatchShardGeneration:

--- a/tests/test_orchestration/test_slurm_sharding.py
+++ b/tests/test_orchestration/test_slurm_sharding.py
@@ -56,7 +56,7 @@ def _mode(path):
     return path.stat().st_mode & 0o777
 
 
-def _make_single_node_container_config():
+def _make_single_node_container_config() -> EvalConfig:
     """Single node pool (use_het disabled) with a containerized eval and gym service.
 
     The gym service has an image so its srun gets ``-w $MASTER_IP`` (single-pool

--- a/tests/test_solvers/test_solvers.py
+++ b/tests/test_solvers/test_solvers.py
@@ -89,6 +89,34 @@ class TestChatSolver:
         result = await solver.solve(_make_seed())
         assert result.response == ""
 
+    @pytest.mark.asyncio
+    async def test_tools_forwarded_from_metadata(self):
+        from nemo_evaluator.solvers.chat import ChatSolver
+
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(return_value=_make_model_response("ok"))
+
+        seed = _make_seed()
+        tools = [{"type": "function", "function": {"name": "get_page"}}]
+        seed.metadata = {"tools": tools}
+
+        solver = ChatSolver(client=mock_client)
+        await solver.solve(seed)
+
+        assert mock_client.chat.await_args.kwargs["tools"] == tools
+
+    @pytest.mark.asyncio
+    async def test_no_tools_passes_none(self):
+        from nemo_evaluator.solvers.chat import ChatSolver
+
+        mock_client = AsyncMock()
+        mock_client.chat = AsyncMock(return_value=_make_model_response("ok"))
+
+        solver = ChatSolver(client=mock_client)
+        await solver.solve(_make_seed())
+
+        assert mock_client.chat.await_args.kwargs["tools"] is None
+
 
 # ---------------------------------------------------------------------------
 # NatSolver


### PR DESCRIPTION
Summary

Enables tool-use (function-calling) benchmarks to run end-to-end through the chat solver, hardens the managed Gym server lifecycle, fixes health-check and SLURM-orchestration edge cases, and adds custom labeling for Gym environments.

Changes

1. Forward tool definitions to the model (tool-use benchmarks)

Agentic/tool-use benchmarks encode their tool schemas and prior tool-call turns in responses_create_params, but none of it reached the model. Three gaps are closed:

- gym_protocol.messages_from_rcp now preserves tool-call structure instead of collapsing every message to {role, content}. Responses-API typed items are translated to
chat-completions form: function_call → an assistant message with tool_cal a role: "tool" message (its output previously rode in output, not content, and was silently dropped). Role-based messages keep their tool_calls / tool_call_id / name fields.
- ModelClient.chat accepts a tools argument and adds it to the request pat part of the cache key, the cache is bypassed when tools are present —otherwise a tool-unaware cached response could be served for a tool-aware request.
- ChatSolver.solve forwards task.metadata["tools"] (populated by GymDatas
- wrap_text_as_gym_response emits the parallel_tool_calls / tool_choice / tools fields the NeMoGymResponse envelope now requires.

2. Reliable teardown of managed Gym servers

ManagedGymEnvironment.stop() only signaled the direct child. When the launcher shell exited before the app.py servers it spawned, those servers were orphaned. Now:

- The server is started with preexec_fn=os.setsid, putting it in its own process group.
- stop() sends SIGTERM to the whole group, polls until every group memberIGKILL if the group survives 15s.

3. Health-check: recognize native Gym servers, simplified

Native Gym servers have no /health route, so startup health-checking woult_for_health now polls /health and /openapi.json (which FastAPI alwaysserves) each cycle; a 200 from either means ready. Every other outcome — connection refused, timeout, 404, 5xx — is treated identically as "not up yet, keep polling until the
deadline," collapsing the earlier nested 404 special-case into one flat h

4. SLURM: emit MASTER_IP for single-node container jobs

On single-pool container jobs, _pin=True adds -w $MASTER_IP to gym srun inode allocations, but MASTER_IP was only defined for multi-node jobs — soset -u aborted the script with MASTER_IP: unbound variable. MASTER_IP discovery is now emitted whenever it will be referenced (_has_multinode_service or (not use_het and use_containers)). The block is reordered after use_containers is computed depends on it. For single-node jobs -w $MASTER_IP resolves to the sole allocated host, a no-op.

5. Custom Gym environment labels

Added a label option (via gym://...?label=<name> query param) so reports can show a meaningful benchmark name instead of an autogenerated gym@host:port. Wired through
GymEnvironment, ManagedGymEnvironment (including the inner delegate), and previously the parsed label was silently dropped for cmd: / module: /nel_benchmark URIs.

6. Defensive null-body guard

ModelClient._parse_response guards against a null JSON body (data.get(...) would otherwise raise AttributeError); it now raises a clean InfraError.

7. Add `timeout=<seconds>` to the gym:// URI query string to override the default /verify (and /seed) HTTP total timeout. Judge-based verifiers whose slowest rows exceed the 60s default can now raise it per-benchmark via config, e.g. gym://host:port?protocol=native&timeout=600. The parsed value is forwarded only when set, so each environment keeps its own default otherwise: GymEnvironment receives `timeout` and ManagedGymEnvironment receives `request_timeout`.

Testing

- New unit tests: tool forwarding in ModelClient and ChatSolver, tool-call translation in messages_from_rcp, and process-group teardown (graceful + SIGKILL escalation).
- pytest -m "not network" passes; ruff clean on all modified files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added end-to-end tool-enabled chat support, including tool fields in Gym protocol responses and richer tool-call message translation.
  - Extended `gym://` URIs with optional `label` and `timeout` query parameters.

- **Bug Fixes**
  - Improved tool-aware chat caching behavior and hardened JSON response handling.
  - Enhanced managed environment health checks and made shutdown more reliable using process-group termination.
  - Fixed SLURM sbatch generation for single-node container jobs by ensuring `MASTER_IP` is correctly set.

- **Tests**
  - Expanded unit and integration coverage for tool forwarding, protocol translation, environment lifecycle, and `gym://` query parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->