### PR TITLE
feat: add optional request-body capture to model_traffic.jsonl

### DIFF
--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -74,7 +74,8 @@ class ModelTrafficCaptureConfig(BaseModel):
     capture_tool_calls: bool = True  # full {id, name, arguments} per call
     capture_reasoning: bool = True  # message.reasoning_content (or SSE delta)
     capture_messages: bool = True  # message.content
-    max_content_chars: int = 100_000  # truncation guard for the three above
+    capture_request_body: bool = False  # effective upstream HTTP request body
+    max_content_chars: int = 0  # truncation guard for captured bodies/content; 0 = no limit
 
 
 class ProxyConfig(BaseModel):

--- a/src/nemo_evaluator/engine/model_traffic_log.py
+++ b/src/nemo_evaluator/engine/model_traffic_log.py
@@ -100,10 +100,7 @@ def format_model_traffic_log_records(
                 row[key] = record[key]
         if record.get("request_hash"):
             row["request_hash"] = record["request_hash"]
-        # Opt-in capture fields from ModelTrafficStore.finish_response: only
-        # forwarded when present in the in-memory record (controlled by the
-        # service's proxy.model_traffic.capture_{tool_calls,reasoning,messages}).
-        for key in ("tool_calls_full", "reasoning_content", "message_content"):
+        for key in ("request_body", "tool_calls_full", "reasoning_content", "message_content"):
             if key in record:
                 row[key] = record[key]
         rows.append(row)

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -133,6 +133,18 @@ def _truncate(value: Any, limit: int) -> Any:
     return value
 
 
+def _capture_request_body_value(body: Any, max_content_chars: int) -> Any | None:
+    if not isinstance(body, dict):
+        return None
+    try:
+        serialized = json.dumps(body, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        return None
+    if max_content_chars > 0 and len(serialized) > max_content_chars:
+        return _truncate(serialized, max_content_chars)
+    return body
+
+
 def _first_str(data: dict[str, Any], *keys: str) -> str:
     for key in keys:
         value = data.get(key)
@@ -143,7 +155,7 @@ def _first_str(data: dict[str, Any], *keys: str) -> str:
 
 def _error_summary(body: Any, max_content_chars: int) -> dict[str, Any]:
     """Return a compact, non-request error summary for non-success responses."""
-    limit = min(max_content_chars, _ERROR_SUMMARY_CHARS)
+    limit = _ERROR_SUMMARY_CHARS if max_content_chars <= 0 else min(max_content_chars, _ERROR_SUMMARY_CHARS)
     out: dict[str, Any] = {}
 
     if isinstance(body, dict):
@@ -374,14 +386,15 @@ class ModelTrafficStore:
         capture_tool_calls: bool = True,
         capture_reasoning: bool = True,
         capture_messages: bool = True,
-        max_content_chars: int = 100_000,
+        capture_request_body: bool = False,
+        max_content_chars: int = 0,
     ) -> None:
         self.store_id = uuid.uuid4().hex
         self.service_name = service_name
         self._lock = threading.Lock()
         self._pending: dict[str, dict[str, Any]] = {}
         self._records_by_session: dict[str, list[dict[str, Any]]] = {}
-        # Capture options for extra response fields persisted to model_traffic.jsonl.
+        self._capture_request_body = capture_request_body
         self._capture_opts = {
             "capture_tool_calls": capture_tool_calls,
             "capture_reasoning": capture_reasoning,
@@ -407,6 +420,10 @@ class ModelTrafficStore:
             # exactly, instead of fingerprinting on response stats.
             "request_hash": _request_hash(body),
         }
+        if self._capture_request_body:
+            captured = _capture_request_body_value(body, self._capture_opts["max_content_chars"])
+            if captured is not None:
+                record["request_body"] = captured
         with self._lock:
             self._pending[req.ctx.request_id] = record
 

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -140,9 +140,7 @@ def _capture_request_body_value(body: Any, max_content_chars: int) -> Any | None
         serialized = json.dumps(body, sort_keys=True, default=str)
     except (TypeError, ValueError):
         return None
-    if max_content_chars > 0 and len(serialized) > max_content_chars:
-        return _truncate(serialized, max_content_chars)
-    return body
+    return _truncate(serialized, max_content_chars)
 
 
 def _first_str(data: dict[str, Any], *keys: str) -> str:

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -796,7 +796,8 @@ def _start_proxy(
         capture_tool_calls=getattr(capture_cfg, "capture_tool_calls", True),
         capture_reasoning=getattr(capture_cfg, "capture_reasoning", True),
         capture_messages=getattr(capture_cfg, "capture_messages", True),
-        max_content_chars=getattr(capture_cfg, "max_content_chars", 100_000),
+        capture_request_body=getattr(capture_cfg, "capture_request_body", False),
+        max_content_chars=getattr(capture_cfg, "max_content_chars", 0),
     )
     register_store(traffic_store)
     proxy_kwargs["model_traffic_store_id"] = traffic_store.store_id

--- a/tests/test_config/test_config_schema.py
+++ b/tests/test_config/test_config_schema.py
@@ -114,7 +114,7 @@ class TestParseEvalConfig:
             pytest.param(
                 {"proxy": {}},
                 {},
-                {"messages": True, "reasoning": True, "tool_calls": True},
+                {"messages": True, "reasoning": True, "tool_calls": True, "request_body": False},
                 True,
                 id="model-traffic-defaults",
             ),
@@ -129,14 +129,27 @@ class TestParseEvalConfig:
                     }
                 },
                 {},
