### PR TITLE
fix(harbor): record Terminus length-error ATIF steps

### DIFF
--- a/.github/workflows/oss-pr-checks.yml
+++ b/.github/workflows/oss-pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install "ruff>=0.1"
+      - run: pip install "ruff==0.9.9"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
 

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1555,23 +1555,37 @@ def _terminus2_build_local_fallback_llm_content(self) -> str:
     )
 
 
-def _terminus2_save_failed_llm_response(self, chat: Any, error_msg: str, content: str, error: Any) -> None:
+def _terminus2_apply_failed_llm_usage(self, chat: Any, error: Any) -> dict[str, Any] | None:
     usage = getattr(error, "llm_usage", None)
-    metrics = None
-    if usage is not None:
-        chat._cumulative_input_tokens += usage.prompt_tokens
-        chat._cumulative_output_tokens += usage.completion_tokens
-        chat._cumulative_cache_tokens += usage.cache_tokens
-        chat._cumulative_cost += usage.cost_usd
-        totals = (chat.total_input_tokens, chat.total_output_tokens, chat.total_cache_tokens, chat.total_cost)
-        chat._api_token_anchor = (len(chat.messages), totals[0] + totals[1])
+    if usage is None:
+        return None
+
+    chat._cumulative_input_tokens += usage.prompt_tokens
+    chat._cumulative_output_tokens += usage.completion_tokens
+    chat._cumulative_cache_tokens += usage.cache_tokens
+    chat._cumulative_cost += usage.cost_usd
+    chat._api_token_anchor = (
+        len(chat.messages),
+        chat.total_input_tokens + chat.total_output_tokens,
+    )
+    return {
+        "prompt_tokens": usage.prompt_tokens,
+        "completion_tokens": usage.completion_tokens,
+        "cached_tokens": usage.cache_tokens or None,
+        "cost_usd": usage.cost_usd or None,
+    }
+
+
+def _terminus2_save_failed_llm_response(self, chat: Any, error_msg: str, content: str, error: Any) -> None:
+    metrics = self._apply_failed_llm_usage(chat, error)
+    if metrics is not None:
+        totals = (
+            chat.total_input_tokens,
+            chat.total_output_tokens,
+            chat.total_cache_tokens,
+            chat.total_cost,
+        )
         self._failed_llm_step_metric_anchor = totals
-        metrics = {
-            "prompt_tokens": usage.prompt_tokens,
-            "completion_tokens": usage.completion_tokens,
-            "cached_tokens": usage.cache_tokens or None,
-            "cost_usd": usage.cost_usd or None,
-        }
 
     pending = getattr(self, "_pending_failed_llm_response_steps", [])
     pending.append(
@@ -1585,6 +1599,21 @@ def _terminus2_save_failed_llm_response(self, chat: Any, error_msg: str, content
         }
     )
     self._pending_failed_llm_response_steps = pending
+
+
+_TERMINUS_LLM_ERROR_SALVAGE_ANCHOR = (
+    "                if response_path is not None:\n"
+    "                    response_path.write_text(salvaged_response)\n"
+    "\n"
+    "                return salvaged_response\n"
+)
+_TERMINUS_LLM_ERROR_SALVAGE_REPLACEMENT = (
+    "                if response_path is not None:\n"
+    "                    response_path.write_text(salvaged_response)\n"
+    "\n"
+    "                self._apply_failed_llm_usage(chat, e)\n"
+    "                return salvaged_response\n"
+)
 
 
 def _terminus2_append_pending_failed_llm_response_steps(
@@ -1628,8 +1657,47 @@ def _patch_terminus_cle_reset() -> None:
     from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
     from harbor.llms import lite_llm as harbor_litellm
 
-    litellm_src = inspect.getsource(inspect.unwrap(harbor_litellm.LiteLLM.call))
+    def get_source(obj: Any, target: str) -> str:
+        try:
+            return inspect.getsource(inspect.unwrap(obj))
+        except OSError as exc:
+            raise RuntimeError(f"Cannot patch {target}: source is unavailable.") from exc
+
+    def require_patterns(src: str, patterns: tuple[str, ...], target: str) -> None:
+        missing = [pattern for pattern in patterns if pattern not in src]
+        if missing:
+            names = ", ".join(repr(pattern.strip().splitlines()[0]) for pattern in missing)
+            raise RuntimeError(f"Cannot patch {target}: required source pattern(s) missing: {names}.")
+
+    def apply_replacements(src: str, replacements: list[tuple[str, str]], target: str) -> str:
+        for anchor, replacement in replacements:
+            occurrences = src.count(anchor)
+            if occurrences != 1:
+                raise RuntimeError(
+                    f"Cannot patch {target}: expected exactly one match for an anchor "
+                    f"but found {occurrences}. Harbor's source has diverged from the expected source."
+                )
+            src = src.replace(anchor, replacement, 1)
+        return src
+
+    litellm_src = get_source(harbor_litellm.LiteLLM.call, "Harbor LiteLLM.call")
+    responses_src = get_source(harbor_litellm.LiteLLM._call_responses, "Harbor LiteLLM._call_responses")
+    query_src = get_source(terminus2_mod.Terminus2._query_llm, "Terminus2._query_llm")
+    run_loop_src = get_source(terminus2_mod.Terminus2._run_agent_loop, "Terminus2._run_agent_loop")
+
+    litellm_call_fn = None
     if "_EVALUATOR_LENGTH_ERROR_DETAILS" not in litellm_src:
+        require_patterns(
+            litellm_src,
+            (
+                "response = await litellm.acompletion(**completion_kwargs)",
+                "usage_info = self._extract_usage_info(response)",
+                'message = choice["message"]',
+                'content = message.get("content") or ""',
+                'reasoning_content = message.get("reasoning_content")',
+            ),
+            "Harbor LiteLLM.call length-error details",
+        )
         anchor = "                truncated_response=content,\n            )\n            raise exc\n"
         replacement = anchor.replace(
             "            raise exc\n",
@@ -1639,40 +1707,65 @@ def _patch_terminus_cle_reset() -> None:
             '            exc.llm_reasoning_content = reasoning_content or message.get("reasoning")\n'
             "            raise exc\n",
         )
-        if litellm_src.count(anchor) != 1:
-            raise RuntimeError("Cannot patch Harbor LiteLLM.call length-error details; lite_llm.py has diverged.")
-        namespace: dict[str, Any] = {}
-        exec(textwrap.dedent(litellm_src.replace(anchor, replacement, 1)), harbor_litellm.__dict__, namespace)
-        harbor_litellm.LiteLLM.call = namespace["call"]
-
-    if not hasattr(terminus2_mod.Terminus2, "_build_local_fallback_llm_content"):
-        terminus2_mod.Terminus2._build_local_fallback_llm_content = _terminus2_build_local_fallback_llm_content
-    if not hasattr(terminus2_mod.Terminus2, "_save_failed_llm_response"):
-        terminus2_mod.Terminus2._save_failed_llm_response = _terminus2_save_failed_llm_response
-    if not hasattr(terminus2_mod.Terminus2, "_append_pending_failed_llm_response_steps"):
-        terminus2_mod.Terminus2._append_pending_failed_llm_response_steps = (
-            _terminus2_append_pending_failed_llm_response_steps
+        litellm_src = apply_replacements(
+            litellm_src,
+            [(anchor, replacement)],
+            "Harbor LiteLLM.call length-error details",
         )
+        namespace: dict[str, Any] = {}
+        exec(textwrap.dedent(litellm_src), harbor_litellm.__dict__, namespace)
+        litellm_call_fn = namespace["call"]
 
-    def apply_replacements(src: str, replacements: list[tuple[str, str]], target: str) -> str:
-        for anchor, replacement in replacements:
-            occurrences = src.count(anchor)
-            if occurrences != 1:
-                raise RuntimeError(
-                    f"Cannot patch {target}: expected exactly one match for an anchor "
-                    f"but found {occurrences}. Harbor's terminus_2.py has diverged from the expected source."
-                )
-            src = src.replace(anchor, replacement, 1)
-        return src
+    responses_call_fn = None
+    if "_EVALUATOR_RESPONSES_LENGTH_ERROR_DETAILS" not in responses_src:
+        require_patterns(
+            responses_src,
+            (
+                "response = await litellm.aresponses(**responses_kwargs)",
+                "reasoning_content = None",
+                "usage_info = self._extract_responses_usage_info(response)",
+                'model_name=getattr(response, "model", None)',
+            ),
+            "Harbor LiteLLM._call_responses length-error details",
+        )
+        anchor = (
+            '            if reason == "max_output_tokens":\n'
+            "                raise OutputLengthExceededError(\n"
+            '                    f"Model {self._model_name} hit max_tokens limit. "\n'
+            '                    f"Response was truncated.",\n'
+            "                    truncated_response=content,\n"
+            "                )\n"
+        )
+        replacement = (
+            '            if reason == "max_output_tokens":\n'
+            "                exc = OutputLengthExceededError(\n"
+            '                    f"Model {self._model_name} hit max_tokens limit. "\n'
+            '                    f"Response was truncated.",\n'
+            "                    truncated_response=content,\n"
+            "                )\n"
+            "                # _EVALUATOR_RESPONSES_LENGTH_ERROR_DETAILS\n"
+            "                exc.llm_usage = usage_info\n"
+            '                exc.llm_model_name = getattr(response, "model", None)\n'
+            "                exc.llm_reasoning_content = reasoning_content\n"
+            "                raise exc\n"
+        )
+        responses_src = apply_replacements(
+            responses_src,
+            [(anchor, replacement)],
+            "Harbor LiteLLM._call_responses length-error details",
+        )
+        namespace = {}
+        exec(textwrap.dedent(responses_src), harbor_litellm.__dict__, namespace)
+        responses_call_fn = namespace["_call_responses"]
 
-    query_src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._query_llm))
     query_replacements = []
     if "full_summarize_failed_with_cle" not in query_src:
         query_replacements.extend(_TERMINUS_CLE_RESET_REPLACEMENTS)
