### PR TITLE
fix: resume cases that crashed during verification instead of scoring 0

### DIFF
--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -80,6 +80,24 @@ def _solve_failed_error_category(error: str, *, is_infra: bool, is_solve_timeout
     return "solve_timeout" if is_solve_timeout else "graceful"
 
 
+def _verify_only_workspace_keys(
+    inferred_cache: dict[tuple[int, int], dict[str, Any]],
+    verified_cache: dict[tuple[int, int], dict[str, Any]],
+) -> set[tuple[int, int]]:
+    """Candidate verify-only rollouts whose verification depends on a captured workspace.
+
+    A rollout that used a sandbox and solved without error is verified against a workspace
+    captured in the previous lifecycle's session, which a fresh resume lifecycle cannot
+    reattach. ``error`` is None only for these workspace-bound rollouts; genuine solve
+    failures keep it set and grade 0 without a workspace, so they are excluded. The caller
+    re-solves the returned rollouts that have a capture marker and leaves the rest to the
+    capture-missing path.
+    """
+    return {
+        k for k, v in inferred_cache.items() if k not in verified_cache and v.get("sandbox_used") and not v.get("error")
+    }
+
+
 async def run_evaluation(
     env: EvalEnvironment,
     solver: Solver,
@@ -215,6 +233,21 @@ async def run_evaluation(
                 if infra_inferred:
                     logger.info(
                         "resume: %d unverified infra-error inference entries will be re-solved", len(infra_inferred)
+                    )
+                # Re-solve verify-only rollouts whose workspace was captured (marker present)
+                # but can't be reattached in a fresh resume lifecycle. Rollouts with no capture
+                # marker fall through to the capture-missing flag path in the loop below.
+                verify_only_workspace = {
+                    k
+                    for k in _verify_only_workspace_keys(inferred_cache, verified_cache)
+                    if has_capture_marker(step_log_dir, *k)
+                }
+                inferred_cache = {k: v for k, v in inferred_cache.items() if k not in verify_only_workspace}
+                if verify_only_workspace:
+                    logger.info(
+                        "resume: %d verify-only workspace rollouts will be re-solved "
+                        "(captured workspace cannot be reattached across resume)",
+                        len(verify_only_workspace),
                     )
                 if inferred_cache:
                     meta = old_meta or {"config_hash": cfg_hash}

--- a/src/nemo_evaluator/sandbox/strategies.py
+++ b/src/nemo_evaluator/sandbox/strategies.py
@@ -307,8 +307,11 @@ class StatelessSandbox:
         self._verify_sandbox = await self._ctx.sandbox_mgr.acquire(spec)
         await self._verify_sandbox.exec("mkdir -p /output /input", timeout_sec=10)
         await self._transfer.pre_restore(self._verify_sandbox)
+        # `test -s` dereferences the symlink and requires a non-empty target, so a dangling
+        # link (a workspace that never transferred) exits non-zero. The trailing stat only
+        # enriches the log.
         check = await self._verify_sandbox.exec(
-            "ls -lh /input/workspace.tar 2>&1",
+            "test -s /input/workspace.tar && stat -L -c '%s bytes' /input/workspace.tar 2>&1",
             timeout_sec=10,
         )
         ws_present = check.return_code == 0

--- a/tests/test_engine/test_infra_error.py
+++ b/tests/test_engine/test_infra_error.py
@@ -20,7 +20,12 @@ import asyncio
 
 import pytest
 
-from nemo_evaluator.engine.eval_loop import _get_error_category, _solve_failed_error_category, run_evaluation
+from nemo_evaluator.engine.eval_loop import (
+    _get_error_category,
+    _solve_failed_error_category,
+    _verify_only_workspace_keys,
+    run_evaluation,
+)
 from nemo_evaluator.environments.base import EvalEnvironment, SeedResult, VerifyResult
 from nemo_evaluator.errors import GracefulError, InfraError
 from nemo_evaluator.observability.types import ModelResponse, StepRecord
@@ -405,3 +410,39 @@ class TestResumeFiltering:
         assert (0, 0) not in i_filtered
         assert (1, 0) in v_filtered
         assert (1, 0) in i_filtered
+
+
+class TestVerifyOnlyWorkspaceKeys:
+    """FEP-888: verify-only sandbox rollouts can't reattach their workspace after resume.
+    `_verify_only_workspace_keys` identifies the candidates to re-solve (excluding genuine
+    failures, which grade 0 without a workspace, and non-sandbox rollouts)."""
+
+    def test_only_unverified_workspace_solves_are_selected(self):
+        verified_cache = {
+            (0, 0): {"reward": 1.0, "scoring_details": {}},
+        }
+        inferred_cache = {
+            # already verified — replayed from verified_cache, never re-solved
+            (0, 0): {"response": "ok", "sandbox_used": True, "error": None},
+            # verify-only successful workspace solve — THE victim, must re-solve
+            (1, 0): {"response": "patch", "sandbox_used": True, "error": None},
+            # diff-carrying timeout: error nulled by the solver, still workspace-bound → re-solve
+            (2, 0): {"response": "patch", "sandbox_used": True, "error": None, "error_kind": "solve_timeout"},
+            # genuine model failure: grades 0 without a workspace → keep cached, no second attempt
+            (3, 0): {"response": "", "sandbox_used": True, "error": "litellm.BadRequestError: 400"},
+            # non-sandbox verify-only: nothing to lose on resume → keep cached (cheap re-verify)
+            (4, 0): {"response": "answer", "sandbox_used": False, "error": None},
+        }
+
+        assert _verify_only_workspace_keys(inferred_cache, verified_cache) == {(1, 0), (2, 0)}
+
+    def test_no_selection_when_nothing_pending(self):
+        verified_cache = {(0, 0): {"reward": 1.0, "scoring_details": {}}}
+        inferred_cache = {(0, 0): {"response": "ok", "sandbox_used": True, "error": None}}
+        assert _verify_only_workspace_keys(inferred_cache, verified_cache) == set()
+
+    def test_records_without_sandbox_used_are_excluded(self):
+        # A record without a sandbox_used field is treated as non-workspace and kept.
+        verified_cache = {}
+        inferred_cache = {(0, 0): {"response": "ok", "error": None}}
+        assert _verify_only_workspace_keys(inferred_cache, verified_cache) == set()

--- a/tests/test_integration/test_eval_loop_integration.py
+++ b/tests/test_integration/test_eval_loop_integration.py
@@ -737,6 +737,43 @@ class TestResumeCaptureMarkers:
         assert result["scoring_details"]["resume_workspace_capture"] == "missing"
         assert any("capture marker" in rec.message for rec in caplog.records)
 
+    def test_verify_only_workspace_reexecuted_on_resume(self, tmp_path, monkeypatch, caplog):
+        """A verify-only sandbox rollout re-solves on resume (proper score) instead of
+        being committed as a workspace-missing zero-reward stub."""
+        self._patch_lifecycle(monkeypatch)
+        log_dir = tmp_path / "logs"
+
+        solves = {"count": 0}
+
+        class _CountingSandboxSolver(_SandboxAcceptingSolver):
+            async def solve(self, task, sandbox=None):
+                solves["count"] += 1
+                return await super().solve(task, sandbox=sandbox)
+
+        asyncio.run(
+            run_evaluation(_MockEnv(), _CountingSandboxSolver(), n_repeats=1, max_problems=1, step_log_dir=log_dir)
+        )
+        assert solves["count"] == 1
+        (log_dir / "verified_log.jsonl").unlink()
+
+        with caplog.at_level(logging.INFO, logger=EVAL_LOOP_LOGGER):
+            bundle = asyncio.run(
+                run_evaluation(
+                    _MockEnv(),
+                    _CountingSandboxSolver(),
+                    n_repeats=1,
+                    max_problems=1,
+                    step_log_dir=log_dir,
+                    resume=True,
+                )
+            )
+
+        (result,) = bundle["_results"]
+        assert "resume_workspace_capture" not in result["scoring_details"]  # not a stub
+        assert result["reward"] == 1.0  # re-verified against a real solve, not a pristine workspace
+        assert solves["count"] == 2  # re-solved on resume rather than replayed from cache
+        assert any("re-solved" in rec.message for rec in caplog.records)
+
     def test_stale_marker_invalidated_by_retry_inference(self, tmp_path, monkeypatch):
         """A verify retry re-solves and re-appends; a kill before the retry's capture
         must not be masked by the marker left over from the first attempt."""
@@ -799,6 +836,77 @@ class TestResumeCaptureMarkers:
 
         (result,) = bundle["_results"]
         assert result["scoring_details"]["resume_workspace_capture"] == "missing"
+
+
+class _MixedPopEnv(_MockEnv):
+    """Three sandbox rollouts mirroring the FEP-888 Run A population."""
+
+    async def seed(self, idx):
+        return SeedResult(prompt=f"q{idx}", expected_answer=f"a{idx}", metadata={"idx": idx})
+
+    async def verify(self, response, expected, **meta):
+        return VerifyResult(reward=1.0 if response == expected else 0.0, scoring_details={"method": "exact"})
+
+
+class _MixedPopSolver:
+    """Per-idx behavior: 0 = solved, 1 = diff-carrying timeout (error nulled, workspace-bound,
+    the p59/p368 case), 2 = genuine solve failure (error set, graded 0 without a workspace)."""
+
+    def __init__(self, calls):
+        self._calls = calls
+
+    async def solve(self, task, sandbox=None):
+        idx = task.metadata["idx"]
+        self._calls.append(idx)
+        if idx == 1:
+            return SolveResult(
+                response=task.expected_answer,
+                error_kind=ErrorKind.SOLVE_TIMEOUT,
+                scoring_details={"error": "turn budget exhausted", "error_category": "turn_budget_exhausted"},
+            )
+        if idx == 2:
+            return SolveResult(response="", error="litellm.BadRequestError: 400", error_kind=ErrorKind.NONE)
+        return SolveResult(response=task.expected_answer)
+
+    async def close(self):
+        pass
+
+
+class TestVerifyOnlyResumeReexecution:
+    """FEP-888 regression: a synthetic checkpoint mirroring Run A (real-schema, produced by
+    run_evaluation). On a kill that lands after the solve checkpoint but before verification,
+    verify-only sandbox rollouts with a recoverable/successful solve must re-execute, while a
+    genuine solve failure must replay graded-0 without a second attempt."""
+
+    def _patch_lifecycle(self, monkeypatch):
+        monkeypatch.setattr(
+            "nemo_evaluator.engine.eval_loop.pick_lifecycle",
+            lambda *args, **kwargs: _DummySandboxLifecycle(),
+        )
+
+    def test_reexecution_matrix_on_verify_only_resume(self, tmp_path, monkeypatch):
+        self._patch_lifecycle(monkeypatch)
+        log_dir = tmp_path / "logs"
+
+        calls_1 = []
+        asyncio.run(run_evaluation(_MixedPopEnv(), _MixedPopSolver(calls_1), n_repeats=1, step_log_dir=log_dir))
+        assert sorted(calls_1) == [0, 1, 2]  # cold run solves everything
+
+        # Simulate the crash window: solves are checkpointed, verification is not.
+        (log_dir / "verified_log.jsonl").unlink()
+
+        calls_2 = []
+        bundle = asyncio.run(
+            run_evaluation(_MixedPopEnv(), _MixedPopSolver(calls_2), n_repeats=1, step_log_dir=log_dir, resume=True)
+        )
+
+        # Success (0) and diff-carrying timeout (1) re-solve; genuine failure (2) does not.
+        assert sorted(calls_2) == [0, 1]
+        results = {r["problem_idx"]: r for r in bundle["_results"]}
+        assert results[0]["reward"] == 1.0
+        assert results[1]["reward"] == 1.0
+        assert results[2]["reward"] == 0.0
+        assert results[2]["scoring_details"]["method"] == "solve_failed"
 
 
 class TestSidecarReset:


### PR DESCRIPTION
## Problem

When a shard dies between a rollout's solve being checkpointed and its verification completing, the resumed shard replays it "verify-only." The captured workspace lived in the previous lifecycle's transfer session, which a fresh resume lifecycle cannot reattach, so verification runs against a pristine repo and commits `reward=0` with no error. This systematically hits the in-flight rollouts at every crash or walltime kill (~7% of rollouts in one incident, ~72% of which passed on a clean re-run), silently suppressing scores in one direction.

## Fix

- On resume, drop verify-only sandbox rollouts that have a capture marker from the inference cache so they re-solve end-to-end in a single lifecycle (real workspace, real score) instead of replaying as a pristine-workspace stub. Rollouts whose capture never completed (no marker) keep the existing capture-missing flag path, since those are ambiguous.
- Harden the verify-side workspace check: `test -s` (dereferences the symlink, requires a non-empty target) replaces `ls -lh`, which returned success on a dangling link and reported a lost workspace as `PRESENT`.

## Files

- `src/nemo_evaluator/engine/eval_loop.py` — `_verify_only_workspace_keys` plus marker-gated re-solve in the resume path.
- `src/nemo_evaluator/sandbox/strategies.py` — hardened workspace-present check.
- `tests/test_engine/test_infra_error.py`, `tests/test_integration/test_eval_loop_integration.py` — predicate unit tests, re-execution matrix, restored capture-marker flag tests.

## Tests

Offline suite green. New tests cover the re-solve matrix (successful and diff-carrying-timeout rollouts re-solve; genuine failures and non-sandbox rollouts stay cached) and the retained marker-missing flag behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