-                {"messages": False, "reasoning": False, "tool_calls": False},
+                {"messages": False, "reasoning": False, "tool_calls": False, "request_body": False},
                 True,
                 id="model-traffic-disabled",
             ),
             pytest.param(
+                {
+                    "proxy": {
+                        "model_traffic": {
+                            "capture_request_body": True,
+                        }
+                    }
+                },
+                {},
+                {"messages": True, "reasoning": True, "tool_calls": True, "request_body": True},
+                True,
+                id="model-traffic-request-body-enabled",
+            ),
+            pytest.param(
                 {"proxy": {}},
                 {"trajectories": {"enrich": False}},
-                {"messages": True, "reasoning": True, "tool_calls": True},
+                {"messages": True, "reasoning": True, "tool_calls": True, "request_body": False},
                 False,
                 id="trajectory-enrichment-disabled",
             ),
@@ -173,7 +186,8 @@ class TestParseEvalConfig:
         assert capture.capture_messages is expected_capture["messages"]
         assert capture.capture_reasoning is expected_capture["reasoning"]
         assert capture.capture_tool_calls is expected_capture["tool_calls"]
-        assert capture.max_content_chars == 100_000
+        assert capture.capture_request_body is expected_capture["request_body"]
+        assert capture.max_content_chars == 0
         assert cfg.output.trajectories.enrich is expected_enrich
 
     def test_vllm_service(self):

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -195,6 +195,103 @@ def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_
         assert "message_content" not in row
 
 