+    if "self._apply_failed_llm_usage(chat, e)" not in query_src:
+        query_replacements.append((_TERMINUS_LLM_ERROR_SALVAGE_ANCHOR, _TERMINUS_LLM_ERROR_SALVAGE_REPLACEMENT))
     if "EVALUATOR_LLM_ERROR_TRAJECTORY_STEP" not in query_src:
         query_replacements.append((_TERMINUS_LLM_ERROR_STEP_QUERY_ANCHOR, _TERMINUS_LLM_ERROR_STEP_QUERY_REPLACEMENT))
 
-    run_loop_src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._run_agent_loop))
     run_loop_patched = "self._append_pending_failed_llm_response_steps(" not in run_loop_src
     if run_loop_patched:
         run_loop_src = apply_replacements(
@@ -1681,14 +1774,36 @@ def _patch_terminus_cle_reset() -> None:
             "Terminus2._run_agent_loop",
         )
 
-    namespace: dict[str, Any] = {}
+    query_fn = None
     if query_replacements:
         query_src = apply_replacements(query_src, query_replacements, "Terminus2._query_llm")
+        namespace = {}
         exec(textwrap.dedent(query_src), terminus2_mod.__dict__, namespace)
-        terminus2_mod.Terminus2._query_llm = namespace["_query_llm"]
+        query_fn = namespace["_query_llm"]
+    run_loop_fn = None
     if run_loop_patched:
+        namespace = {}
         exec(textwrap.dedent(run_loop_src), terminus2_mod.__dict__, namespace)
-        terminus2_mod.Terminus2._run_agent_loop = namespace["_run_agent_loop"]
+        run_loop_fn = namespace["_run_agent_loop"]
+
+    if litellm_call_fn is not None:
+        harbor_litellm.LiteLLM.call = litellm_call_fn
+    if responses_call_fn is not None:
+        harbor_litellm.LiteLLM._call_responses = responses_call_fn
+    if not hasattr(terminus2_mod.Terminus2, "_build_local_fallback_llm_content"):
+        terminus2_mod.Terminus2._build_local_fallback_llm_content = _terminus2_build_local_fallback_llm_content
+    if not hasattr(terminus2_mod.Terminus2, "_apply_failed_llm_usage"):
+        terminus2_mod.Terminus2._apply_failed_llm_usage = _terminus2_apply_failed_llm_usage
+    if not hasattr(terminus2_mod.Terminus2, "_save_failed_llm_response"):
+        terminus2_mod.Terminus2._save_failed_llm_response = _terminus2_save_failed_llm_response
+    if not hasattr(terminus2_mod.Terminus2, "_append_pending_failed_llm_response_steps"):
+        terminus2_mod.Terminus2._append_pending_failed_llm_response_steps = (
+            _terminus2_append_pending_failed_llm_response_steps
+        )
+    if query_fn is not None:
+        terminus2_mod.Terminus2._query_llm = query_fn
+    if run_loop_fn is not None:
+        terminus2_mod.Terminus2._run_agent_loop = run_loop_fn
     _TERMINUS_CLE_RESET_PATCHED = True
     logger.info(
         "Patched Terminus2._query_llm: reset chat on full-summary CLE, "

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1555,6 +1555,68 @@ def _terminus2_build_local_fallback_llm_content(self) -> str:
     )
 
 
+def _terminus2_save_failed_llm_response(self, chat: Any, error_msg: str, content: str, error: Any) -> None:
+    usage = getattr(error, "llm_usage", None)
+    metrics = None
+    if usage is not None:
+        chat._cumulative_input_tokens += usage.prompt_tokens
+        chat._cumulative_output_tokens += usage.completion_tokens
+        chat._cumulative_cache_tokens += usage.cache_tokens
+        chat._cumulative_cost += usage.cost_usd
+        totals = (chat.total_input_tokens, chat.total_output_tokens, chat.total_cache_tokens, chat.total_cost)
+        chat._api_token_anchor = (len(chat.messages), totals[0] + totals[1])
+        self._failed_llm_step_metric_anchor = totals
+        metrics = {
+            "prompt_tokens": usage.prompt_tokens,
+            "completion_tokens": usage.completion_tokens,
+            "cached_tokens": usage.cache_tokens or None,
+            "cost_usd": usage.cost_usd or None,
+        }
+
+    pending = getattr(self, "_pending_failed_llm_response_steps", [])
+    pending.append(
+        {
+            "source": "agent",
+            "model_name": getattr(error, "llm_model_name", None) or self._model_name,
+            "message": content,
+            "reasoning_content": getattr(error, "llm_reasoning_content", None),
+            "observation": {"results": [{"content": error_msg}]},
+            "metrics": metrics,
+        }
+    )
+    self._pending_failed_llm_response_steps = pending
+
+
+def _terminus2_append_pending_failed_llm_response_steps(
+    self,
+    tokens_before_input: int,
+    tokens_before_output: int,
+    tokens_before_cache: int,
+    cost_before: float,
+) -> tuple[int, int, int, float]:
+    pending = getattr(self, "_pending_failed_llm_response_steps", None)
+    if pending and getattr(self, "_trajectory_steps", None) is not None:
+        from datetime import datetime, timezone
+
+        from harbor.models.trajectories import Step
+
+        for step in pending:
+            self._trajectory_steps.append(
+                Step(
+                    step_id=len(self._trajectory_steps) + 1,
+                    timestamp=datetime.now(timezone.utc).isoformat(),
+                    **step,
+                )
+            )
+        self._pending_failed_llm_response_steps = []
+
+    anchor = getattr(self, "_failed_llm_step_metric_anchor", None)
+    if anchor is None:
+        return tokens_before_input, tokens_before_output, tokens_before_cache, cost_before
+    self._failed_llm_step_metric_anchor = None
+    return anchor
+
+
 def _patch_terminus_cle_reset() -> None:
     global _TERMINUS_CLE_RESET_PATCHED
     if _TERMINUS_CLE_RESET_PATCHED:
