### PR TITLE
fix(docker): ship the export extra in the base image

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -41,7 +41,9 @@ COPY pyproject.toml README.md ./
 COPY src/ src/
 COPY harbor_datasets/registry_overrides/ harbor_datasets/registry_overrides/
 
-RUN pip install --no-cache-dir ".[scoring,stats]"
+# export ships the exporter runtimes (mlflow, wandb): every component image
+# builds FROM this base, so configured in-run exports work in shipped images.
+RUN pip install --no-cache-dir ".[scoring,stats,export]"
 
 ENV PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
## Summary

Every published image carries the in-run exporter code (`nemo_evaluator/engine/exporters/`), but `mlflow`/`wandb` live in the `export` extra that no Dockerfile installs — `Dockerfile.base`/`Dockerfile.harbor` install `.[scoring,stats]` and `Dockerfile.full` installs `.[all]`, which excludes `export`. Any config with `output.export: [mlflow]` therefore logs `Export to mlflow failed: mlflow is required to use MLflowExporter` at the end of an otherwise healthy containerized run (non-fatal, so it's easy to miss).

This appears to be a regression by omission from the pre-0.3.0 architecture: the old launcher's `all` extra included the exporter packages and was pip-installed at runtime outside the eval container (#691, #901, #911); the 0.3.0 rewrite moved export in-process and redefined `all` without them, and no image ever picked the `export` extra up. (Gym images work incidentally — NeMo Gym's core deps include mlflow.)

Install the extra in the base image: every component image builds `FROM` it, so all shipped images inherit the exporter runtimes with a one-line change.

## Testing

- Image-level: after build, `python -c "import mlflow, wandb"` succeeds in the base and component images.
- Behavior: a containerized run with `output.export: [mlflow]` completes its export instead of raising the ImportError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)