### PR TITLE
fix: pin boto3 to 1.43.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "datasets>=2.14",
     "jinja2>=3.0",
     "starlette>=0.27",
-    "boto3>=1.28",
+    "boto3==1.43.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Pin the NeMo Evaluator core dependency from `boto3>=1.28` to `boto3==1.43.0`.

This keeps the `boto3` version installed by NeMo Evaluator compatible with the `botocore==1.43.0` version selected by the Megatron-Bridge dependency graph during a normal `uv run` synchronization.

## Problem

The NeMo Framework image initially contains a healthy AWS SDK pair:

```text
boto3==1.43.47
botocore==1.43.47
```

The installed reverse-dependency tree shows that `boto3` enters the image through NeMo Evaluator:

```text
nemo-fw
├── nemo-evaluator
│   └── boto3
└── nvidia-lm-eval
    └── nemo-evaluator
        └── boto3
```

Megatron-Bridge has a separate dependency path that introduces `botocore` without introducing `boto3`:

```text
megatron-core[dev]
└── megatron-energon==7.4.0
    └── s3fs==2026.4.0
        └── aiobotocore==3.7.0
            └── botocore>=1.42.90,<1.43.1
```

Megatron-Bridge therefore resolves and records `botocore==1.43.0`, while `boto3` is absent from its lockfile.

## Failure mechanism

The shipped Megatron-Bridge example scripts use `uv run`. Its normal inexact synchronization updates packages represented in the Bridge lockfile while retaining unrelated packages already installed in the image.

As a result, the first example invocation changes only one side of the AWS SDK pair:

```text
Before uv run:
  boto3==1.43.47
  botocore==1.43.47

After uv run:
  boto3==1.43.47
  botocore==1.43.0
```

The mismatched pair fails when `boto3==1.43.47` imports `DocumentModifiedShape` from `botocore.docs.utils`; that symbol is unavailable in `botocore==1.43.0`.

This surfaces during `import megatron.bridge` through the following runtime import path:

```text
megatron.bridge
→ transformers
→ accelerate
→ Accelerate SageMaker configuration
→ boto3
→ botocore
```

Accelerate triggers the import, but it is not the source of the `boto3` dependency in this image. NeMo Evaluator declares and installs `boto3`.

The failed `uv run` also leaves `/opt/venv` in the mismatched state, so subsequent examples in the same container continue to fail.

## Why this fix

Changing the examples to `uv run --no-sync` would alter their existing behavior: missing or stale Bridge dependencies would no longer be synchronized automatically. The examples are expected to retain normal `uv run` semantics.

Pinning at the package that already owns the direct `boto3` requirement ensures the final image starts with a version compatible with the Bridge-resolved botocore version. It does not add a new dependency or couple Evaluator code to Megatron-Bridge internals.

The relevant constraints intersect at `botocore==1.43.0`:

```text
boto3==1.43.0       requires botocore>=1.43.0,<1.44.0
aiobotocore==3.7.0  requires botocore>=1.42.90,<1.43.1
```

After rebuilding the image and running a Bridge example, the expected pair is:

```text
boto3==1.43.0
botocore==1.43.0
```

## Scope

This PR changes one dependency declaration in `pyproject.toml`:

```diff
-    "boto3>=1.28",
+    "boto3==1.43.0",
```

No runtime code, API, or evaluation behavior is changed.

## Validation

Completed:

- Confirmed the PR changes only `pyproject.toml`.
- Confirmed the exact dependency diff shown above.
- Confirmed `boto3==1.43.0` and `aiobotocore==3.7.0` share the compatible `botocore==1.43.0` intersection.
- Confirmed the installed reverse-dependency tree identifies `nemo-evaluator` as the direct consumer of `boto3`.

Required image validation:

```bash
uv pip tree --python /opt/venv/bin/python --invert --package boto3
/opt/venv/bin/python -c "import boto3, botocore; print(boto3.__version__, botocore.__version__)"

cd /opt/Megatron-Bridge
uv run python -c "import megatron.bridge"

/opt/venv/bin/python -c "import boto3, botocore; print(boto3.__version__, botocore.__version__)"
```

The version pair should remain `1.43.0 / 1.43.0`, and `import megatron.bridge` should succeed before and after the `uv run` invocation.

Local Python and pre-commit execution in the agent environment was blocked by the host sandbox error `bwrap: setting up uid map: Permission denied`; CI and rebuilt-image validation are still required.