+@pytest.mark.parametrize(
+    "capture_kwargs,expect_request_fields",
+    [
+        pytest.param({}, False, id="request-body-default-off"),
+        pytest.param({"capture_request_body": True}, True, id="request-body-enabled"),
+    ],
+)
+def test_format_log_record_request_body_capture_fields(
+    capture_kwargs: dict,
+    expect_request_fields: bool,
+) -> None:
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = "req-body-session"
+    request_body = {
+        "model": "m",
+        "messages": [{"role": "user", "content": "solve with a tool"}],
+    }
+    ctx.extra["upstream_request_body"] = request_body
+    store = ModelTrafficStore(service_name="solver", **capture_kwargs)
+    store.start_request(
+        AdapterRequest(method="POST", path="/chat/completions", headers={}, body={"model": "m"}, ctx=ctx)
+    )
+    store.finish_response(
+        AdapterResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            latency_ms=10.0,
+            ctx=ctx,
+            body=_capture_response_body(),
+        )
+    )
+    rows = format_model_traffic_log_records(
+        store.drain_session("req-body-session"),
+        benchmark="b",
+        problem_idx=0,
+        repeat=0,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["request_hash"]
+    if expect_request_fields:
+        assert row["request_body"] == request_body
+    else:
+        assert "request_body" not in row
+
+
+def test_format_log_record_request_body_truncation() -> None:
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = "req-body-trunc-session"
+    request_body = {"model": "m", "messages": [{"role": "user", "content": "x" * 200}]}
+    ctx.extra["upstream_request_body"] = request_body
+    store = ModelTrafficStore(service_name="solver", capture_request_body=True, max_content_chars=50)
+    store.start_request(
+        AdapterRequest(method="POST", path="/chat/completions", headers={}, body={"model": "m"}, ctx=ctx)
+    )
+    store.finish_response(
+        AdapterResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            latency_ms=10.0,
+            ctx=ctx,
+            body=_capture_response_body(),
+        )
+    )
+    rows = format_model_traffic_log_records(
+        store.drain_session("req-body-trunc-session"),
+        benchmark="b",
+        problem_idx=0,
+        repeat=0,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert isinstance(row["request_body"], str)
+    assert "...[truncated," in row["request_body"]
+
+
+def test_format_log_record_request_body_on_error() -> None:
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = "req-body-error-session"
+    request_body = {"model": "m", "messages": [{"role": "user", "content": "hello"}]}
+    ctx.extra["upstream_request_body"] = request_body
+    store = ModelTrafficStore(service_name="solver", capture_request_body=True)
+    req = AdapterRequest(method="POST", path="/chat/completions", headers={}, body={"model": "m"}, ctx=ctx)
+    store.start_request(req)
+    store.finish_error(req=req, latency_ms=1.0, error_type="timeout")
+
+    rows = format_model_traffic_log_records(
+        store.drain_session("req-body-error-session"),
+        benchmark="b",
+        problem_idx=0,
+        repeat=0,
+    )
+    assert len(rows) == 1
+    assert rows[0]["request_body"] == request_body
+    assert rows[0]["error_type"] == "timeout"
+
+
 def test_non_success_response_forwards_compact_error_summary() -> None:
     ctx = InterceptorContext()
     ctx.extra["session_id"] = "bad-request-session"
@@ -333,6 +430,7 @@ async def test_model_traffic_writes_compact_log_and_inference_stats(tmp_path: Pa
         assert traffic["reasoning_content"] == "I need to inspect the workspace."
         assert traffic["tool_calls_full"] == [{"id": "call_1", "name": "bash", "arguments": '{"command":"ls"}'}]
         assert traffic["token_provenance"] == "provider_reported"
+        assert "request_body" not in traffic
         assert "request" not in traffic
         assert "response" not in traffic
 

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -236,7 +236,7 @@ def test_format_log_record_request_body_capture_fields(
     row = rows[0]
     assert row["request_hash"]
     if expect_request_fields:
-        assert row["request_body"] == request_body
+        assert row["request_body"] == json.dumps(request_body, sort_keys=True, default=str)
     else:
         assert "request_body" not in row
 
@@ -288,7 +288,7 @@ def test_format_log_record_request_body_on_error() -> None:
         repeat=0,
     )
     assert len(rows) == 1
-    assert rows[0]["request_body"] == request_body
+    assert rows[0]["request_body"] == json.dumps(request_body, sort_keys=True, default=str)
     assert rows[0]["error_type"] == "timeout"
 
 


### PR DESCRIPTION
Opt in via `proxy.model_traffic.capture_request_body` to persist the effective upstream HTTP body alongside existing response fields. Also forward request_hash to the log and default `max_content_chars` to 0 (no limit) while keeping error summaries bounded.


## Summary
Extended model_traffic.jsonl capture so you can optionally log the upstream HTTP request body, not just response fields.

### Changes
Added `proxy.model_traffic.capture_request_body` (default: false)
When enabled, writes request_body to `model_traffic.jsonl `(the effective upstream body after extra_body merge)
Also forwards request_hash to the log (was computed but not written before)
Changed `max_content_chars` default to 0 (no limit); set a positive value to truncate large bodies/content
Example config
```
services:
  solver:
    type: api
    url: http://localhost:8000/v1
    proxy:
      model_traffic:
        capture_request_body: true
        # max_content_chars: 50000  # optional; omit or 0 = no limit
```
Example log row

```
{
  "model_traffic_request_id": "sess-abc:req-1",
  "request_hash": "a1b2c3d4e5f6g7h8",
  "request_body": {
    "model": "gpt-4",
    "messages": [{"role": "user", "content": "solve with a tool"}]
  },
  "message_content": "the answer is 42",
  "usage": {"prompt_tokens": 10, "completion_tokens": 5}
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added opt-in upstream request-body capture for model traffic logs, including in formatted log output.
  * When enabled, request bodies are serialized deterministically and truncated to a configured character limit.

* **Bug Fixes**
  * Request-body capture is now disabled by default to avoid unintentionally recording sensitive content.
  * Default request-body capture limit is reduced to 0, effectively preventing capture unless explicitly configured.

* **Tests**
  * Expanded configuration and model-traffic logging tests to cover request-body capture, truncation, and default omission.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->