### PR TITLE
fix: support local Slurm job lifecycle without SSH hostname

### DIFF
--- a/src/nemo_evaluator/cli/eval.py
+++ b/src/nemo_evaluator/cli/eval.py
@@ -474,6 +474,7 @@ def eval_logs(run_id, output_dir, job_id, host, follow, tail_lines, shard_idx):
     ex = _get_executor_for_run(run_meta)
 
     if follow and run_meta.executor == "slurm":
+        import shlex
         import subprocess
         import sys
 
@@ -482,7 +483,7 @@ def eval_logs(run_id, output_dir, job_id, host, follow, tail_lines, shard_idx):
         username = details.get("username") or None
         rdir = details.get("remote_dir", run_meta.output_dir)
         job_ids = details.get("job_ids", [])
-        is_sharded_run = len(job_ids) > 1
+        is_sharded_run = bool(details.get("is_sharded")) or len(job_ids) > 1
 
         if is_sharded_run and shard_idx is None:
             from nemo_evaluator.executors.slurm_executor import (
@@ -530,10 +531,15 @@ def eval_logs(run_id, output_dir, job_id, host, follow, tail_lines, shard_idx):
             latest_id = _resolve_latest_job_id_from_meta(details)
             log_file = f"{rdir}/logs/slurm-{latest_id}.log"
 
-        target = f"{username}@{hostname}" if username else hostname
-        n_arg = f"-n {tail_lines}" if tail_lines else "-n 50"
-        cmd = ["ssh", target, f"tail {n_arg} -f {log_file}"]
-        click.echo(f"Streaming: {target}:{log_file}", err=True)
+        tail_cmd = ["tail", "-n", str(tail_lines or 50), "-f", log_file]
+        if hostname:
+            target = f"{username}@{hostname}" if username else hostname
+            cmd = ["ssh", target, shlex.join(tail_cmd)]
+            location = f"{target}:{log_file}"
+        else:
+            cmd = tail_cmd
+            location = log_file
+        click.echo(f"Streaming: {location}", err=True)
         try:
             subprocess.run(cmd, check=False)
         except KeyboardInterrupt:

--- a/src/nemo_evaluator/executors/slurm_executor.py
+++ b/src/nemo_evaluator/executors/slurm_executor.py
@@ -62,18 +62,18 @@ def _is_sharded(meta: dict) -> bool:
 
 
 def _resolve_latest_job_id(
-    hostname: str,
+    hostname: str | None,
     remote_dir: str,
     fallback_id: str,
     username: str | None = None,
 ) -> str:
-    """Follow .nel_job_chain on the remote host to get the latest job ID."""
-    if not remote_dir or not hostname:
+    """Follow .nel_job_chain on the Slurm host to get the latest job ID."""
+    if not remote_dir:
         return fallback_id
     try:
-        from nemo_evaluator.executors.ssh import ssh_run
+        from nemo_evaluator.executors.ssh import run_on_slurm_host
 
-        chain = ssh_run(
+        chain = run_on_slurm_host(
             hostname,
             f"tail -1 {shlex.quote(remote_dir + '/.nel_job_chain')} 2>/dev/null",
             username=username,
@@ -86,7 +86,7 @@ def _resolve_latest_job_id(
 
 
 def _resolve_shard_latest_ids(
-    hostname: str,
+    hostname: str | None,
     parent_dir: str,
     job_ids: list[str],
     username: str | None = None,
@@ -103,9 +103,9 @@ def _resolve_shard_latest_ids(
         chain_path = shlex.quote(f"{parent_dir}/shard_{i}/.nel_job_chain")
         cmds.append(f'c=$(tail -1 {chain_path} 2>/dev/null); echo "${{c:-{fb}}}"')
     try:
-        from nemo_evaluator.executors.ssh import ssh_run
+        from nemo_evaluator.executors.ssh import run_on_slurm_host
 
-        output = ssh_run(hostname, "; ".join(cmds), username=username, timeout=15.0)
+        output = run_on_slurm_host(hostname, "; ".join(cmds), username=username, timeout=15.0)
         lines = _extract_job_id_lines(output)
         if len(lines) == n:
             return [ln or fb for ln, fb in zip(lines, job_ids)]
@@ -115,7 +115,7 @@ def _resolve_shard_latest_ids(
 
 
 def _find_pending_successors(
-    hostname: str,
+    hostname: str | None,
     job_ids: list[str],
     username: str | None = None,
     remote_dir: str | None = None,
@@ -133,9 +133,9 @@ def _find_pending_successors(
     if not job_ids or not remote_dir:
         return {}
     try:
-        from nemo_evaluator.executors.ssh import ssh_run
+        from nemo_evaluator.executors.ssh import run_on_slurm_host
 
-        output = ssh_run(
+        output = run_on_slurm_host(
             hostname,
             "squeue -u $USER -h -o '%i %T %o' -t PENDING,RUNNING 2>/dev/null",
             username=username,
@@ -192,7 +192,7 @@ def _find_pending_successors(
 
 
 def _collect_successor_ids(
-    hostname: str,
+    hostname: str | None,
     job_ids: list[str],
     username: str | None,
     remote_dir: str,
@@ -206,9 +206,9 @@ def _collect_successor_ids(
     if not job_ids or not remote_dir:
         return set()
     try:
-        from nemo_evaluator.executors.ssh import ssh_run
+        from nemo_evaluator.executors.ssh import run_on_slurm_host
 
-        output = ssh_run(
+        output = run_on_slurm_host(
             hostname,
             "squeue -u $USER -h -o '%i %T %o' -t PENDING,RUNNING 2>/dev/null",
             username=username,
@@ -244,16 +244,19 @@ def _collect_successor_ids(
 
 def _update_aggregate_meta(remote_dir: str, new_job_ids: list[str]) -> None:
     """Find and update the sharded aggregate meta by remote_dir match."""
-    jobs_dir = _jobs_store()
-    if not jobs_dir.is_dir():
+    if not new_job_ids:
         return
-    for meta_path in jobs_dir.glob(f"sharded_*/{_META_FILE}"):
+    jobs_dir = _jobs_store()
+    meta_paths = list(jobs_dir.glob(f"sharded_*/{_META_FILE}")) if jobs_dir.is_dir() else []
+    local_meta_path = Path(remote_dir) / _META_FILE
+    if local_meta_path.is_file():
+        meta_paths.append(local_meta_path)
+    for meta_path in meta_paths:
         try:
             agg = json.loads(meta_path.read_text())
             if agg.get("remote_dir") == remote_dir:
                 agg["job_ids"] = new_job_ids
                 meta_path.write_text(json.dumps(agg, indent=2))
-                return
         except (json.JSONDecodeError, OSError):
             continue
 
@@ -273,15 +276,15 @@ class _ShardProgress:
 
 
 def _fetch_eval_progress(
-    hostname: str,
+    hostname: str | None,
     rdir: str,
     shard_count: int | None = None,
     username: str | None = None,
 ) -> dict[str, _ShardProgress]:
-    """Count verified samples, expected total, and avg reward per shard via one SSH call."""
+    """Count verified samples, expected total, and avg reward in one host command."""
     import re as _re
 
-    from nemo_evaluator.executors.ssh import ssh_run
+    from nemo_evaluator.executors.ssh import run_on_slurm_host
 
     qdir = shlex.quote(rdir)
     glob = f"{qdir}/shard_*" if shard_count else qdir
@@ -297,7 +300,7 @@ def _fetch_eval_progress(
         f"for f in {glob}/*/*/verified_log.jsonl; do "
         f'[ -f "$f" ] && {awk_reward}"$f"; done 2>/dev/null'
     )
-    output = ssh_run(hostname, cmd, username=username, timeout=15.0)
+    output = run_on_slurm_host(hostname, cmd, username=username, timeout=15.0)
     sections = output.split("---")
     wc_out = sections[0] if sections else ""
     log_out = sections[1].strip() if len(sections) > 1 else ""
@@ -378,6 +381,8 @@ class SlurmExecutor(Executor):
 
         from nemo_evaluator.orchestration.slurm_gen import stamp_output_dir, write_sbatch
 
+        if not config.cluster.hostname:
+            config.output.dir = str(Path(config.output.dir).expanduser().resolve())
         parent_dir = config.output.dir
         stamped_run_id = stamp_output_dir(config)
         resolved_dir = config.output.dir  # may now include timestamped subdir
@@ -433,138 +438,137 @@ class SlurmExecutor(Executor):
                 click.echo(f"\nAfter all shards complete:  nel eval merge {resolved_dir}")
             return
 
-        if is_remote:
-            from nemo_evaluator.executors.ssh import copy_to_remote, submit_eval
+        from nemo_evaluator.executors.ssh import copy_to_remote, submit_eval, submit_sbatch
 
-            job_ids: list[str] = []
-            submission_error: Exception | None = None
-            snapshot_upload_failed = False
-            try:
-                if snapshot_path is not None:
-                    # Best-effort: never block submission on the snapshot upload.
-                    try:
-                        copy_to_remote(
-                            config.cluster.hostname,
-                            [snapshot_path],
-                            resolved_dir,
-                            config.cluster.username,
-                            local_base=staging_root,
-                        )
-                    except Exception as exc:  # noqa: BLE001
-                        snapshot_upload_failed = True
-                        click.echo(f"Warning: could not upload config snapshot: {exc}")
-                for script_path in script_paths:
+        hostname = config.cluster.hostname or ""
+        username = config.cluster.username or ""
+        job_ids: list[str] = []
+        submission_error: Exception | None = None
+        snapshot_upload_failed = False
+        try:
+            if is_remote and snapshot_path is not None:
+                # Best-effort: never block submission on the snapshot upload.
+                try:
+                    copy_to_remote(
+                        hostname,
+                        [snapshot_path],
+                        resolved_dir,
+                        username,
+                        local_base=staging_root,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    snapshot_upload_failed = True
+                    click.echo(f"Warning: could not upload config snapshot: {exc}")
+            for script_path in script_paths:
+                if is_remote:
                     # Include all extras under the script's staging dir, not
                     # just direct siblings — legacy container:// benchmarks
                     # write run_config.yaml under {staging}/{safe_name}/ which
-                    # the sbatch then bind-mounts.  Filter by ancestor.
+                    # the sbatch then bind-mounts. Filter by ancestor.
                     local_base = script_path.parent
                     shard_extras = [p for p in extra_paths if local_base in p.parents]
-                    shard_remote = f"{resolved_dir}/{script_path.parent.name}" if is_sharded else resolved_dir
+                    shard_dir = f"{resolved_dir}/{script_path.parent.name}" if is_sharded else resolved_dir
                     meta = submit_eval(
                         script_path=script_path,
-                        hostname=config.cluster.hostname,
-                        remote_dir=shard_remote,
-                        username=config.cluster.username,
+                        hostname=hostname,
+                        remote_dir=shard_dir,
+                        username=username,
                         extra_files=shard_extras,
                         local_base=local_base,
                     )
-                    meta["parent_dir"] = parent_dir
-                    meta["submitted_at"] = datetime.now(timezone.utc).isoformat()
+                else:
+                    shard_dir = str(script_path.parent)
+                    job_id = submit_sbatch(None, str(script_path))
+                    meta = {
+                        "job_id": job_id,
+                        "hostname": "",
+                        "username": "",
+                        "remote_dir": shard_dir,
+                        "script": str(script_path),
+                    }
 
-                    meta_dir = _jobs_store() / meta["job_id"]
-                    meta_dir.mkdir(parents=True, exist_ok=True)
-                    meta_path = meta_dir / _META_FILE
-                    meta_path.write_text(json.dumps(meta, indent=2))
-                    job_ids.append(meta["job_id"])
+                job_id = str(meta["job_id"])
+                job_ids.append(job_id)
+                click.echo(f"SLURM job submitted: {job_id}  ({script_path.name})")
+                meta["job_id"] = job_id
+                meta["parent_dir"] = parent_dir
+                meta["submitted_at"] = datetime.now(timezone.utc).isoformat()
 
-                    click.echo(f"SLURM job submitted: {meta['job_id']}  ({script_path.name})")
-            except Exception as exc:
-                submission_error = exc
-            finally:
-                if local_staging:
-                    if snapshot_upload_failed and snapshot_path is not None:
-                        # Keep only the secret-free snapshot; staging also holds .secrets.env.
-                        try:
-                            kept = shutil.move(str(snapshot_path), tempfile.mkdtemp(prefix="nel-snapshot-"))
-                            click.echo("Config snapshot kept locally. To retry the upload:")
-                            click.echo(f"  scp {kept} {config.cluster.hostname}:{resolved_dir}/")
-                        except OSError as exc:
-                            click.echo(f"Warning: could not preserve config snapshot: {exc}")
-                    shutil.rmtree(local_staging, ignore_errors=True)
+                meta_dir = _jobs_store() / job_id
+                meta_dir.mkdir(parents=True, exist_ok=True)
+                (meta_dir / _META_FILE).write_text(json.dumps(meta, indent=2))
+                if not is_remote:
+                    (Path(shard_dir) / _META_FILE).write_text(json.dumps(meta, indent=2))
 
-            from nemo_evaluator.run_store import (
-                RunMeta,
-                config_summary,
-                generate_run_id,
-            )
+        except Exception as exc:
+            submission_error = exc
+        finally:
+            if local_staging:
+                if snapshot_upload_failed and snapshot_path is not None:
+                    # Keep only the secret-free snapshot; staging also holds .secrets.env.
+                    try:
+                        kept = shutil.move(str(snapshot_path), tempfile.mkdtemp(prefix="nel-snapshot-"))
+                        click.echo("Config snapshot kept locally. To retry the upload:")
+                        click.echo(f"  scp {kept} {hostname}:{resolved_dir}/")
+                    except OSError as exc:
+                        click.echo(f"Warning: could not preserve config snapshot: {exc}")
+                shutil.rmtree(local_staging, ignore_errors=True)
 
-            if not job_ids:
-                raise click.ClickException(f"No shards submitted: {submission_error}")
+        from nemo_evaluator.run_store import (
+            RunMeta,
+            config_summary,
+            generate_run_id,
+        )
 
-            run_id = stamped_run_id or generate_run_id(config)
-            run_meta = RunMeta(
-                run_id=run_id,
-                executor="slurm",
-                output_dir=resolved_dir,
-                started_at=datetime.now(timezone.utc).isoformat(),
-                config_summary=config_summary(config),
-                details={
-                    "job_id": job_ids[0],
-                    "job_ids": job_ids,
-                    "hostname": config.cluster.hostname,
-                    "remote_dir": resolved_dir,
-                    "username": config.cluster.username or "",
-                    "parent_dir": parent_dir,
-                    "is_sharded": is_sharded,
-                },
-            )
-            run_meta.save()
+        if not job_ids:
+            raise click.ClickException(f"No shards submitted: {submission_error}")
 
-            if is_sharded and job_ids:
-                agg_meta = {
-                    "job_id": job_ids[0],
-                    "job_ids": job_ids,
-                    "hostname": config.cluster.hostname,
-                    "remote_dir": resolved_dir,
-                    "username": config.cluster.username or "",
-                    "parent_dir": parent_dir,
-                    "is_sharded": True,
-                    "num_shards": len(job_ids),
-                    "submitted_at": datetime.now(timezone.utc).isoformat(),
-                }
-                agg_dir = _jobs_store() / f"sharded_{job_ids[0]}"
-                agg_dir.mkdir(parents=True, exist_ok=True)
-                (agg_dir / _META_FILE).write_text(json.dumps(agg_meta, indent=2))
+        run_id = stamped_run_id or generate_run_id(config)
+        submitted_at = datetime.now(timezone.utc).isoformat()
+        run_details = {
+            "job_id": job_ids[0],
+            "job_ids": job_ids,
+            "hostname": hostname,
+            "remote_dir": resolved_dir,
+            "username": username,
+            "parent_dir": parent_dir,
+            "is_sharded": is_sharded,
+        }
+        RunMeta(
+            run_id=run_id,
+            executor="slurm",
+            output_dir=resolved_dir,
+            started_at=submitted_at,
+            config_summary=config_summary(config),
+            details=run_details,
+        ).save()
 
-            host = config.cluster.hostname
-            click.echo(f"\nrun_id: {run_id}  |  {len(job_ids)} job(s)")
-            click.echo(f"Remote dir: {host}:{resolved_dir}")
-            click.echo(f"Metadata:   {_jobs_store()}")
-            click.echo(f"\nTail logs:  nel eval logs -r {run_id} -f")
-            click.echo(f"Status:     nel eval status -r {run_id}")
-            if is_sharded:
-                click.echo(f"Merge:      nel eval merge {resolved_dir}")
-            if submission_error:
-                click.echo(
-                    f"\nWARNING: Only {len(job_ids)}/{len(script_paths)} shards submitted. Error: {submission_error}",
-                    err=True,
-                )
-            return
-
-        import subprocess
-
-        for script_path in script_paths:
-            result = subprocess.run(
-                ["sbatch", str(script_path)],
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode != 0:
-                raise click.ClickException(f"sbatch failed for {script_path}: {result.stderr}")
-            click.echo(result.stdout.strip())
         if is_sharded:
-            click.echo(f"\nAfter all shards complete:  nel eval merge {resolved_dir}")
+            aggregate_meta = {
+                **run_details,
+                "is_sharded": True,
+                "num_shards": len(job_ids),
+                "submitted_at": submitted_at,
+            }
+            aggregate_dir = _jobs_store() / f"sharded_{job_ids[0]}"
+            aggregate_dir.mkdir(parents=True, exist_ok=True)
+            (aggregate_dir / _META_FILE).write_text(json.dumps(aggregate_meta, indent=2))
+            if not is_remote:
+                (Path(resolved_dir) / _META_FILE).write_text(json.dumps(aggregate_meta, indent=2))
+
+        click.echo(f"\nrun_id: {run_id}  |  {len(job_ids)} job(s)")
+        location = f"{hostname}:{resolved_dir}" if is_remote else resolved_dir
+        click.echo(f"Output dir:  {location}")
+        click.echo(f"Metadata:    {_jobs_store()}")
+        click.echo(f"\nTail logs:  nel eval logs -r {run_id} -f")
+        click.echo(f"Status:     nel eval status -r {run_id}")
+        if is_sharded:
+            click.echo(f"Merge:      nel eval merge {resolved_dir}")
+        if submission_error:
+            click.echo(
+                f"\nWARNING: Only {len(job_ids)}/{len(script_paths)} shards submitted. Error: {submission_error}",
+                err=True,
+            )
 
     def status(self, output_dir: str | Path) -> ProcessState:
         meta = _read_meta(output_dir)
@@ -572,7 +576,7 @@ class SlurmExecutor(Executor):
             return ProcessState("slurm", False, {"error": f"No {_META_FILE} found"})
 
         job_ids = _get_job_ids(meta)
-        hostname = meta["hostname"]
+        hostname = meta.get("hostname") or None
         username = meta.get("username") or None
 
         if not _is_sharded(meta):
@@ -664,10 +668,10 @@ class SlurmExecutor(Executor):
         details = {"shards": shards_summary, **details}
 
         try:
-            from nemo_evaluator.executors.ssh import ssh_run
+            from nemo_evaluator.executors.ssh import run_on_slurm_host
 
             qdir = shlex.quote(rdir)
-            merge_out = ssh_run(
+            merge_out = run_on_slurm_host(
                 hostname,
                 f"[[ -f {qdir}/.merge_lock/.done ]] && echo DONE "
                 f"|| ([[ -d {qdir}/.merge_lock ]] && echo IN_PROGRESS || echo PENDING)",
@@ -687,7 +691,7 @@ class SlurmExecutor(Executor):
             return False
 
         job_ids = _get_job_ids(meta)
-        hostname = meta["hostname"]
+        hostname = meta.get("hostname") or None
         username = meta.get("username") or None
         rdir = meta.get("remote_dir", str(output_dir))
 
@@ -699,28 +703,29 @@ class SlurmExecutor(Executor):
             if shard_idx < 0 or shard_idx >= len(job_ids):
                 logger.error("Shard index %d out of range (0-%d)", shard_idx, len(job_ids) - 1)
                 return False
-            latest = _resolve_latest_job_id(hostname, f"{rdir}/shard_{shard_idx}", job_ids[shard_idx], username)
-            return self._cancel_with_successors(hostname, rdir, [latest], username)
+            shard_dir = f"{rdir}/shard_{shard_idx}"
+            latest = _resolve_latest_job_id(hostname, shard_dir, job_ids[shard_idx], username)
+            return self._cancel_with_successors(hostname, shard_dir, [latest], username)
 
         latest_ids = _resolve_shard_latest_ids(hostname, rdir, job_ids, username)
         return self._cancel_with_successors(hostname, rdir, latest_ids, username)
 
     @staticmethod
     def _cancel_with_successors(
-        hostname: str,
+        hostname: str | None,
         rdir: str,
         target_ids: list[str],
         username: str | None,
     ) -> bool:
-        from nemo_evaluator.executors.ssh import ssh_run
+        from nemo_evaluator.executors.ssh import run_on_slurm_host
 
         all_ids = set(target_ids)
 
         all_ids.update(_collect_successor_ids(hostname, target_ids, username, rdir))
 
-        ids_str = " ".join(sorted(all_ids))
+        ids_str = " ".join(shlex.quote(job_id) for job_id in sorted(all_ids))
         try:
-            ssh_run(hostname, f"scancel {ids_str}", username=username, timeout=15.0)
+            run_on_slurm_host(hostname, f"scancel {ids_str}", username=username, timeout=15.0)
             logger.info("Cancelled SLURM jobs: %s", ids_str)
         except Exception as e:
             logger.error("Failed to cancel jobs %s: %s", ids_str, e)
@@ -734,7 +739,12 @@ class SlurmExecutor(Executor):
         if late:
             logger.info("Cancelling late-started successors: %s", " ".join(sorted(late)))
             try:
-                ssh_run(hostname, f"scancel {' '.join(sorted(late))}", username=username, timeout=15.0)
+                run_on_slurm_host(
+                    hostname,
+                    f"scancel {' '.join(shlex.quote(job_id) for job_id in sorted(late))}",
+                    username=username,
+                    timeout=15.0,
+                )
             except Exception:
                 logger.warning("Failed to cancel late successors: %s", " ".join(sorted(late)))
 
@@ -751,9 +761,9 @@ class SlurmExecutor(Executor):
         meta = _read_meta(output_dir)
         if meta is None:
             return None
-        from nemo_evaluator.executors.ssh import ssh_run
+        from nemo_evaluator.executors.ssh import run_on_slurm_host
 
-        hostname = meta["hostname"]
+        hostname = meta.get("hostname") or None
         username = meta.get("username") or None
         rdir = meta.get("remote_dir", str(output_dir))
         job_ids = _get_job_ids(meta)
@@ -762,8 +772,18 @@ class SlurmExecutor(Executor):
             latest_id = _resolve_latest_job_id(hostname, rdir, job_ids[0] if job_ids else "", username)
             log_file = f"{rdir}/logs/slurm-{latest_id}.log"
             if tail:
-                return ssh_run(hostname, f"tail -n {tail} {log_file}", username=username, timeout=30.0)
-            return ssh_run(hostname, f"cat {log_file}", username=username, timeout=60.0)
+                return run_on_slurm_host(
+                    hostname,
+                    f"tail -n {tail} {shlex.quote(log_file)}",
+                    username=username,
+                    timeout=30.0,
+                )
+            return run_on_slurm_host(
+                hostname,
+                f"cat {shlex.quote(log_file)}",
+                username=username,
+                timeout=60.0,
+            )
 
         if shard_idx is not None:
             if shard_idx < 0 or shard_idx >= len(job_ids):
@@ -772,61 +792,68 @@ class SlurmExecutor(Executor):
             latest_id = _resolve_latest_job_id(hostname, shard_rdir, job_ids[shard_idx], username)
             log_file = f"{shard_rdir}/logs/slurm-{latest_id}.log"
             if tail:
-                return ssh_run(hostname, f"tail -n {tail} {log_file}", username=username, timeout=30.0)
-            return ssh_run(hostname, f"cat {log_file}", username=username, timeout=60.0)
+                return run_on_slurm_host(
+                    hostname,
+                    f"tail -n {tail} {shlex.quote(log_file)}",
+                    username=username,
+                    timeout=30.0,
+                )
+            return run_on_slurm_host(
+                hostname,
+                f"cat {shlex.quote(log_file)}",
+                username=username,
+                timeout=60.0,
+            )
 
         tail_n = tail or 20
         cmds = []
         for i, fb in enumerate(job_ids):
             sdir = shlex.quote(f"{rdir}/shard_{i}")
             cmds.append(
-                f'echo "=== shard_{i} (job {fb}) ==="; '
-                f'_l=$(tail -1 {sdir}/.nel_job_chain 2>/dev/null); _l="${{_l:-{fb}}}"; '
-                f'tail -n {tail_n} {sdir}/logs/slurm-$_l.log 2>/dev/null || echo "(no log yet)"'
+                f'echo "=== shard_{i} (job {fb}) ==="; _sdir={sdir}; '
+                f'_l=$(tail -1 "$_sdir/.nel_job_chain" 2>/dev/null); _l="${{_l:-{fb}}}"; '
+                f'tail -n {tail_n} "$_sdir/logs/slurm-$_l.log" 2>/dev/null || echo "(no log yet)"'
             )
         script = '; echo ""; '.join(cmds)
         try:
-            return ssh_run(hostname, script, username=username, timeout=60.0)
+            return run_on_slurm_host(hostname, script, username=username, timeout=60.0)
         except Exception as e:
             return f"Failed to fetch logs: {e}"
 
     def resume_run(self, run_meta, **kwargs) -> None:
-        import re
-        import shlex as shlex_mod
-
         import click
 
         details = run_meta.details
-        hostname = details.get("hostname", "")
+        hostname = details.get("hostname") or None
         username = details.get("username") or None
         rdir = details.get("remote_dir", run_meta.output_dir)
         job_ids = _get_job_ids(details)
         continue_attempts = kwargs.get("continue_attempts", False)
         shard_idx = kwargs.get("shard_idx")
 
-        from nemo_evaluator.executors.ssh import ssh_run
+        from nemo_evaluator.executors.ssh import run_on_slurm_host, submit_sbatch
 
         if not _is_sharded(details):
             script = f"{rdir}/nel_eval.sbatch"
             if not continue_attempts:
-                ssh_run(
+                run_on_slurm_host(
                     hostname,
-                    f"rm -f {shlex_mod.quote(rdir)}/.nel_infra_retries {shlex_mod.quote(rdir)}/.nel_accumulated_walltime",
+                    f"rm -f {shlex.quote(rdir)}/.nel_infra_retries {shlex.quote(rdir)}/.nel_accumulated_walltime",
                     username=username,
                     timeout=10.0,
                 )
-            output = ssh_run(hostname, f"sbatch {shlex_mod.quote(script)}", username=username, timeout=30.0)
-            click.echo(f"Resubmitted: {output.strip()}")
-            m = re.search(r"(\d+)", output)
-            if m:
-                new_id = m.group(1)
-                run_meta.update_details(job_id=new_id, job_ids=[new_id])
-                new_meta_dir = _jobs_store() / new_id
-                new_meta_dir.mkdir(parents=True, exist_ok=True)
-                (new_meta_dir / _META_FILE).write_text(json.dumps({**details, "job_id": new_id}, indent=2))
-                click.echo(f"New job ID: {new_id}")
-                click.echo(f"Tail logs:  nel eval logs -r {run_meta.run_id} -f")
-                click.echo(f"Status:     nel eval status -r {run_meta.run_id}")
+            new_id = submit_sbatch(hostname, script, username)
+            click.echo(f"Resubmitted: {new_id}")
+            new_meta = {**details, "job_id": new_id, "job_ids": [new_id]}
+            new_meta_dir = _jobs_store() / new_id
+            new_meta_dir.mkdir(parents=True, exist_ok=True)
+            (new_meta_dir / _META_FILE).write_text(json.dumps(new_meta, indent=2))
+            if hostname is None:
+                (Path(rdir) / _META_FILE).write_text(json.dumps(new_meta, indent=2))
+            run_meta.update_details(job_id=new_id, job_ids=[new_id])
+            click.echo(f"New job ID: {new_id}")
+            click.echo(f"Tail logs:  nel eval logs -r {run_meta.run_id} -f")
+            click.echo(f"Status:     nel eval status -r {run_meta.run_id}")
             return
 
         from nemo_evaluator.executors.ssh import batch_check_job_status
@@ -865,21 +892,35 @@ class SlurmExecutor(Executor):
             script = f"{shard_dir}/nel_eval.sbatch"
             try:
                 if not continue_attempts:
-                    ssh_run(
+                    run_on_slurm_host(
                         hostname,
-                        f"rm -f {shlex_mod.quote(shard_dir)}/.nel_infra_retries "
-                        f"{shlex_mod.quote(shard_dir)}/.nel_accumulated_walltime",
+                        f"rm -f {shlex.quote(shard_dir)}/.nel_infra_retries "
+                        f"{shlex.quote(shard_dir)}/.nel_accumulated_walltime",
                         username=username,
                         timeout=10.0,
                     )
-                output = ssh_run(hostname, f"sbatch {shlex_mod.quote(script)}", username=username, timeout=30.0)
-                click.echo(f"  shard_{i}: {output.strip()}")
-                m = re.search(r"(\d+)", output)
-                if m:
-                    new_job_ids[i] = m.group(1)
+                new_id = submit_sbatch(hostname, script, username)
+                click.echo(f"  shard_{i}: {new_id}")
             except Exception as e:
                 click.echo(f"  shard_{i}: FAILED — {e}", err=True)
                 failed_shards.append(i)
+                continue
+
+            new_meta = {
+                **details,
+                "job_id": new_id,
+                "job_ids": [new_id],
+                "remote_dir": shard_dir,
+                "script": script,
+                "is_sharded": False,
+            }
+            new_meta.pop("num_shards", None)
+            new_meta_dir = _jobs_store() / new_id
+            new_meta_dir.mkdir(parents=True, exist_ok=True)
+            (new_meta_dir / _META_FILE).write_text(json.dumps(new_meta, indent=2))
+            if hostname is None:
+                (Path(shard_dir) / _META_FILE).write_text(json.dumps(new_meta, indent=2))
+            new_job_ids[i] = new_id
 
         if new_job_ids != list(job_ids):
             run_meta.update_details(job_ids=new_job_ids)
@@ -899,7 +940,7 @@ class SlurmExecutor(Executor):
 
 
 def _resolve_latest_job_id_from_meta(meta: dict) -> str:
-    """Follow .nel_job_chain on the remote host to get the latest job ID.
+    """Follow .nel_job_chain on the Slurm host to get the latest job ID.
 
     Backward-compatible wrapper — delegates to _resolve_latest_job_id.
     """

--- a/src/nemo_evaluator/executors/ssh.py
+++ b/src/nemo_evaluator/executors/ssh.py
@@ -246,7 +246,7 @@ def check_job_status(
     try:
         output = run_on_slurm_host(
             hostname,
-            f"squeue --job {shlex.quote(job_id)} --noheader --format=%i|%j|%T|%M|%N",
+            f"squeue --job {shlex.quote(job_id)} --noheader --format='%i|%j|%T|%M|%N'",
             username=username,
             timeout=15.0,
         )
@@ -305,7 +305,7 @@ def batch_check_job_status(
     try:
         output = run_on_slurm_host(
             hostname,
-            f"squeue --jobs {ids_str} --noheader --format=%i|%j|%T|%M|%N",
+            f"squeue --jobs {ids_str} --noheader --format='%i|%j|%T|%M|%N'",
             username=username,
             timeout=15.0,
         )

--- a/src/nemo_evaluator/executors/ssh.py
+++ b/src/nemo_evaluator/executors/ssh.py
@@ -100,6 +100,18 @@ def ssh_run(hostname: str, remote_cmd: str, username: str | None = None, timeout
     return _ssh(target, remote_cmd, timeout=timeout)
 
 
+def run_on_slurm_host(
+    hostname: str | None,
+    command: str,
+    username: str | None = None,
+    timeout: float = 30.0,
+) -> str:
+    """Run a command where Slurm is available, locally or through SSH."""
+    if hostname:
+        return ssh_run(hostname, command, username=username, timeout=timeout)
+    return _run(["bash", "-c", command], timeout=timeout)
+
+
 def _scp(local_path: str, remote_dest: str, target: str, timeout: float = 60.0) -> str:
     _ensure_master(target)
     return _run(["scp", "-p", *_ssh_opts(target), local_path, remote_dest], timeout=timeout)
@@ -205,39 +217,44 @@ def copy_to_remote(
 
 
 def submit_sbatch(
-    hostname: str,
+    hostname: str | None,
     remote_script: str,
     username: str | None = None,
 ) -> str:
-    """Submit an sbatch script on the remote host and return the SLURM job ID."""
-    target = _ssh_target(hostname, username)
-    output = _ssh(target, f"sbatch {shlex.quote(remote_script)}")
+    """Submit an sbatch script and return the SLURM job ID."""
+    output = run_on_slurm_host(
+        hostname,
+        f"sbatch --parsable {shlex.quote(remote_script)}",
+        username=username,
+    )
 
-    # sbatch output: "Submitted batch job 12345"
-    parts = output.split()
-    if len(parts) >= 4 and parts[-1].isdigit():
-        return parts[-1]
+    # ``--parsable`` emits ``job_id`` or ``job_id;cluster``. Use the final
+    # non-empty line so an SSH login banner cannot hide an otherwise valid ID.
+    lines = [line.strip() for line in output.splitlines() if line.strip()]
+    job_id = lines[-1].split(";", 1)[0] if lines else ""
+    if job_id.isdigit():
+        return job_id
     raise SSHError(f"Could not parse sbatch output: {output}")
 
 
 def check_job_status(
-    hostname: str,
+    hostname: str | None,
     job_id: str,
     username: str | None = None,
 ) -> dict[str, str]:
     """Check SLURM job status via squeue, falling back to sacct."""
-    target = _ssh_target(hostname, username)
     try:
-        output = _ssh(
-            target,
+        output = run_on_slurm_host(
+            hostname,
             f"squeue --job {shlex.quote(job_id)} --noheader --format=%i|%j|%T|%M|%N",
+            username=username,
             timeout=15.0,
         )
     except SSHError:
         return {"job_id": job_id, "state": "UNKNOWN"}
 
     if not output.strip():
-        return _sacct_status(target, job_id)
+        return _sacct_status(hostname, job_id, username)
 
     fields = output.strip().split("|")
     if len(fields) >= 5:
@@ -251,12 +268,13 @@ def check_job_status(
     return {"job_id": job_id, "state": output.strip()}
 
 
-def _sacct_status(target: str, job_id: str) -> dict[str, str]:
+def _sacct_status(hostname: str | None, job_id: str, username: str | None = None) -> dict[str, str]:
     """Fall back to sacct for completed/failed jobs no longer in squeue."""
     try:
-        output = _ssh(
-            target,
+        output = run_on_slurm_host(
+            hostname,
             f"sacct -j {shlex.quote(job_id)} --noheader --parsable2 --format=JobID,State,ExitCode -n",
+            username=username,
             timeout=15.0,
         )
     except SSHError:
@@ -274,21 +292,21 @@ def _sacct_status(target: str, job_id: str) -> dict[str, str]:
 
 
 def batch_check_job_status(
-    hostname: str,
+    hostname: str | None,
     job_ids: list[str],
     username: str | None = None,
 ) -> dict[str, dict[str, str]]:
     """Check multiple SLURM jobs in one squeue + sacct round-trip."""
     if not job_ids:
         return {}
-    target = _ssh_target(hostname, username)
     ids_str = ",".join(shlex.quote(j) for j in job_ids)
 
     results: dict[str, dict[str, str]] = {}
     try:
-        output = _ssh(
-            target,
+        output = run_on_slurm_host(
+            hostname,
             f"squeue --jobs {ids_str} --noheader --format=%i|%j|%T|%M|%N",
+            username=username,
             timeout=15.0,
         )
         for line in output.strip().splitlines():
@@ -310,9 +328,10 @@ def batch_check_job_status(
     if missing:
         sacct_ids = ",".join(shlex.quote(j) for j in missing)
         try:
-            output = _ssh(
-                target,
+            output = run_on_slurm_host(
+                hostname,
                 f"sacct -j {sacct_ids} --noheader --parsable2 --format=JobID,State,ExitCode -n",
+                username=username,
                 timeout=15.0,
             )
             for line in output.strip().splitlines():
@@ -334,13 +353,17 @@ def batch_check_job_status(
 
 
 def cancel_job(
-    hostname: str,
+    hostname: str | None,
     job_id: str,
     username: str | None = None,
 ) -> None:
     """Cancel a SLURM job via scancel."""
-    target = _ssh_target(hostname, username)
-    _ssh(target, f"scancel {shlex.quote(job_id)}", timeout=15.0)
+    run_on_slurm_host(
+        hostname,
+        f"scancel {shlex.quote(job_id)}",
+        username=username,
+        timeout=15.0,
+    )
     logger.info("Cancelled SLURM job %s", job_id)
 
 

--- a/tests/test_orchestration/test_slurm_sharding.py
+++ b/tests/test_orchestration/test_slurm_sharding.py
@@ -18,6 +18,8 @@ import json
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from nemo_evaluator.config import EvalConfig
 from nemo_evaluator.orchestration.slurm_gen import generate_sbatch, write_sbatch
 
@@ -2392,7 +2394,7 @@ class TestShardedResume:
             "11": {"job_id": "11", "state": "FAILED"},
             "12": {"job_id": "12", "state": "TIMEOUT"},
         }
-        mock_ssh.return_value = "Submitted batch job 200"
+        mock_ssh.return_value = "200"
 
         rm = self._make_run_meta(job_ids)
         with patch.object(rm, "update_details"):
@@ -2411,7 +2413,7 @@ class TestShardedResume:
 
         job_ids = ["10", "11"]
         mock_latest.return_value = job_ids
-        mock_ssh.return_value = "Submitted batch job 300"
+        mock_ssh.return_value = "300"
 
         rm = self._make_run_meta(job_ids)
         with patch.object(rm, "update_details"):
@@ -2710,7 +2712,7 @@ class TestResumePartialFailure:
                 call_count[0] += 1
                 if "shard_1" in cmd:
                     raise Exception("Connection reset")
-                return f"Submitted batch job {200 + call_count[0]}"
+                return str(200 + call_count[0])
             return ""
 
         mock_ssh.side_effect = ssh_side_effect
@@ -2843,7 +2845,7 @@ class TestNonShardedResume:
         from nemo_evaluator.executors.slurm_executor import SlurmExecutor
         from nemo_evaluator.run_store import RunMeta
 
-        mock_ssh.return_value = "Submitted batch job 500"
+        mock_ssh.return_value = "500"
 
         rm = RunMeta(
             run_id="test-run",
@@ -2869,6 +2871,306 @@ class TestNonShardedResume:
         call_kwargs = mock_update.call_args[1]
         assert call_kwargs["job_id"] == "500"
         assert call_kwargs["job_ids"] == ["500"]
+
+
+class TestLocalSlurmLifecycle:
+    def test_status_uses_local_slurm_host(self):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+
+        meta = {"job_id": "100", "hostname": "", "username": "", "remote_dir": "/run"}
+        with (
+            patch("nemo_evaluator.executors.slurm_executor._read_meta", return_value=meta),
+            patch("nemo_evaluator.executors.slurm_executor._resolve_latest_job_id", return_value="200"),
+            patch("nemo_evaluator.executors.slurm_executor._fetch_eval_progress", return_value={}),
+            patch(
+                "nemo_evaluator.executors.ssh.check_job_status",
+                return_value={"job_id": "200", "state": "RUNNING"},
+            ) as check_status,
+        ):
+            state = SlurmExecutor().status("/run")
+
+        assert state.running is True
+        check_status.assert_called_once_with(hostname=None, job_id="200", username=None)
+
+    def test_stop_uses_local_slurm_host(self):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+
+        meta = {"job_id": "100", "hostname": "", "username": "", "remote_dir": "/run"}
+        with (
+            patch("nemo_evaluator.executors.slurm_executor._read_meta", return_value=meta),
+            patch("nemo_evaluator.executors.slurm_executor._resolve_latest_job_id", return_value="100"),
+            patch("nemo_evaluator.executors.slurm_executor._collect_successor_ids", return_value=set()),
+            patch("nemo_evaluator.executors.slurm_executor.time.sleep"),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value="") as run_on_host,
+            patch("nemo_evaluator.executors.ssh.ssh_run") as ssh_run,
+        ):
+            assert SlurmExecutor().stop("/run") is True
+
+        run_on_host.assert_called_once_with(None, "scancel 100", username=None, timeout=15.0)
+        ssh_run.assert_not_called()
+
+    def test_logs_use_local_slurm_host(self):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+
+        meta = {"job_id": "100", "hostname": "", "username": "", "remote_dir": "/run"}
+        with (
+            patch("nemo_evaluator.executors.slurm_executor._read_meta", return_value=meta),
+            patch("nemo_evaluator.executors.slurm_executor._resolve_latest_job_id", return_value="100"),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value="local log") as run_on_host,
+            patch("nemo_evaluator.executors.ssh.ssh_run") as ssh_run,
+        ):
+            content = SlurmExecutor().logs("/run", tail=25)
+
+        assert content == "local log"
+        run_on_host.assert_called_once_with(None, "tail -n 25 /run/logs/slurm-100.log", username=None, timeout=30.0)
+        ssh_run.assert_not_called()
+
+    def test_resume_updates_local_output_and_central_metadata(self, tmp_path, monkeypatch):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+        from nemo_evaluator.run_store import RunMeta
+
+        output_dir = tmp_path / "run"
+        output_dir.mkdir()
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+        run_meta = RunMeta(
+            run_id="local-run",
+            executor="slurm",
+            output_dir=str(output_dir),
+            started_at="2026-01-01",
+            details={
+                "job_id": "100",
+                "job_ids": ["100"],
+                "hostname": "",
+                "remote_dir": str(output_dir),
+                "username": "",
+            },
+        )
+
+        with (
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value="") as run_on_host,
+            patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="500") as submit,
+            patch("nemo_evaluator.executors.ssh.ssh_run") as ssh_run,
+        ):
+            SlurmExecutor().resume_run(run_meta)
+
+        run_on_host.assert_called_once()
+        assert run_on_host.call_args.args[0] is None
+        submit.assert_called_once_with(None, f"{output_dir}/nel_eval.sbatch", None)
+        ssh_run.assert_not_called()
+        assert run_meta.details["job_id"] == "500"
+        assert run_meta.details["job_ids"] == ["500"]
+
+        output_meta = json.loads((output_dir / "slurm_job.json").read_text())
+        stored_meta = json.loads((tmp_path / "xdg" / "nel" / "jobs" / "500" / "slurm_job.json").read_text())
+        assert output_meta == stored_meta
+        assert output_meta["job_id"] == "500"
+
+    def test_sharded_resume_updates_local_metadata_and_preserves_anchor_job_id(self, tmp_path, monkeypatch):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+        from nemo_evaluator.run_store import RunMeta
+
+        output_dir = tmp_path / "run"
+        shard_dir = output_dir / "shard_0"
+        shard_dir.mkdir(parents=True)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+        aggregate = {
+            "job_id": "100",
+            "job_ids": ["100", "101"],
+            "hostname": "",
+            "remote_dir": str(output_dir),
+            "is_sharded": True,
+        }
+        (output_dir / "slurm_job.json").write_text(json.dumps(aggregate))
+        run_meta = RunMeta(
+            run_id="local-sharded-run",
+            executor="slurm",
+            output_dir=str(output_dir),
+            started_at="2026-01-01",
+            details=dict(aggregate),
+        )
+
+        with (
+            patch(
+                "nemo_evaluator.executors.slurm_executor._resolve_shard_latest_ids",
+                return_value=["100", "101"],
+            ),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value=""),
+            patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="500"),
+        ):
+            SlurmExecutor().resume_run(run_meta, shard_idx=0)
+
+        assert run_meta.details["job_id"] == "100"
+        assert run_meta.details["job_ids"] == ["500", "101"]
+        shard_meta = json.loads((shard_dir / "slurm_job.json").read_text())
+        assert shard_meta["job_id"] == "500"
+        parent_meta = json.loads((output_dir / "slurm_job.json").read_text())
+        assert parent_meta["job_id"] == "100"
+        assert parent_meta["job_ids"] == ["500", "101"]
+
+    def test_sharded_resume_marks_per_shard_metadata_non_sharded(self, tmp_path, monkeypatch):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+        from nemo_evaluator.run_store import RunMeta
+
+        output_dir = tmp_path / "run"
+        shard_dir = output_dir / "shard_0"
+        shard_dir.mkdir(parents=True)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+        details = {
+            "job_id": "100",
+            "job_ids": ["100", "101"],
+            "hostname": "",
+            "remote_dir": str(output_dir),
+            "is_sharded": True,
+        }
+        run_meta = RunMeta(
+            run_id="local-sharded-run",
+            executor="slurm",
+            output_dir=str(output_dir),
+            started_at="2026-01-01",
+            details=details,
+        )
+
+        with (
+            patch(
+                "nemo_evaluator.executors.slurm_executor._resolve_shard_latest_ids",
+                return_value=["100", "101"],
+            ),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value=""),
+            patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="500"),
+        ):
+            SlurmExecutor().resume_run(run_meta, shard_idx=0)
+
+        shard_meta = json.loads((shard_dir / "slurm_job.json").read_text())
+        stored_meta = json.loads((tmp_path / "xdg" / "nel" / "jobs" / "500" / "slurm_job.json").read_text())
+        assert shard_meta["is_sharded"] is False
+        assert stored_meta["is_sharded"] is False
+
+    def test_stop_specific_shard_cancels_its_auto_resume_successor(self):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+
+        meta = {
+            "job_id": "100",
+            "job_ids": ["100", "101", "102"],
+            "hostname": "",
+            "remote_dir": "/run",
+            "username": "",
+            "is_sharded": True,
+        }
+
+        def fake_run(_hostname, command, **_kwargs):
+            if command.startswith("squeue "):
+                return "400 PENDING /run/shard_2/nel_eval.sbatch\n"
+            return ""
+
+        with (
+            patch("nemo_evaluator.executors.slurm_executor._read_meta", return_value=meta),
+            patch("nemo_evaluator.executors.slurm_executor._resolve_latest_job_id", return_value="102"),
+            patch("nemo_evaluator.executors.slurm_executor.time.sleep"),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", side_effect=fake_run) as run_on_host,
+        ):
+            assert SlurmExecutor().stop("/run", shard_idx=2) is True
+
+        scancel_commands = [call.args[1] for call in run_on_host.call_args_list if call.args[1].startswith("scancel ")]
+        assert scancel_commands == ["scancel 102 400"]
+
+    def test_local_logs_quote_path_with_spaces(self):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+
+        meta = {
+            "job_id": "100",
+            "hostname": "",
+            "username": "",
+            "remote_dir": "/shared/run with spaces",
+        }
+        with (
+            patch("nemo_evaluator.executors.slurm_executor._read_meta", return_value=meta),
+            patch("nemo_evaluator.executors.slurm_executor._resolve_latest_job_id", return_value="100"),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value="local log") as run_on_host,
+        ):
+            assert SlurmExecutor().logs("/shared/run with spaces") == "local log"
+
+        run_on_host.assert_called_once_with(
+            None,
+            "cat '/shared/run with spaces/logs/slurm-100.log'",
+            username=None,
+            timeout=60.0,
+        )
+
+    def test_non_sharded_resume_metadata_failure_keeps_new_job_visible(self, tmp_path, capsys):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+        from nemo_evaluator.run_store import RunMeta
+
+        output_dir = tmp_path / "run"
+        output_dir.mkdir()
+        blocked_store = tmp_path / "blocked-store"
+        blocked_store.write_text("not a directory")
+        run_meta = RunMeta(
+            run_id="local-run",
+            executor="slurm",
+            output_dir=str(output_dir),
+            started_at="2026-01-01",
+            details={
+                "job_id": "100",
+                "job_ids": ["100"],
+                "hostname": "",
+                "remote_dir": str(output_dir),
+            },
+        )
+
+        with (
+            patch("nemo_evaluator.executors.slurm_executor._jobs_store", return_value=blocked_store),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value="") as run_on_host,
+            patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="500"),
+            patch("nemo_evaluator.executors.ssh.cancel_job") as cancel_job,
+            pytest.raises(OSError),
+        ):
+            SlurmExecutor().resume_run(run_meta)
+
+        cancel_job.assert_not_called()
+        assert "Resubmitted: 500" in capsys.readouterr().out
+        assert run_meta.details["job_id"] == "100"
+        assert run_meta.details["job_ids"] == ["100"]
+        assert not (output_dir / "slurm_job.json").exists()
+        assert all(not call.args[1].startswith("scancel ") for call in run_on_host.call_args_list)
+
+    def test_sharded_resume_metadata_failure_keeps_new_job_visible(self, tmp_path, capsys):
+        from nemo_evaluator.executors.slurm_executor import SlurmExecutor
+        from nemo_evaluator.run_store import RunMeta
+
+        output_dir = tmp_path / "run"
+        (output_dir / "shard_0").mkdir(parents=True)
+        blocked_store = tmp_path / "blocked-store"
+        blocked_store.write_text("not a directory")
+        run_meta = RunMeta(
+            run_id="local-sharded-run",
+            executor="slurm",
+            output_dir=str(output_dir),
+            started_at="2026-01-01",
+            details={
+                "job_id": "100",
+                "job_ids": ["100"],
+                "hostname": "",
+                "remote_dir": str(output_dir),
+                "is_sharded": True,
+            },
+        )
+
+        with (
+            patch("nemo_evaluator.executors.slurm_executor._jobs_store", return_value=blocked_store),
+            patch("nemo_evaluator.executors.slurm_executor._resolve_shard_latest_ids", return_value=["100"]),
+            patch("nemo_evaluator.executors.ssh.run_on_slurm_host", return_value="") as run_on_host,
+            patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="500"),
+            patch("nemo_evaluator.executors.ssh.cancel_job") as cancel_job,
+            pytest.raises(OSError),
+        ):
+            SlurmExecutor().resume_run(run_meta, shard_idx=0)
+
+        cancel_job.assert_not_called()
+        assert "shard_0: 500" in capsys.readouterr().out
+        assert run_meta.details["job_id"] == "100"
+        assert run_meta.details["job_ids"] == ["100"]
+        assert not (output_dir / "shard_0" / "slurm_job.json").exists()
+        assert all(not call.args[1].startswith("scancel ") for call in run_on_host.call_args_list)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_orchestration/test_ssh_executor.py
+++ b/tests/test_orchestration/test_ssh_executor.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Tests for the SSH-based remote SLURM submission helpers.
+"""Tests for local/SSH SLURM command and remote submission helpers.
 
-The functions under test shell out to ``ssh`` / ``scp`` so we patch
-``_ssh`` and ``_scp`` and assert on the calls they would have made.
+The functions under test shell out to local commands, ``ssh``, or ``scp``,
+so tests patch those process boundaries and assert on the exact calls.
 """
 
 from __future__ import annotations
@@ -27,6 +27,64 @@ def _record_calls():
         return ""
 
     return ssh_calls, scp_calls, fake_ssh, fake_scp
+
+
+def test_run_on_slurm_host_local_uses_bash_without_ssh():
+    with (
+        patch.object(ssh_mod, "_run", return_value="local output") as run_mock,
+        patch.object(ssh_mod, "ssh_run") as ssh_mock,
+    ):
+        output = ssh_mod.run_on_slurm_host(None, "squeue --me", timeout=17.0)
+
+    assert output == "local output"
+    run_mock.assert_called_once_with(["bash", "-c", "squeue --me"], timeout=17.0)
+    ssh_mock.assert_not_called()
+
+
+def test_run_on_slurm_host_remote_delegates_to_ssh():
+    with (
+        patch.object(ssh_mod, "_run") as run_mock,
+        patch.object(ssh_mod, "ssh_run", return_value="remote output") as ssh_mock,
+    ):
+        output = ssh_mod.run_on_slurm_host("loginhost", "squeue --me", username="user", timeout=19.0)
+
+    assert output == "remote output"
+    ssh_mock.assert_called_once_with("loginhost", "squeue --me", username="user", timeout=19.0)
+    run_mock.assert_not_called()
+
+
+def test_submit_sbatch_local_uses_parsable_and_accepts_cluster_suffix():
+    with patch.object(ssh_mod, "run_on_slurm_host", return_value="12345;cluster-a\n") as run_mock:
+        job_id = ssh_mod.submit_sbatch(None, "/shared/eval run/nel_eval.sbatch")
+
+    assert job_id == "12345"
+    run_mock.assert_called_once_with(
+        None,
+        "sbatch --parsable '/shared/eval run/nel_eval.sbatch'",
+        username=None,
+    )
+
+
+def test_check_job_status_local_falls_back_from_squeue_to_sacct():
+    def fake_run(command, timeout=30.0):
+        assert command[:2] == ["bash", "-c"]
+        if command[2].startswith("squeue "):
+            return ""
+        if command[2].startswith("sacct "):
+            return "12345|COMPLETED|0:0\n"
+        raise AssertionError(f"unexpected command: {command}")
+
+    with (
+        patch.object(ssh_mod, "_run", side_effect=fake_run) as run_mock,
+        patch.object(ssh_mod, "ssh_run") as ssh_mock,
+    ):
+        status = ssh_mod.check_job_status(None, "12345")
+
+    assert status == {"job_id": "12345", "state": "COMPLETED", "exit_code": "0:0"}
+    assert run_mock.call_count == 2
+    assert "squeue --job 12345" in run_mock.call_args_list[0].args[0][2]
+    assert "sacct -j 12345" in run_mock.call_args_list[1].args[0][2]
+    ssh_mock.assert_not_called()
 
 
 def test_copy_to_remote_local_base_preserves_subdir_structure(tmp_path: Path):

--- a/tests/test_serving/test_cli_commands.py
+++ b/tests/test_serving/test_cli_commands.py
@@ -106,6 +106,82 @@ class TestEvalRun:
         assert call_kwargs.kwargs.get("dry_run") is True or call_kwargs[1].get("dry_run") is True
 
 
+class TestEvalLogs:
+    def test_follow_local_slurm_uses_tail_without_ssh(self, runner):
+        from nemo_evaluator.run_store import RunMeta
+
+        run_meta = RunMeta(
+            run_id="local-slurm-run",
+            executor="slurm",
+            output_dir="/shared/eval/run",
+            started_at="2026-07-21T00:00:00+00:00",
+            details={
+                "job_id": "12345",
+                "hostname": "",
+                "remote_dir": "/shared/eval/run",
+            },
+        )
+
+        with (
+            patch("nemo_evaluator.cli.eval._resolve_run_or_fail", return_value=run_meta),
+            patch("nemo_evaluator.cli.eval._get_executor_for_run", return_value=MagicMock()),
+            patch(
+                "nemo_evaluator.executors.slurm_executor._resolve_latest_job_id_from_meta",
+                return_value="12345",
+            ),
+            patch("subprocess.run") as mock_run,
+        ):
+            result = runner.invoke(
+                cli,
+                ["eval", "logs", "--run-id", run_meta.run_id, "--follow", "--tail", "25"],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_run.assert_called_once_with(
+            ["tail", "-n", "25", "-f", "/shared/eval/run/logs/slurm-12345.log"],
+            check=False,
+        )
+        assert "ssh" not in mock_run.call_args.args[0]
+
+    def test_follow_single_shard_local_slurm_uses_shard_zero_log(self, runner):
+        from nemo_evaluator.run_store import RunMeta
+
+        run_meta = RunMeta(
+            run_id="single-shard-local-slurm-run",
+            executor="slurm",
+            output_dir="/shared/eval/run",
+            started_at="2026-07-21T00:00:00+00:00",
+            details={
+                "job_id": "12345",
+                "job_ids": ["12345"],
+                "hostname": "",
+                "remote_dir": "/shared/eval/run",
+                "is_sharded": True,
+            },
+        )
+
+        with (
+            patch("nemo_evaluator.cli.eval._resolve_run_or_fail", return_value=run_meta),
+            patch("nemo_evaluator.cli.eval._get_executor_for_run", return_value=MagicMock()),
+            patch(
+                "nemo_evaluator.executors.slurm_executor._resolve_latest_job_id",
+                return_value="12345",
+            ) as mock_resolve_latest,
+            patch("subprocess.run") as mock_run,
+        ):
+            result = runner.invoke(
+                cli,
+                ["eval", "logs", "--run-id", run_meta.run_id, "--follow", "--shard", "0"],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_resolve_latest.assert_called_once_with("", "/shared/eval/run/shard_0", "12345", None)
+        mock_run.assert_called_once_with(
+            ["tail", "-n", "50", "-f", "/shared/eval/run/shard_0/logs/slurm-12345.log"],
+            check=False,
+        )
+
+
 class TestValidateCommand:
     def test_validate_missing_file(self, runner):
         result = runner.invoke(cli, ["eval", "validate", "/nonexistent_xyz.yaml"])

--- a/tests/test_slurm_executor_snapshot.py
+++ b/tests/test_slurm_executor_snapshot.py
@@ -12,8 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Remote SLURM submission: snapshot upload and staging cleanup semantics."""
+"""SLURM submission metadata, snapshot, and partial-failure semantics."""
 
+import json
 from unittest.mock import patch
 
 import nemo_evaluator.executors.slurm_executor as slurm_executor_module
@@ -48,6 +49,28 @@ def _remote_config(tmp_path):
         output=OutputConfig(dir=str(tmp_path / "remote_out")),
     )
     # The CLI loader attaches the pre-expansion composed dict; simulate it.
+    config._composed_raw = {"services": {"m": {"api_key": "${KEY}"}}}
+    return config
+
+
+def _local_config(tmp_path, *, shards=None):
+    config = EvalConfig(
+        services={
+            "m": ExternalApiService(
+                type="api",
+                url="http://localhost:8000/v1/chat/completions",
+                protocol="chat_completions",
+                model="test-model",
+            )
+        },
+        benchmarks=[BenchmarkConfig(name="gsm8k", solver=SimpleSolver(type="simple", service="m"))],
+        cluster=SlurmCluster(
+            type="slurm",
+            shards=shards,
+            node_pools={"compute": NodePool(partition="batch")},
+        ),
+        output=OutputConfig(dir=str(tmp_path / "local_out"), timestamped=False),
+    )
     config._composed_raw = {"services": {"m": {"api_key": "${KEY}"}}}
     return config
 
@@ -105,3 +128,133 @@ def test_failed_upload_keeps_only_snapshot(tmp_path, monkeypatch, capsys):
     assert kept.exists()
     assert "${KEY}" in kept.read_text()
     assert f"scp {kept} login.example.com:{config.output.dir}/" in out
+
+
+def test_local_submission_persists_job_and_run_metadata(tmp_path, monkeypatch):
+    config = _local_config(tmp_path)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    with (
+        patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="42") as submit_mock,
+        patch("nemo_evaluator.executors.ssh.submit_eval") as remote_submit,
+        patch("nemo_evaluator.executors.ssh.copy_to_remote") as remote_copy,
+    ):
+        SlurmExecutor().run(config)
+
+    script = tmp_path / "local_out" / "nel_eval.sbatch"
+    submit_mock.assert_called_once_with(None, str(script))
+    remote_submit.assert_not_called()
+    remote_copy.assert_not_called()
+
+    output_meta = json.loads((tmp_path / "local_out" / "slurm_job.json").read_text())
+    stored_meta = json.loads((tmp_path / "xdg" / "nel" / "jobs" / "42" / "slurm_job.json").read_text())
+    assert output_meta == stored_meta
+    assert output_meta["job_id"] == "42"
+    assert output_meta["hostname"] == ""
+    assert output_meta["remote_dir"] == str(tmp_path / "local_out")
+
+    run_meta = json.loads((tmp_path / "local_out" / "nel_run.json").read_text())
+    assert run_meta["executor"] == "slurm"
+    assert run_meta["details"]["job_ids"] == ["42"]
+    assert run_meta["details"]["hostname"] == ""
+
+
+def test_local_sharded_submission_persists_per_shard_and_aggregate_metadata(tmp_path, monkeypatch):
+    config = _local_config(tmp_path, shards=2)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    with patch("nemo_evaluator.executors.ssh.submit_sbatch", side_effect=["42", "43"]):
+        SlurmExecutor().run(config)
+
+    output_dir = tmp_path / "local_out"
+    for shard_idx, job_id in enumerate(("42", "43")):
+        shard_meta = json.loads((output_dir / f"shard_{shard_idx}" / "slurm_job.json").read_text())
+        assert shard_meta["job_id"] == job_id
+        assert shard_meta["remote_dir"] == str(output_dir / f"shard_{shard_idx}")
+
+    aggregate = json.loads((output_dir / "slurm_job.json").read_text())
+    assert aggregate["job_id"] == "42"
+    assert aggregate["job_ids"] == ["42", "43"]
+    assert aggregate["is_sharded"] is True
+    assert aggregate["num_shards"] == 2
+
+    run_meta = json.loads((output_dir / "nel_run.json").read_text())
+    assert run_meta["details"]["job_ids"] == ["42", "43"]
+    assert run_meta["details"]["remote_dir"] == str(output_dir)
+
+
+def test_local_relative_output_is_persisted_as_absolute(tmp_path, monkeypatch):
+    config = _local_config(tmp_path)
+    config.output.dir = "relative-output"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    with patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="42"):
+        SlurmExecutor().run(config)
+
+    expected = tmp_path / "relative-output"
+    assert config.output.dir == str(expected)
+    output_meta = json.loads((expected / "slurm_job.json").read_text())
+    run_meta = json.loads((expected / "nel_run.json").read_text())
+    assert output_meta["remote_dir"] == str(expected)
+    assert run_meta["output_dir"] == str(expected)
+    assert run_meta["details"]["remote_dir"] == str(expected)
+
+
+def test_second_shard_submit_failure_keeps_submitted_job_and_warns(tmp_path, monkeypatch, capsys):
+    config = _local_config(tmp_path, shards=2)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+
+    with (
+        patch(
+            "nemo_evaluator.executors.ssh.submit_sbatch",
+            side_effect=["42", RuntimeError("second sbatch failed")],
+        ) as submit_mock,
+        patch("nemo_evaluator.executors.ssh.cancel_job") as cancel_mock,
+        patch("nemo_evaluator.executors.ssh.run_on_slurm_host") as run_on_host,
+    ):
+        SlurmExecutor().run(config)
+
+    assert submit_mock.call_count == 2
+    cancel_mock.assert_not_called()
+    captured = capsys.readouterr()
+    assert "SLURM job submitted: 42" in captured.out
+    assert "run_id:" in captured.out
+    assert "WARNING: Only 1/2 shards submitted" in captured.err
+    output_dir = tmp_path / "local_out"
+    aggregate = json.loads((output_dir / "slurm_job.json").read_text())
+    assert aggregate["job_ids"] == ["42"]
+    shard_meta = json.loads((output_dir / "shard_0" / "slurm_job.json").read_text())
+    stored_meta = json.loads((tmp_path / "xdg" / "nel" / "jobs" / "42" / "slurm_job.json").read_text())
+    run_meta = json.loads((output_dir / "nel_run.json").read_text())
+    assert shard_meta["job_id"] == "42"
+    assert stored_meta == shard_meta
+    assert run_meta["details"]["job_ids"] == ["42"]
+    assert not (output_dir / "shard_1" / "slurm_job.json").exists()
+    assert all(not call.args[1].startswith("scancel ") for call in run_on_host.call_args_list)
+
+
+def test_metadata_write_failure_keeps_job_id_visible_for_manual_recovery(tmp_path, monkeypatch, capsys):
+    config = _local_config(tmp_path)
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    blocked_jobs_store = tmp_path / "blocked-jobs-store"
+    blocked_jobs_store.write_text("not a directory")
+    monkeypatch.setattr(slurm_executor_module, "_jobs_store", lambda: blocked_jobs_store)
+
+    with (
+        patch("nemo_evaluator.executors.ssh.submit_sbatch", return_value="42"),
+        patch("nemo_evaluator.executors.ssh.cancel_job") as cancel_mock,
+        patch("nemo_evaluator.executors.ssh.run_on_slurm_host") as run_on_host,
+    ):
+        SlurmExecutor().run(config)
+
+    cancel_mock.assert_not_called()
+    captured = capsys.readouterr()
+    assert "SLURM job submitted: 42" in captured.out
+    assert "run_id:" in captured.out
+    assert "WARNING: Only 1/1 shards submitted" in captured.err
+    run_meta = json.loads((tmp_path / "local_out" / "nel_run.json").read_text())
+    assert run_meta["details"]["job_id"] == "42"
+    assert run_meta["details"]["job_ids"] == ["42"]
+    assert not (tmp_path / "local_out" / "slurm_job.json").exists()
+    assert all(not call.args[1].startswith("scancel ") for call in run_on_host.call_args_list)


### PR DESCRIPTION
## Problem

Submitting to Slurm without `cluster.hostname` (running directly on a login
node) leaves no recoverable identity: `sbatch` output is echoed and dropped —
no `slurm_job.json`, no RunMeta. Every subsequent lifecycle operation
(`status` / `stop` / `logs` / `resume`, and `logs -f` streaming) assumes an
SSH hostname and fails for local submissions.

## Solution

- Add `run_on_slurm_host()`: one branch point that delegates to SSH when a
  hostname is configured and runs the command locally otherwise. All
  lifecycle helpers route through it.
- Local and remote submissions now persist identical job metadata and
  RunMeta, so every downstream operation works unchanged in both modes.
- Job IDs are parsed strictly via `sbatch --parsable` (banner-safe).
- All shell calls carry timeouts.

## Deliberately preserved

Remote behavior is unchanged, including partial-submission semantics:
when a later shard fails to submit, already-submitted shards are kept,
metadata is written, and a `WARNING: Only X/Y shards submitted` is printed.

## Two behavior fixes (called out explicitly)

1. `stop --shard N` now cancels the shard's auto-resume successor. The
   successor lookup previously searched the parent directory and missed it,
   so a "stopped" shard could keep running through its chained resubmission.
2. Sharded resume writes per-shard job metadata for resubmitted jobs, so
   they can be resolved by job ID afterwards (mirrors what submission does).

## Testing

- 21 new offline tests: local/remote branching, `--parsable` parsing incl.
  `job_id;cluster`, squeue→sacct fallback, single & sharded metadata
  persistence, job-chain resolution, scancel with successors, resume paths,
  path quoting.
- Full offline suite (`-m "not network"`): no new failures vs `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified SLURM command execution that automatically uses local execution when no remote host is provided, improving local-only workflows (submission, status, cancel, logs, and resume).
  * Enhanced sharded-run support, including shard-aware log following and improved shard detection.
* **Bug Fixes**
  * Standardized job-id extraction from `sbatch --parsable`, with safer quoting/escaping for job IDs and log paths.
  * Improved metadata aggregation and update behavior during resume, including partial submission and metadata-write failures.
* **Tests**
  * Expanded coverage for local vs remote execution, resume behavior, and `eval logs --follow` for sharded runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->