@@ -1564,33 +1626,74 @@ def _patch_terminus_cle_reset() -> None:
     import textwrap
 
     from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
+    from harbor.llms import lite_llm as harbor_litellm
 
-    original = terminus2_mod.Terminus2._query_llm
-    src = inspect.getsource(inspect.unwrap(original))
-
-    if "full_summarize_failed_with_cle" in src:
-        _TERMINUS_CLE_RESET_PATCHED = True
-        logger.info("Terminus2._query_llm already contains the CLE chat-reset logic; skipping patch")
-        return
-
-    for anchor, replacement in _TERMINUS_CLE_RESET_REPLACEMENTS:
-        occurrences = src.count(anchor)
-        if occurrences != 1:
-            raise RuntimeError(
-                "Cannot patch Terminus2._query_llm for CLE chat reset: expected exactly "
-                f"one match for an anchor but found {occurrences}. Harbor's terminus_2.py "
-                "has diverged from the expected source."
-            )
-        src = src.replace(anchor, replacement, 1)
+    litellm_src = inspect.getsource(inspect.unwrap(harbor_litellm.LiteLLM.call))
+    if "_EVALUATOR_LENGTH_ERROR_DETAILS" not in litellm_src:
+        anchor = "                truncated_response=content,\n            )\n            raise exc\n"
+        replacement = anchor.replace(
+            "            raise exc\n",
+            "            # _EVALUATOR_LENGTH_ERROR_DETAILS\n"
+            "            exc.llm_usage = usage_info\n"
+            '            exc.llm_model_name = response.get("model")\n'
+            '            exc.llm_reasoning_content = reasoning_content or message.get("reasoning")\n'
+            "            raise exc\n",
+        )
+        if litellm_src.count(anchor) != 1:
+            raise RuntimeError("Cannot patch Harbor LiteLLM.call length-error details; lite_llm.py has diverged.")
+        namespace: dict[str, Any] = {}
+        exec(textwrap.dedent(litellm_src.replace(anchor, replacement, 1)), harbor_litellm.__dict__, namespace)
+        harbor_litellm.LiteLLM.call = namespace["call"]
 
     if not hasattr(terminus2_mod.Terminus2, "_build_local_fallback_llm_content"):
         terminus2_mod.Terminus2._build_local_fallback_llm_content = _terminus2_build_local_fallback_llm_content
+    if not hasattr(terminus2_mod.Terminus2, "_save_failed_llm_response"):
+        terminus2_mod.Terminus2._save_failed_llm_response = _terminus2_save_failed_llm_response
+    if not hasattr(terminus2_mod.Terminus2, "_append_pending_failed_llm_response_steps"):
+        terminus2_mod.Terminus2._append_pending_failed_llm_response_steps = (
+            _terminus2_append_pending_failed_llm_response_steps
+        )
+
+    def apply_replacements(src: str, replacements: list[tuple[str, str]], target: str) -> str:
+        for anchor, replacement in replacements:
+            occurrences = src.count(anchor)
+            if occurrences != 1:
+                raise RuntimeError(
+                    f"Cannot patch {target}: expected exactly one match for an anchor "
+                    f"but found {occurrences}. Harbor's terminus_2.py has diverged from the expected source."
+                )
+            src = src.replace(anchor, replacement, 1)
+        return src
+
+    query_src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._query_llm))
+    query_replacements = []
+    if "full_summarize_failed_with_cle" not in query_src:
+        query_replacements.extend(_TERMINUS_CLE_RESET_REPLACEMENTS)
+    if "EVALUATOR_LLM_ERROR_TRAJECTORY_STEP" not in query_src:
+        query_replacements.append((_TERMINUS_LLM_ERROR_STEP_QUERY_ANCHOR, _TERMINUS_LLM_ERROR_STEP_QUERY_REPLACEMENT))
+
+    run_loop_src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._run_agent_loop))
+    run_loop_patched = "self._append_pending_failed_llm_response_steps(" not in run_loop_src
+    if run_loop_patched:
+        run_loop_src = apply_replacements(
+            run_loop_src,
+            [(_TERMINUS_LLM_ERROR_STEP_APPEND_ANCHOR, _TERMINUS_LLM_ERROR_STEP_APPEND_REPLACEMENT)],
+            "Terminus2._run_agent_loop",
+        )
 
     namespace: dict[str, Any] = {}
-    exec(textwrap.dedent(src), terminus2_mod.__dict__, namespace)
-    terminus2_mod.Terminus2._query_llm = namespace["_query_llm"]
+    if query_replacements:
+        query_src = apply_replacements(query_src, query_replacements, "Terminus2._query_llm")
+        exec(textwrap.dedent(query_src), terminus2_mod.__dict__, namespace)
+        terminus2_mod.Terminus2._query_llm = namespace["_query_llm"]
+    if run_loop_patched:
+        exec(textwrap.dedent(run_loop_src), terminus2_mod.__dict__, namespace)
+        terminus2_mod.Terminus2._run_agent_loop = namespace["_run_agent_loop"]
     _TERMINUS_CLE_RESET_PATCHED = True
-    logger.info("Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback")
+    logger.info(
+        "Patched Terminus2._query_llm: reset chat on full-summary CLE, "
+        "parseable local fallback, and failed-LLM response ATIF accounting"
+    )
 
 
 _TERMINUS_UNWIND_MIN_PAIRS = 10
@@ -1744,6 +1847,35 @@ def _patch_terminus_api_token_anchor() -> None:
     terminus2_mod.Terminus2._count_total_tokens = _terminus2_count_total_tokens
     _TERMINUS_API_ANCHOR_PATCHED = True
     logger.info("Patched Terminus2._count_total_tokens: anchor on API usage + litellm token remainder")
