### PR TITLE
fix: make model traffic flushing OOM-safe

### DIFF
--- a/src/nemo_evaluator/engine/model_traffic_log.py
+++ b/src/nemo_evaluator/engine/model_traffic_log.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Iterable, Iterator
 
 from nemo_evaluator.engine.step_log import StepLog
 from nemo_evaluator.observability.model_traffic import ModelTrafficStore
@@ -37,7 +37,7 @@ def _timestamp(value: Any) -> str:
 def drain_model_traffic_session(
     model_traffic_store: ModelTrafficStore | None,
     session_id: str | None,
-) -> list[dict[str, Any]]:
+) -> Iterable[dict[str, Any]]:
     """Return and clear traffic records for one Adapter Session."""
     if model_traffic_store is None or not session_id:
         return []
@@ -46,7 +46,7 @@ def drain_model_traffic_session(
 
 async def append_model_traffic_records(
     model_traffic_log: StepLog | None,
-    records: list[dict[str, Any]],
+    records: Iterable[dict[str, Any]],
     *,
     benchmark: str,
     problem_idx: int,
@@ -55,7 +55,7 @@ async def append_model_traffic_records(
     """Append captured model traffic as attempt-scoped step-log rows."""
     if model_traffic_log is None or not records:
         return
-    for traffic_record in format_model_traffic_log_records(
+    for traffic_record in _iter_model_traffic_log_records(
         records,
         benchmark=benchmark,
         problem_idx=problem_idx,
@@ -64,15 +64,14 @@ async def append_model_traffic_records(
         await model_traffic_log.append(traffic_record)
 
 
-def format_model_traffic_log_records(
-    records: list[dict[str, Any]],
+def _iter_model_traffic_log_records(
+    records: Iterable[dict[str, Any]],
     *,
     benchmark: str,
     problem_idx: int,
     repeat: int,
-) -> list[dict[str, Any]]:
+) -> Iterator[dict[str, Any]]:
     """Convert drained traffic records into model_traffic.jsonl rows."""
-    rows: list[dict[str, Any]] = []
     for record in records:
         usage = record.get("usage") or {}
         row = {
@@ -103,5 +102,22 @@ def format_model_traffic_log_records(
         for key in ("request_body", "tool_calls_full", "reasoning_content", "message_content"):
             if key in record:
                 row[key] = record[key]
-        rows.append(row)
-    return rows
+        yield row
+
+
+def format_model_traffic_log_records(
+    records: Iterable[dict[str, Any]],
+    *,
+    benchmark: str,
+    problem_idx: int,
+    repeat: int,
+) -> list[dict[str, Any]]:
+    """Convert drained traffic records into model_traffic.jsonl rows."""
+    return list(
+        _iter_model_traffic_log_records(
+            records,
+            benchmark=benchmark,
+            problem_idx=problem_idx,
+            repeat=repeat,
+        )
+    )

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -4,10 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import tempfile
 import threading
 import time
 import uuid
 from collections import Counter
+from contextlib import suppress
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator
 
 
@@ -99,14 +103,16 @@ def _usage(raw: Any) -> dict[str, int]:
     if total is None and prompt is not None and completion is not None:
         total = prompt + completion
 
-    out: dict[str, int] = {}
-    for key, value in {
+    values = {
         "prompt_tokens": prompt,
         "completion_tokens": completion,
         "total_tokens": total,
         "reasoning_tokens": reasoning,
         "cached_tokens": cached,
-    }.items():
+    }
+    out: dict[str, int] = {}
+    for key in _USAGE_KEYS:
+        value = values[key]
         if value is not None:
             out[key] = value
     return out
@@ -376,6 +382,110 @@ def _is_success(record: dict[str, Any]) -> bool:
     return 200 <= _int(record.get("status_code")) < 400
 
 
+class DrainedModelTrafficSession:
+    """Disk-backed drained traffic records for one Adapter session."""
+
+    def __init__(self, path: Path | None) -> None:
+        self._path = path
+        self._loaded_records: list[dict[str, Any]] | None = None
+        self._model_calls = 0
+        self._usage: dict[str, int] = {}
+        self._tool_count = 0
+        self._tool_names: Counter[str] = Counter()
+        self._stats_complete = False
+
+    def __bool__(self) -> bool:
+        if self._loaded_records is not None:
+            return bool(self._loaded_records)
+        return self._path is not None and self._path.exists()
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        if self._loaded_records is not None:
+            yield from self._loaded_records
+            if not self._stats_complete:
+                self._compute_stats_from_records(self._loaded_records)
+            return
+        yield from self._iter_file()
+
+    def __len__(self) -> int:
+        self._load()
+        return len(self._loaded_records or [])
+
+    def __getitem__(self, index: int) -> dict[str, Any]:
+        self._load()
+        return (self._loaded_records or [])[index]
+
+    def __del__(self) -> None:
+        self.discard()
+
+    def _load(self) -> None:
+        if self._loaded_records is None:
+            self._loaded_records = list(self._iter_file())
+
+    def _iter_file(self) -> Iterator[dict[str, Any]]:
+        path = self._path
+        if path is None:
+            return
+        try:
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    record = json.loads(line)
+                    if isinstance(record, dict):
+                        yield record
+                        self._add_stats(record)
+            self._stats_complete = True
+        finally:
+            self.discard()
+
+    def _add_stats(self, record: dict[str, Any]) -> None:
+        self._model_calls += 1
+        if not _is_success(record):
+            return
+        for key, value in (record.get("usage") or {}).items():
+            if key in _USAGE_KEYS:
+                self._usage[key] = self._usage.get(key, 0) + _int(value)
+        stats = record.get("tool_calls") or {}
+        self._tool_count += _int(stats.get("count"))
+        self._tool_names.update(stats.get("names") or {})
+
+    def _compute_stats_from_records(self, records: list[dict[str, Any]]) -> None:
+        self._model_calls = 0
+        self._usage = {}
+        self._tool_count = 0
+        self._tool_names = Counter()
+        for record in records:
+            self._add_stats(record)
+        self._stats_complete = True
+
+    def model_stats(self) -> dict[str, Any] | None:
+        if not self._stats_complete:
+            if self._loaded_records is not None:
+                self._compute_stats_from_records(self._loaded_records)
+            else:
+                for _ in self:
+                    pass
+        if self._model_calls == 0:
+            return None
+        usage = dict(self._usage)
+        if usage:
+            usage["token_provenance"] = _PROVIDER
+        return {
+            "usage": usage,
+            "tool_calls": {"count": self._tool_count, "names": dict(sorted(self._tool_names.items()))},
+            "model_calls": self._model_calls,
+        }
+
+    def discard(self) -> None:
+        path = self._path
+        self._path = None
+        if path is not None:
+            with suppress(OSError):
+                path.unlink(missing_ok=True)
+
+
 class ModelTrafficStore:
     def __init__(
         self,
@@ -386,12 +496,21 @@ class ModelTrafficStore:
         capture_messages: bool = True,
         capture_request_body: bool = False,
         max_content_chars: int = 0,
+        spool_dir: str | Path | None = None,
     ) -> None:
         self.store_id = uuid.uuid4().hex
         self.service_name = service_name
         self._lock = threading.Lock()
         self._pending: dict[str, dict[str, Any]] = {}
-        self._records_by_session: dict[str, list[dict[str, Any]]] = {}
+        if spool_dir is None:
+            self._spool_tmp = tempfile.TemporaryDirectory(prefix="nemo-evaluator-model-traffic-")
+            spool_dir = self._spool_tmp.name
+        else:
+            self._spool_tmp = None
+            spool_dir = Path(spool_dir) / self.store_id
+        self._spool_dir = Path(spool_dir)
+        self._spool_dir.mkdir(parents=True, mode=0o700, exist_ok=True)
+        os.chmod(self._spool_dir, 0o700)
         self._capture_request_body = capture_request_body
         self._capture_opts = {
             "capture_tool_calls": capture_tool_calls,
@@ -402,6 +521,24 @@ class ModelTrafficStore:
 
     def close(self) -> None:
         unregister_store(self.store_id)
+        if self._spool_tmp is not None:
+            self._spool_tmp.cleanup()
+            self._spool_tmp = None
+
+    def _session_path(self, session_id: str) -> Path:
+        digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+        return self._spool_dir / f"{digest}.jsonl"
+
+    def _append_record(self, record: dict[str, Any]) -> None:
+        session_id = record.get("session_id")
+        if not session_id:
+            return
+        line = json.dumps(record, default=str)
+        path = self._session_path(str(session_id))
+        with self._lock:
+            fd = os.open(path, os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
+            with os.fdopen(fd, "a", encoding="utf-8") as f:
+                f.write(line + "\n")
 
     def start_request(self, req: AdapterRequest) -> None:
         body = req.ctx.extra.get("upstream_request_body") or req.body
@@ -454,10 +591,7 @@ class ModelTrafficStore:
             for key in ("tool_calls_full", "reasoning_content", "message_content"):
                 if key in summary:
                     record[key] = summary[key]
-        session_id = record.get("session_id")
-        if session_id:
-            with self._lock:
-                self._records_by_session.setdefault(str(session_id), []).append(record)
+        self._append_record(record)
 
     def finish_error(self, req: AdapterRequest, *, latency_ms: float, error_type: str) -> None:
         with self._lock:
@@ -483,16 +617,18 @@ class ModelTrafficStore:
                 "error_type": error_type,
             }
         )
-        session_id = record.get("session_id")
-        if session_id:
-            with self._lock:
-                self._records_by_session.setdefault(str(session_id), []).append(record)
+        self._append_record(record)
 
-    def drain_session(self, session_id: str | None) -> list[dict[str, Any]]:
+    def drain_session(self, session_id: str | None) -> DrainedModelTrafficSession:
         if not session_id:
-            return []
+            return DrainedModelTrafficSession(None)
+        path = self._session_path(session_id)
+        drain_path = path.with_suffix(f".{uuid.uuid4().hex}.drain")
         with self._lock:
-            return self._records_by_session.pop(session_id, [])
+            if not path.exists():
+                return DrainedModelTrafficSession(None)
+            path.replace(drain_path)
+        return DrainedModelTrafficSession(drain_path)
 
 
 def _successful(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -518,7 +654,9 @@ def _aggregate_tool_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
     return {"count": total, "names": dict(sorted(names.items()))}
 
 
-def aggregate_model_traffic_stats(records: list[dict[str, Any]]) -> dict[str, Any] | None:
+def aggregate_model_traffic_stats(records: list[dict[str, Any]] | DrainedModelTrafficSession) -> dict[str, Any] | None:
+    if isinstance(records, DrainedModelTrafficSession):
+        return records.model_stats()
     if not records:
         return None
     return {

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -391,7 +391,9 @@ class DrainedModelTrafficSession:
 
     A file-backed session may be streamed only once: iterating (or loading) it
     consumes and deletes the spool file. Any later access raises DrainedSessionError
-    rather than silently returning empty or partial data.
+    rather than silently returning empty or partial data. Truth-testing stays honest
+    after consumption ("did the session have records?"), so a stale ``if session:``
+    guard falls through to ``__iter__``, which raises.
     """
 
     def __init__(self, path: Path | None) -> None:
@@ -408,7 +410,15 @@ class DrainedModelTrafficSession:
     def __bool__(self) -> bool:
         if self._loaded_records is not None:
             return bool(self._loaded_records)
-        return self._path is not None and self._path.exists()
+        if self._path is not None and self._path.exists():
+            return True
+        # The spool file is gone: answer from completed stats if we have them
+        # (a consumed session keeps reading truthy so guarded reuse reaches
+        # __iter__ and fails loud there), otherwise surface the interruption.
+        if self._stats_complete:
+            return self._model_calls > 0
+        self._ensure_readable()
+        return False
 
     def __iter__(self) -> Iterator[dict[str, Any]]:
         # Lazy so a caller-triggered materialization (e.g. list()/len() consulting

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -382,8 +382,17 @@ def _is_success(record: dict[str, Any]) -> bool:
     return 200 <= _int(record.get("status_code")) < 400
 
 
+class DrainedSessionError(RuntimeError):
+    """A DrainedModelTrafficSession was accessed after being consumed or interrupted."""
+
+
 class DrainedModelTrafficSession:
-    """Disk-backed drained traffic records for one Adapter session."""
+    """Disk-backed drained traffic records for one Adapter session.
+
+    A file-backed session may be streamed only once: iterating (or loading) it
+    consumes and deletes the spool file. Any later access raises DrainedSessionError
+    rather than silently returning empty or partial data.
+    """
 
     def __init__(self, path: Path | None) -> None:
         self._path = path
@@ -393,6 +402,8 @@ class DrainedModelTrafficSession:
         self._tool_count = 0
         self._tool_names: Counter[str] = Counter()
         self._stats_complete = False
+        self._iter_started = False
+        self._broken = False
 
     def __bool__(self) -> bool:
         if self._loaded_records is not None:
@@ -400,11 +411,14 @@ class DrainedModelTrafficSession:
         return self._path is not None and self._path.exists()
 
     def __iter__(self) -> Iterator[dict[str, Any]]:
+        # Lazy so a caller-triggered materialization (e.g. list()/len() consulting
+        # __len__ for a length hint) is observed here before we fall back to streaming.
         if self._loaded_records is not None:
             yield from self._loaded_records
             if not self._stats_complete:
                 self._compute_stats_from_records(self._loaded_records)
             return
+        self._ensure_readable()
         yield from self._iter_file()
 
     def __len__(self) -> int:
@@ -418,14 +432,26 @@ class DrainedModelTrafficSession:
     def __del__(self) -> None:
         self.discard()
 
+    def _ensure_readable(self) -> None:
+        if self._loaded_records is not None:
+            return
+        if self._broken:
+            raise DrainedSessionError("drained traffic session iteration was interrupted")
+        if self._iter_started:
+            raise DrainedSessionError("drained traffic session was already consumed and released")
+
     def _load(self) -> None:
-        if self._loaded_records is None:
-            self._loaded_records = list(self._iter_file())
+        if self._loaded_records is not None:
+            return
+        self._ensure_readable()
+        self._loaded_records = list(self._iter_file())
 
     def _iter_file(self) -> Iterator[dict[str, Any]]:
         path = self._path
         if path is None:
             return
+        self._iter_started = True
+        completed = False
         try:
             with path.open(encoding="utf-8") as f:
                 for line in f:
@@ -437,7 +463,10 @@ class DrainedModelTrafficSession:
                         yield record
                         self._add_stats(record)
             self._stats_complete = True
+            completed = True
         finally:
+            if not completed:
+                self._broken = True
             self.discard()
 
     def _add_stats(self, record: dict[str, Any]) -> None:
@@ -465,7 +494,8 @@ class DrainedModelTrafficSession:
             if self._loaded_records is not None:
                 self._compute_stats_from_records(self._loaded_records)
             else:
-                for _ in self:
+                self._ensure_readable()
+                for _ in self._iter_file():
                     pass
         if self._model_calls == 0:
             return None

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import gc
 import http.server
 import json
 import stat
@@ -232,7 +233,8 @@ async def test_model_traffic_spools_and_flushes_session(tmp_path: Path) -> None:
     assert [(row["status_code"], row["problem_idx"], row["repeat"]) for row in rows] == [(200, 12, 3), (400, 12, 3)]
     assert all(row["request_body"] for row in rows)
     assert rows[1]["usage"] == {}
-    assert not list(spool_dir.rglob("*.jsonl"))
+    assert not list(spool_dir.rglob("*.drain"))
+    assert not [p for p in spool_dir.rglob("*") if p.is_file()]
     assert stats == {
         "usage": {
             "prompt_tokens": 3,
@@ -243,6 +245,47 @@ async def test_model_traffic_spools_and_flushes_session(tmp_path: Path) -> None:
         "tool_calls": {"count": 1, "names": {"w": 1}},
         "model_calls": 2,
     }
+
+
+def test_dropped_drained_session_unlinks_spool_without_iterating(tmp_path: Path) -> None:
+    session_id = "discard-session"
+    spool_dir = tmp_path / "spool"
+    store = ModelTrafficStore(service_name="solver", spool_dir=spool_dir)
+    try:
+        ctx = InterceptorContext()
+        ctx.extra["session_id"] = session_id
+        store.start_request(
+            AdapterRequest(
+                method="POST",
+                path="/chat/completions",
+                headers={},
+                body={"model": "m", "messages": [{"role": "user", "content": "turn"}]},
+                ctx=ctx,
+            )
+        )
+        store.finish_response(
+            AdapterResponse(
+                status_code=200,
+                headers={"content-type": "application/json"},
+                latency_ms=10.0,
+                ctx=ctx,
+                body=_capture_response_body(),
+            )
+        )
+
+        # The eval-loop error paths drain the session and drop the return value
+        # without iterating it, so only __del__ -> discard() unlinks the spool file.
+        drained = store.drain_session(session_id)
+        drain_path = drained._path
+        assert drain_path is not None and drain_path.exists()
+
+        del drained
+        gc.collect()
+
+        assert not drain_path.exists()
+        assert not [p for p in spool_dir.rglob("*") if p.is_file()]
+    finally:
+        store.close()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -31,6 +31,7 @@ from nemo_evaluator.engine.model_traffic_log import append_model_traffic_records
 from nemo_evaluator.engine.step_log import INFERENCE_LOG, MODEL_TRAFFIC_LOG, StepLog
 from nemo_evaluator.environments.base import EvalEnvironment, SeedResult, VerifyResult
 from nemo_evaluator.observability.model_traffic import (
+    DrainedSessionError,
     ModelTrafficStore,
     aggregate_model_traffic_stats,
     register_store,
@@ -150,6 +151,23 @@ def _format_drained(
     )
     assert len(rows) == 1
     return rows[0]
+
+
+def _record_call(store: ModelTrafficStore, session_id: str, *, status_code: int = 200) -> None:
+    ctx = InterceptorContext()
+    ctx.extra["session_id"] = session_id
+    request_body = {"model": "m", "messages": [{"role": "user", "content": "hi"}]}
+    ctx.extra["upstream_request_body"] = request_body
+    store.start_request(AdapterRequest(method="POST", path="/chat/completions", headers={}, body=request_body, ctx=ctx))
+    store.finish_response(
+        AdapterResponse(
+            status_code=status_code,
+            headers={"content-type": "application/json"},
+            latency_ms=10.0,
+            ctx=ctx,
+            body=_capture_response_body(),
+        )
+    )
 
 
 def _capture_response_body(
@@ -284,6 +302,58 @@ def test_dropped_drained_session_unlinks_spool_without_iterating(tmp_path: Path)
 
         assert not drain_path.exists()
         assert not [p for p in spool_dir.rglob("*") if p.is_file()]
+    finally:
+        store.close()
+
+
+def test_drained_session_rejects_reuse_after_streaming(tmp_path: Path) -> None:
+    store = ModelTrafficStore(service_name="solver", spool_dir=tmp_path / "spool")
+    try:
+        _record_call(store, "reuse-session")
+        session = store.drain_session("reuse-session")
+
+        # Stream once (file-backed, not materialized). list(iter(...)) drains the
+        # iterator without letting list() consult __len__ and materialize the file.
+        streamed = list(iter(session))
+        assert len(streamed) == 1
+        assert session.model_stats()["model_calls"] == 1
+
+        with pytest.raises(DrainedSessionError):
+            list(iter(session))
+        with pytest.raises(DrainedSessionError):
+            len(session)
+        with pytest.raises(DrainedSessionError):
+            session[0]
+    finally:
+        store.close()
+
+
+def test_drained_session_rejects_access_after_interrupted_iteration(tmp_path: Path) -> None:
+    store = ModelTrafficStore(service_name="solver", spool_dir=tmp_path / "spool")
+    try:
+        _record_call(store, "broken-session")
+        _record_call(store, "broken-session")
+        session = store.drain_session("broken-session")
+
+        iterator = iter(session)
+        next(iterator)
+        iterator.close()
+
+        with pytest.raises(DrainedSessionError):
+            session.model_stats()
+        with pytest.raises(DrainedSessionError):
+            list(session)
+    finally:
+        store.close()
+
+
+def test_drained_empty_session_is_not_treated_as_consumed(tmp_path: Path) -> None:
+    store = ModelTrafficStore(service_name="solver", spool_dir=tmp_path / "spool")
+    try:
+        session = store.drain_session("missing-session")
+        assert list(session) == []
+        assert list(session) == []
+        assert session.model_stats() is None
     finally:
         store.close()
 

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import http.server
 import json
+import stat
 import threading
 from pathlib import Path
 
@@ -25,11 +26,12 @@ from nemo_evaluator.adapters.proxy import start_adapter_proxy
 from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
 from nemo_evaluator.engine.eval_loop import run_evaluation
 from nemo_evaluator.engine.model_client import ModelClient
-from nemo_evaluator.engine.model_traffic_log import format_model_traffic_log_records
-from nemo_evaluator.engine.step_log import INFERENCE_LOG, MODEL_TRAFFIC_LOG
+from nemo_evaluator.engine.model_traffic_log import append_model_traffic_records, format_model_traffic_log_records
+from nemo_evaluator.engine.step_log import INFERENCE_LOG, MODEL_TRAFFIC_LOG, StepLog
 from nemo_evaluator.environments.base import EvalEnvironment, SeedResult, VerifyResult
 from nemo_evaluator.observability.model_traffic import (
     ModelTrafficStore,
+    aggregate_model_traffic_stats,
     register_store,
 )
 from nemo_evaluator.solvers.base import SolveResult
@@ -129,6 +131,26 @@ def _jsonl(path: Path):
     return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
 
 
+def _format_drained(
+    store: ModelTrafficStore,
+    session_id: str,
+    *,
+    benchmark: str = "b",
+    problem_idx: int = 0,
+    repeat: int = 0,
+) -> dict:
+    rows = list(
+        format_model_traffic_log_records(
+            store.drain_session(session_id),
+            benchmark=benchmark,
+            problem_idx=problem_idx,
+            repeat=repeat,
+        )
+    )
+    assert len(rows) == 1
+    return rows[0]
+
+
 def _capture_response_body(
     *,
     content: str = "the answer is 42",
@@ -150,6 +172,76 @@ def _capture_response_body(
             }
         ],
         "usage": {"prompt_tokens": 3, "completion_tokens": 4, "total_tokens": 7},
+    }
+
+
+async def test_model_traffic_spools_and_flushes_session(tmp_path: Path) -> None:
+    session_id = "flush-session"
+    spool_dir = tmp_path / "spool"
+    store = ModelTrafficStore(service_name="solver", capture_request_body=True, spool_dir=spool_dir)
+    log = StepLog(tmp_path / MODEL_TRAFFIC_LOG)
+    log.open(truncate=True)
+    try:
+        for index, status_code in enumerate((200, 400)):
+            request_body = {"model": "m", "messages": [{"role": "user", "content": f"turn {index}"}]}
+            ctx = InterceptorContext()
+            ctx.extra["session_id"] = session_id
+            ctx.extra["upstream_request_body"] = request_body
+            store.start_request(
+                AdapterRequest(
+                    method="POST",
+                    path="/chat/completions",
+                    headers={},
+                    body=request_body,
+                    ctx=ctx,
+                )
+            )
+            store.finish_response(
+                AdapterResponse(
+                    status_code=status_code,
+                    headers={"content-type": "application/json"},
+                    latency_ms=10.0,
+                    ctx=ctx,
+                    body=_capture_response_body()
+                    if status_code == 200
+                    else {"error": {"message": "bad request", "type": "invalid_request_error"}},
+                )
+            )
+
+        assert store._pending == {}
+        assert not hasattr(store, "_records_by_session")
+        assert stat.S_IMODE(store._spool_dir.stat().st_mode) == 0o700
+        spool_files = list(spool_dir.rglob("*.jsonl"))
+        assert len(spool_files) == 1
+        assert stat.S_IMODE(spool_files[0].stat().st_mode) == 0o600
+        model_traffic = store.drain_session(session_id)
+        await append_model_traffic_records(
+            log,
+            model_traffic,
+            benchmark="b",
+            problem_idx=12,
+            repeat=3,
+        )
+        stats = aggregate_model_traffic_stats(model_traffic)
+    finally:
+        log.close()
+        store.close()
+
+    rows = _jsonl(tmp_path / MODEL_TRAFFIC_LOG)
+    assert len(rows) == 2
+    assert [(row["status_code"], row["problem_idx"], row["repeat"]) for row in rows] == [(200, 12, 3), (400, 12, 3)]
+    assert all(row["request_body"] for row in rows)
+    assert rows[1]["usage"] == {}
+    assert not list(spool_dir.rglob("*.jsonl"))
+    assert stats == {
+        "usage": {
+            "prompt_tokens": 3,
+            "completion_tokens": 4,
+            "total_tokens": 7,
+            "token_provenance": "provider_reported",
+        },
+        "tool_calls": {"count": 1, "names": {"w": 1}},
+        "model_calls": 2,
     }
 
 
@@ -180,9 +272,7 @@ def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_
             body=_capture_response_body(),
         )
     )
-    rows = format_model_traffic_log_records(store.drain_session("cap-session"), benchmark="b", problem_idx=0, repeat=0)
-    assert len(rows) == 1
-    row = rows[0]
+    row = _format_drained(store, "cap-session")
     assert row["tool_calls"] == {"count": 1, "names": {"w": 1}}
     assert row["request_hash"]
     if expect_response_fields:
@@ -226,14 +316,7 @@ def test_format_log_record_request_body_capture_fields(
             body=_capture_response_body(),
         )
     )
-    rows = format_model_traffic_log_records(
-        store.drain_session("req-body-session"),
-        benchmark="b",
-        problem_idx=0,
-        repeat=0,
-    )
-    assert len(rows) == 1
-    row = rows[0]
+    row = _format_drained(store, "req-body-session")
     assert row["request_hash"]
     if expect_request_fields:
         assert row["request_body"] == json.dumps(request_body, sort_keys=True, default=str)
@@ -259,14 +342,7 @@ def test_format_log_record_request_body_truncation() -> None:
             body=_capture_response_body(),
         )
     )
-    rows = format_model_traffic_log_records(
-        store.drain_session("req-body-trunc-session"),
-        benchmark="b",
-        problem_idx=0,
-        repeat=0,
-    )
-    assert len(rows) == 1
-    row = rows[0]
+    row = _format_drained(store, "req-body-trunc-session")
     assert isinstance(row["request_body"], str)
     assert "...[truncated," in row["request_body"]
 
@@ -281,15 +357,9 @@ def test_format_log_record_request_body_on_error() -> None:
     store.start_request(req)
     store.finish_error(req=req, latency_ms=1.0, error_type="timeout")
 
-    rows = format_model_traffic_log_records(
-        store.drain_session("req-body-error-session"),
-        benchmark="b",
-        problem_idx=0,
-        repeat=0,
-    )
-    assert len(rows) == 1
-    assert rows[0]["request_body"] == json.dumps(request_body, sort_keys=True, default=str)
-    assert rows[0]["error_type"] == "timeout"
+    row = _format_drained(store, "req-body-error-session")
+    assert row["request_body"] == json.dumps(request_body, sort_keys=True, default=str)
+    assert row["error_type"] == "timeout"
 
 
 def test_non_success_response_forwards_compact_error_summary() -> None:
@@ -315,15 +385,7 @@ def test_non_success_response_forwards_compact_error_summary() -> None:
         )
     )
 
-    rows = format_model_traffic_log_records(
-        store.drain_session("bad-request-session"),
-        benchmark="b",
-        problem_idx=0,
-        repeat=0,
-    )
-
-    assert len(rows) == 1
-    row = rows[0]
+    row = _format_drained(store, "bad-request-session")
     assert row["status_code"] == 400
     assert row["usage"] == {}
     assert "token_provenance" not in row
@@ -370,24 +432,24 @@ data: [DONE]
         )
     )
 
-    rows = format_model_traffic_log_records(
-        store.drain_session("stream-session"),
+    row = _format_drained(
+        store,
+        "stream-session",
         benchmark="model_traffic_env",
         problem_idx=0,
         repeat=0,
     )
 
-    assert len(rows) == 1
-    assert rows[0]["model"] == "stream-model"
-    assert rows[0]["finish_reason"] == "tool_calls"
-    assert rows[0]["usage"] == {
+    assert row["model"] == "stream-model"
+    assert row["finish_reason"] == "tool_calls"
+    assert row["usage"] == {
         "prompt_tokens": 7,
         "completion_tokens": 5,
         "total_tokens": 12,
         "reasoning_tokens": 3,
     }
-    assert rows[0]["tool_calls"] == {"count": 2, "names": {"bash": 1, "python": 1}}
-    assert rows[0]["token_provenance"] == "provider_reported"
+    assert row["tool_calls"] == {"count": 2, "names": {"bash": 1, "python": 1}}
+    assert row["token_provenance"] == "provider_reported"
 
 
 async def test_model_traffic_writes_compact_log_and_inference_stats(tmp_path: Path) -> None:

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -318,6 +318,10 @@ def test_drained_session_rejects_reuse_after_streaming(tmp_path: Path) -> None:
         assert len(streamed) == 1
         assert session.model_stats()["model_calls"] == 1
 
+        # Consumed but non-empty: truth-testing stays honest instead of
+        # reading falsy-empty, so `if session:` guards don't silently drop it.
+        assert bool(session) is True
+
         with pytest.raises(DrainedSessionError):
             list(iter(session))
         with pytest.raises(DrainedSessionError):
@@ -343,6 +347,8 @@ def test_drained_session_rejects_access_after_interrupted_iteration(tmp_path: Pa
             session.model_stats()
         with pytest.raises(DrainedSessionError):
             list(session)
+        with pytest.raises(DrainedSessionError):
+            bool(session)
     finally:
         store.close()
 
@@ -351,11 +357,39 @@ def test_drained_empty_session_is_not_treated_as_consumed(tmp_path: Path) -> Non
     store = ModelTrafficStore(service_name="solver", spool_dir=tmp_path / "spool")
     try:
         session = store.drain_session("missing-session")
+        assert not session
         assert list(session) == []
         assert list(session) == []
+        assert not session
         assert session.model_stats() is None
     finally:
         store.close()
+
+
+async def test_append_after_consumption_fails_loud_instead_of_dropping(tmp_path: Path) -> None:
+    store = ModelTrafficStore(service_name="solver", spool_dir=tmp_path / "spool")
+    log = StepLog(tmp_path / MODEL_TRAFFIC_LOG)
+    log.open(truncate=True)
+    try:
+        _record_call(store, "stats-first-session")
+        session = store.drain_session("stats-first-session")
+
+        # Aggregating first consumes the spool file; the append that follows
+        # must raise instead of silently writing nothing.
+        assert aggregate_model_traffic_stats(session)["model_calls"] == 1
+        with pytest.raises(DrainedSessionError):
+            await append_model_traffic_records(
+                log,
+                session,
+                benchmark="b",
+                problem_idx=0,
+                repeat=0,
+            )
+    finally:
+        log.close()
+        store.close()
+
+    assert _jsonl(tmp_path / MODEL_TRAFFIC_LOG) == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- make completed model-traffic records leave process memory by spooling drained session data to disk
- keep evaluator-loop semantics and public helper names unchanged
- stream final `model_traffic.jsonl` appends from the drained session

## Validation
- Output parity against `origin/main`: deterministic 4-row case covering 200 JSON, 400 JSON error, client-side timeout/error, and 200 SSE produced byte-identical `model_traffic.jsonl`. SHA-256: `acd48628e6700f555962b81453ed32cecd4d6d23cb6271a16c0bfd1a5db0fb41`. Artifacts: `/tmp/model-traffic-before-after-28FzCr`.
- Capture+flush stress: 5,000 completed calls, 20,000 captured request chars/call; output row count/stats/size stayed identical (`5,000` rows, `99.35 MB`, `60,000` total tokens). Retained RSS after capture dropped from `168.55 MB` to `63.41 MB`; total measured Python time changed from `0.537s` to `0.880s`. Artifacts: `/tmp/model-traffic-mem-wall-91zgfb`.
- Capture-only OOM path: 10,000 completed calls, 20,000 captured request chars/call. `origin/main` retained RSS grew by `200.25 MB` (`68.36 -> 268.61 MB`); this PR stayed flat (`62.50 -> 62.50 MB`) and moved `196.47 MB` to disk. Capture wall time changed from `0.623s` to `0.965s`. Artifacts: `/tmp/model-traffic-capture-mem-UcWUQl`.
- `uv run --python 3.12 --extra dev python -m pytest tests/test_engine/test_model_traffic_capture.py tests/test_adapters/test_interceptors_extended.py -q` (`38 passed`)
- `ruff check` and `ruff format --check` passed for changed files

GitLab MR: https://gitlab-master.nvidia.com/dl/JoC/competitive_evaluation/nemo-evaluator-next/-/merge_requests/232


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model traffic is now spooled to disk as append-only JSONL and drained for processing, enabling better handling of large sessions.
  * Added disk-backed drained sessions with lazy iteration, on-demand stats, and automatic cleanup.

* **Bug Fixes**
  * Updated traffic-log formatting and aggregation to accept streaming/iterable inputs while preserving correct per-row fields (status, usage, tool-call details), including error cases.

* **Tests**
  * Added end-to-end coverage for spooling/flush, drained lifecycle and reuse/rejection behavior, permission semantics, cleanup without iteration, and updated formatting assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->