+
+
+_TERMINUS_LLM_ERROR_STEP_QUERY_ANCHOR = (
+    '            chat.messages.append({"role": "user", "content": prompt})\n'
+    '            chat.messages.append({"role": "assistant", "content": truncated_response})\n'
+    "            chat.reset_response_chain()\n"
+)
+
+_TERMINUS_LLM_ERROR_STEP_QUERY_REPLACEMENT = (
+    _TERMINUS_LLM_ERROR_STEP_QUERY_ANCHOR + "\n"
+    "            # EVALUATOR_LLM_ERROR_TRAJECTORY_STEP\n"
+    "            self._save_failed_llm_response(chat, error_msg, truncated_response, e)\n"
+)
+
+_TERMINUS_LLM_ERROR_STEP_APPEND_ANCHOR = (
+    "                self._pending_handoff_prompt = None\n"
+    "\n"
+    "            # Create message content from analysis and plan, or use raw response if raw_content is enabled\n"
+)
+
+_TERMINUS_LLM_ERROR_STEP_APPEND_REPLACEMENT = (
+    "                self._pending_handoff_prompt = None\n"
+    "\n"
+    "            tokens_before_input, tokens_before_output, tokens_before_cache, cost_before = "
+    "self._append_pending_failed_llm_response_steps("
+    "tokens_before_input, tokens_before_output, tokens_before_cache, cost_before)\n"
+    "\n"
+    "            # Create message content from analysis and plan, or use raw response if raw_content is enabled\n"
+)
 
 
 # Matches the vLLM ``VLLMValidationError`` phrasing raised by self-hosted vLLM

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1612,7 +1612,11 @@ _TERMINUS_LLM_ERROR_SALVAGE_REPLACEMENT = (
     "                    response_path.write_text(salvaged_response)\n"
     "\n"
     "                self._apply_failed_llm_usage(chat, e)\n"
-    "                return salvaged_response\n"
+    "                return LLMResponse(\n"
+    "                    content=salvaged_response,\n"
+    '                    reasoning_content=getattr(e, "llm_reasoning_content", None),\n'
+    '                    model_name=getattr(e, "llm_model_name", None) or self._model_name,\n'
+    "                )\n"
 )
 
 

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -38,7 +38,8 @@ from nemo_evaluator.solvers.harbor import (
 
 def _query_llm_with_marker(self, *args, **kwargs):
     full_summarize_failed_with_cle = False
-    return full_summarize_failed_with_cle
+    marker = "EVALUATOR_LLM_ERROR_TRAJECTORY_STEP"
+    return full_summarize_failed_with_cle, marker
 
 
 def _unwind_with_marker(self, chat, target_free_tokens=4000):
@@ -63,16 +64,23 @@ def patch_sandbox():
     """Snapshot terminus-2/Chat patch targets and guard flags; restore after."""
     from harbor.agents.terminus_2 import terminus_2 as t2
     from harbor.llms.chat import Chat
+    from harbor.llms.lite_llm import LiteLLM
 
     terminus = t2.Terminus2
     saved_methods = {
         "_query_llm": terminus._query_llm,
+        "_run_agent_loop": terminus._run_agent_loop,
         "_unwind": terminus._unwind_messages_to_free_tokens,
         "_count": terminus._count_total_tokens,
         "chat_chat": Chat.chat,
+        "litellm_call": LiteLLM.call,
     }
     had_fallback = "_build_local_fallback_llm_content" in terminus.__dict__
     fallback_val = terminus.__dict__.get("_build_local_fallback_llm_content")
+    had_failed_llm_saver = "_save_failed_llm_response" in terminus.__dict__
+    failed_llm_saver_val = terminus.__dict__.get("_save_failed_llm_response")
+    had_failed_llm_appender = "_append_pending_failed_llm_response_steps" in terminus.__dict__
+    failed_llm_appender_val = terminus.__dict__.get("_append_pending_failed_llm_response_steps")
     had_records = "_records_api_token_anchor" in Chat.__dict__
     records_val = Chat.__dict__.get("_records_api_token_anchor")
     saved_flags = {name: getattr(harbor, name) for name in _FLAGS}
@@ -83,13 +91,23 @@ def patch_sandbox():
     yield SimpleNamespace(harbor=harbor, t2=t2, terminus=terminus, Chat=Chat)
 
     terminus._query_llm = saved_methods["_query_llm"]
+    terminus._run_agent_loop = saved_methods["_run_agent_loop"]
     terminus._unwind_messages_to_free_tokens = saved_methods["_unwind"]
     terminus._count_total_tokens = saved_methods["_count"]
     Chat.chat = saved_methods["chat_chat"]
+    LiteLLM.call = saved_methods["litellm_call"]
     if had_fallback:
         terminus._build_local_fallback_llm_content = fallback_val
     elif "_build_local_fallback_llm_content" in terminus.__dict__:
         delattr(terminus, "_build_local_fallback_llm_content")
+    if had_failed_llm_saver:
+        terminus._save_failed_llm_response = failed_llm_saver_val
+    elif "_save_failed_llm_response" in terminus.__dict__:
+        delattr(terminus, "_save_failed_llm_response")
+    if had_failed_llm_appender:
+        terminus._append_pending_failed_llm_response_steps = failed_llm_appender_val
+    elif "_append_pending_failed_llm_response_steps" in terminus.__dict__:
+        delattr(terminus, "_append_pending_failed_llm_response_steps")
     if had_records:
         Chat._records_api_token_anchor = records_val
     elif "_records_api_token_anchor" in Chat.__dict__:
@@ -235,6 +253,8 @@ class TestPatchCleReset:
         assert harbor._TERMINUS_CLE_RESET_PATCHED is True
         assert terminus._query_llm is not original
         assert hasattr(terminus, "_build_local_fallback_llm_content")
+        assert hasattr(terminus, "_save_failed_llm_response")
+        assert hasattr(terminus, "_append_pending_failed_llm_response_steps")
 
     def test_idempotent_when_flag_set(self, patch_sandbox):
         terminus = patch_sandbox.terminus
@@ -409,6 +429,129 @@ class TestPatchApiTokenAnchor:
         patch_sandbox.terminus._count_total_tokens = _diverged_method
         with pytest.raises(RuntimeError, match="diverged"):
             _patch_terminus_api_token_anchor()
+
+
+# ── failed LLM response accounting ───────────────────────────────────────
+
+
+class _FakeLiteLLMChoice(dict):
+    def __init__(self, data, token_ids):
+        super().__init__(data)
+        self.provider_specific_fields = {"token_ids": token_ids}
+
+
+class _FakeLiteLLMResponse(dict):
+    def __init__(self, *, content, finish_reason, prompt_tokens, completion_tokens, model, reasoning):
+        choice = _FakeLiteLLMChoice(
+            {
+                "message": {"content": content, "reasoning": reasoning},
+                "finish_reason": finish_reason,
+                "logprobs": {"content": [{"logprob": -0.1}] * completion_tokens},
+            },
+            list(range(completion_tokens)),
+        )
+        super().__init__({"model": model, "choices": [choice]})
+        self.prompt_token_ids = list(range(prompt_tokens))
+        self.usage = SimpleNamespace(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+        )
+        self._hidden_params = {"response_cost": 0.0}
+
+
+class TestPatchFailedLLMResponseAccounting:
+    async def test_length_response_becomes_ordered_atif_step_without_double_count(
+        self, patch_sandbox, monkeypatch, tmp_path
+    ):
+        import litellm
+        from harbor.agents.terminus_2 import terminus_2
+        from harbor.llms.chat import Chat
+        from harbor.models.trajectories import Step
+
+        _patch_terminus_cle_reset()
+
+        wire_totals = []
+
+        async def fake_acompletion(**_kwargs):
+            if not wire_totals:
+                wire_totals.append(11)
+                return _FakeLiteLLMResponse(
+                    content="TRUNCATED_OUTPUT",
+                    finish_reason="length",
+                    prompt_tokens=7,
+                    completion_tokens=4,
+                    model="wire-model",
+                    reasoning="raw-reasoning-field",
+                )
+            wire_totals.append(8)
+            return _FakeLiteLLMResponse(
+                content=json.dumps(
+                    {
+                        "analysis": "retry analysis",
+                        "plan": "retry plan",
+                        "commands": [],
+                        "task_complete": False,
+                    }
+                ),
+                finish_reason="stop",
+                prompt_tokens=6,
+                completion_tokens=2,
+                model="retry-model",
+                reasoning="retry-reasoning",
+            )
+
+        monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+        agent = terminus_2.Terminus2(
+            tmp_path,
+            model_name="openai/nano-v3.5",
+            parser_name="json",
+            max_turns=1,
+            api_base="http://model.test",
+            collect_rollout_details=True,
+            enable_summarize=False,
+            record_terminal_session=False,
+            suppress_max_turns_warning=True,
+            llm_call_kwargs={"max_tokens": 4},
+        )
+        agent._context = SimpleNamespace(n_input_tokens=None, n_output_tokens=None, n_cache_tokens=None, cost_usd=None)
+        agent._session = SimpleNamespace(is_session_alive=lambda: _return_async(True))
+        agent._trajectory_steps = [Step(step_id=1, source="user", message="initial prompt")]
+        agent._llm.get_model_output_limit = lambda: 4
+        dumped_step_counts = []
+        agent._dump_trajectory = lambda: dumped_step_counts.append(len(agent._trajectory_steps))
+        agent._record_asciinema_marker = lambda *_args, **_kwargs: None
+
+        async def execute_commands(_commands, _session):
+            return False, "observation"
+
+        agent._execute_commands = execute_commands
+        await agent._run_agent_loop("initial prompt", Chat(agent._llm))
+
+        assert dumped_step_counts == [3]
+        assert [step.source for step in agent._trajectory_steps] == ["user", "agent", "agent"]
+        assert [step.message for step in agent._trajectory_steps] == [
+            "initial prompt",
+            "TRUNCATED_OUTPUT",
+            "Analysis: retry analysis\nPlan: retry plan",
+        ]
+        failed_step, retry_step = agent._trajectory_steps[1:]
+        assert failed_step.reasoning_content == "raw-reasoning-field"
+        assert failed_step.metrics.prompt_tokens + failed_step.metrics.completion_tokens == 11
+        assert retry_step.metrics.prompt_tokens + retry_step.metrics.completion_tokens == 8
+        assert sum(wire_totals) == sum(
+            step.metrics.prompt_tokens + step.metrics.completion_tokens for step in agent._trajectory_steps[1:]
+        )
+
+    def test_terminus_run_loop_diverged_source_raises(self, patch_sandbox):
+        patch_sandbox.terminus._run_agent_loop = _diverged_method
+        with pytest.raises(RuntimeError, match="diverged"):
+            _patch_terminus_cle_reset()
+
+
+async def _return_async(value):
+    return value
 
 
 # ── HarborSolver._create_agent gating ────────────────────────────────────

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -65,6 +65,20 @@ async def _litellm_call_length_anchor_missing_locals(self, *args, **kwargs):
             raise exc
 
 
+async def _responses_api_length_anchor_missing_locals(self, *args, **kwargs):
+    from harbor.llms.base import OutputLengthExceededError
+
+    content = "missing responses local guard"
+    reason = "max_output_tokens"
+    if True:
+        if True:
+            if reason == "max_output_tokens":
+                raise OutputLengthExceededError(
+                    f"Model {self._model_name} hit max_tokens limit. Response was truncated.",
+                    truncated_response=content,
+                )
+
+
 _FLAGS = (
     "_TERMINUS_CLE_RESET_PATCHED",
     "_TERMINUS_UNWIND_PATCHED",
@@ -312,6 +326,20 @@ class TestPatchCleReset:
         assert patch_sandbox.terminus._query_llm is original_query
         assert "_apply_failed_llm_usage" not in patch_sandbox.terminus.__dict__
 
+    def test_responses_length_patch_requires_expected_locals_before_mutating(self, patch_sandbox):
+        from harbor.llms.lite_llm import LiteLLM
+
+        original_call = LiteLLM.call
+        original_query = patch_sandbox.terminus._query_llm
+        LiteLLM._call_responses = _responses_api_length_anchor_missing_locals
+        with pytest.raises(RuntimeError, match="required source pattern"):
+            _patch_terminus_cle_reset()
+
+        assert LiteLLM.call is original_call
+        assert LiteLLM._call_responses is _responses_api_length_anchor_missing_locals
+        assert patch_sandbox.terminus._query_llm is original_query
+        assert "_apply_failed_llm_usage" not in patch_sandbox.terminus.__dict__
+
 
 # ── _patch_terminus_unwind_min_pairs ─────────────────────────────────────
 
@@ -478,10 +506,23 @@ class _FakeLiteLLMChoice(dict):
 
 
 class _FakeLiteLLMResponse(dict):
-    def __init__(self, *, content, finish_reason, prompt_tokens, completion_tokens, model, reasoning):
+    def __init__(
+        self,
+        *,
+        content,
+        finish_reason,
+        prompt_tokens,
+        completion_tokens,
+        model,
+        reasoning,
+        reasoning_content=None,
+    ):
+        message = {"content": content, "reasoning": reasoning}
+        if reasoning_content is not None:
+            message["reasoning_content"] = reasoning_content
         choice = _FakeLiteLLMChoice(
             {
-                "message": {"content": content, "reasoning": reasoning},
+                "message": message,
                 "finish_reason": finish_reason,
                 "logprobs": {"content": [{"logprob": -0.1}] * completion_tokens},
             },
@@ -550,6 +591,70 @@ class _FakeLengthChat:
 
 
 class TestPatchFailedLLMResponseAccounting:
+    async def test_chat_completion_length_error_keeps_usage_model_and_reasoning(self, patch_sandbox, monkeypatch):
+        import litellm
+        from harbor.llms.base import OutputLengthExceededError
+        from harbor.llms.lite_llm import LiteLLM
+
+        _patch_terminus_cle_reset()
+
+        async def fake_acompletion(**_kwargs):
+            return _FakeLiteLLMResponse(
+                content="TRUNCATED_OUTPUT",
+                finish_reason="length",
+                prompt_tokens=23,
+                completion_tokens=9,
+                model="wire-model",
+                reasoning="fallback-reasoning",
+                reasoning_content="preferred-reasoning",
+            )
+
+        monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+        llm = LiteLLM(
+            model_name="openai/nano-v3.5",
+            api_base="http://model.test",
+            api_key="test-key",
+        )
+        with pytest.raises(OutputLengthExceededError) as excinfo:
+            await llm.call("prompt")
+
+        error = excinfo.value
+        assert error.truncated_response == "TRUNCATED_OUTPUT"
+        assert error.llm_model_name == "wire-model"
+        assert error.llm_reasoning_content == "preferred-reasoning"
+        assert error.llm_usage.prompt_tokens == 23
+        assert error.llm_usage.completion_tokens == 9
+
+    async def test_chat_completion_length_error_uses_reasoning_fallback(self, patch_sandbox, monkeypatch):
+        import litellm
+        from harbor.llms.base import OutputLengthExceededError
+        from harbor.llms.lite_llm import LiteLLM
+
+        _patch_terminus_cle_reset()
+
+        async def fake_acompletion(**_kwargs):
+            return _FakeLiteLLMResponse(
+                content="TRUNCATED_OUTPUT",
+                finish_reason="length",
+                prompt_tokens=5,
+                completion_tokens=4,
+                model="wire-model",
+                reasoning="fallback-reasoning",
+            )
+
+        monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+        llm = LiteLLM(
+            model_name="openai/nano-v3.5",
+            api_base="http://model.test",
+            api_key="test-key",
+        )
+        with pytest.raises(OutputLengthExceededError) as excinfo:
+            await llm.call("prompt")
+
+        assert excinfo.value.llm_reasoning_content == "fallback-reasoning"
+
     async def test_responses_api_length_error_keeps_usage_details(self, patch_sandbox, monkeypatch):
         import litellm
         from harbor.llms.base import OutputLengthExceededError
@@ -578,6 +683,33 @@ class TestPatchFailedLLMResponseAccounting:
         assert error.llm_usage.prompt_tokens == 13
         assert error.llm_usage.completion_tokens == 5
 
+    async def test_responses_api_length_error_keeps_details_via_call(self, patch_sandbox, monkeypatch):
+        import litellm
+        from harbor.llms.base import OutputLengthExceededError
+        from harbor.llms.lite_llm import LiteLLM
+
+        _patch_terminus_cle_reset()
+
+        async def fake_aresponses(**kwargs):
+            assert kwargs["input"] == [{"role": "user", "content": "prompt"}]
+            return _FakeResponsesAPIResponse()
+
+        monkeypatch.setattr(litellm, "aresponses", fake_aresponses)
+
+        llm = LiteLLM(
+            model_name="openai/nano-v3.5",
+            api_base="http://model.test",
+            api_key="test-key",
+            use_responses_api=True,
+        )
+        with pytest.raises(OutputLengthExceededError) as excinfo:
+            await llm.call("prompt")
+
+        assert excinfo.value.truncated_response == "TRUNCATED_RESPONSES_OUTPUT"
+        assert excinfo.value.llm_model_name == "responses-model"
+        assert excinfo.value.llm_usage.prompt_tokens == 13
+        assert excinfo.value.llm_usage.completion_tokens == 5
+
     async def test_salvaged_length_response_counts_usage_without_failed_step(self, patch_sandbox, tmp_path):
         from harbor.agents.terminus_2 import terminus_2
         from harbor.llms.base import OutputLengthExceededError
@@ -605,12 +737,77 @@ class TestPatchFailedLLMResponseAccounting:
 
         result = await agent._query_llm(chat, "prompt", (None, None, None))
 
-        assert result == salvaged
+        assert result.content == salvaged
+        assert result.model_name == "openai/nano-v3.5"
         assert chat.total_input_tokens == 19
         assert chat.total_output_tokens == 7
         assert chat.total_cache_tokens == 3
         assert chat.total_cost == 0.25
         assert chat._api_token_anchor == (0, 26)
+        assert getattr(agent, "_pending_failed_llm_response_steps", []) == []
+
+    async def test_salvaged_length_response_is_recorded_as_normal_step(self, patch_sandbox, monkeypatch, tmp_path):
+        import litellm
+        from harbor.agents.terminus_2 import terminus_2
+        from harbor.llms.chat import Chat
+        from harbor.models.trajectories import Step
+
+        _patch_terminus_cle_reset()
+
+        salvaged = (
+            "<response>\n"
+            "<analysis>salvaged analysis</analysis>\n"
+            "<plan>salvaged plan</plan>\n"
+            "<commands>\n"
+            "</commands>\n"
+            "<task_complete>false</task_complete>\n"
+            "</response>"
+        )
+
+        async def fake_acompletion(**_kwargs):
+            return _FakeLiteLLMResponse(
+                content=salvaged + "\nTRAILING_TRUNCATED_TEXT",
+                finish_reason="length",
+                prompt_tokens=13,
+                completion_tokens=5,
+                model="wire-model",
+                reasoning="salvaged-reasoning",
+            )
+
+        monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+
+        agent = terminus_2.Terminus2(
+            tmp_path,
+            model_name="openai/nano-v3.5",
+            parser_name="xml",
+            max_turns=1,
+            api_base="http://model.test",
+            collect_rollout_details=True,
+            enable_summarize=False,
+            record_terminal_session=False,
+            suppress_max_turns_warning=True,
+            llm_call_kwargs={"max_tokens": 5},
+        )
+        agent._context = SimpleNamespace(n_input_tokens=None, n_output_tokens=None, n_cache_tokens=None, cost_usd=None)
+        agent._session = SimpleNamespace(is_session_alive=lambda: _return_async(True))
+        agent._trajectory_steps = [Step(step_id=1, source="user", message="initial prompt")]
+        agent._dump_trajectory = lambda: None
+        agent._record_asciinema_marker = lambda *_args, **_kwargs: None
+
+        async def execute_commands(_commands, _session):
+            return False, "observation"
+
+        chat = Chat(agent._llm)
+        agent._execute_commands = execute_commands
+        await agent._run_agent_loop("initial prompt", chat)
+
+        assert [step.source for step in agent._trajectory_steps] == ["user", "agent"]
+        step = agent._trajectory_steps[1]
+        assert step.model_name == "wire-model"
+        assert step.reasoning_content == "salvaged-reasoning"
+        assert step.message == "Analysis: salvaged analysis\nPlan: salvaged plan"
+        assert step.metrics.prompt_tokens == 13
+        assert step.metrics.completion_tokens == 5
         assert getattr(agent, "_pending_failed_llm_response_steps", []) == []
 
     async def test_length_response_becomes_ordered_atif_step_without_double_count(
@@ -697,9 +894,16 @@ class TestPatchFailedLLMResponseAccounting:
         )
 
     def test_terminus_run_loop_diverged_source_raises(self, patch_sandbox):
+        from harbor.llms.lite_llm import LiteLLM
+
+        original_call = LiteLLM.call
+        original_responses = LiteLLM._call_responses
         patch_sandbox.terminus._run_agent_loop = _diverged_method
         with pytest.raises(RuntimeError, match="diverged"):
             _patch_terminus_cle_reset()
+        assert LiteLLM.call is original_call
+        assert LiteLLM._call_responses is original_responses
+        assert "_apply_failed_llm_usage" not in patch_sandbox.terminus.__dict__
 
 
 async def _return_async(value):

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -816,15 +816,29 @@ class TestPatchFailedLLMResponseAccounting:
         import litellm
         from harbor.agents.terminus_2 import terminus_2
         from harbor.llms.chat import Chat
-        from harbor.models.trajectories import Step
+        from harbor.models.trajectories import Agent, FinalMetrics, Step, Trajectory
+
+        from nemo_evaluator.reports.trajectories import generate_trajectories_report
 
         _patch_terminus_cle_reset()
 
-        wire_totals = []
+        wire_rows = []
 
         async def fake_acompletion(**_kwargs):
-            if not wire_totals:
-                wire_totals.append(11)
+            if not wire_rows:
+                wire_rows.append(
+                    {
+                        "problem_idx": 0,
+                        "repeat": 0,
+                        "session_id": "sess-length-retry",
+                        "status_code": 200,
+                        "finish_reason": "length",
+                        "timestamp": "2026-07-24T00:00:00.000Z",
+                        "model": "wire-model",
+                        "request_hash": "length-call",
+                        "usage": {"prompt_tokens": 7, "completion_tokens": 4, "total_tokens": 11},
+                    }
+                )
                 return _FakeLiteLLMResponse(
                     content="TRUNCATED_OUTPUT",
                     finish_reason="length",
@@ -833,7 +847,19 @@ class TestPatchFailedLLMResponseAccounting:
                     model="wire-model",
                     reasoning="raw-reasoning-field",
                 )
-            wire_totals.append(8)
+            wire_rows.append(
+                {
+                    "problem_idx": 0,
+                    "repeat": 0,
+                    "session_id": "sess-length-retry",
+                    "status_code": 200,
+                    "finish_reason": "stop",
+                    "timestamp": "2026-07-24T00:00:01.000Z",
+                    "model": "retry-model",
+                    "request_hash": "retry-call",
+                    "usage": {"prompt_tokens": 6, "completion_tokens": 2, "total_tokens": 8},
+                }
+            )
             return _FakeLiteLLMResponse(
                 content=json.dumps(
                     {
@@ -889,9 +915,58 @@ class TestPatchFailedLLMResponseAccounting:
         assert failed_step.reasoning_content == "raw-reasoning-field"
         assert failed_step.metrics.prompt_tokens + failed_step.metrics.completion_tokens == 11
         assert retry_step.metrics.prompt_tokens + retry_step.metrics.completion_tokens == 8
-        assert sum(wire_totals) == sum(
+        assert sum(row["usage"]["total_tokens"] for row in wire_rows) == sum(
             step.metrics.prompt_tokens + step.metrics.completion_tokens for step in agent._trajectory_steps[1:]
         )
+
+        bench_dir = tmp_path / "pb"
+        bench_dir.mkdir()
+        agent_steps = [step for step in agent._trajectory_steps if step.source == "agent"]
+        prompt_total = sum(step.metrics.prompt_tokens or 0 for step in agent_steps if step.metrics)
+        completion_total = sum(step.metrics.completion_tokens or 0 for step in agent_steps if step.metrics)
+        trajectory = Trajectory(
+            session_id="sess-length-retry",
+            agent=Agent(name="terminus-2", version="test", model_name="openai/nano-v3.5"),
+            steps=agent._trajectory_steps,
+            final_metrics=FinalMetrics(
+                total_prompt_tokens=prompt_total,
+                total_completion_tokens=completion_total,
+                total_steps=len(agent._trajectory_steps),
+            ),
+        )
+        trajectory_row = {
+            "problem_idx": 0,
+            "repeat": 0,
+            "reward": 0.0,
+            "trajectory": [trajectory.model_dump(mode="json", exclude_none=True)],
+        }
+        (bench_dir / "trajectories.jsonl").write_text(json.dumps(trajectory_row) + "\n", encoding="utf-8")
+        (bench_dir / "model_traffic.jsonl").write_text(
+            "".join(json.dumps(row) + "\n" for row in wire_rows),
+            encoding="utf-8",
+        )
+
+        report_path = generate_trajectories_report(tmp_path, enrich=True)
+        report = json.loads(report_path.read_text(encoding="utf-8"))["benchmarks"][0]
+        tokens = report["tokens_stats"]
+        assert tokens["per_step_sum"] == 19
+        assert tokens["wire_total"] == 19
+        assert tokens["wire_total_for_trajectory_comparison"] == 19
+        assert tokens["final_metrics_total"] == 19
+        assert tokens["problems_with_per_step_vs_final_metrics_mismatch"] == 0
+        assert tokens["problems_with_wire_vs_final_metrics_mismatch"] == 0
+        assert tokens["all_sources_match"] is True
+        assert report["wire_calls"]["problems_with_more_wire_than_steps"] == 0
+        assert report["wire_calls"]["problems_with_fewer_wire_than_steps"] == 0
+
+        enriched = json.loads((bench_dir / "trajectories_enriched.jsonl").read_text(encoding="utf-8"))
+        enriched_agent_steps = [step for step in enriched["trajectory"][0]["steps"] if step["source"] == "agent"]
+        assert [step["message"] for step in enriched_agent_steps] == [
+            "TRUNCATED_OUTPUT",
+            "Analysis: retry analysis\nPlan: retry plan",
+        ]
+        assert [step["metrics"]["total_tokens"] for step in enriched_agent_steps] == [11, 8]
+        assert [step["metrics"]["extra"]["finish_reason"] for step in enriched_agent_steps] == ["length", "stop"]
 
     def test_terminus_run_loop_diverged_source_raises(self, patch_sandbox):
         from harbor.llms.lite_llm import LiteLLM

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -39,7 +39,8 @@ from nemo_evaluator.solvers.harbor import (
 def _query_llm_with_marker(self, *args, **kwargs):
     full_summarize_failed_with_cle = False
     marker = "EVALUATOR_LLM_ERROR_TRAJECTORY_STEP"
-    return full_summarize_failed_with_cle, marker
+    usage_marker = "self._apply_failed_llm_usage(chat, e)"
+    return full_summarize_failed_with_cle, marker, usage_marker
 
 
 def _unwind_with_marker(self, chat, target_free_tokens=4000):
@@ -49,6 +50,19 @@ def _unwind_with_marker(self, chat, target_free_tokens=4000):
 
 def _diverged_method(self, *args, **kwargs):
     return None
+
+
+async def _litellm_call_length_anchor_missing_locals(self, *args, **kwargs):
+    from harbor.llms.base import OutputLengthExceededError
+
+    content = "missing local guard"
+    if True:
+        if True:
+            exc = OutputLengthExceededError(
+                "length",
+                truncated_response=content,
+            )
+            raise exc
 
 
 _FLAGS = (
@@ -74,9 +88,12 @@ def patch_sandbox():
         "_count": terminus._count_total_tokens,
         "chat_chat": Chat.chat,
         "litellm_call": LiteLLM.call,
+        "litellm_call_responses": LiteLLM._call_responses,
     }
     had_fallback = "_build_local_fallback_llm_content" in terminus.__dict__
     fallback_val = terminus.__dict__.get("_build_local_fallback_llm_content")
+    had_failed_llm_usage = "_apply_failed_llm_usage" in terminus.__dict__
+    failed_llm_usage_val = terminus.__dict__.get("_apply_failed_llm_usage")
     had_failed_llm_saver = "_save_failed_llm_response" in terminus.__dict__
     failed_llm_saver_val = terminus.__dict__.get("_save_failed_llm_response")
     had_failed_llm_appender = "_append_pending_failed_llm_response_steps" in terminus.__dict__
@@ -96,10 +113,15 @@ def patch_sandbox():
     terminus._count_total_tokens = saved_methods["_count"]
     Chat.chat = saved_methods["chat_chat"]
     LiteLLM.call = saved_methods["litellm_call"]
+    LiteLLM._call_responses = saved_methods["litellm_call_responses"]
     if had_fallback:
         terminus._build_local_fallback_llm_content = fallback_val
     elif "_build_local_fallback_llm_content" in terminus.__dict__:
         delattr(terminus, "_build_local_fallback_llm_content")
+    if had_failed_llm_usage:
+        terminus._apply_failed_llm_usage = failed_llm_usage_val
+    elif "_apply_failed_llm_usage" in terminus.__dict__:
+        delattr(terminus, "_apply_failed_llm_usage")
     if had_failed_llm_saver:
         terminus._save_failed_llm_response = failed_llm_saver_val
     elif "_save_failed_llm_response" in terminus.__dict__:
@@ -253,6 +275,7 @@ class TestPatchCleReset:
         assert harbor._TERMINUS_CLE_RESET_PATCHED is True
         assert terminus._query_llm is not original
         assert hasattr(terminus, "_build_local_fallback_llm_content")
+        assert hasattr(terminus, "_apply_failed_llm_usage")
         assert hasattr(terminus, "_save_failed_llm_response")
         assert hasattr(terminus, "_append_pending_failed_llm_response_steps")
 
@@ -274,6 +297,20 @@ class TestPatchCleReset:
         patch_sandbox.terminus._query_llm = _diverged_method
         with pytest.raises(RuntimeError, match="diverged"):
             _patch_terminus_cle_reset()
+
+    def test_litellm_length_patch_requires_expected_locals_before_mutating(self, patch_sandbox):
+        from harbor.llms.lite_llm import LiteLLM
+
+        LiteLLM.call = _litellm_call_length_anchor_missing_locals
+        original_responses = LiteLLM._call_responses
+        original_query = patch_sandbox.terminus._query_llm
+        with pytest.raises(RuntimeError, match="required source pattern"):
+            _patch_terminus_cle_reset()
+
+        assert LiteLLM.call is _litellm_call_length_anchor_missing_locals
+        assert LiteLLM._call_responses is original_responses
+        assert patch_sandbox.terminus._query_llm is original_query
+        assert "_apply_failed_llm_usage" not in patch_sandbox.terminus.__dict__
 
 
 # ── _patch_terminus_unwind_min_pairs ─────────────────────────────────────
@@ -460,7 +497,122 @@ class _FakeLiteLLMResponse(dict):
         self._hidden_params = {"response_cost": 0.0}
 
 
+class _FakeResponsesAPIResponse:
+    def __init__(self):
+        self.status = "incomplete"
+        self.incomplete_details = SimpleNamespace(reason="max_output_tokens")
+        self.model = "responses-model"
+        self.id = "resp-1"
+        self.usage = SimpleNamespace(input_tokens=13, output_tokens=5)
+        self.output = [
+            SimpleNamespace(
+                type="message",
+                content=[SimpleNamespace(type="output_text", text="TRUNCATED_RESPONSES_OUTPUT")],
+            )
+        ]
+        self._hidden_params = {"response_cost": 0.0}
+
+
+class _FakeLengthChat:
+    def __init__(self, error):
+        self._error = error
+        self._messages = []
+        self._cumulative_input_tokens = 0
+        self._cumulative_output_tokens = 0
+        self._cumulative_cache_tokens = 0
+        self._cumulative_cost = 0.0
+
+    @property
+    def messages(self):
+        return self._messages
+
+    @property
+    def total_input_tokens(self):
+        return self._cumulative_input_tokens
+
+    @property
+    def total_output_tokens(self):
+        return self._cumulative_output_tokens
+
+    @property
+    def total_cache_tokens(self):
+        return self._cumulative_cache_tokens
+
+    @property
+    def total_cost(self):
+        return self._cumulative_cost
+
+    async def chat(self, *_args, **_kwargs):
+        raise self._error
+
+    def reset_response_chain(self):
+        pass
+
+
 class TestPatchFailedLLMResponseAccounting:
+    async def test_responses_api_length_error_keeps_usage_details(self, patch_sandbox, monkeypatch):
+        import litellm
+        from harbor.llms.base import OutputLengthExceededError
+        from harbor.llms.lite_llm import LiteLLM
+
+        _patch_terminus_cle_reset()
+
+        async def fake_aresponses(**_kwargs):
+            return _FakeResponsesAPIResponse()
+
+        monkeypatch.setattr(litellm, "aresponses", fake_aresponses)
+
+        llm = LiteLLM(
+            model_name="openai/nano-v3.5",
+            api_base="http://model.test",
+            api_key="test-key",
+            use_responses_api=True,
+        )
+        with pytest.raises(OutputLengthExceededError) as excinfo:
+            await llm._call_responses("prompt")
+
+        error = excinfo.value
+        assert error.truncated_response == "TRUNCATED_RESPONSES_OUTPUT"
+        assert error.llm_model_name == "responses-model"
+        assert error.llm_reasoning_content is None
+        assert error.llm_usage.prompt_tokens == 13
+        assert error.llm_usage.completion_tokens == 5
+
+    async def test_salvaged_length_response_counts_usage_without_failed_step(self, patch_sandbox, tmp_path):
+        from harbor.agents.terminus_2 import terminus_2
+        from harbor.llms.base import OutputLengthExceededError
+        from harbor.models.metric.usage_info import UsageInfo
+
+        _patch_terminus_cle_reset()
+
+        salvaged = (
+            "<response><analysis>a</analysis><plan>p</plan><commands></commands>"
+            "<task_complete>false</task_complete></response>"
+        )
+        error = OutputLengthExceededError("length", truncated_response=salvaged + " trailing tokens")
+        error.llm_usage = UsageInfo(prompt_tokens=19, completion_tokens=7, cache_tokens=3, cost_usd=0.25)
+
+        chat = _FakeLengthChat(error)
+        agent = terminus_2.Terminus2(
+            tmp_path,
+            model_name="openai/nano-v3.5",
+            parser_name="xml",
+            max_turns=1,
+            api_base="http://model.test",
+            suppress_max_turns_warning=True,
+        )
+        agent._parser = SimpleNamespace(salvage_truncated_response=lambda _content: (salvaged, False))
+
+        result = await agent._query_llm(chat, "prompt", (None, None, None))
+
+        assert result == salvaged
+        assert chat.total_input_tokens == 19
+        assert chat.total_output_tokens == 7
+        assert chat.total_cache_tokens == 3
+        assert chat.total_cost == 0.25
+        assert chat._api_token_anchor == (0, 26)
+        assert getattr(agent, "_pending_failed_llm_response_steps", []) == []
+
     async def test_length_response_becomes_ordered_atif_step_without_double_count(
         self, patch_sandbox, monkeypatch, tmp_path
     ):


### PR DESCRIPTION
## Summary
- Preserve successful LiteLLM `finish_reason="length"` call usage/model/reasoning on the raised output-length error.
- Queue the failed Terminus-2 model-call response and inject it as an ATIF agent step before the normal retry step.
- Keep Terminus behavior unchanged: the truncated response is still rejected and retried with the existing output-length prompt.

## Validation
- `uvx ruff check src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_terminus_patches.py`
- `python -m py_compile src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_terminus_patches.py`
- `git diff --check -- src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_terminus_patches.py`
- `uv run pytest tests/test_solvers/test_harbor_terminus_patches.py -q` (`41 passed`)
- `uv run pytest tests/test_solvers/test_harbor_solver.py -q` (`110 passed`)
- Forced small-`max_tokens` smoke: wire total `19`, ATIF per-step total `19`, final metrics total `19`, ordered steps `user -> failed agent -> retry agent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation trajectories now consistently include a “failure step” contribution when LLM calls fail during context recovery, summarization, or length/context errors, followed by the eventual retry step.
  * Improved preservation of failure metadata (including available model/reasoning info) and more reliable token/cost accounting to avoid double-counting.
  * Hardened runtime patching so evaluator accounting changes only apply when expected source patterns are present, preventing partial/incorrect instrumentation.
* **Tests**
  * Expanded CLE/Terminus patch coverage for truncation and retry flows, including ordering, metadata handling, and failure-vs-retry accounting accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->