### PR TITLE
feat: add compaction event log, fix turn counting

### DIFF
--- a/.github/workflows/oss-pr-checks.yml
+++ b/.github/workflows/oss-pr-checks.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-      - run: pip install "ruff>=0.1"
+      - run: pip install "ruff==0.15.22"
       - run: ruff check src/ tests/
       - run: ruff format --check src/ tests/
 

--- a/src/nemo_evaluator/adapters/call_kind.py
+++ b/src/nemo_evaluator/adapters/call_kind.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping
+
+NEL_CALL_KIND_HEADER = "x-nel-call-kind"
+NEL_CALL_KIND_COMPACTION = "compaction"
+
+
+def is_compaction_call_kind(value: str | None) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() == NEL_CALL_KIND_COMPACTION
+
+
+def strip_call_kind_header(headers: MutableMapping[str, str]) -> str | None:
+    kind = None
+    for key in list(headers):
+        if key.lower() == NEL_CALL_KIND_HEADER:
+            kind = headers.pop(key)
+    return kind
+
+
+def merge_compaction_extra_headers(kwargs: Mapping[str, Any] | None = None) -> dict[str, Any]:
+    out = dict(kwargs or {})
+    existing = out.get("extra_headers")
+    headers = dict(existing) if isinstance(existing, Mapping) else {}
+    headers[NEL_CALL_KIND_HEADER] = NEL_CALL_KIND_COMPACTION
+    out["extra_headers"] = headers
+    return out

--- a/src/nemo_evaluator/adapters/interceptors/turn_counter.py
+++ b/src/nemo_evaluator/adapters/interceptors/turn_counter.py
@@ -120,15 +120,32 @@ class Interceptor(RequestInterceptor):
 
     async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
         kind = strip_call_kind_header(req.headers)
-        if is_compaction_call_kind(kind):
-            key = req.ctx.extra.get("session_id") or "?"
-            logger.debug("task %s skipping turn budget for compaction call", key)
-            return req
-
         key = req.ctx.extra.get("session_id")
         if not key:
             key = _session_key_from_body(req.body)
-            logger.warning("no session_id in context — falling back to body-hash key %s", key)
+            if not is_compaction_call_kind(kind):
+                logger.warning("no session_id in context — falling back to body-hash key %s", key)
+
+        if is_compaction_call_kind(kind):
+            if self._max is not None:
+                async with self._lock:
+                    sess = self._sessions.get(key)
+                    agent_turns = sess.count if sess is not None else 0
+                if agent_turns >= self._max:
+                    logger.warning(
+                        "task %s REJECTED compaction (agent turns %d/%d; no remaining agent turns)",
+                        key,
+                        agent_turns,
+                        self._max,
+                    )
+                    from nemo_evaluator.errors import GracefulError
+
+                    raise GracefulError(
+                        f"Turn budget exhausted: {agent_turns}/{self._max} turns used. "
+                        f"Skipping compaction because no further agent turns remain."
+                    )
+            logger.debug("task %s skipping turn budget for compaction call", key)
+            return req
 
         async with self._lock:
             now = time.monotonic()

--- a/src/nemo_evaluator/adapters/interceptors/turn_counter.py
+++ b/src/nemo_evaluator/adapters/interceptors/turn_counter.py
@@ -22,6 +22,10 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
+from nemo_evaluator.adapters.call_kind import (
+    is_compaction_call_kind,
+    strip_call_kind_header,
+)
 from nemo_evaluator.adapters.types import AdapterRequest, RequestInterceptor
 
 logger = logging.getLogger(__name__)
@@ -115,6 +119,12 @@ class Interceptor(RequestInterceptor):
             )
 
     async def intercept_request(self, req: AdapterRequest) -> AdapterRequest:
+        kind = strip_call_kind_header(req.headers)
+        if is_compaction_call_kind(kind):
+            key = req.ctx.extra.get("session_id") or "?"
+            logger.debug("task %s skipping turn budget for compaction call", key)
+            return req
+
         key = req.ctx.extra.get("session_id")
         if not key:
             key = _session_key_from_body(req.body)

--- a/src/nemo_evaluator/solvers/compaction_logging.py
+++ b/src/nemo_evaluator/solvers/compaction_logging.py
@@ -1,0 +1,282 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+CompactionTrigger = Literal[
+    "proactive_threshold",
+    "context_length_exceeded",
+    "agent_initiated",
+    "unknown",
+]
+
+CompactionStrategy = Literal[
+    "terminus_three_phase_subagent",
+    "terminus_short_fallback",
+    "terminus_ultimate_fallback",
+    "openhands_condensation",
+    "single_pass_summary",
+    "unknown",
+]
+
+CompactionBoundary = Literal["replace", "truncate", "append"]
+
+CompactionOutcome = Literal["failed"]
+
+CompactionPhase = Literal["summary", "questions", "answers"]
+
+COMPACTION_MESSAGE = "Context compaction performed"
+
+
+@dataclass
+class CompactionTokens:
+    prompt_tokens_approx: int
+    context_limit: int
+    free_tokens: int
+
+
+@dataclass
+class CompactionTokensIntermediate:
+    after_unwind: CompactionTokens | None = None
+    after_chat_reset: CompactionTokens | None = None
+
+
+@dataclass
+class StepsCompacted:
+    first_step_id: int
+    last_step_id: int
+    step_count: int
+
+
+@dataclass
+class CompactionMechanism:
+    unwind_applied: bool = False
+    chat_reset_applied: bool = False
+    messages_unwound_pairs: int = 0
+    unwind_target_free_tokens: int | None = None
+
+
+@dataclass
+class CompactionAttempt:
+    strategy: CompactionStrategy
+    outcome: CompactionOutcome = "failed"
+    error: str | None = None
+    llm_calls: int | None = None
+    phases_completed: list[CompactionPhase] | None = None
+    subagent_trajectory_ref: list[dict[str, Any]] | None = None
+
+
+@dataclass
+class CompactionObservationExtra:
+    compaction_prompt_tokens: int | None = None
+    compaction_completion_tokens: int | None = None
+    compaction_cost_usd: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        if self.compaction_prompt_tokens is not None:
+            out["compaction_prompt_tokens"] = self.compaction_prompt_tokens
+        if self.compaction_completion_tokens is not None:
+            out["compaction_completion_tokens"] = self.compaction_completion_tokens
+        if self.compaction_cost_usd is not None:
+            out["compaction_cost_usd"] = self.compaction_cost_usd
+        return out
+
+
+@dataclass
+class CompactionEvent:
+    compaction_index: int
+    trigger: CompactionTrigger
+    strategy: CompactionStrategy
+    replacement_content: str
+    tokens_before: CompactionTokens
+    tokens_after: CompactionTokens
+    llm_call_count: int
+    tokens_intermediate: CompactionTokensIntermediate | None = None
+    boundary: CompactionBoundary = "replace"
+    steps_compacted: StepsCompacted | None = None
+    mechanism: CompactionMechanism | None = None
+    subagent_trajectory_ref: list[dict[str, Any]] | None = None
+    attempts: list[CompactionAttempt] | None = None
+    observation_extra: CompactionObservationExtra | None = None
+    timestamp: str | None = None
+    message: str = COMPACTION_MESSAGE
+
+
+def _subagent_ref_to_dict(ref: dict[str, Any]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    session_id = ref.get("session_id")
+    if session_id is None and ref.get("trajectory_id") is not None:
+        session_id = ref.get("trajectory_id")
+    if session_id is not None:
+        out["session_id"] = session_id
+    if ref.get("trajectory_path") is not None:
+        out["trajectory_path"] = ref["trajectory_path"]
+    extra = ref.get("extra")
+    if extra:
+        out["extra"] = extra
+    return out
+
+
+def _attempt_to_dict(attempt: CompactionAttempt) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "strategy": attempt.strategy,
+        "outcome": attempt.outcome,
+    }
+    if attempt.error is not None:
+        out["error"] = attempt.error
+    if attempt.llm_calls is not None:
+        out["llm_calls"] = attempt.llm_calls
+    if attempt.phases_completed is not None:
+        out["phases_completed"] = list(attempt.phases_completed)
+    if attempt.subagent_trajectory_ref is not None:
+        out["subagent_trajectory_ref"] = [_subagent_ref_to_dict(r) for r in attempt.subagent_trajectory_ref]
+    return out
+
+
+def _tokens_to_dict(tokens: CompactionTokens) -> dict[str, Any]:
+    return {
+        "prompt_tokens_approx": tokens.prompt_tokens_approx,
+        "context_limit": tokens.context_limit,
+        "free_tokens": tokens.free_tokens,
+    }
+
+
+def _intermediate_tokens_to_dict(
+    intermediate: CompactionTokensIntermediate,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    if intermediate.after_unwind is not None:
+        out["after_unwind"] = _tokens_to_dict(intermediate.after_unwind)
+    if intermediate.after_chat_reset is not None:
+        out["after_chat_reset"] = _tokens_to_dict(intermediate.after_chat_reset)
+    return out
+
+
+def _mechanism_to_dict(mechanism: CompactionMechanism) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "unwind_applied": mechanism.unwind_applied,
+        "chat_reset_applied": mechanism.chat_reset_applied,
+        "messages_unwound_pairs": mechanism.messages_unwound_pairs,
+    }
+    if mechanism.unwind_target_free_tokens is not None:
+        out["unwind_target_free_tokens"] = mechanism.unwind_target_free_tokens
+    return out
+
+
+def subagent_trajectory_refs_to_dicts(refs: Any) -> list[dict[str, Any]] | None:
+    if not refs:
+        return None
+    out: list[dict[str, Any]] = []
+    for ref in refs:
+        if hasattr(ref, "model_dump"):
+            dumped = ref.model_dump(exclude_none=True, mode="json")
+            out.append(dumped)
+        elif isinstance(ref, dict):
+            out.append(dict(ref))
+        else:
+            raise TypeError(f"Unsupported subagent trajectory ref type: {type(ref)!r}")
+    return out
+
+
+def compaction_event_to_harbor_step(event: CompactionEvent, step_id: int) -> tuple[Any, int]:
+    from harbor.models.trajectories.observation import Observation
+    from harbor.models.trajectories.observation_result import ObservationResult
+    from harbor.models.trajectories.step import Step
+    from harbor.models.trajectories.subagent_trajectory_ref import SubagentTrajectoryRef
+
+    raw = build_compaction_step(event, step_id)
+    llm_call_count = int(raw["llm_call_count"])
+    observation_raw = raw["observation"]["results"][0]
+    refs = None
+    subagent_refs = observation_raw.get("subagent_trajectory_ref")
+    if subagent_refs:
+        refs = [SubagentTrajectoryRef.model_validate(item) for item in subagent_refs]
+    observation = Observation(
+        results=[
+            ObservationResult(
+                content=observation_raw.get("content"),
+                subagent_trajectory_ref=refs,
+            )
+        ]
+    )
+    step = Step(
+        step_id=raw["step_id"],
+        timestamp=raw["timestamp"],
+        source=raw["source"],
+        message=raw["message"],
+        observation=observation,
+        extra=raw["extra"],
+    )
+    return step, llm_call_count
+
+
+def build_compaction_step(event: CompactionEvent, step_id: int) -> dict[str, Any]:
+    timestamp = event.timestamp or datetime.now(timezone.utc).isoformat()
+
+    observation_result: dict[str, Any] = {
+        "content": event.replacement_content,
+    }
+    if event.subagent_trajectory_ref:
+        observation_result["subagent_trajectory_ref"] = [
+            _subagent_ref_to_dict(r) for r in event.subagent_trajectory_ref
+        ]
+    if event.observation_extra is not None:
+        obs_extra = event.observation_extra.to_dict()
+        if obs_extra:
+            observation_result["extra"] = obs_extra
+
+    compaction_extra: dict[str, Any] = {
+        "compaction_index": event.compaction_index,
+        "trigger": event.trigger,
+        "strategy": event.strategy,
+        "tokens_before": _tokens_to_dict(event.tokens_before),
+        "tokens_after": _tokens_to_dict(event.tokens_after),
+    }
+    if event.tokens_intermediate is not None:
+        intermediate = _intermediate_tokens_to_dict(event.tokens_intermediate)
+        if intermediate:
+            compaction_extra["tokens_intermediate"] = intermediate
+    if event.steps_compacted is not None:
+        compaction_extra["steps_compacted"] = {
+            "first_step_id": event.steps_compacted.first_step_id,
+            "last_step_id": event.steps_compacted.last_step_id,
+            "step_count": event.steps_compacted.step_count,
+        }
+    if event.mechanism is not None:
+        compaction_extra["mechanism"] = _mechanism_to_dict(event.mechanism)
+    if event.attempts:
+        compaction_extra["attempts"] = [_attempt_to_dict(a) for a in event.attempts]
+
+    return {
+        "step_id": step_id,
+        "timestamp": timestamp,
+        "source": "system",
+        "message": event.message,
+        "llm_call_count": event.llm_call_count,
+        "observation": {
+            "results": [observation_result],
+        },
+        "extra": {
+            "context_management": {
+                "type": "compaction",
+                "boundary": event.boundary,
+            },
+            "compaction": compaction_extra,
+        },
+    }
+
+
+def llm_call_count_for_strategy(strategy: CompactionStrategy) -> int:
+    if strategy == "terminus_three_phase_subagent":
+        return 3
+    if strategy == "terminus_short_fallback":
+        return 1
+    if strategy == "terminus_ultimate_fallback":
+        return 0
+    if strategy in ("openhands_condensation", "single_pass_summary"):
+        return 1
+    return 0

--- a/src/nemo_evaluator/solvers/compaction_logging.py
+++ b/src/nemo_evaluator/solvers/compaction_logging.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Literal
@@ -130,6 +131,57 @@ class CompactionEvent:
     openhands_extra: OpenHandsCompactionExtra | None = None
     timestamp: str | None = None
     message: str = COMPACTION_MESSAGE
+    handoff_prompt: str | None = None
+
+
+def _content_to_text(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, dict):
+                text = part.get("text")
+                if text is not None:
+                    parts.append(str(text))
+                else:
+                    parts.append(json.dumps(part, ensure_ascii=False))
+            else:
+                text = getattr(part, "text", None)
+                if text is not None:
+                    parts.append(str(text))
+                else:
+                    parts.append(str(part))
+        return "\n".join(parts)
+    return str(content)
+
+
+def normalize_chat_message(message: Any) -> dict[str, Any]:
+    if not isinstance(message, dict):
+        raise TypeError(f"Expected chat message dict, got {type(message)!r}")
+    role = message.get("role")
+    if role is None:
+        raise ValueError("Chat message is missing required 'role' field")
+    out: dict[str, Any] = {
+        "role": role,
+        "content": _content_to_text(message.get("content")),
+    }
+    if message.get("tool_calls") is not None:
+        out["tool_calls"] = message["tool_calls"]
+    if message.get("tool_call_id") is not None:
+        out["tool_call_id"] = message["tool_call_id"]
+    if message.get("name") is not None:
+        out["name"] = message["name"]
+    return out
+
+
+def serialize_chat_messages(messages: list[Any]) -> str:
+    normalized = [normalize_chat_message(message) for message in messages]
+    return json.dumps(normalized, ensure_ascii=False)
 
 
 def _subagent_ref_to_dict(ref: dict[str, Any]) -> dict[str, Any]:

--- a/src/nemo_evaluator/solvers/compaction_logging.py
+++ b/src/nemo_evaluator/solvers/compaction_logging.py
@@ -49,13 +49,6 @@ class CompactionTokensIntermediate:
 
 
 @dataclass
-class StepsCompacted:
-    first_step_id: int
-    last_step_id: int
-    step_count: int
-
-
-@dataclass
 class CompactionMechanism:
     unwind_applied: bool = False
     chat_reset_applied: bool = False
@@ -130,7 +123,6 @@ class CompactionEvent:
     llm_call_count: int
     tokens_intermediate: CompactionTokensIntermediate | None = None
     boundary: CompactionBoundary = "replace"
-    steps_compacted: StepsCompacted | None = None
     mechanism: CompactionMechanism | None = None
     subagent_trajectory_ref: list[dict[str, Any]] | None = None
     attempts: list[CompactionAttempt] | None = None
@@ -147,8 +139,6 @@ def _subagent_ref_to_dict(ref: dict[str, Any]) -> dict[str, Any]:
         session_id = ref.get("trajectory_id")
     if session_id is not None:
         out["session_id"] = session_id
-    if ref.get("trajectory_path") is not None:
-        out["trajectory_path"] = ref["trajectory_path"]
     extra = ref.get("extra")
     if extra:
         out["extra"] = extra
@@ -216,14 +206,13 @@ def subagent_trajectory_refs_to_dicts(refs: Any) -> list[dict[str, Any]] | None:
     return out
 
 
-def compaction_event_to_harbor_step(event: CompactionEvent, step_id: int) -> tuple[Any, int]:
+def compaction_event_to_harbor_step(event: CompactionEvent, step_id: int) -> Any:
     from harbor.models.trajectories.observation import Observation
     from harbor.models.trajectories.observation_result import ObservationResult
     from harbor.models.trajectories.step import Step
     from harbor.models.trajectories.subagent_trajectory_ref import SubagentTrajectoryRef
 
     raw = build_compaction_step(event, step_id)
-    llm_call_count = int(raw["llm_call_count"])
     observation_raw = raw["observation"]["results"][0]
     refs = None
     subagent_refs = observation_raw.get("subagent_trajectory_ref")
@@ -245,7 +234,7 @@ def compaction_event_to_harbor_step(event: CompactionEvent, step_id: int) -> tup
         observation=observation,
         extra=raw["extra"],
     )
-    return step, llm_call_count
+    return step
 
 
 def build_compaction_step(event: CompactionEvent, step_id: int) -> dict[str, Any]:
@@ -267,6 +256,7 @@ def build_compaction_step(event: CompactionEvent, step_id: int) -> dict[str, Any
         "compaction_index": event.compaction_index,
         "trigger": event.trigger,
         "strategy": event.strategy,
+        "llm_call_count": event.llm_call_count,
         "tokens_before": _tokens_to_dict(event.tokens_before),
         "tokens_after": _tokens_to_dict(event.tokens_after),
     }
@@ -274,27 +264,23 @@ def build_compaction_step(event: CompactionEvent, step_id: int) -> dict[str, Any
         intermediate = _intermediate_tokens_to_dict(event.tokens_intermediate)
         if intermediate:
             compaction_extra["tokens_intermediate"] = intermediate
-    if event.steps_compacted is not None:
-        compaction_extra["steps_compacted"] = {
-            "first_step_id": event.steps_compacted.first_step_id,
-            "last_step_id": event.steps_compacted.last_step_id,
-            "step_count": event.steps_compacted.step_count,
-        }
+    strategy_details: dict[str, Any] | None = None
     if event.mechanism is not None:
-        compaction_extra["mechanism"] = _mechanism_to_dict(event.mechanism)
-    if event.attempts:
-        compaction_extra["attempts"] = [_attempt_to_dict(a) for a in event.attempts]
-    if event.openhands_extra is not None:
+        strategy_details = _mechanism_to_dict(event.mechanism)
+    elif event.openhands_extra is not None:
         oh_extra = event.openhands_extra.to_dict()
         if oh_extra:
-            compaction_extra["openhands"] = oh_extra
+            strategy_details = oh_extra
+    if strategy_details is not None:
+        compaction_extra["strategy_details"] = strategy_details
+    if event.attempts:
+        compaction_extra["attempts"] = [_attempt_to_dict(a) for a in event.attempts]
 
     return {
         "step_id": step_id,
         "timestamp": timestamp,
         "source": "system",
         "message": event.message,
-        "llm_call_count": event.llm_call_count,
         "observation": {
             "results": [observation_result],
         },

--- a/src/nemo_evaluator/solvers/compaction_logging.py
+++ b/src/nemo_evaluator/solvers/compaction_logging.py
@@ -270,14 +270,14 @@ def compaction_event_to_harbor_step(event: CompactionEvent, step_id: int) -> Any
     subagent_refs = observation_raw.get("subagent_trajectory_ref")
     if subagent_refs:
         refs = [SubagentTrajectoryRef.model_validate(item) for item in subagent_refs]
-    observation = Observation(
-        results=[
-            ObservationResult(
-                content=observation_raw.get("content"),
-                subagent_trajectory_ref=refs,
-            )
-        ]
-    )
+    obs_result_kwargs: dict[str, Any] = {
+        "content": observation_raw.get("content"),
+        "subagent_trajectory_ref": refs,
+    }
+    obs_extra = observation_raw.get("extra")
+    if obs_extra and "extra" in getattr(ObservationResult, "model_fields", {}):
+        obs_result_kwargs["extra"] = obs_extra
+    observation = Observation(results=[ObservationResult(**obs_result_kwargs)])
     step = Step(
         step_id=raw["step_id"],
         timestamp=raw["timestamp"],

--- a/src/nemo_evaluator/solvers/compaction_logging.py
+++ b/src/nemo_evaluator/solvers/compaction_logging.py
@@ -7,9 +7,13 @@ from datetime import datetime, timezone
 from typing import Any, Literal
 
 CompactionTrigger = Literal[
-    "proactive_threshold",
-    "context_length_exceeded",
-    "agent_initiated",
+    "terminus_proactive_threshold",
+    "terminus_context_length_exceeded",
+    "terminus_agent_initiated",
+    "openhands_condensation_events",
+    "openhands_condensation_tokens",
+    "openhands_condensation_request",
+    "openhands_condensation_hard_reset",
     "unknown",
 ]
 
@@ -70,6 +74,35 @@ class CompactionAttempt:
 
 
 @dataclass
+class OpenHandsCompactionExtra:
+    reason: str | None = None
+    requirement: str | None = None
+    hard_reset: bool = False
+    forgotten_event_count: int = 0
+    max_size: int | None = None
+    max_tokens: int | None = None
+    keep_first: int | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {}
+        if self.reason is not None:
+            out["reason"] = self.reason
+        if self.requirement is not None:
+            out["requirement"] = self.requirement
+        if self.hard_reset:
+            out["hard_reset"] = True
+        if self.forgotten_event_count:
+            out["forgotten_event_count"] = self.forgotten_event_count
+        if self.max_size is not None:
+            out["max_size"] = self.max_size
+        if self.max_tokens is not None:
+            out["max_tokens"] = self.max_tokens
+        if self.keep_first is not None:
+            out["keep_first"] = self.keep_first
+        return out
+
+
+@dataclass
 class CompactionObservationExtra:
     compaction_prompt_tokens: int | None = None
     compaction_completion_tokens: int | None = None
@@ -102,6 +135,7 @@ class CompactionEvent:
     subagent_trajectory_ref: list[dict[str, Any]] | None = None
     attempts: list[CompactionAttempt] | None = None
     observation_extra: CompactionObservationExtra | None = None
+    openhands_extra: OpenHandsCompactionExtra | None = None
     timestamp: str | None = None
     message: str = COMPACTION_MESSAGE
 
@@ -250,6 +284,10 @@ def build_compaction_step(event: CompactionEvent, step_id: int) -> dict[str, Any
         compaction_extra["mechanism"] = _mechanism_to_dict(event.mechanism)
     if event.attempts:
         compaction_extra["attempts"] = [_attempt_to_dict(a) for a in event.attempts]
+    if event.openhands_extra is not None:
+        oh_extra = event.openhands_extra.to_dict()
+        if oh_extra:
+            compaction_extra["openhands"] = oh_extra
 
     return {
         "step_id": step_id,

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -268,6 +268,20 @@ async def _download_agent_logs_inner(
             pass
 
 
+def _openhands_compaction_module_files() -> dict[str, bytes]:
+    solvers_dir = Path(__file__).parent
+    return {
+        "/installed-agent/nel/nemo_evaluator/__init__.py": b"",
+        "/installed-agent/nel/nemo_evaluator/solvers/__init__.py": b"",
+        "/installed-agent/nel/nemo_evaluator/solvers/compaction_logging.py": (
+            solvers_dir / "compaction_logging.py"
+        ).read_bytes(),
+        "/installed-agent/nel/nemo_evaluator/solvers/openhands_compaction.py": (
+            solvers_dir / "openhands_compaction.py"
+        ).read_bytes(),
+    }
+
+
 async def _patch_openhands_sdk(sandbox: Sandbox, *, cmd_timeout: float | None = None) -> None:
     """Apply runtime patches to the OpenHands SDK inside the sandbox.
 
@@ -304,6 +318,10 @@ async def _patch_openhands_sdk(sandbox: Sandbox, *, cmd_timeout: float | None = 
        Inject the env lookup so ``solver.agent_kwargs.llm_kwargs.timeout``
        (mapped to ``container_env.LLM_TIMEOUT``) reaches OpenHands
        ``LLM(timeout=...)`` and LiteLLM per-request timeouts.
+
+    6. **Log OpenHands condensation in ATIF trajectories** — upload NEL
+       compaction helpers and splice system compaction steps after
+       ``build_trajectory()`` when ``Condensation`` events are present.
     """
     # -- Patch 0: disable stuck detection + default visualizer -----------
     # stuck_detection=False: the SDK's heuristic mis-flags reasoning-model
@@ -895,6 +913,97 @@ print(f'budget_flush={success}')
             "Budget-flush patch problem (rc=%d): %s",
             r4.return_code,
             stdout4 or (r4.stderr or "")[:300],
+        )
+
+    _compaction_files_payload = {
+        path: base64.b64encode(content).decode() for path, content in _openhands_compaction_module_files().items()
+    }
+    _compaction_upload_script = (
+        "import base64, json, os\n"
+        f"files = json.loads({json.dumps(_compaction_files_payload)!r})\n"
+        "for path, content_b64 in files.items():\n"
+        "    os.makedirs(os.path.dirname(path), exist_ok=True)\n"
+        "    with open(path, 'wb') as f:\n"
+        "        f.write(base64.b64decode(content_b64))\n"
+        "print('nel_compaction_modules=ok')\n"
+    )
+    encoded_compaction_upload = base64.b64encode(_compaction_upload_script.encode()).decode()
+    r_compaction_upload = await sandbox.exec(
+        f"echo {encoded_compaction_upload} | base64 -d | python3",
+        timeout_sec=10,
+    )
+    stdout_compaction_upload = (r_compaction_upload.stdout or "").strip()
+    logger.info("OpenHands compaction module upload: %s", stdout_compaction_upload)
+    if r_compaction_upload.return_code != 0 or "ok" not in stdout_compaction_upload:
+        logger.warning(
+            "OpenHands compaction module upload problem (rc=%d): %s",
+            r_compaction_upload.return_code,
+            stdout_compaction_upload or (r_compaction_upload.stderr or "")[:300],
+        )
+
+    _compaction_inject_script = """\
+import sys
+p = '/installed-agent/run_agent.py'
+c = open(p).read()
+
+old = (
+    '    trajectory = build_trajectory(\\n'
+    '        events_list,\\n'
+    '        metrics,\\n'
+    '        model,\\n'
+    '        system_prompt=system_prompt,\\n'
+    '        tool_definitions=tool_definitions,\\n'
+    '    )\\n'
+    '\\n'
+    '    trajectory_path = Path(args.trajectory_path)'
+)
+
+new = (
+    '    trajectory = build_trajectory(\\n'
+    '        events_list,\\n'
+    '        metrics,\\n'
+    '        model,\\n'
+    '        system_prompt=system_prompt,\\n'
+    '        tool_definitions=tool_definitions,\\n'
+    '    )\\n'
+    '    if "/installed-agent/nel" not in sys.path:\\n'
+    '        sys.path.insert(0, "/installed-agent/nel")\\n'
+    '    from nemo_evaluator.solvers.openhands_compaction import enrich_trajectory_with_compaction\\n'
+    '    _ctx_lim_raw = os.environ.get("CONTEXT_LIMIT") or os.environ.get("MAX_INPUT_TOKENS") or "128000"\\n'
+    '    _ctx_lim = int(_ctx_lim_raw)\\n'
+    '    _oh_cfg = {}\\n'
+    '    if os.environ.get("OPENHANDS_CONDENSER_MAX_SIZE"):\\n'
+    '        _oh_cfg["max_size"] = int(os.environ["OPENHANDS_CONDENSER_MAX_SIZE"])\\n'
+    '    if os.environ.get("OPENHANDS_CONDENSER_MAX_TOKENS"):\\n'
+    '        _oh_cfg["max_tokens"] = int(os.environ["OPENHANDS_CONDENSER_MAX_TOKENS"])\\n'
+    '    if os.environ.get("OPENHANDS_CONDENSER_KEEP_FIRST"):\\n'
+    '        _oh_cfg["keep_first"] = int(os.environ["OPENHANDS_CONDENSER_KEEP_FIRST"])\\n'
+    '    trajectory = enrich_trajectory_with_compaction(\\n'
+    '        trajectory, conversation.state.events, llm, _ctx_lim, condenser_config=_oh_cfg or None,\\n'
+    '    )\\n'
+    '\\n'
+    '    trajectory_path = Path(args.trajectory_path)'
+)
+
+already = 'enrich_trajectory_with_compaction' in c
+ok = old in c and not already
+if ok:
+    c = c.replace(old, new, 1)
+    open(p, 'w').write(c)
+print(f'openhands_compaction_inject={ok} already={already}')
+"""
+    encoded_compaction_inject = base64.b64encode(_compaction_inject_script.encode()).decode()
+    r_compaction_inject = await sandbox.exec(
+        f"echo {encoded_compaction_inject} | base64 -d | python3",
+        timeout_sec=10,
+    )
+    stdout_compaction_inject = (r_compaction_inject.stdout or "").strip()
+    logger.info("OpenHands compaction inject: %s", stdout_compaction_inject)
+    if r_compaction_inject.return_code != 0 or "openhands_compaction_inject=False" in stdout_compaction_inject:
+        logger.warning(
+            "OpenHands compaction inject problem (rc=%d): %s",
+            r_compaction_inject.return_code,
+            stdout_compaction_inject or (r_compaction_inject.stderr or "")[:300],
         )
 
 
@@ -1831,7 +1940,7 @@ def _terminus2_nel_set_proactive_pending_compaction(self, chat, prompt: str, sub
     self._nel_last_unwind_target = None
     self._nel_cle_chat_reset_applied = False
     self._nel_pending_compaction = self._nel_make_compaction_event(
-        trigger="proactive_threshold",
+        trigger="terminus_proactive_threshold",
         strategy="terminus_three_phase_subagent",
         replacement_content=prompt,
         subagent_refs=subagent_refs,
@@ -1866,7 +1975,7 @@ def _terminus2_nel_set_cle_pending_compaction(
             after_chat_reset=tokens_after_chat_reset,
         )
     self._nel_pending_compaction = self._nel_make_compaction_event(
-        trigger="context_length_exceeded",
+        trigger="terminus_context_length_exceeded",
         strategy=strategy,
         replacement_content=summary_prompt,
         subagent_refs=subagent_refs,

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -668,7 +668,7 @@ new_cond_build = (
     '        from openhands.sdk.context.condenser import LLMSummarizingCondenser\\n'
     '        _hdrs = dict(llm.extra_headers or {})\\n'
     '        _hdrs["x-nel-call-kind"] = "compaction"\\n'
-    '        _cond_llm = llm.model_copy(update={"extra_headers": _hdrs})\\n'
+    '        _cond_llm = llm.model_copy(update={"extra_headers": _hdrs, "usage_id": f"{llm.usage_id}-compaction"})\\n'
     '        _ck = {"llm": _cond_llm, "max_size": int(_cms), "keep_first": 4}\\n'
     '        _cmt = os.environ.get("OH_CONDENSER_MAX_TOKENS")\\n'
     '        if _cmt:\\n'

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1862,6 +1862,7 @@ def _terminus2_nel_make_compaction_event(
     tokens_before: CompactionTokens,
     tokens_after: CompactionTokens,
     tokens_intermediate: CompactionTokensIntermediate | None = None,
+    handoff_prompt: str | None = None,
 ) -> CompactionEvent:
     from nemo_evaluator.solvers.compaction_logging import (
         CompactionEvent,
@@ -1883,6 +1884,7 @@ def _terminus2_nel_make_compaction_event(
         llm_call_count=llm_call_count_for_strategy(strategy),
         mechanism=self._nel_compaction_mechanism(),
         subagent_trajectory_ref=subagent_trajectory_refs_to_dicts(subagent_refs),
+        handoff_prompt=handoff_prompt,
         attempts=attempts or None,
     )
 
@@ -1905,6 +1907,8 @@ def _terminus2_nel_record_failed_compaction_attempt(
 
 
 def _terminus2_nel_set_proactive_pending_compaction(self, chat, prompt: str, subagent_refs: Any) -> None:
+    from nemo_evaluator.solvers.compaction_logging import serialize_chat_messages
+
     self._nel_ensure_compaction_state()
     tokens_before = self._nel_stashed_tokens_before
     tokens_after = self._nel_stashed_tokens_after
@@ -1917,15 +1921,17 @@ def _terminus2_nel_set_proactive_pending_compaction(self, chat, prompt: str, sub
     self._nel_last_unwind_pairs = 0
     self._nel_last_unwind_target = None
     self._nel_cle_chat_reset_applied = False
+    replacement_messages = list(chat.messages) + [{"role": "user", "content": prompt}]
     self._nel_pending_compaction = self._nel_make_compaction_event(
         trigger="terminus_proactive_threshold",
         strategy="terminus_three_phase_subagent",
-        replacement_content=prompt,
+        replacement_content=serialize_chat_messages(replacement_messages),
         subagent_refs=subagent_refs,
         attempts=None,
         tokens_before=tokens_before,
         tokens_after=tokens_after,
         tokens_intermediate=tokens_intermediate,
+        handoff_prompt=prompt,
     )
     self._nel_stashed_tokens_before = None
     self._nel_stashed_tokens_after = None
@@ -1934,6 +1940,7 @@ def _terminus2_nel_set_proactive_pending_compaction(self, chat, prompt: str, sub
 
 def _terminus2_nel_set_cle_pending_compaction(
     self,
+    chat,
     summary_prompt: str,
     strategy: CompactionStrategy,
     attempts: list[CompactionAttempt],
@@ -1943,7 +1950,10 @@ def _terminus2_nel_set_cle_pending_compaction(
     tokens_after_unwind: CompactionTokens | None,
     tokens_after_chat_reset: CompactionTokens | None,
 ) -> None:
-    from nemo_evaluator.solvers.compaction_logging import CompactionTokensIntermediate
+    from nemo_evaluator.solvers.compaction_logging import (
+        CompactionTokensIntermediate,
+        serialize_chat_messages,
+    )
 
     self._nel_ensure_compaction_state()
     tokens_intermediate = None
@@ -1955,12 +1965,13 @@ def _terminus2_nel_set_cle_pending_compaction(
     self._nel_pending_compaction = self._nel_make_compaction_event(
         trigger="terminus_context_length_exceeded",
         strategy=strategy,
-        replacement_content=summary_prompt,
+        replacement_content=serialize_chat_messages(list(chat.messages)),
         subagent_refs=subagent_refs,
         attempts=attempts or None,
         tokens_before=tokens_before,
         tokens_after=tokens_after,
         tokens_intermediate=tokens_intermediate,
+        handoff_prompt=summary_prompt,
     )
 
 
@@ -1976,7 +1987,7 @@ def _terminus2_nel_flush_pending_compaction(self, chat) -> None:
     step = compaction_event_to_harbor_step(event, step_id)
     self._trajectory_steps.append(step)
 
-    handoff_prompt = event.replacement_content
+    handoff_prompt = event.handoff_prompt
     self._nel_pending_compaction = None
     self._pending_subagent_refs = None
     self._pending_handoff_prompt = None
@@ -2248,6 +2259,7 @@ _TERMINUS_COMPACTION_QUERY_LLM_PENDING_FLUSH_REPLACEMENT = (
     "                response_path.write_text(llm_response.content)\n"
     "            nel_cle_tokens_after = self._nel_token_snapshot(chat)\n"
     "            self._nel_set_cle_pending_compaction(\n"
+    "                chat,\n"
     "                summary_prompt,\n"
     "                nel_cle_strategy,\n"
     "                nel_cle_attempts,\n"

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import contextlib
+import copy
 import json
 import logging
 import os
@@ -901,6 +902,46 @@ print(f'budget_flush={success}')
 # ---------------------------------------------------------------------------
 
 
+def _flatten_atif_continuation_chain(root: dict[str, Any], agent_logs_dir: Path) -> dict[str, Any]:
+    merged = copy.deepcopy(root)
+    steps: list[dict[str, Any]] = list(merged.get("steps") or [])
+    current = root
+    while True:
+        continued_ref = current.get("continued_trajectory_ref")
+        if not continued_ref or not isinstance(continued_ref, str):
+            break
+        next_path = agent_logs_dir / continued_ref
+        if not next_path.is_file():
+            logger.warning(
+                "continued_trajectory_ref %r points to missing file %s",
+                continued_ref,
+                next_path,
+            )
+            break
+        try:
+            continuation = json.loads(next_path.read_text())
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Failed to read continuation trajectory %s: %s", next_path, exc)
+            break
+        if not isinstance(continuation, dict):
+            break
+        cont_steps = continuation.get("steps")
+        if isinstance(cont_steps, list):
+            steps.extend(copy.deepcopy(cont_steps))
+        current = continuation
+
+    for index, step in enumerate(steps, start=1):
+        if isinstance(step, dict):
+            step["step_id"] = index
+
+    merged["steps"] = steps
+    merged.pop("continued_trajectory_ref", None)
+    final_metrics = current.get("final_metrics")
+    if isinstance(final_metrics, dict):
+        merged["final_metrics"] = copy.deepcopy(final_metrics)
+    return merged
+
+
 def _recover_from_logs(agent_logs_dir: Path) -> dict[str, Any]:
     """Read trajectory + token counts from *agent_logs_dir*.
 
@@ -932,8 +973,14 @@ def _recover_from_logs(agent_logs_dir: Path) -> dict[str, Any]:
 
         parsed = _parse_atif(raw)
         if parsed:
+            doc = parsed["doc"]
+            if tf.name == "trajectory.json":
+                doc = _flatten_atif_continuation_chain(doc, agent_logs_dir)
+                merged_parse = _parse_atif(doc)
+                if merged_parse:
+                    parsed = merged_parse
             logger.info("Trajectory loaded from %s", tf.name)
-            out["trajectory"] = [parsed["doc"]]
+            out["trajectory"] = [doc]
             out["prompt_tokens"] = parsed["prompt_tokens"]
             out["completion_tokens"] = parsed["completion_tokens"]
             out["response"] = parsed["response"]

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -33,6 +33,16 @@ from typing import TYPE_CHECKING, Any
 from nemo_evaluator.errors import GracefulError, InfraError
 from nemo_evaluator.observability.types import ModelResponse
 from nemo_evaluator.solvers.base import ErrorKind, SolveResult
+from nemo_evaluator.solvers.compaction_logging import (
+    CompactionAttempt,
+    CompactionEvent,
+    CompactionMechanism,
+    CompactionStrategy,
+    CompactionTokens,
+    CompactionTokensIntermediate,
+    CompactionTrigger,
+    StepsCompacted,
+)
 from nemo_evaluator.solvers.trajectory_util import build_atif_trajectory
 
 if TYPE_CHECKING:
@@ -1249,6 +1259,7 @@ def _patch_terminus_tmux_send_keys() -> None:
 
 
 _TERMINUS_CLE_RESET_PATCHED = False
+_TERMINUS_QUERY_LLM_SRC: str | None = None
 
 _TERMINUS_CLE_RESET_REPLACEMENTS = [
     (
@@ -1321,7 +1332,7 @@ def _terminus2_build_local_fallback_llm_content(self) -> str:
 
 
 def _patch_terminus_cle_reset() -> None:
-    global _TERMINUS_CLE_RESET_PATCHED
+    global _TERMINUS_CLE_RESET_PATCHED, _TERMINUS_QUERY_LLM_SRC
     if _TERMINUS_CLE_RESET_PATCHED:
         return
 
@@ -1331,7 +1342,9 @@ def _patch_terminus_cle_reset() -> None:
     from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
 
     original = terminus2_mod.Terminus2._query_llm
-    src = inspect.getsource(inspect.unwrap(original))
+    if _TERMINUS_QUERY_LLM_SRC is None:
+        _TERMINUS_QUERY_LLM_SRC = inspect.getsource(inspect.unwrap(original))
+    src = _TERMINUS_QUERY_LLM_SRC
 
     if "full_summarize_failed_with_cle" in src:
         _TERMINUS_CLE_RESET_PATCHED = True
@@ -1354,6 +1367,7 @@ def _patch_terminus_cle_reset() -> None:
     namespace: dict[str, Any] = {}
     exec(textwrap.dedent(src), terminus2_mod.__dict__, namespace)
     terminus2_mod.Terminus2._query_llm = namespace["_query_llm"]
+    _TERMINUS_QUERY_LLM_SRC = src
     _TERMINUS_CLE_RESET_PATCHED = True
     logger.info("Patched Terminus2._query_llm: reset chat on full-summary CLE + parseable local fallback")
 
@@ -1387,6 +1401,16 @@ _TERMINUS_UNWIND_REPLACEMENTS = [
         "                pairs_removed += 1\n"
         "            else:\n"
         "                break\n",
+    ),
+    (
+        "        chat.reset_response_chain()\n"
+        "        free_tokens = context_limit - self._count_total_tokens(chat)\n"
+        "        self.logger.debug(\n",
+        "        chat.reset_response_chain()\n"
+        "        self._nel_last_unwind_pairs = pairs_removed\n"
+        "        self._nel_last_unwind_target = target_free_tokens\n"
+        "        free_tokens = context_limit - self._count_total_tokens(chat)\n"
+        "        self.logger.debug(\n",
     ),
 ]
 
@@ -1578,6 +1602,565 @@ def _patch_harbor_lite_llm_context_length_matcher() -> None:
     harbor_litellm.LiteLLM._is_context_length_error = _patched
     _HARBOR_LITELLM_CTXLIM_PATCHED = True
     logger.info('Patched Harbor LiteLLM._is_context_length_error to recognize vLLM "model\'s context length" phrasing')
+
+
+_TERMINUS_COMPACTION_PATCHED = False
+
+_RUN_AGENT_LOOP_COMPACTION_ANCHOR = (
+    "            # If we have pending subagent refs, add a system step to record the delegation\n"
+    "            # This must happen before we build the agent step\n"
+    "            # We use len(self._trajectory_steps) + 1 as the step_id to ensure it's sequential\n"
+    "            if self._pending_subagent_refs:\n"
+    "                self._trajectory_steps.append(\n"
+    "                    Step(\n"
+    "                        step_id=len(self._trajectory_steps) + 1,\n"
+    "                        timestamp=datetime.now(timezone.utc).isoformat(),\n"
+    '                        source="system",\n'
+    '                        message="Performed context summarization and handoff to continue task.",\n'
+    "                        observation=Observation(\n"
+    "                            results=[\n"
+    "                                ObservationResult(\n"
+    "                                    subagent_trajectory_ref=self._pending_subagent_refs\n"
+    "                                )\n"
+    "                            ]\n"
+    "                        ),\n"
+    "                    )\n"
+    "                )\n"
+    "                self._pending_subagent_refs = None\n"
+    "\n"
+    "            # Handle handoff prompt based on linear_history mode\n"
+    "            if self._pending_handoff_prompt:\n"
+    "                # If linear_history mode is enabled, split trajectory immediately WITHOUT adding handoff step\n"
+    "                # The handoff step will be added to the continuation trajectory during the split\n"
+    "                if self._linear_history:\n"
+    "                    self._split_trajectory_on_summarization(\n"
+    "                        self._pending_handoff_prompt\n"
+    "                    )\n"
+    "                else:\n"
+    "                    # For non-linear mode, add the handoff prompt as a user step\n"
+    "                    self._trajectory_steps.append(\n"
+    "                        Step(\n"
+    "                            step_id=len(self._trajectory_steps) + 1,\n"
+    "                            timestamp=datetime.now(timezone.utc).isoformat(),\n"
+    '                            source="user",\n'
+    "                            message=self._pending_handoff_prompt,\n"
+    "                        )\n"
+    "                    )\n"
+    "                self._pending_handoff_prompt = None\n"
+)
+
+_RUN_AGENT_LOOP_COMPACTION_REPLACEMENT = "            self._nel_flush_pending_compaction(chat)\n"
+
+_PROACTIVE_COMPACTION_ANCHOR = (
+    "                if proactive_summary_result:\n"
+    "                    prompt, subagent_refs = proactive_summary_result\n"
+    "                    # Store subagent_refs to add a system step later\n"
+    "                    self._pending_subagent_refs = subagent_refs\n"
+    "                    # Also store the handoff prompt to add as a user step\n"
+    "                    self._pending_handoff_prompt = prompt\n"
+)
+
+_PROACTIVE_COMPACTION_REPLACEMENT = (
+    "                if proactive_summary_result:\n"
+    "                    prompt, subagent_refs = proactive_summary_result\n"
+    "                    self._pending_subagent_refs = subagent_refs\n"
+    "                    self._pending_handoff_prompt = prompt\n"
+    "                    self._nel_set_proactive_pending_compaction(chat, prompt, subagent_refs)\n"
+)
+
+_PROACTIVE_CHECK_ANCHOR = (
+    "            try:\n"
+    "                summary_prompt, subagent_trajectory_refs = await self._summarize(\n"
+    "                    chat, original_instruction, session\n"
+    "                )\n"
+    "                return (summary_prompt, subagent_trajectory_refs)\n"
+)
+
+_PROACTIVE_CHECK_REPLACEMENT = (
+    "            try:\n"
+    "                nel_proactive_tokens_before = self._nel_token_snapshot(chat)\n"
+    "                summary_prompt, subagent_trajectory_refs = await self._summarize(\n"
+    "                    chat, original_instruction, session\n"
+    "                )\n"
+    "                nel_proactive_tokens_after = self._nel_token_snapshot(chat)\n"
+    "                self._nel_stash_compaction_token_snapshots(\n"
+    "                    nel_proactive_tokens_before,\n"
+    "                    nel_proactive_tokens_after,\n"
+    "                    None,\n"
+    "                )\n"
+    "                return (summary_prompt, subagent_trajectory_refs)\n"
+)
+
+
+def _terminus2_nel_ensure_compaction_state(self) -> None:
+    if not hasattr(self, "_nel_pending_compaction"):
+        self._nel_pending_compaction = None
+    if not hasattr(self, "_nel_compaction_step_overlays"):
+        self._nel_compaction_step_overlays: dict[int, dict[str, Any]] = {}
+    if not hasattr(self, "_nel_last_unwind_pairs"):
+        self._nel_last_unwind_pairs = 0
+    if not hasattr(self, "_nel_last_unwind_target"):
+        self._nel_last_unwind_target = None
+    if not hasattr(self, "_nel_cle_chat_reset_applied"):
+        self._nel_cle_chat_reset_applied = False
+    if not hasattr(self, "_nel_stashed_tokens_before"):
+        self._nel_stashed_tokens_before = None
+    if not hasattr(self, "_nel_stashed_tokens_after"):
+        self._nel_stashed_tokens_after = None
+    if not hasattr(self, "_nel_stashed_tokens_intermediate"):
+        self._nel_stashed_tokens_intermediate = None
+
+
+def _terminus2_nel_stash_compaction_token_snapshots(
+    self,
+    tokens_before: CompactionTokens,
+    tokens_after: CompactionTokens,
+    tokens_intermediate: CompactionTokensIntermediate | None,
+) -> None:
+    self._nel_ensure_compaction_state()
+    self._nel_stashed_tokens_before = tokens_before
+    self._nel_stashed_tokens_after = tokens_after
+    self._nel_stashed_tokens_intermediate = tokens_intermediate
+
+
+def _terminus2_nel_token_snapshot(self, chat) -> CompactionTokens:
+    from nemo_evaluator.solvers.compaction_logging import CompactionTokens
+
+    context_limit = self._llm.get_model_context_limit()
+    current_tokens = self._count_total_tokens(chat)
+    return CompactionTokens(
+        prompt_tokens_approx=current_tokens,
+        context_limit=context_limit,
+        free_tokens=context_limit - current_tokens,
+    )
+
+
+def _terminus2_nel_steps_compacted(self) -> StepsCompacted | None:
+    from nemo_evaluator.solvers.compaction_logging import StepsCompacted
+
+    if not self._trajectory_steps:
+        return None
+    first_step_id = 2 if len(self._trajectory_steps) > 1 else 1
+    last_step_id = len(self._trajectory_steps)
+    if last_step_id < first_step_id:
+        return None
+    return StepsCompacted(
+        first_step_id=first_step_id,
+        last_step_id=last_step_id,
+        step_count=last_step_id - first_step_id + 1,
+    )
+
+
+def _terminus2_nel_compaction_mechanism(self) -> CompactionMechanism:
+    from nemo_evaluator.solvers.compaction_logging import CompactionMechanism
+
+    unwind_pairs = int(getattr(self, "_nel_last_unwind_pairs", 0) or 0)
+    return CompactionMechanism(
+        unwind_applied=unwind_pairs > 0,
+        chat_reset_applied=bool(getattr(self, "_nel_cle_chat_reset_applied", False)),
+        messages_unwound_pairs=unwind_pairs,
+        unwind_target_free_tokens=getattr(self, "_nel_last_unwind_target", None),
+    )
+
+
+def _terminus2_nel_make_compaction_event(
+    self,
+    *,
+    trigger: CompactionTrigger,
+    strategy: CompactionStrategy,
+    replacement_content: str,
+    subagent_refs: Any,
+    attempts: list[CompactionAttempt] | None,
+    tokens_before: CompactionTokens,
+    tokens_after: CompactionTokens,
+    tokens_intermediate: CompactionTokensIntermediate | None = None,
+) -> CompactionEvent:
+    from nemo_evaluator.solvers.compaction_logging import (
+        CompactionEvent,
+        llm_call_count_for_strategy,
+        subagent_trajectory_refs_to_dicts,
+    )
+
+    if strategy != "terminus_three_phase_subagent":
+        self._summarization_count += 1
+    compaction_index = self._summarization_count
+    return CompactionEvent(
+        compaction_index=compaction_index,
+        trigger=trigger,
+        strategy=strategy,
+        replacement_content=replacement_content,
+        tokens_before=tokens_before,
+        tokens_after=tokens_after,
+        tokens_intermediate=tokens_intermediate,
+        llm_call_count=llm_call_count_for_strategy(strategy),
+        steps_compacted=self._nel_steps_compacted(),
+        mechanism=self._nel_compaction_mechanism(),
+        subagent_trajectory_ref=subagent_trajectory_refs_to_dicts(subagent_refs),
+        attempts=attempts or None,
+    )
+
+
+def _terminus2_nel_record_failed_compaction_attempt(
+    self,
+    attempts: list[CompactionAttempt],
+    strategy: CompactionStrategy,
+    error: str,
+) -> None:
+    from nemo_evaluator.solvers.compaction_logging import CompactionAttempt, llm_call_count_for_strategy
+
+    attempts.append(
+        CompactionAttempt(
+            strategy=strategy,
+            error=error,
+            llm_calls=llm_call_count_for_strategy(strategy),
+        )
+    )
+
+
+def _terminus2_nel_set_proactive_pending_compaction(self, chat, prompt: str, subagent_refs: Any) -> None:
+    self._nel_ensure_compaction_state()
+    tokens_before = self._nel_stashed_tokens_before
+    tokens_after = self._nel_stashed_tokens_after
+    tokens_intermediate = self._nel_stashed_tokens_intermediate
+    if tokens_before is None or tokens_after is None:
+        raise RuntimeError(
+            "Proactive compaction token snapshots are missing; "
+            "_check_proactive_summarization was not patched to capture them."
+        )
+    self._nel_last_unwind_pairs = 0
+    self._nel_last_unwind_target = None
+    self._nel_cle_chat_reset_applied = False
+    self._nel_pending_compaction = self._nel_make_compaction_event(
+        trigger="proactive_threshold",
+        strategy="terminus_three_phase_subagent",
+        replacement_content=prompt,
+        subagent_refs=subagent_refs,
+        attempts=None,
+        tokens_before=tokens_before,
+        tokens_after=tokens_after,
+        tokens_intermediate=tokens_intermediate,
+    )
+    self._nel_stashed_tokens_before = None
+    self._nel_stashed_tokens_after = None
+    self._nel_stashed_tokens_intermediate = None
+
+
+def _terminus2_nel_set_cle_pending_compaction(
+    self,
+    summary_prompt: str,
+    strategy: CompactionStrategy,
+    attempts: list[CompactionAttempt],
+    subagent_refs: Any,
+    tokens_before: CompactionTokens,
+    tokens_after: CompactionTokens,
+    tokens_after_unwind: CompactionTokens | None,
+    tokens_after_chat_reset: CompactionTokens | None,
+) -> None:
+    from nemo_evaluator.solvers.compaction_logging import CompactionTokensIntermediate
+
+    self._nel_ensure_compaction_state()
+    tokens_intermediate = None
+    if tokens_after_unwind is not None or tokens_after_chat_reset is not None:
+        tokens_intermediate = CompactionTokensIntermediate(
+            after_unwind=tokens_after_unwind,
+            after_chat_reset=tokens_after_chat_reset,
+        )
+    self._nel_pending_compaction = self._nel_make_compaction_event(
+        trigger="context_length_exceeded",
+        strategy=strategy,
+        replacement_content=summary_prompt,
+        subagent_refs=subagent_refs,
+        attempts=attempts or None,
+        tokens_before=tokens_before,
+        tokens_after=tokens_after,
+        tokens_intermediate=tokens_intermediate,
+    )
+
+
+def _terminus2_nel_flush_pending_compaction(self, chat) -> None:
+    from nemo_evaluator.solvers.compaction_logging import compaction_event_to_harbor_step
+
+    self._nel_ensure_compaction_state()
+    event = self._nel_pending_compaction
+    if event is None:
+        return
+
+    step_id = len(self._trajectory_steps) + 1
+    step, llm_call_count = compaction_event_to_harbor_step(event, step_id)
+    self._trajectory_steps.append(step)
+    self._nel_compaction_step_overlays[step_id] = {"llm_call_count": llm_call_count}
+
+    handoff_prompt = event.replacement_content
+    self._nel_pending_compaction = None
+    self._pending_subagent_refs = None
+    self._pending_handoff_prompt = None
+    self._nel_cle_chat_reset_applied = False
+    self._nel_last_unwind_pairs = 0
+    self._nel_last_unwind_target = None
+
+    if self._linear_history and handoff_prompt:
+        self._split_trajectory_on_summarization(handoff_prompt)
+
+
+def _terminus2_nel_dump_trajectory_with_continuation_index(self, continuation_index: int) -> None:
+    from harbor.models.trajectories.agent import Agent
+    from harbor.models.trajectories.final_metrics import FinalMetrics
+    from harbor.models.trajectories.trajectory import Trajectory
+    from harbor.utils.trajectory_utils import format_trajectory_json
+
+    if not self._context:
+        self.logger.warning("No context available, skipping trajectory dump")
+        return
+
+    final_metrics = FinalMetrics(
+        total_prompt_tokens=self._context.n_input_tokens,
+        total_completion_tokens=self._context.n_output_tokens,
+        total_cached_tokens=self._context.n_cache_tokens or 0,
+        total_cost_usd=self._context.cost_usd if self._context.cost_usd else None,
+    )
+
+    agent_extra = {
+        "parser": self._parser_name,
+        "temperature": self._temperature,
+    }
+    if self._llm_kwargs:
+        agent_extra["llm_kwargs"] = self._llm_kwargs
+    if self._linear_history and continuation_index > 0:
+        agent_extra["continuation_index"] = continuation_index
+
+    continued_trajectory_ref = None
+    if self._linear_history and continuation_index < self._summarization_count:
+        next_continuation_index = continuation_index + 1
+        continued_trajectory_ref = f"trajectory.cont-{next_continuation_index}.json"
+
+    trajectory = Trajectory(
+        session_id=self._session_id,
+        agent=Agent(
+            name=self.name(),
+            version=self.version() or "unknown",
+            model_name=self._model_name,
+            extra=agent_extra,
+        ),
+        steps=self._trajectory_steps,
+        final_metrics=final_metrics,
+        continued_trajectory_ref=continued_trajectory_ref,
+    )
+
+    if self._linear_history and continuation_index > 0:
+        trajectory_path = self.logs_dir / f"trajectory.cont-{continuation_index}.json"
+    else:
+        trajectory_path = self.logs_dir / "trajectory.json"
+
+    trajectory_dict = trajectory.to_json_dict()
+    overlays = getattr(self, "_nel_compaction_step_overlays", None) or {}
+    for step in trajectory_dict.get("steps", []):
+        step_id = step.get("step_id")
+        if step_id in overlays:
+            step.update(overlays[step_id])
+
+    try:
+        with open(trajectory_path, "w") as f:
+            json_str = format_trajectory_json(trajectory_dict)
+            f.write(json_str)
+        self.logger.debug(f"Trajectory dumped to {trajectory_path}")
+    except Exception as e:
+        self.logger.error(f"Failed to dump trajectory: {e}")
+
+
+def _apply_source_replacements(src: str, replacements: list[tuple[str, str]], *, label: str) -> str:
+    for anchor, replacement in replacements:
+        occurrences = src.count(anchor)
+        if occurrences != 1:
+            raise RuntimeError(
+                f"Cannot patch {label}: expected exactly one match for an anchor but found "
+                f"{occurrences}. Harbor's terminus_2.py has diverged from the expected source."
+            )
+        src = src.replace(anchor, replacement, 1)
+    return src
+
+
+def _patch_terminus_compaction_logging() -> None:
+    global _TERMINUS_COMPACTION_PATCHED, _TERMINUS_QUERY_LLM_SRC
+    if _TERMINUS_COMPACTION_PATCHED:
+        return
+
+    import inspect
+    import textwrap
+
+    from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
+
+    terminus2_mod.Terminus2._nel_ensure_compaction_state = _terminus2_nel_ensure_compaction_state
+    terminus2_mod.Terminus2._nel_stash_compaction_token_snapshots = _terminus2_nel_stash_compaction_token_snapshots
+    terminus2_mod.Terminus2._nel_token_snapshot = _terminus2_nel_token_snapshot
+    terminus2_mod.Terminus2._nel_steps_compacted = _terminus2_nel_steps_compacted
+    terminus2_mod.Terminus2._nel_compaction_mechanism = _terminus2_nel_compaction_mechanism
+    terminus2_mod.Terminus2._nel_make_compaction_event = _terminus2_nel_make_compaction_event
+    terminus2_mod.Terminus2._nel_record_failed_compaction_attempt = _terminus2_nel_record_failed_compaction_attempt
+    terminus2_mod.Terminus2._nel_set_proactive_pending_compaction = _terminus2_nel_set_proactive_pending_compaction
+    terminus2_mod.Terminus2._nel_set_cle_pending_compaction = _terminus2_nel_set_cle_pending_compaction
+    terminus2_mod.Terminus2._nel_flush_pending_compaction = _terminus2_nel_flush_pending_compaction
+    terminus2_mod.Terminus2._dump_trajectory_with_continuation_index = (
+        _terminus2_nel_dump_trajectory_with_continuation_index
+    )
+
+    run_loop_src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._run_agent_loop))
+    if "_nel_flush_pending_compaction" in run_loop_src:
+        _TERMINUS_COMPACTION_PATCHED = True
+        logger.info("Terminus2._run_agent_loop already contains compaction logging; skipping patch")
+        return
+
+    run_loop_src = _apply_source_replacements(
+        run_loop_src,
+        [
+            (_PROACTIVE_COMPACTION_ANCHOR, _PROACTIVE_COMPACTION_REPLACEMENT),
+            (_RUN_AGENT_LOOP_COMPACTION_ANCHOR, _RUN_AGENT_LOOP_COMPACTION_REPLACEMENT),
+        ],
+        label="Terminus2._run_agent_loop for compaction logging",
+    )
+    run_loop_namespace: dict[str, Any] = {}
+    exec(textwrap.dedent(run_loop_src), terminus2_mod.__dict__, run_loop_namespace)
+    terminus2_mod.Terminus2._run_agent_loop = run_loop_namespace["_run_agent_loop"]
+
+    proactive_method = inspect.unwrap(terminus2_mod.Terminus2._check_proactive_summarization)
+    try:
+        proactive_src = inspect.getsource(proactive_method)
+    except OSError:
+        proactive_src = ""
+    if "_nel_stash_compaction_token_snapshots" not in proactive_src:
+        if not proactive_src:
+            if "_nel_stash_compaction_token_snapshots" not in proactive_method.__code__.co_names:
+                raise RuntimeError(
+                    "Cannot patch Terminus2._check_proactive_summarization for compaction logging: "
+                    "source is unavailable and the method is not already patched."
+                )
+        else:
+            proactive_src = _apply_source_replacements(
+                proactive_src,
+                [(_PROACTIVE_CHECK_ANCHOR, _PROACTIVE_CHECK_REPLACEMENT)],
+                label="Terminus2._check_proactive_summarization for compaction logging",
+            )
+            proactive_namespace: dict[str, Any] = {}
+            exec(textwrap.dedent(proactive_src), terminus2_mod.__dict__, proactive_namespace)
+            terminus2_mod.Terminus2._check_proactive_summarization = proactive_namespace[
+                "_check_proactive_summarization"
+            ]
+
+    if _TERMINUS_QUERY_LLM_SRC is None:
+        _TERMINUS_QUERY_LLM_SRC = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._query_llm))
+    query_src = _TERMINUS_QUERY_LLM_SRC
+    if "_nel_set_cle_pending_compaction" not in query_src:
+        query_replacements = [
+            (
+                "            self._unwind_messages_to_free_tokens(chat, target_free_tokens=4000)\n"
+                "\n"
+                "            summary_prompt = None\n",
+                "            nel_cle_tokens_before = self._nel_token_snapshot(chat)\n"
+                "            nel_cle_tokens_after_unwind = None\n"
+                "            nel_cle_tokens_after_chat_reset = None\n"
+                "            self._unwind_messages_to_free_tokens(chat, target_free_tokens=4000)\n"
+                "            nel_cle_tokens_after_unwind = self._nel_token_snapshot(chat)\n"
+                "            nel_cle_attempts = []\n"
+                '            nel_cle_strategy = "terminus_ultimate_fallback"\n'
+                "            nel_cle_subagent_refs = None\n"
+                "\n"
+                "            summary_prompt = None\n",
+            ),
+            (
+                '                self.logger.debug("SUMMARIZATION: Full summary succeeded")\n',
+                '                self.logger.debug("SUMMARIZATION: Full summary succeeded")\n'
+                '                nel_cle_strategy = "terminus_three_phase_subagent"\n'
+                "                nel_cle_subagent_refs = subagent_trajectory_refs\n",
+            ),
+            (
+                '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n',
+                '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n'
+                "                self._nel_record_failed_compaction_attempt(\n"
+                '                    nel_cle_attempts, "terminus_three_phase_subagent", str(e)\n'
+                "                )\n",
+            ),
+            (
+                '                    self.logger.debug("SUMMARIZATION: Short summary succeeded")\n',
+                '                    self.logger.debug("SUMMARIZATION: Short summary succeeded")\n'
+                '                    nel_cle_strategy = "terminus_short_fallback"\n',
+            ),
+            (
+                '                    self.logger.error(f"SUMMARIZATION: Short summary failed: {e}")\n',
+                '                    self.logger.error(f"SUMMARIZATION: Short summary failed: {e}")\n'
+                "                    self._nel_record_failed_compaction_attempt(\n"
+                '                        nel_cle_attempts, "terminus_short_fallback", str(e)\n'
+                "                    )\n",
+            ),
+        ]
+        if "full_summarize_failed_with_cle" in query_src:
+            query_replacements.append(
+                (
+                    "            if full_summarize_failed_with_cle:\n"
+                    "                chat._messages = [chat.messages[0]]\n"
+                    "                chat.reset_response_chain()\n",
+                    "            if full_summarize_failed_with_cle:\n"
+                    "                chat._messages = [chat.messages[0]]\n"
+                    "                chat.reset_response_chain()\n"
+                    "                self._nel_cle_chat_reset_applied = True\n"
+                    "                nel_cle_tokens_after_chat_reset = self._nel_token_snapshot(chat)\n",
+                )
+            )
+        else:
+            query_replacements.append(
+                (
+                    "            if prompt_path is not None:\n"
+                    "                prompt_path.write_text(summary_prompt)\n"
+                    "\n"
+                    "            try:\n"
+                    "                start_time = time.time()\n"
+                    "                llm_response = await chat.chat(\n",
+                    "            if prompt_path is not None:\n"
+                    "                prompt_path.write_text(summary_prompt)\n"
+                    "\n"
+                    "            self._nel_cle_chat_reset_applied = False\n"
+                    "\n"
+                    "            try:\n"
+                    "                start_time = time.time()\n"
+                    "                llm_response = await chat.chat(\n",
+                )
+            )
+
+        query_replacements.append(
+            (
+                "            if response_path is not None:\n"
+                "                response_path.write_text(llm_response.content)\n"
+                "            return llm_response\n"
+                "\n"
+                "        except OutputLengthExceededError as e:\n",
+                "            if response_path is not None:\n"
+                "                response_path.write_text(llm_response.content)\n"
+                "            nel_cle_tokens_after = self._nel_token_snapshot(chat)\n"
+                "            self._nel_set_cle_pending_compaction(\n"
+                "                summary_prompt,\n"
+                "                nel_cle_strategy,\n"
+                "                nel_cle_attempts,\n"
+                "                nel_cle_subagent_refs,\n"
+                "                nel_cle_tokens_before,\n"
+                "                nel_cle_tokens_after,\n"
+                "                nel_cle_tokens_after_unwind,\n"
+                "                nel_cle_tokens_after_chat_reset,\n"
+                "            )\n"
+                "            return llm_response\n"
+                "\n"
+                "        except OutputLengthExceededError as e:\n",
+            )
+        )
+        query_src = _apply_source_replacements(
+            query_src,
+            query_replacements,
+            label="Terminus2._query_llm for compaction logging",
+        )
+        query_namespace: dict[str, Any] = {}
+        exec(textwrap.dedent(query_src), terminus2_mod.__dict__, query_namespace)
+        terminus2_mod.Terminus2._query_llm = query_namespace["_query_llm"]
+        _TERMINUS_QUERY_LLM_SRC = query_src
+
+    _TERMINUS_COMPACTION_PATCHED = True
+    logger.info("Patched Terminus2 for ATIF context compaction logging")
 
 
 _TOKENIZER_REGISTRY: dict[str, dict] = {}
@@ -1788,6 +2371,7 @@ class HarborSolver:
             _patch_terminus_unwind_min_pairs()
             _patch_terminus_api_token_anchor()
             _patch_harbor_lite_llm_context_length_matcher()
+            _patch_terminus_compaction_logging()
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
         _configure_terminus_tokenizer(

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1813,6 +1813,8 @@ def _terminus2_nel_ensure_compaction_state(self) -> None:
         self._nel_stashed_tokens_after = None
     if not hasattr(self, "_nel_stashed_tokens_intermediate"):
         self._nel_stashed_tokens_intermediate = None
+    if not hasattr(self, "_nel_compaction_count"):
+        self._nel_compaction_count = 0
 
 
 def _terminus2_nel_stash_compaction_token_snapshots(
@@ -1870,9 +1872,9 @@ def _terminus2_nel_make_compaction_event(
         subagent_trajectory_refs_to_dicts,
     )
 
-    if strategy != "terminus_three_phase_subagent":
-        self._summarization_count += 1
-    compaction_index = self._summarization_count
+    self._nel_ensure_compaction_state()
+    self._nel_compaction_count += 1
+    compaction_index = self._nel_compaction_count
     return CompactionEvent(
         compaction_index=compaction_index,
         trigger=trigger,

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -321,6 +321,11 @@ async def _patch_openhands_sdk(sandbox: Sandbox, *, cmd_timeout: float | None = 
     6. **Log OpenHands condensation in ATIF trajectories** — upload NEL
        compaction helpers and splice system compaction steps after
        ``build_trajectory()`` when ``Condensation`` events are present.
+
+    7. **Exclude condensation-only steps from ``max_iteration_per_run``** —
+       when ``agent.step`` returns after emitting ``Condensation``, do not
+       increment the conversation iteration counter so compaction does not
+       consume the agent step budget.
     """
     # -- Patch 0: disable stuck detection + default visualizer -----------
     # stuck_detection=False: the SDK's heuristic mis-flags reasoning-model
@@ -443,6 +448,81 @@ print(f'agent.py FINISHED={ok1} nudge={ok2} at {p}')
             "Agent.py patch problem (rc=%d): %s",
             r2.return_code,
             stdout2 or (r2.stderr or "")[:300],
+        )
+
+    _max_iter_patch_script = """\
+import glob
+fs = glob.glob('/opt/openhands-sdk-venv/lib/python*/site-packages/openhands/sdk/conversation/impl/local_conversation.py')
+p = fs[0] if fs else ''
+assert p, 'local_conversation.py not found'
+c = open(p).read()
+if '_nel_last = self._state.events[-1]' in c:
+    print(f'local_conversation.py max_iter condensation skip: already patched at {p}')
+else:
+    old_imp = (
+        'from openhands.sdk.event import (\\n'
+        '    ActionEvent,\\n'
+        '    AgentErrorEvent,\\n'
+        '    CondensationRequest,\\n'
+    )
+    new_imp = (
+        'from openhands.sdk.event import (\\n'
+        '    ActionEvent,\\n'
+        '    AgentErrorEvent,\\n'
+        '    Condensation,\\n'
+        '    CondensationRequest,\\n'
+    )
+    ok_imp = old_imp in c
+    if ok_imp:
+        c = c.replace(old_imp, new_imp, 1)
+    old_inc = (
+        '                    finally:\\n'
+        '                        self._step_holds_state_lock = False\\n'
+        '                    iteration += 1\\n'
+    )
+    new_inc = (
+        '                    finally:\\n'
+        '                        self._step_holds_state_lock = False\\n'
+        '                    _nel_last = self._state.events[-1] if self._state.events else None\\n'
+        '                    if not isinstance(_nel_last, Condensation):\\n'
+        '                        iteration += 1\\n'
+    )
+    n_inc = c.count(old_inc)
+    if n_inc:
+        c = c.replace(old_inc, new_inc)
+    old_inc_async = (
+        '                        finally:\\n'
+        '                            self._step_holds_state_lock = False\\n'
+        '                        iteration += 1\\n'
+    )
+    new_inc_async = (
+        '                        finally:\\n'
+        '                            self._step_holds_state_lock = False\\n'
+        '                        _nel_last = self._state.events[-1] if self._state.events else None\\n'
+        '                        if not isinstance(_nel_last, Condensation):\\n'
+        '                            iteration += 1\\n'
+    )
+    n_inc_async = c.count(old_inc_async)
+    if n_inc_async:
+        c = c.replace(old_inc_async, new_inc_async)
+    if ok_imp or n_inc or n_inc_async:
+        open(p, 'w').write(c)
+    print(f'local_conversation.py max_iter condensation skip: import={ok_imp} sync={n_inc} async={n_inc_async} at {p}')
+"""
+    encoded_max_iter = base64.b64encode(_max_iter_patch_script.encode()).decode()
+    r_max_iter = await sandbox.exec(
+        f"echo {encoded_max_iter} | base64 -d | python3",
+        timeout_sec=10,
+    )
+    stdout_max_iter = (r_max_iter.stdout or "").strip()
+    logger.info("Max-iteration condensation skip patch: %s", stdout_max_iter)
+    if r_max_iter.return_code != 0 or (
+        "already patched" not in stdout_max_iter and "sync=0" in stdout_max_iter and "async=0" in stdout_max_iter
+    ):
+        logger.warning(
+            "Max-iteration condensation skip patch problem (rc=%d): %s",
+            r_max_iter.return_code,
+            stdout_max_iter or (r_max_iter.stderr or "")[:300],
         )
 
     # -- Patch 2: capture reasoning, metrics, and tool timing in ATIF --------
@@ -586,7 +666,10 @@ new_cond_build = (
     '    _cms = os.environ.get("OH_CONDENSER_MAX_SIZE")\\n'
     '    if _cms:\\n'
     '        from openhands.sdk.context.condenser import LLMSummarizingCondenser\\n'
-    '        _ck = {"llm": llm, "max_size": int(_cms), "keep_first": 4}\\n'
+    '        _hdrs = dict(llm.extra_headers or {})\\n'
+    '        _hdrs["x-nel-call-kind"] = "compaction"\\n'
+    '        _cond_llm = llm.model_copy(update={"extra_headers": _hdrs})\\n'
+    '        _ck = {"llm": _cond_llm, "max_size": int(_cms), "keep_first": 4}\\n'
     '        _cmt = os.environ.get("OH_CONDENSER_MAX_TOKENS")\\n'
     '        if _cmt:\\n'
     '            _ck["max_tokens"] = int(_cmt)\\n'
@@ -2062,6 +2145,65 @@ def _apply_source_replacements(src: str, replacements: list[tuple[str, str]], *,
     return src
 
 
+def _strip_def_indent(src: str) -> str:
+    lines = src.splitlines(True)
+    if not lines:
+        return src
+    first = lines[0]
+    indent = len(first) - len(first.lstrip(" "))
+    if indent == 0:
+        return src
+    prefix = " " * indent
+    return "".join(line[indent:] if line.startswith(prefix) else line for line in lines)
+
+
+_SHORT_SUMMARY_LLM_CALL_ANCHOR = (
+    "                    short_llm_response: LLMResponse = await self._llm.call(\n"
+    "                        prompt=short_prompt,\n"
+    "                        **self._llm_call_kwargs,\n"
+    "                    )\n"
+)
+_SHORT_SUMMARY_LLM_CALL_REPLACEMENT = (
+    "                    short_llm_response: LLMResponse = await self._llm.call(\n"
+    "                        prompt=short_prompt,\n"
+    "                        **self._nel_compaction_llm_call_kwargs(),\n"
+    "                    )\n"
+)
+
+_RUN_SUBAGENT_KWARGS_ANCHOR = (
+    "        response: LLMResponse = await self._llm.call(\n"
+    "            prompt=prompt,\n"
+    "            message_history=message_history,\n"
+    "            **self._llm_call_kwargs,\n"
+    "        )\n"
+)
+_RUN_SUBAGENT_KWARGS_REPLACEMENT = (
+    "        response: LLMResponse = await self._llm.call(\n"
+    "            prompt=prompt,\n"
+    "            message_history=message_history,\n"
+    "            **(llm_call_kwargs if llm_call_kwargs is not None else self._llm_call_kwargs),\n"
+    "        )\n"
+)
+
+_RUN_SUBAGENT_SIGNATURE_ANCHOR = (
+    "        summary_text: str,\n"
+    '        subagent_name_for_logging: str = "subagent",\n'
+    "    ) -> tuple[LLMResponse, SubagentTrajectoryRef]:\n"
+)
+_RUN_SUBAGENT_SIGNATURE_REPLACEMENT = (
+    "        summary_text: str,\n"
+    '        subagent_name_for_logging: str = "subagent",\n'
+    "        llm_call_kwargs: dict | None = None,\n"
+    "    ) -> tuple[LLMResponse, SubagentTrajectoryRef]:\n"
+)
+
+
+def _terminus2_nel_compaction_llm_call_kwargs(self) -> dict[str, Any]:
+    from nemo_evaluator.adapters.call_kind import merge_compaction_extra_headers
+
+    return merge_compaction_extra_headers(self._llm_call_kwargs)
+
+
 def _patch_terminus_compaction_logging() -> None:
     global _TERMINUS_COMPACTION_PATCHED, _TERMINUS_QUERY_LLM_SRC
     if _TERMINUS_COMPACTION_PATCHED:
@@ -2081,56 +2223,58 @@ def _patch_terminus_compaction_logging() -> None:
     terminus2_mod.Terminus2._nel_set_proactive_pending_compaction = _terminus2_nel_set_proactive_pending_compaction
     terminus2_mod.Terminus2._nel_set_cle_pending_compaction = _terminus2_nel_set_cle_pending_compaction
     terminus2_mod.Terminus2._nel_flush_pending_compaction = _terminus2_nel_flush_pending_compaction
+    terminus2_mod.Terminus2._nel_compaction_llm_call_kwargs = _terminus2_nel_compaction_llm_call_kwargs
     terminus2_mod.Terminus2._dump_trajectory_with_continuation_index = (
         _terminus2_nel_dump_trajectory_with_continuation_index
     )
 
     run_loop_src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._run_agent_loop))
     if "_nel_flush_pending_compaction" in run_loop_src:
-        _TERMINUS_COMPACTION_PATCHED = True
-        logger.info("Terminus2._run_agent_loop already contains compaction logging; skipping patch")
-        return
+        logger.info("Terminus2._run_agent_loop already contains compaction logging; skipping run-loop patch")
+    else:
+        run_loop_src = _apply_source_replacements(
+            run_loop_src,
+            [
+                (_PROACTIVE_COMPACTION_ANCHOR, _PROACTIVE_COMPACTION_REPLACEMENT),
+                (_RUN_AGENT_LOOP_COMPACTION_ANCHOR, _RUN_AGENT_LOOP_COMPACTION_REPLACEMENT),
+            ],
+            label="Terminus2._run_agent_loop for compaction logging",
+        )
+        run_loop_namespace: dict[str, Any] = {}
+        exec(textwrap.dedent(run_loop_src), terminus2_mod.__dict__, run_loop_namespace)
+        terminus2_mod.Terminus2._run_agent_loop = run_loop_namespace["_run_agent_loop"]
 
-    run_loop_src = _apply_source_replacements(
-        run_loop_src,
-        [
-            (_PROACTIVE_COMPACTION_ANCHOR, _PROACTIVE_COMPACTION_REPLACEMENT),
-            (_RUN_AGENT_LOOP_COMPACTION_ANCHOR, _RUN_AGENT_LOOP_COMPACTION_REPLACEMENT),
-        ],
-        label="Terminus2._run_agent_loop for compaction logging",
-    )
-    run_loop_namespace: dict[str, Any] = {}
-    exec(textwrap.dedent(run_loop_src), terminus2_mod.__dict__, run_loop_namespace)
-    terminus2_mod.Terminus2._run_agent_loop = run_loop_namespace["_run_agent_loop"]
-
-    proactive_method = inspect.unwrap(terminus2_mod.Terminus2._check_proactive_summarization)
-    try:
-        proactive_src = inspect.getsource(proactive_method)
-    except OSError:
-        proactive_src = ""
-    if "_nel_stash_compaction_token_snapshots" not in proactive_src:
-        if not proactive_src:
-            if "_nel_stash_compaction_token_snapshots" not in proactive_method.__code__.co_names:
-                raise RuntimeError(
-                    "Cannot patch Terminus2._check_proactive_summarization for compaction logging: "
-                    "source is unavailable and the method is not already patched."
+        proactive_method = inspect.unwrap(terminus2_mod.Terminus2._check_proactive_summarization)
+        try:
+            proactive_src = inspect.getsource(proactive_method)
+        except OSError:
+            proactive_src = ""
+        if "_nel_stash_compaction_token_snapshots" not in proactive_src:
+            if not proactive_src:
+                if "_nel_stash_compaction_token_snapshots" not in proactive_method.__code__.co_names:
+                    raise RuntimeError(
+                        "Cannot patch Terminus2._check_proactive_summarization for compaction logging: "
+                        "source is unavailable and the method is not already patched."
+                    )
+            else:
+                proactive_src = _apply_source_replacements(
+                    proactive_src,
+                    [(_PROACTIVE_CHECK_ANCHOR, _PROACTIVE_CHECK_REPLACEMENT)],
+                    label="Terminus2._check_proactive_summarization for compaction logging",
                 )
-        else:
-            proactive_src = _apply_source_replacements(
-                proactive_src,
-                [(_PROACTIVE_CHECK_ANCHOR, _PROACTIVE_CHECK_REPLACEMENT)],
-                label="Terminus2._check_proactive_summarization for compaction logging",
-            )
-            proactive_namespace: dict[str, Any] = {}
-            exec(textwrap.dedent(proactive_src), terminus2_mod.__dict__, proactive_namespace)
-            terminus2_mod.Terminus2._check_proactive_summarization = proactive_namespace[
-                "_check_proactive_summarization"
-            ]
+                proactive_namespace: dict[str, Any] = {}
+                exec(textwrap.dedent(proactive_src), terminus2_mod.__dict__, proactive_namespace)
+                terminus2_mod.Terminus2._check_proactive_summarization = proactive_namespace[
+                    "_check_proactive_summarization"
+                ]
 
     if _TERMINUS_QUERY_LLM_SRC is None:
-        _TERMINUS_QUERY_LLM_SRC = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._query_llm))
+        try:
+            _TERMINUS_QUERY_LLM_SRC = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._query_llm))
+        except OSError:
+            _TERMINUS_QUERY_LLM_SRC = ""
     query_src = _TERMINUS_QUERY_LLM_SRC
-    if "_nel_set_cle_pending_compaction" not in query_src:
+    if query_src and "_nel_set_cle_pending_compaction" not in query_src:
         query_replacements = [
             (
                 "            self._unwind_messages_to_free_tokens(chat, target_free_tokens=4000)\n"
@@ -2171,6 +2315,10 @@ def _patch_terminus_compaction_logging() -> None:
                 "                    self._nel_record_failed_compaction_attempt(\n"
                 '                        nel_cle_attempts, "terminus_short_fallback", str(e)\n'
                 "                    )\n",
+            ),
+            (
+                _SHORT_SUMMARY_LLM_CALL_ANCHOR,
+                _SHORT_SUMMARY_LLM_CALL_REPLACEMENT,
             ),
         ]
         if "full_summarize_failed_with_cle" in query_src:
@@ -2240,9 +2388,91 @@ def _patch_terminus_compaction_logging() -> None:
         exec(textwrap.dedent(query_src), terminus2_mod.__dict__, query_namespace)
         terminus2_mod.Terminus2._query_llm = query_namespace["_query_llm"]
         _TERMINUS_QUERY_LLM_SRC = query_src
+    elif query_src and "_nel_compaction_llm_call_kwargs()" not in query_src:
+        if _SHORT_SUMMARY_LLM_CALL_ANCHOR not in query_src:
+            raise RuntimeError(
+                "Cannot patch Terminus2._query_llm short-summary call for compaction turn marker: "
+                "expected source anchor not found."
+            )
+        query_src = _apply_source_replacements(
+            query_src,
+            [(_SHORT_SUMMARY_LLM_CALL_ANCHOR, _SHORT_SUMMARY_LLM_CALL_REPLACEMENT)],
+            label="Terminus2._query_llm short-summary compaction turn marker",
+        )
+        query_namespace = {}
+        exec(textwrap.dedent(query_src), terminus2_mod.__dict__, query_namespace)
+        terminus2_mod.Terminus2._query_llm = query_namespace["_query_llm"]
+        _TERMINUS_QUERY_LLM_SRC = query_src
 
     _TERMINUS_COMPACTION_PATCHED = True
     logger.info("Patched Terminus2 for ATIF context compaction logging")
+
+
+_TERMINUS_COMPACTION_TURN_MARKER_PATCHED = False
+
+
+def _patch_terminus_compaction_turn_marker() -> None:
+    global _TERMINUS_COMPACTION_TURN_MARKER_PATCHED
+    if _TERMINUS_COMPACTION_TURN_MARKER_PATCHED:
+        return
+
+    import inspect
+
+    from harbor.agents.terminus_2 import terminus_2 as terminus2_mod
+
+    terminus2_mod.Terminus2._nel_compaction_llm_call_kwargs = _terminus2_nel_compaction_llm_call_kwargs
+
+    run_subagent_src = inspect.getsource(inspect.unwrap(terminus2_mod.Terminus2._run_subagent))
+    if "llm_call_kwargs if llm_call_kwargs is not None" not in run_subagent_src:
+        run_subagent_src = _apply_source_replacements(
+            run_subagent_src,
+            [
+                (_RUN_SUBAGENT_SIGNATURE_ANCHOR, _RUN_SUBAGENT_SIGNATURE_REPLACEMENT),
+                (_RUN_SUBAGENT_KWARGS_ANCHOR, _RUN_SUBAGENT_KWARGS_REPLACEMENT),
+            ],
+            label="Terminus2._run_subagent for optional llm_call_kwargs",
+        )
+        run_subagent_namespace: dict[str, Any] = {}
+        exec(_strip_def_indent(run_subagent_src), terminus2_mod.__dict__, run_subagent_namespace)
+        terminus2_mod.Terminus2._run_subagent = run_subagent_namespace["_run_subagent"]
+
+    summarize_method = inspect.unwrap(terminus2_mod.Terminus2._summarize)
+    try:
+        summarize_src = inspect.getsource(summarize_method)
+    except OSError:
+        summarize_src = ""
+    if summarize_src and "_nel_compaction_llm_call_kwargs()" not in summarize_src:
+        summarize_replacements = [
+            (
+                '            subagent_name_for_logging="summary generation LLM call",\n        )\n',
+                '            subagent_name_for_logging="summary generation LLM call",\n'
+                "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
+                "        )\n",
+            ),
+            (
+                '            subagent_name_for_logging="questions subagent",\n        )\n',
+                '            subagent_name_for_logging="questions subagent",\n'
+                "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
+                "        )\n",
+            ),
+            (
+                '            subagent_name_for_logging="answers subagent",\n        )\n',
+                '            subagent_name_for_logging="answers subagent",\n'
+                "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
+                "        )\n",
+            ),
+        ]
+        summarize_src = _apply_source_replacements(
+            summarize_src,
+            summarize_replacements,
+            label="Terminus2._summarize compaction llm_call_kwargs",
+        )
+        summarize_namespace: dict[str, Any] = {}
+        exec(_strip_def_indent(summarize_src), terminus2_mod.__dict__, summarize_namespace)
+        terminus2_mod.Terminus2._summarize = summarize_namespace["_summarize"]
+
+    _TERMINUS_COMPACTION_TURN_MARKER_PATCHED = True
+    logger.info("Patched Terminus2 to mark compaction LLM calls for turn_counter")
 
 
 _TOKENIZER_REGISTRY: dict[str, dict] = {}
@@ -2454,6 +2684,7 @@ class HarborSolver:
             _patch_terminus_api_token_anchor()
             _patch_harbor_lite_llm_context_length_matcher()
             _patch_terminus_compaction_logging()
+            _patch_terminus_compaction_turn_marker()
         if "model_name" not in kwargs and model_id:
             kwargs["model_name"] = model_id
         _configure_terminus_tokenizer(

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -41,6 +41,10 @@ from nemo_evaluator.solvers.compaction_logging import (
     CompactionTokens,
     CompactionTokensIntermediate,
     CompactionTrigger,
+    compaction_event_to_harbor_step,
+    llm_call_count_for_strategy,
+    serialize_chat_messages,
+    subagent_trajectory_refs_to_dicts,
 )
 from nemo_evaluator.solvers.trajectory_util import build_atif_trajectory
 
@@ -1290,10 +1294,18 @@ def _flatten_atif_continuation_chain(root: dict[str, Any], agent_logs_dir: Path)
     merged = copy.deepcopy(root)
     steps: list[dict[str, Any]] = list(merged.get("steps") or [])
     current = root
+    seen: set[str] = set()
     while True:
         continued_ref = current.get("continued_trajectory_ref")
         if not continued_ref or not isinstance(continued_ref, str):
             break
+        if continued_ref in seen:
+            logger.warning(
+                "Cycle detected in trajectory continuation chain at %r; stopping merge",
+                continued_ref,
+            )
+            break
+        seen.add(continued_ref)
         next_path = agent_logs_dir / continued_ref
         if not next_path.is_file():
             logger.warning(
@@ -2112,8 +2124,6 @@ def _terminus2_nel_stash_compaction_token_snapshots(
 
 
 def _terminus2_nel_token_snapshot(self, chat) -> CompactionTokens:
-    from nemo_evaluator.solvers.compaction_logging import CompactionTokens
-
     context_limit = self._llm.get_model_context_limit()
     current_tokens = self._count_total_tokens(chat)
     return CompactionTokens(
@@ -2124,8 +2134,6 @@ def _terminus2_nel_token_snapshot(self, chat) -> CompactionTokens:
 
 
 def _terminus2_nel_compaction_mechanism(self) -> CompactionMechanism:
-    from nemo_evaluator.solvers.compaction_logging import CompactionMechanism
-
     unwind_pairs = int(getattr(self, "_nel_last_unwind_pairs", 0) or 0)
     return CompactionMechanism(
         unwind_applied=unwind_pairs > 0,
@@ -2148,12 +2156,6 @@ def _terminus2_nel_make_compaction_event(
     tokens_intermediate: CompactionTokensIntermediate | None = None,
     handoff_prompt: str | None = None,
 ) -> CompactionEvent:
-    from nemo_evaluator.solvers.compaction_logging import (
-        CompactionEvent,
-        llm_call_count_for_strategy,
-        subagent_trajectory_refs_to_dicts,
-    )
-
     self._nel_ensure_compaction_state()
     self._nel_compaction_count += 1
     compaction_index = self._nel_compaction_count
@@ -2179,8 +2181,6 @@ def _terminus2_nel_record_failed_compaction_attempt(
     strategy: CompactionStrategy,
     error: str,
 ) -> None:
-    from nemo_evaluator.solvers.compaction_logging import CompactionAttempt, llm_call_count_for_strategy
-
     attempts.append(
         CompactionAttempt(
             strategy=strategy,
@@ -2191,8 +2191,6 @@ def _terminus2_nel_record_failed_compaction_attempt(
 
 
 def _terminus2_nel_set_proactive_pending_compaction(self, chat, prompt: str, subagent_refs: Any) -> None:
-    from nemo_evaluator.solvers.compaction_logging import serialize_chat_messages
-
     self._nel_ensure_compaction_state()
     tokens_before = self._nel_stashed_tokens_before
     tokens_after = self._nel_stashed_tokens_after
@@ -2234,11 +2232,6 @@ def _terminus2_nel_set_cle_pending_compaction(
     tokens_after_unwind: CompactionTokens | None,
     tokens_after_chat_reset: CompactionTokens | None,
 ) -> None:
-    from nemo_evaluator.solvers.compaction_logging import (
-        CompactionTokensIntermediate,
-        serialize_chat_messages,
-    )
-
     self._nel_ensure_compaction_state()
     tokens_intermediate = None
     if tokens_after_unwind is not None or tokens_after_chat_reset is not None:
@@ -2260,8 +2253,6 @@ def _terminus2_nel_set_cle_pending_compaction(
 
 
 def _terminus2_nel_flush_pending_compaction(self, chat) -> None:
-    from nemo_evaluator.solvers.compaction_logging import compaction_event_to_harbor_step
-
     self._nel_ensure_compaction_state()
     event = self._nel_pending_compaction
     if event is None:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -1797,91 +1797,6 @@ def _patch_harbor_lite_llm_context_length_matcher() -> None:
 
 _TERMINUS_COMPACTION_PATCHED = False
 
-_RUN_AGENT_LOOP_COMPACTION_ANCHOR = (
-    "            # If we have pending subagent refs, add a system step to record the delegation\n"
-    "            # This must happen before we build the agent step\n"
-    "            # We use len(self._trajectory_steps) + 1 as the step_id to ensure it's sequential\n"
-    "            if self._pending_subagent_refs:\n"
-    "                self._trajectory_steps.append(\n"
-    "                    Step(\n"
-    "                        step_id=len(self._trajectory_steps) + 1,\n"
-    "                        timestamp=datetime.now(timezone.utc).isoformat(),\n"
-    '                        source="system",\n'
-    '                        message="Performed context summarization and handoff to continue task.",\n'
-    "                        observation=Observation(\n"
-    "                            results=[\n"
-    "                                ObservationResult(\n"
-    "                                    subagent_trajectory_ref=self._pending_subagent_refs\n"
-    "                                )\n"
-    "                            ]\n"
-    "                        ),\n"
-    "                    )\n"
-    "                )\n"
-    "                self._pending_subagent_refs = None\n"
-    "\n"
-    "            # Handle handoff prompt based on linear_history mode\n"
-    "            if self._pending_handoff_prompt:\n"
-    "                # If linear_history mode is enabled, split trajectory immediately WITHOUT adding handoff step\n"
-    "                # The handoff step will be added to the continuation trajectory during the split\n"
-    "                if self._linear_history:\n"
-    "                    self._split_trajectory_on_summarization(\n"
-    "                        self._pending_handoff_prompt\n"
-    "                    )\n"
-    "                else:\n"
-    "                    # For non-linear mode, add the handoff prompt as a user step\n"
-    "                    self._trajectory_steps.append(\n"
-    "                        Step(\n"
-    "                            step_id=len(self._trajectory_steps) + 1,\n"
-    "                            timestamp=datetime.now(timezone.utc).isoformat(),\n"
-    '                            source="user",\n'
-    "                            message=self._pending_handoff_prompt,\n"
-    "                        )\n"
-    "                    )\n"
-    "                self._pending_handoff_prompt = None\n"
-)
-
-_RUN_AGENT_LOOP_COMPACTION_REPLACEMENT = "            self._nel_flush_pending_compaction(chat)\n"
-
-_PROACTIVE_COMPACTION_ANCHOR = (
-    "                if proactive_summary_result:\n"
-    "                    prompt, subagent_refs = proactive_summary_result\n"
-    "                    # Store subagent_refs to add a system step later\n"
-    "                    self._pending_subagent_refs = subagent_refs\n"
-    "                    # Also store the handoff prompt to add as a user step\n"
-    "                    self._pending_handoff_prompt = prompt\n"
-)
-
-_PROACTIVE_COMPACTION_REPLACEMENT = (
-    "                if proactive_summary_result:\n"
-    "                    prompt, subagent_refs = proactive_summary_result\n"
-    "                    self._pending_subagent_refs = subagent_refs\n"
-    "                    self._pending_handoff_prompt = prompt\n"
-    "                    self._nel_set_proactive_pending_compaction(chat, prompt, subagent_refs)\n"
-)
-
-_PROACTIVE_CHECK_ANCHOR = (
-    "            try:\n"
-    "                summary_prompt, subagent_trajectory_refs = await self._summarize(\n"
-    "                    chat, original_instruction, session\n"
-    "                )\n"
-    "                return (summary_prompt, subagent_trajectory_refs)\n"
-)
-
-_PROACTIVE_CHECK_REPLACEMENT = (
-    "            try:\n"
-    "                nel_proactive_tokens_before = self._nel_token_snapshot(chat)\n"
-    "                summary_prompt, subagent_trajectory_refs = await self._summarize(\n"
-    "                    chat, original_instruction, session\n"
-    "                )\n"
-    "                nel_proactive_tokens_after = self._nel_token_snapshot(chat)\n"
-    "                self._nel_stash_compaction_token_snapshots(\n"
-    "                    nel_proactive_tokens_before,\n"
-    "                    nel_proactive_tokens_after,\n"
-    "                    None,\n"
-    "                )\n"
-    "                return (summary_prompt, subagent_trajectory_refs)\n"
-)
-
 
 def _terminus2_nel_ensure_compaction_state(self) -> None:
     if not hasattr(self, "_nel_pending_compaction"):
@@ -2157,44 +2072,194 @@ def _strip_def_indent(src: str) -> str:
     return "".join(line[indent:] if line.startswith(prefix) else line for line in lines)
 
 
-_SHORT_SUMMARY_LLM_CALL_ANCHOR = (
-    "                    short_llm_response: LLMResponse = await self._llm.call(\n"
-    "                        prompt=short_prompt,\n"
-    "                        **self._llm_call_kwargs,\n"
-    "                    )\n"
-)
-_SHORT_SUMMARY_LLM_CALL_REPLACEMENT = (
-    "                    short_llm_response: LLMResponse = await self._llm.call(\n"
-    "                        prompt=short_prompt,\n"
-    "                        **self._nel_compaction_llm_call_kwargs(),\n"
-    "                    )\n"
+_TERMINUS_COMPACTION_RUN_LOOP_REPLACEMENTS = [
+    (
+        "                if proactive_summary_result:\n"
+        "                    prompt, subagent_refs = proactive_summary_result\n"
+        "                    # Store subagent_refs to add a system step later\n"
+        "                    self._pending_subagent_refs = subagent_refs\n"
+        "                    # Also store the handoff prompt to add as a user step\n"
+        "                    self._pending_handoff_prompt = prompt\n",
+        "                if proactive_summary_result:\n"
+        "                    prompt, subagent_refs = proactive_summary_result\n"
+        "                    self._pending_subagent_refs = subagent_refs\n"
+        "                    self._pending_handoff_prompt = prompt\n"
+        "                    self._nel_set_proactive_pending_compaction(chat, prompt, subagent_refs)\n",
+    ),
+    (
+        "            # If we have pending subagent refs, add a system step to record the delegation\n"
+        "            # This must happen before we build the agent step\n"
+        "            # We use len(self._trajectory_steps) + 1 as the step_id to ensure it's sequential\n"
+        "            if self._pending_subagent_refs:\n"
+        "                self._trajectory_steps.append(\n"
+        "                    Step(\n"
+        "                        step_id=len(self._trajectory_steps) + 1,\n"
+        "                        timestamp=datetime.now(timezone.utc).isoformat(),\n"
+        '                        source="system",\n'
+        '                        message="Performed context summarization and handoff to continue task.",\n'
+        "                        observation=Observation(\n"
+        "                            results=[\n"
+        "                                ObservationResult(\n"
+        "                                    subagent_trajectory_ref=self._pending_subagent_refs\n"
+        "                                )\n"
+        "                            ]\n"
+        "                        ),\n"
+        "                    )\n"
+        "                )\n"
+        "                self._pending_subagent_refs = None\n"
+        "\n"
+        "            # Handle handoff prompt based on linear_history mode\n"
+        "            if self._pending_handoff_prompt:\n"
+        "                # If linear_history mode is enabled, split trajectory immediately WITHOUT adding handoff step\n"
+        "                # The handoff step will be added to the continuation trajectory during the split\n"
+        "                if self._linear_history:\n"
+        "                    self._split_trajectory_on_summarization(\n"
+        "                        self._pending_handoff_prompt\n"
+        "                    )\n"
+        "                else:\n"
+        "                    # For non-linear mode, add the handoff prompt as a user step\n"
+        "                    self._trajectory_steps.append(\n"
+        "                        Step(\n"
+        "                            step_id=len(self._trajectory_steps) + 1,\n"
+        "                            timestamp=datetime.now(timezone.utc).isoformat(),\n"
+        '                            source="user",\n'
+        "                            message=self._pending_handoff_prompt,\n"
+        "                        )\n"
+        "                    )\n"
+        "                self._pending_handoff_prompt = None\n",
+        "            self._nel_flush_pending_compaction(chat)\n",
+    ),
+]
+
+_TERMINUS_COMPACTION_PROACTIVE_CHECK_REPLACEMENTS = [
+    (
+        "            try:\n"
+        "                summary_prompt, subagent_trajectory_refs = await self._summarize(\n"
+        "                    chat, original_instruction, session\n"
+        "                )\n"
+        "                return (summary_prompt, subagent_trajectory_refs)\n",
+        "            try:\n"
+        "                nel_proactive_tokens_before = self._nel_token_snapshot(chat)\n"
+        "                summary_prompt, subagent_trajectory_refs = await self._summarize(\n"
+        "                    chat, original_instruction, session\n"
+        "                )\n"
+        "                nel_proactive_tokens_after = self._nel_token_snapshot(chat)\n"
+        "                self._nel_stash_compaction_token_snapshots(\n"
+        "                    nel_proactive_tokens_before,\n"
+        "                    nel_proactive_tokens_after,\n"
+        "                    None,\n"
+        "                )\n"
+        "                return (summary_prompt, subagent_trajectory_refs)\n",
+    ),
+]
+
+_TERMINUS_COMPACTION_SHORT_SUMMARY_REPLACEMENTS = [
+    (
+        "                    short_llm_response: LLMResponse = await self._llm.call(\n"
+        "                        prompt=short_prompt,\n"
+        "                        **self._llm_call_kwargs,\n"
+        "                    )\n",
+        "                    short_llm_response: LLMResponse = await self._llm.call(\n"
+        "                        prompt=short_prompt,\n"
+        "                        **self._nel_compaction_llm_call_kwargs(),\n"
+        "                    )\n",
+    ),
+]
+
+_TERMINUS_COMPACTION_QUERY_LLM_REPLACEMENTS = [
+    (
+        "            self._unwind_messages_to_free_tokens(chat, target_free_tokens=4000)\n"
+        "\n"
+        "            summary_prompt = None\n",
+        "            nel_cle_tokens_before = self._nel_token_snapshot(chat)\n"
+        "            nel_cle_tokens_after_unwind = None\n"
+        "            nel_cle_tokens_after_chat_reset = None\n"
+        "            self._unwind_messages_to_free_tokens(chat, target_free_tokens=4000)\n"
+        "            nel_cle_tokens_after_unwind = self._nel_token_snapshot(chat)\n"
+        "            nel_cle_attempts = []\n"
+        '            nel_cle_strategy = "terminus_ultimate_fallback"\n'
+        "            nel_cle_subagent_refs = None\n"
+        "\n"
+        "            summary_prompt = None\n",
+    ),
+    (
+        '                self.logger.debug("SUMMARIZATION: Full summary succeeded")\n',
+        '                self.logger.debug("SUMMARIZATION: Full summary succeeded")\n'
+        '                nel_cle_strategy = "terminus_three_phase_subagent"\n'
+        "                nel_cle_subagent_refs = subagent_trajectory_refs\n",
+    ),
+    (
+        '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n',
+        '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n'
+        "                self._nel_record_failed_compaction_attempt(\n"
+        '                    nel_cle_attempts, "terminus_three_phase_subagent", str(e)\n'
+        "                )\n",
+    ),
+    (
+        '                    self.logger.debug("SUMMARIZATION: Short summary succeeded")\n',
+        '                    self.logger.debug("SUMMARIZATION: Short summary succeeded")\n'
+        '                    nel_cle_strategy = "terminus_short_fallback"\n',
+    ),
+    (
+        '                    self.logger.error(f"SUMMARIZATION: Short summary failed: {e}")\n',
+        '                    self.logger.error(f"SUMMARIZATION: Short summary failed: {e}")\n'
+        "                    self._nel_record_failed_compaction_attempt(\n"
+        '                        nel_cle_attempts, "terminus_short_fallback", str(e)\n'
+        "                    )\n",
+    ),
+    *_TERMINUS_COMPACTION_SHORT_SUMMARY_REPLACEMENTS,
+]
+
+_TERMINUS_COMPACTION_QUERY_LLM_CLE_CHAT_RESET_REPLACEMENT = (
+    "            if full_summarize_failed_with_cle:\n"
+    "                chat._messages = [chat.messages[0]]\n"
+    "                chat.reset_response_chain()\n",
+    "            if full_summarize_failed_with_cle:\n"
+    "                chat._messages = [chat.messages[0]]\n"
+    "                chat.reset_response_chain()\n"
+    "                self._nel_cle_chat_reset_applied = True\n"
+    "                nel_cle_tokens_after_chat_reset = self._nel_token_snapshot(chat)\n",
 )
 
-_RUN_SUBAGENT_KWARGS_ANCHOR = (
-    "        response: LLMResponse = await self._llm.call(\n"
-    "            prompt=prompt,\n"
-    "            message_history=message_history,\n"
-    "            **self._llm_call_kwargs,\n"
-    "        )\n"
-)
-_RUN_SUBAGENT_KWARGS_REPLACEMENT = (
-    "        response: LLMResponse = await self._llm.call(\n"
-    "            prompt=prompt,\n"
-    "            message_history=message_history,\n"
-    "            **(llm_call_kwargs if llm_call_kwargs is not None else self._llm_call_kwargs),\n"
-    "        )\n"
+_TERMINUS_COMPACTION_QUERY_LLM_NO_CLE_CHAT_RESET_REPLACEMENT = (
+    "            if prompt_path is not None:\n"
+    "                prompt_path.write_text(summary_prompt)\n"
+    "\n"
+    "            try:\n"
+    "                start_time = time.time()\n"
+    "                llm_response = await chat.chat(\n",
+    "            if prompt_path is not None:\n"
+    "                prompt_path.write_text(summary_prompt)\n"
+    "\n"
+    "            self._nel_cle_chat_reset_applied = False\n"
+    "\n"
+    "            try:\n"
+    "                start_time = time.time()\n"
+    "                llm_response = await chat.chat(\n",
 )
 
-_RUN_SUBAGENT_SIGNATURE_ANCHOR = (
-    "        summary_text: str,\n"
-    '        subagent_name_for_logging: str = "subagent",\n'
-    "    ) -> tuple[LLMResponse, SubagentTrajectoryRef]:\n"
-)
-_RUN_SUBAGENT_SIGNATURE_REPLACEMENT = (
-    "        summary_text: str,\n"
-    '        subagent_name_for_logging: str = "subagent",\n'
-    "        llm_call_kwargs: dict | None = None,\n"
-    "    ) -> tuple[LLMResponse, SubagentTrajectoryRef]:\n"
+_TERMINUS_COMPACTION_QUERY_LLM_PENDING_FLUSH_REPLACEMENT = (
+    "            if response_path is not None:\n"
+    "                response_path.write_text(llm_response.content)\n"
+    "            return llm_response\n"
+    "\n"
+    "        except OutputLengthExceededError as e:\n",
+    "            if response_path is not None:\n"
+    "                response_path.write_text(llm_response.content)\n"
+    "            nel_cle_tokens_after = self._nel_token_snapshot(chat)\n"
+    "            self._nel_set_cle_pending_compaction(\n"
+    "                summary_prompt,\n"
+    "                nel_cle_strategy,\n"
+    "                nel_cle_attempts,\n"
+    "                nel_cle_subagent_refs,\n"
+    "                nel_cle_tokens_before,\n"
+    "                nel_cle_tokens_after,\n"
+    "                nel_cle_tokens_after_unwind,\n"
+    "                nel_cle_tokens_after_chat_reset,\n"
+    "            )\n"
+    "            return llm_response\n"
+    "\n"
+    "        except OutputLengthExceededError as e:\n",
 )
 
 
@@ -2234,10 +2299,7 @@ def _patch_terminus_compaction_logging() -> None:
     else:
         run_loop_src = _apply_source_replacements(
             run_loop_src,
-            [
-                (_PROACTIVE_COMPACTION_ANCHOR, _PROACTIVE_COMPACTION_REPLACEMENT),
-                (_RUN_AGENT_LOOP_COMPACTION_ANCHOR, _RUN_AGENT_LOOP_COMPACTION_REPLACEMENT),
-            ],
+            _TERMINUS_COMPACTION_RUN_LOOP_REPLACEMENTS,
             label="Terminus2._run_agent_loop for compaction logging",
         )
         run_loop_namespace: dict[str, Any] = {}
@@ -2259,7 +2321,7 @@ def _patch_terminus_compaction_logging() -> None:
             else:
                 proactive_src = _apply_source_replacements(
                     proactive_src,
-                    [(_PROACTIVE_CHECK_ANCHOR, _PROACTIVE_CHECK_REPLACEMENT)],
+                    _TERMINUS_COMPACTION_PROACTIVE_CHECK_REPLACEMENTS,
                     label="Terminus2._check_proactive_summarization for compaction logging",
                 )
                 proactive_namespace: dict[str, Any] = {}
@@ -2275,110 +2337,12 @@ def _patch_terminus_compaction_logging() -> None:
             _TERMINUS_QUERY_LLM_SRC = ""
     query_src = _TERMINUS_QUERY_LLM_SRC
     if query_src and "_nel_set_cle_pending_compaction" not in query_src:
-        query_replacements = [
-            (
-                "            self._unwind_messages_to_free_tokens(chat, target_free_tokens=4000)\n"
-                "\n"
-                "            summary_prompt = None\n",
-                "            nel_cle_tokens_before = self._nel_token_snapshot(chat)\n"
-                "            nel_cle_tokens_after_unwind = None\n"
-                "            nel_cle_tokens_after_chat_reset = None\n"
-                "            self._unwind_messages_to_free_tokens(chat, target_free_tokens=4000)\n"
-                "            nel_cle_tokens_after_unwind = self._nel_token_snapshot(chat)\n"
-                "            nel_cle_attempts = []\n"
-                '            nel_cle_strategy = "terminus_ultimate_fallback"\n'
-                "            nel_cle_subagent_refs = None\n"
-                "\n"
-                "            summary_prompt = None\n",
-            ),
-            (
-                '                self.logger.debug("SUMMARIZATION: Full summary succeeded")\n',
-                '                self.logger.debug("SUMMARIZATION: Full summary succeeded")\n'
-                '                nel_cle_strategy = "terminus_three_phase_subagent"\n'
-                "                nel_cle_subagent_refs = subagent_trajectory_refs\n",
-            ),
-            (
-                '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n',
-                '                self.logger.debug(f"SUMMARIZATION: Full summary failed: {e}")\n'
-                "                self._nel_record_failed_compaction_attempt(\n"
-                '                    nel_cle_attempts, "terminus_three_phase_subagent", str(e)\n'
-                "                )\n",
-            ),
-            (
-                '                    self.logger.debug("SUMMARIZATION: Short summary succeeded")\n',
-                '                    self.logger.debug("SUMMARIZATION: Short summary succeeded")\n'
-                '                    nel_cle_strategy = "terminus_short_fallback"\n',
-            ),
-            (
-                '                    self.logger.error(f"SUMMARIZATION: Short summary failed: {e}")\n',
-                '                    self.logger.error(f"SUMMARIZATION: Short summary failed: {e}")\n'
-                "                    self._nel_record_failed_compaction_attempt(\n"
-                '                        nel_cle_attempts, "terminus_short_fallback", str(e)\n'
-                "                    )\n",
-            ),
-            (
-                _SHORT_SUMMARY_LLM_CALL_ANCHOR,
-                _SHORT_SUMMARY_LLM_CALL_REPLACEMENT,
-            ),
-        ]
+        query_replacements = list(_TERMINUS_COMPACTION_QUERY_LLM_REPLACEMENTS)
         if "full_summarize_failed_with_cle" in query_src:
-            query_replacements.append(
-                (
-                    "            if full_summarize_failed_with_cle:\n"
-                    "                chat._messages = [chat.messages[0]]\n"
-                    "                chat.reset_response_chain()\n",
-                    "            if full_summarize_failed_with_cle:\n"
-                    "                chat._messages = [chat.messages[0]]\n"
-                    "                chat.reset_response_chain()\n"
-                    "                self._nel_cle_chat_reset_applied = True\n"
-                    "                nel_cle_tokens_after_chat_reset = self._nel_token_snapshot(chat)\n",
-                )
-            )
+            query_replacements.append(_TERMINUS_COMPACTION_QUERY_LLM_CLE_CHAT_RESET_REPLACEMENT)
         else:
-            query_replacements.append(
-                (
-                    "            if prompt_path is not None:\n"
-                    "                prompt_path.write_text(summary_prompt)\n"
-                    "\n"
-                    "            try:\n"
-                    "                start_time = time.time()\n"
-                    "                llm_response = await chat.chat(\n",
-                    "            if prompt_path is not None:\n"
-                    "                prompt_path.write_text(summary_prompt)\n"
-                    "\n"
-                    "            self._nel_cle_chat_reset_applied = False\n"
-                    "\n"
-                    "            try:\n"
-                    "                start_time = time.time()\n"
-                    "                llm_response = await chat.chat(\n",
-                )
-            )
-
-        query_replacements.append(
-            (
-                "            if response_path is not None:\n"
-                "                response_path.write_text(llm_response.content)\n"
-                "            return llm_response\n"
-                "\n"
-                "        except OutputLengthExceededError as e:\n",
-                "            if response_path is not None:\n"
-                "                response_path.write_text(llm_response.content)\n"
-                "            nel_cle_tokens_after = self._nel_token_snapshot(chat)\n"
-                "            self._nel_set_cle_pending_compaction(\n"
-                "                summary_prompt,\n"
-                "                nel_cle_strategy,\n"
-                "                nel_cle_attempts,\n"
-                "                nel_cle_subagent_refs,\n"
-                "                nel_cle_tokens_before,\n"
-                "                nel_cle_tokens_after,\n"
-                "                nel_cle_tokens_after_unwind,\n"
-                "                nel_cle_tokens_after_chat_reset,\n"
-                "            )\n"
-                "            return llm_response\n"
-                "\n"
-                "        except OutputLengthExceededError as e:\n",
-            )
-        )
+            query_replacements.append(_TERMINUS_COMPACTION_QUERY_LLM_NO_CLE_CHAT_RESET_REPLACEMENT)
+        query_replacements.append(_TERMINUS_COMPACTION_QUERY_LLM_PENDING_FLUSH_REPLACEMENT)
         query_src = _apply_source_replacements(
             query_src,
             query_replacements,
@@ -2389,14 +2353,15 @@ def _patch_terminus_compaction_logging() -> None:
         terminus2_mod.Terminus2._query_llm = query_namespace["_query_llm"]
         _TERMINUS_QUERY_LLM_SRC = query_src
     elif query_src and "_nel_compaction_llm_call_kwargs()" not in query_src:
-        if _SHORT_SUMMARY_LLM_CALL_ANCHOR not in query_src:
+        short_summary_anchor = _TERMINUS_COMPACTION_SHORT_SUMMARY_REPLACEMENTS[0][0]
+        if short_summary_anchor not in query_src:
             raise RuntimeError(
                 "Cannot patch Terminus2._query_llm short-summary call for compaction turn marker: "
                 "expected source anchor not found."
             )
         query_src = _apply_source_replacements(
             query_src,
-            [(_SHORT_SUMMARY_LLM_CALL_ANCHOR, _SHORT_SUMMARY_LLM_CALL_REPLACEMENT)],
+            _TERMINUS_COMPACTION_SHORT_SUMMARY_REPLACEMENTS,
             label="Terminus2._query_llm short-summary compaction turn marker",
         )
         query_namespace = {}
@@ -2409,6 +2374,51 @@ def _patch_terminus_compaction_logging() -> None:
 
 
 _TERMINUS_COMPACTION_TURN_MARKER_PATCHED = False
+
+_TERMINUS_COMPACTION_RUN_SUBAGENT_REPLACEMENTS = [
+    (
+        "        summary_text: str,\n"
+        '        subagent_name_for_logging: str = "subagent",\n'
+        "    ) -> tuple[LLMResponse, SubagentTrajectoryRef]:\n",
+        "        summary_text: str,\n"
+        '        subagent_name_for_logging: str = "subagent",\n'
+        "        llm_call_kwargs: dict | None = None,\n"
+        "    ) -> tuple[LLMResponse, SubagentTrajectoryRef]:\n",
+    ),
+    (
+        "        response: LLMResponse = await self._llm.call(\n"
+        "            prompt=prompt,\n"
+        "            message_history=message_history,\n"
+        "            **self._llm_call_kwargs,\n"
+        "        )\n",
+        "        response: LLMResponse = await self._llm.call(\n"
+        "            prompt=prompt,\n"
+        "            message_history=message_history,\n"
+        "            **(llm_call_kwargs if llm_call_kwargs is not None else self._llm_call_kwargs),\n"
+        "        )\n",
+    ),
+]
+
+_TERMINUS_COMPACTION_SUMMARIZE_REPLACEMENTS = [
+    (
+        '            subagent_name_for_logging="summary generation LLM call",\n        )\n',
+        '            subagent_name_for_logging="summary generation LLM call",\n'
+        "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
+        "        )\n",
+    ),
+    (
+        '            subagent_name_for_logging="questions subagent",\n        )\n',
+        '            subagent_name_for_logging="questions subagent",\n'
+        "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
+        "        )\n",
+    ),
+    (
+        '            subagent_name_for_logging="answers subagent",\n        )\n',
+        '            subagent_name_for_logging="answers subagent",\n'
+        "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
+        "        )\n",
+    ),
+]
 
 
 def _patch_terminus_compaction_turn_marker() -> None:
@@ -2426,10 +2436,7 @@ def _patch_terminus_compaction_turn_marker() -> None:
     if "llm_call_kwargs if llm_call_kwargs is not None" not in run_subagent_src:
         run_subagent_src = _apply_source_replacements(
             run_subagent_src,
-            [
-                (_RUN_SUBAGENT_SIGNATURE_ANCHOR, _RUN_SUBAGENT_SIGNATURE_REPLACEMENT),
-                (_RUN_SUBAGENT_KWARGS_ANCHOR, _RUN_SUBAGENT_KWARGS_REPLACEMENT),
-            ],
+            _TERMINUS_COMPACTION_RUN_SUBAGENT_REPLACEMENTS,
             label="Terminus2._run_subagent for optional llm_call_kwargs",
         )
         run_subagent_namespace: dict[str, Any] = {}
@@ -2442,29 +2449,9 @@ def _patch_terminus_compaction_turn_marker() -> None:
     except OSError:
         summarize_src = ""
     if summarize_src and "_nel_compaction_llm_call_kwargs()" not in summarize_src:
-        summarize_replacements = [
-            (
-                '            subagent_name_for_logging="summary generation LLM call",\n        )\n',
-                '            subagent_name_for_logging="summary generation LLM call",\n'
-                "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
-                "        )\n",
-            ),
-            (
-                '            subagent_name_for_logging="questions subagent",\n        )\n',
-                '            subagent_name_for_logging="questions subagent",\n'
-                "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
-                "        )\n",
-            ),
-            (
-                '            subagent_name_for_logging="answers subagent",\n        )\n',
-                '            subagent_name_for_logging="answers subagent",\n'
-                "            llm_call_kwargs=self._nel_compaction_llm_call_kwargs(),\n"
-                "        )\n",
-            ),
-        ]
         summarize_src = _apply_source_replacements(
             summarize_src,
-            summarize_replacements,
+            _TERMINUS_COMPACTION_SUMMARIZE_REPLACEMENTS,
             label="Terminus2._summarize compaction llm_call_kwargs",
         )
         summarize_namespace: dict[str, Any] = {}

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -41,7 +41,6 @@ from nemo_evaluator.solvers.compaction_logging import (
     CompactionTokens,
     CompactionTokensIntermediate,
     CompactionTrigger,
-    StepsCompacted,
 )
 from nemo_evaluator.solvers.trajectory_util import build_atif_trajectory
 
@@ -972,12 +971,12 @@ new = (
     '    _ctx_lim_raw = os.environ.get("CONTEXT_LIMIT") or os.environ.get("MAX_INPUT_TOKENS") or "128000"\\n'
     '    _ctx_lim = int(_ctx_lim_raw)\\n'
     '    _oh_cfg = {}\\n'
-    '    if os.environ.get("OPENHANDS_CONDENSER_MAX_SIZE"):\\n'
-    '        _oh_cfg["max_size"] = int(os.environ["OPENHANDS_CONDENSER_MAX_SIZE"])\\n'
-    '    if os.environ.get("OPENHANDS_CONDENSER_MAX_TOKENS"):\\n'
-    '        _oh_cfg["max_tokens"] = int(os.environ["OPENHANDS_CONDENSER_MAX_TOKENS"])\\n'
-    '    if os.environ.get("OPENHANDS_CONDENSER_KEEP_FIRST"):\\n'
-    '        _oh_cfg["keep_first"] = int(os.environ["OPENHANDS_CONDENSER_KEEP_FIRST"])\\n'
+    '    if os.environ.get("OH_CONDENSER_MAX_SIZE"):\\n'
+    '        _oh_cfg["max_size"] = int(os.environ["OH_CONDENSER_MAX_SIZE"])\\n'
+    '    if os.environ.get("OH_CONDENSER_MAX_TOKENS"):\\n'
+    '        _oh_cfg["max_tokens"] = int(os.environ["OH_CONDENSER_MAX_TOKENS"])\\n'
+    '    if os.environ.get("OH_CONDENSER_KEEP_FIRST"):\\n'
+    '        _oh_cfg["keep_first"] = int(os.environ["OH_CONDENSER_KEEP_FIRST"])\\n'
     '    trajectory = enrich_trajectory_with_compaction(\\n'
     '        trajectory, conversation.state.events, llm, _ctx_lim, condenser_config=_oh_cfg or None,\\n'
     '    )\\n'
@@ -1804,8 +1803,6 @@ _PROACTIVE_CHECK_REPLACEMENT = (
 def _terminus2_nel_ensure_compaction_state(self) -> None:
     if not hasattr(self, "_nel_pending_compaction"):
         self._nel_pending_compaction = None
-    if not hasattr(self, "_nel_compaction_step_overlays"):
-        self._nel_compaction_step_overlays: dict[int, dict[str, Any]] = {}
     if not hasattr(self, "_nel_last_unwind_pairs"):
         self._nel_last_unwind_pairs = 0
     if not hasattr(self, "_nel_last_unwind_target"):
@@ -1841,22 +1838,6 @@ def _terminus2_nel_token_snapshot(self, chat) -> CompactionTokens:
         prompt_tokens_approx=current_tokens,
         context_limit=context_limit,
         free_tokens=context_limit - current_tokens,
-    )
-
-
-def _terminus2_nel_steps_compacted(self) -> StepsCompacted | None:
-    from nemo_evaluator.solvers.compaction_logging import StepsCompacted
-
-    if not self._trajectory_steps:
-        return None
-    first_step_id = 2 if len(self._trajectory_steps) > 1 else 1
-    last_step_id = len(self._trajectory_steps)
-    if last_step_id < first_step_id:
-        return None
-    return StepsCompacted(
-        first_step_id=first_step_id,
-        last_step_id=last_step_id,
-        step_count=last_step_id - first_step_id + 1,
     )
 
 
@@ -1902,7 +1883,6 @@ def _terminus2_nel_make_compaction_event(
         tokens_after=tokens_after,
         tokens_intermediate=tokens_intermediate,
         llm_call_count=llm_call_count_for_strategy(strategy),
-        steps_compacted=self._nel_steps_compacted(),
         mechanism=self._nel_compaction_mechanism(),
         subagent_trajectory_ref=subagent_trajectory_refs_to_dicts(subagent_refs),
         attempts=attempts or None,
@@ -1995,9 +1975,8 @@ def _terminus2_nel_flush_pending_compaction(self, chat) -> None:
         return
 
     step_id = len(self._trajectory_steps) + 1
-    step, llm_call_count = compaction_event_to_harbor_step(event, step_id)
+    step = compaction_event_to_harbor_step(event, step_id)
     self._trajectory_steps.append(step)
-    self._nel_compaction_step_overlays[step_id] = {"llm_call_count": llm_call_count}
 
     handoff_prompt = event.replacement_content
     self._nel_pending_compaction = None
@@ -2061,11 +2040,6 @@ def _terminus2_nel_dump_trajectory_with_continuation_index(self, continuation_in
         trajectory_path = self.logs_dir / "trajectory.json"
 
     trajectory_dict = trajectory.to_json_dict()
-    overlays = getattr(self, "_nel_compaction_step_overlays", None) or {}
-    for step in trajectory_dict.get("steps", []):
-        step_id = step.get("step_id")
-        if step_id in overlays:
-            step.update(overlays[step_id])
 
     try:
         with open(trajectory_path, "w") as f:
@@ -2101,7 +2075,6 @@ def _patch_terminus_compaction_logging() -> None:
     terminus2_mod.Terminus2._nel_ensure_compaction_state = _terminus2_nel_ensure_compaction_state
     terminus2_mod.Terminus2._nel_stash_compaction_token_snapshots = _terminus2_nel_stash_compaction_token_snapshots
     terminus2_mod.Terminus2._nel_token_snapshot = _terminus2_nel_token_snapshot
-    terminus2_mod.Terminus2._nel_steps_compacted = _terminus2_nel_steps_compacted
     terminus2_mod.Terminus2._nel_compaction_mechanism = _terminus2_nel_compaction_mechanism
     terminus2_mod.Terminus2._nel_make_compaction_event = _terminus2_nel_make_compaction_event
     terminus2_mod.Terminus2._nel_record_failed_compaction_attempt = _terminus2_nel_record_failed_compaction_attempt

--- a/src/nemo_evaluator/solvers/openhands_compaction.py
+++ b/src/nemo_evaluator/solvers/openhands_compaction.py
@@ -25,6 +25,12 @@ DEFAULT_OPENHANDS_MAX_SIZE = 80
 DEFAULT_OPENHANDS_KEEP_FIRST = 4
 
 
+def event_counts_toward_max_iterations(event: Event | None) -> bool:
+    if event is None:
+        return True
+    return not isinstance(event, Condensation)
+
+
 def _parse_timestamp(value: str | None) -> datetime | None:
     if not value:
         return None

--- a/src/nemo_evaluator/solvers/openhands_compaction.py
+++ b/src/nemo_evaluator/solvers/openhands_compaction.py
@@ -19,6 +19,7 @@ from nemo_evaluator.solvers.compaction_logging import (
     OpenHandsCompactionExtra,
     build_compaction_step,
     llm_call_count_for_strategy,
+    serialize_chat_messages,
 )
 
 DEFAULT_OPENHANDS_MAX_SIZE = 80
@@ -136,6 +137,38 @@ def token_snapshot(
     )
 
 
+def _openhands_message_to_chat_dict(message: Any) -> dict[str, Any]:
+    from openhands.sdk.llm import ImageContent, TextContent
+
+    texts: list[str] = []
+    for item in message.content:
+        if isinstance(item, TextContent):
+            texts.append(item.text)
+        elif isinstance(item, ImageContent):
+            texts.append(f"[Image: {len(item.image_urls)} URLs]")
+        else:
+            texts.append(str(item))
+    out: dict[str, Any] = {
+        "role": message.role,
+        "content": "\n".join(texts),
+    }
+    if message.tool_calls:
+        out["tool_calls"] = [tool_call.to_chat_dict() for tool_call in message.tool_calls]
+    if message.tool_call_id is not None:
+        out["tool_call_id"] = message.tool_call_id
+    if message.name is not None:
+        out["name"] = message.name
+    return out
+
+
+def serialize_openhands_view(view_events: list[Any]) -> str:
+    from openhands.sdk.event.base import LLMConvertibleEvent
+
+    llm_convertible = [event for event in view_events if isinstance(event, LLMConvertibleEvent)]
+    messages = LLMConvertibleEvent.events_to_messages(llm_convertible)
+    return serialize_chat_messages([_openhands_message_to_chat_dict(message) for message in messages])
+
+
 def _observation_extra_for_response(llm: LLM, response_id: str | None) -> CompactionObservationExtra | None:
     if not response_id:
         return None
@@ -224,7 +257,7 @@ def build_compaction_events_from_run(
             compaction_index=compaction_index,
             trigger=trigger,
             strategy="openhands_condensation",
-            replacement_content=event.summary or "",
+            replacement_content=serialize_openhands_view(view_after_events),
             tokens_before=tokens_before,
             tokens_after=tokens_after,
             llm_call_count=llm_call_count_for_strategy("openhands_condensation"),

--- a/src/nemo_evaluator/solvers/openhands_compaction.py
+++ b/src/nemo_evaluator/solvers/openhands_compaction.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from openhands.sdk.context.condenser.utils import get_total_token_count
-from openhands.sdk.context.view import View
-from openhands.sdk.event.base import Event
-from openhands.sdk.event.condenser import Condensation, CondensationRequest
-from openhands.sdk.llm import LLM
+try:
+    from openhands.sdk.context.condenser.utils import get_total_token_count
+    from openhands.sdk.context.view import View
+    from openhands.sdk.event.base import Event
+    from openhands.sdk.event.condenser import Condensation, CondensationRequest
+    from openhands.sdk.llm import LLM
+except ImportError:
+    pass
+
+if TYPE_CHECKING:
+    from openhands.sdk.context.condenser.utils import get_total_token_count
+    from openhands.sdk.context.view import View
+    from openhands.sdk.event.base import Event
+    from openhands.sdk.event.condenser import Condensation, CondensationRequest
+    from openhands.sdk.llm import LLM
 
 from nemo_evaluator.solvers.compaction_logging import (
     CompactionEvent,
@@ -24,12 +34,6 @@ from nemo_evaluator.solvers.compaction_logging import (
 
 DEFAULT_OPENHANDS_MAX_SIZE = 80
 DEFAULT_OPENHANDS_KEEP_FIRST = 4
-
-
-def event_counts_toward_max_iterations(event: Event | None) -> bool:
-    if event is None:
-        return True
-    return not isinstance(event, Condensation)
 
 
 def _parse_timestamp(value: str | None) -> datetime | None:

--- a/src/nemo_evaluator/solvers/openhands_compaction.py
+++ b/src/nemo_evaluator/solvers/openhands_compaction.py
@@ -7,7 +7,6 @@ from typing import Any
 
 from openhands.sdk.context.condenser.utils import get_total_token_count
 from openhands.sdk.context.view import View
-from openhands.sdk.event import ActionEvent, MessageEvent, ObservationEvent
 from openhands.sdk.event.base import Event
 from openhands.sdk.event.condenser import Condensation, CondensationRequest
 from openhands.sdk.llm import LLM
@@ -18,7 +17,6 @@ from nemo_evaluator.solvers.compaction_logging import (
     CompactionTokens,
     CompactionTrigger,
     OpenHandsCompactionExtra,
-    StepsCompacted,
     build_compaction_step,
     llm_call_count_for_strategy,
 )
@@ -150,46 +148,6 @@ def _observation_extra_for_response(llm: LLM, response_id: str | None) -> Compac
     return None
 
 
-def build_event_to_step_map(events: list[Event]) -> dict[str, int]:
-    event_to_step: dict[str, int] = {}
-    step_id = 1
-    for event in events:
-        if isinstance(event, MessageEvent):
-            if event.source == "user":
-                event_to_step[event.id] = step_id
-                step_id += 1
-            elif event.source == "agent":
-                event_to_step[event.id] = step_id
-                step_id += 1
-        elif isinstance(event, ActionEvent):
-            event_to_step[event.id] = step_id
-            step_id += 1
-        elif isinstance(event, ObservationEvent):
-            pass
-        elif isinstance(event, Condensation):
-            pass
-    return event_to_step
-
-
-def map_forgotten_to_steps(
-    forgotten_event_ids: set[str],
-    event_to_step: dict[str, int],
-) -> StepsCompacted | None:
-    step_ids: list[int] = []
-    for event_id in forgotten_event_ids:
-        mapped = event_to_step.get(event_id)
-        if mapped is not None:
-            step_ids.append(mapped)
-    if not step_ids:
-        return None
-    step_ids = sorted(set(step_ids))
-    return StepsCompacted(
-        first_step_id=step_ids[0],
-        last_step_id=step_ids[-1],
-        step_count=len(step_ids),
-    )
-
-
 def _resolve_condenser_config(condenser_config: dict[str, Any] | None) -> dict[str, int | None]:
     cfg = condenser_config or {}
     max_size = cfg.get("max_size")
@@ -210,7 +168,6 @@ def build_compaction_events_from_run(
     condenser_config: dict[str, Any] | None = None,
 ) -> list[tuple[str, CompactionEvent]]:
     cfg = _resolve_condenser_config(condenser_config)
-    event_to_step = build_event_to_step_map(events)
     out: list[tuple[str, CompactionEvent]] = []
     compaction_index = 0
     idx = 0
@@ -243,9 +200,14 @@ def build_compaction_events_from_run(
             reason = "request"
         elif trigger == "openhands_condensation_hard_reset":
             reason = "hard_reset"
+        hard_requirement_triggers = (
+            "openhands_condensation_tokens",
+            "openhands_condensation_request",
+            "openhands_condensation_hard_reset",
+        )
         openhands_extra = OpenHandsCompactionExtra(
             reason=reason,
-            requirement="hard" if hard_reset or trigger == "openhands_condensation_request" else "soft",
+            requirement="hard" if trigger in hard_requirement_triggers else "soft",
             hard_reset=hard_reset,
             forgotten_event_count=len(event.forgotten_event_ids),
             max_size=int(cfg["max_size"]),
@@ -260,7 +222,6 @@ def build_compaction_events_from_run(
             tokens_before=tokens_before,
             tokens_after=tokens_after,
             llm_call_count=llm_call_count_for_strategy("openhands_condensation"),
-            steps_compacted=map_forgotten_to_steps(event.forgotten_event_ids, event_to_step),
             observation_extra=_observation_extra_for_response(llm, event.llm_response_id),
             openhands_extra=openhands_extra,
             timestamp=event.timestamp,

--- a/src/nemo_evaluator/solvers/openhands_compaction.py
+++ b/src/nemo_evaluator/solvers/openhands_compaction.py
@@ -1,0 +1,319 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from openhands.sdk.context.condenser.utils import get_total_token_count
+from openhands.sdk.context.view import View
+from openhands.sdk.event import ActionEvent, MessageEvent, ObservationEvent
+from openhands.sdk.event.base import Event
+from openhands.sdk.event.condenser import Condensation, CondensationRequest
+from openhands.sdk.llm import LLM
+
+from nemo_evaluator.solvers.compaction_logging import (
+    CompactionEvent,
+    CompactionObservationExtra,
+    CompactionTokens,
+    CompactionTrigger,
+    OpenHandsCompactionExtra,
+    StepsCompacted,
+    build_compaction_step,
+    llm_call_count_for_strategy,
+)
+
+DEFAULT_OPENHANDS_MAX_SIZE = 80
+DEFAULT_OPENHANDS_KEEP_FIRST = 4
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    text = str(value).replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _timestamp_sort_key(value: str | None) -> tuple[int, str]:
+    parsed = _parse_timestamp(value)
+    if parsed is None:
+        return (1, str(value or ""))
+    return (0, parsed.isoformat())
+
+
+def is_hard_reset(condensation: Condensation, view_before: View) -> bool:
+    if condensation.summary_offset != 0:
+        return False
+    if not view_before.events:
+        return False
+    forgotten = condensation.forgotten_event_ids
+    if not forgotten:
+        return False
+    view_ids = {event.id for event in view_before.events}
+    return view_ids.issubset(forgotten)
+
+
+def _segment_since_previous_condensation(events: list[Event], condensation_idx: int) -> list[Event]:
+    start = 0
+    idx = 0
+    while idx < condensation_idx:
+        if isinstance(events[idx], Condensation):
+            start = idx + 1
+        idx += 1
+    return events[start:condensation_idx]
+
+
+def _has_condensation_request(segment: list[Event]) -> bool:
+    for event in segment:
+        if isinstance(event, CondensationRequest):
+            return True
+    return False
+
+
+def _replay_openhands_reasons(
+    view_before: View,
+    llm: LLM,
+    *,
+    max_size: int,
+    max_tokens: int | None,
+) -> set[str]:
+    reasons: set[str] = set()
+    if len(view_before) > max_size:
+        reasons.add("events")
+    if max_tokens is not None:
+        total_tokens = get_total_token_count(view_before.events, llm)
+        if total_tokens > max_tokens:
+            reasons.add("tokens")
+    return reasons
+
+
+def infer_openhands_trigger(
+    events: list[Event],
+    condensation_idx: int,
+    condensation: Condensation,
+    view_before: View,
+    llm: LLM,
+    *,
+    max_size: int,
+    max_tokens: int | None,
+) -> CompactionTrigger:
+    if is_hard_reset(condensation, view_before):
+        return "openhands_condensation_hard_reset"
+    segment = _segment_since_previous_condensation(events, condensation_idx)
+    if _has_condensation_request(segment):
+        return "openhands_condensation_request"
+    reasons = _replay_openhands_reasons(
+        view_before,
+        llm,
+        max_size=max_size,
+        max_tokens=max_tokens,
+    )
+    if "tokens" in reasons:
+        return "openhands_condensation_tokens"
+    if "events" in reasons:
+        return "openhands_condensation_events"
+    return "unknown"
+
+
+def token_snapshot(
+    view_events: list[Any],
+    llm: LLM,
+    context_limit: int,
+) -> CompactionTokens:
+    prompt_tokens = int(get_total_token_count(view_events, llm))
+    free_tokens = max(0, context_limit - prompt_tokens)
+    return CompactionTokens(
+        prompt_tokens_approx=prompt_tokens,
+        context_limit=context_limit,
+        free_tokens=free_tokens,
+    )
+
+
+def _observation_extra_for_response(llm: LLM, response_id: str | None) -> CompactionObservationExtra | None:
+    if not response_id:
+        return None
+    usages = getattr(getattr(llm, "metrics", None), "token_usages", None) or []
+    for usage in usages:
+        if getattr(usage, "response_id", None) != response_id:
+            continue
+        prompt_tokens = getattr(usage, "prompt_tokens", None)
+        completion_tokens = getattr(usage, "completion_tokens", None)
+        cost = getattr(usage, "cost", None)
+        return CompactionObservationExtra(
+            compaction_prompt_tokens=int(prompt_tokens) if prompt_tokens is not None else None,
+            compaction_completion_tokens=int(completion_tokens) if completion_tokens is not None else None,
+            compaction_cost_usd=float(cost) if cost is not None else None,
+        )
+    return None
+
+
+def build_event_to_step_map(events: list[Event]) -> dict[str, int]:
+    event_to_step: dict[str, int] = {}
+    step_id = 1
+    for event in events:
+        if isinstance(event, MessageEvent):
+            if event.source == "user":
+                event_to_step[event.id] = step_id
+                step_id += 1
+            elif event.source == "agent":
+                event_to_step[event.id] = step_id
+                step_id += 1
+        elif isinstance(event, ActionEvent):
+            event_to_step[event.id] = step_id
+            step_id += 1
+        elif isinstance(event, ObservationEvent):
+            pass
+        elif isinstance(event, Condensation):
+            pass
+    return event_to_step
+
+
+def map_forgotten_to_steps(
+    forgotten_event_ids: set[str],
+    event_to_step: dict[str, int],
+) -> StepsCompacted | None:
+    step_ids: list[int] = []
+    for event_id in forgotten_event_ids:
+        mapped = event_to_step.get(event_id)
+        if mapped is not None:
+            step_ids.append(mapped)
+    if not step_ids:
+        return None
+    step_ids = sorted(set(step_ids))
+    return StepsCompacted(
+        first_step_id=step_ids[0],
+        last_step_id=step_ids[-1],
+        step_count=len(step_ids),
+    )
+
+
+def _resolve_condenser_config(condenser_config: dict[str, Any] | None) -> dict[str, int | None]:
+    cfg = condenser_config or {}
+    max_size = cfg.get("max_size")
+    max_tokens = cfg.get("max_tokens")
+    keep_first = cfg.get("keep_first")
+    return {
+        "max_size": int(max_size) if max_size is not None else DEFAULT_OPENHANDS_MAX_SIZE,
+        "max_tokens": int(max_tokens) if max_tokens is not None else None,
+        "keep_first": int(keep_first) if keep_first is not None else DEFAULT_OPENHANDS_KEEP_FIRST,
+    }
+
+
+def build_compaction_events_from_run(
+    events: list[Event],
+    llm: LLM,
+    context_limit: int,
+    *,
+    condenser_config: dict[str, Any] | None = None,
+) -> list[tuple[str, CompactionEvent]]:
+    cfg = _resolve_condenser_config(condenser_config)
+    event_to_step = build_event_to_step_map(events)
+    out: list[tuple[str, CompactionEvent]] = []
+    compaction_index = 0
+    idx = 0
+    while idx < len(events):
+        event = events[idx]
+        if not isinstance(event, Condensation):
+            idx += 1
+            continue
+        compaction_index += 1
+        view_before = View.from_events(events[:idx])
+        view_after_events = event.apply(view_before.events)
+        tokens_before = token_snapshot(view_before.events, llm, context_limit)
+        tokens_after = token_snapshot(view_after_events, llm, context_limit)
+        trigger = infer_openhands_trigger(
+            events,
+            idx,
+            event,
+            view_before,
+            llm,
+            max_size=int(cfg["max_size"]),
+            max_tokens=cfg["max_tokens"],
+        )
+        hard_reset = trigger == "openhands_condensation_hard_reset"
+        reason = None
+        if trigger == "openhands_condensation_events":
+            reason = "events"
+        elif trigger == "openhands_condensation_tokens":
+            reason = "tokens"
+        elif trigger == "openhands_condensation_request":
+            reason = "request"
+        elif trigger == "openhands_condensation_hard_reset":
+            reason = "hard_reset"
+        openhands_extra = OpenHandsCompactionExtra(
+            reason=reason,
+            requirement="hard" if hard_reset or trigger == "openhands_condensation_request" else "soft",
+            hard_reset=hard_reset,
+            forgotten_event_count=len(event.forgotten_event_ids),
+            max_size=int(cfg["max_size"]),
+            max_tokens=cfg["max_tokens"],
+            keep_first=int(cfg["keep_first"]),
+        )
+        compaction_event = CompactionEvent(
+            compaction_index=compaction_index,
+            trigger=trigger,
+            strategy="openhands_condensation",
+            replacement_content=event.summary or "",
+            tokens_before=tokens_before,
+            tokens_after=tokens_after,
+            llm_call_count=llm_call_count_for_strategy("openhands_condensation"),
+            steps_compacted=map_forgotten_to_steps(event.forgotten_event_ids, event_to_step),
+            observation_extra=_observation_extra_for_response(llm, event.llm_response_id),
+            openhands_extra=openhands_extra,
+            timestamp=event.timestamp,
+        )
+        out.append((event.timestamp, compaction_event))
+        idx += 1
+    return out
+
+
+def splice_compaction_steps_into_trajectory(
+    trajectory: dict[str, Any],
+    compaction_entries: list[tuple[str, CompactionEvent]],
+) -> dict[str, Any]:
+    if not compaction_entries:
+        return trajectory
+    steps = list(trajectory.get("steps") or [])
+    pending = list(compaction_entries)
+    pending.sort(key=lambda item: _timestamp_sort_key(item[0]))
+    merged: list[dict[str, Any]] = []
+    pending_idx = 0
+    for step in steps:
+        step_ts = step.get("timestamp")
+        while pending_idx < len(pending):
+            compaction_ts, compaction_event = pending[pending_idx]
+            if _timestamp_sort_key(compaction_ts) > _timestamp_sort_key(step_ts):
+                break
+            merged.append(build_compaction_step(compaction_event, step_id=0))
+            pending_idx += 1
+        merged.append(step)
+    while pending_idx < len(pending):
+        _, compaction_event = pending[pending_idx]
+        merged.append(build_compaction_step(compaction_event, step_id=0))
+        pending_idx += 1
+    for index, step in enumerate(merged):
+        step["step_id"] = index + 1
+    trajectory["steps"] = merged
+    return trajectory
+
+
+def enrich_trajectory_with_compaction(
+    trajectory: dict[str, Any],
+    events: list[Event],
+    llm: LLM,
+    context_limit: int,
+    *,
+    condenser_config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    compaction_entries = build_compaction_events_from_run(
+        events,
+        llm,
+        context_limit,
+        condenser_config=condenser_config,
+    )
+    if not compaction_entries:
+        return trajectory
+    return splice_compaction_steps_into_trajectory(trajectory, compaction_entries)

--- a/tests/test_adapters/test_call_kind.py
+++ b/tests/test_adapters/test_call_kind.py
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from nemo_evaluator.adapters.call_kind import (
+    NEL_CALL_KIND_COMPACTION,
+    NEL_CALL_KIND_HEADER,
+    is_compaction_call_kind,
+    merge_compaction_extra_headers,
+    strip_call_kind_header,
+)
+
+
+def test_merge_compaction_extra_headers_sets_marker():
+    out = merge_compaction_extra_headers({"temperature": 0.2})
+    assert out["temperature"] == 0.2
+    assert out["extra_headers"][NEL_CALL_KIND_HEADER] == NEL_CALL_KIND_COMPACTION
+
+
+def test_merge_compaction_extra_headers_preserves_existing():
+    out = merge_compaction_extra_headers({"extra_headers": {"X-Keep": "1"}})
+    assert out["extra_headers"]["X-Keep"] == "1"
+    assert out["extra_headers"][NEL_CALL_KIND_HEADER] == NEL_CALL_KIND_COMPACTION
+
+
+def test_strip_call_kind_header_is_case_insensitive():
+    headers = {"X-NEL-Call-Kind": "compaction", "content-type": "application/json"}
+    kind = strip_call_kind_header(headers)
+    assert is_compaction_call_kind(kind)
+    assert "X-NEL-Call-Kind" not in headers
+    assert headers["content-type"] == "application/json"

--- a/tests/test_adapters/test_interceptors.py
+++ b/tests/test_adapters/test_interceptors.py
@@ -241,6 +241,107 @@ async def test_turn_counter_basic():
         await ic.intercept_request(_req({"model": "test", "messages": [{"role": "user", "content": "hi"}]}))
 
 
+async def test_turn_counter_skips_compaction_calls():
+    from nemo_evaluator.adapters.call_kind import NEL_CALL_KIND_COMPACTION, NEL_CALL_KIND_HEADER
+
+    ic = InterceptorRegistry.create("turn_counter", {"max_turns": 2})
+    body = {"model": "test", "messages": [{"role": "user", "content": "hi"}]}
+
+    for _ in range(5):
+        req = _req(body)
+        req.ctx.extra["session_id"] = "sess"
+        req.headers[NEL_CALL_KIND_HEADER] = NEL_CALL_KIND_COMPACTION
+        result = await ic.intercept_request(req)
+        assert NEL_CALL_KIND_HEADER not in result.headers
+        assert NEL_CALL_KIND_HEADER not in {k.lower() for k in result.headers}
+
+    for _ in range(2):
+        req = _req(body)
+        req.ctx.extra["session_id"] = "sess"
+        await ic.intercept_request(req)
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "sess"
+    with pytest.raises(GracefulError, match="Turn budget exhausted"):
+        await ic.intercept_request(req)
+
+
+async def test_turn_counter_compaction_interleaved_with_agent_calls():
+    from nemo_evaluator.adapters.call_kind import NEL_CALL_KIND_COMPACTION, NEL_CALL_KIND_HEADER
+
+    ic = InterceptorRegistry.create("turn_counter", {"max_turns": 3})
+    body = {"model": "test", "messages": [{"role": "user", "content": "hi"}]}
+
+    async def agent_turn():
+        req = _req(body)
+        req.ctx.extra["session_id"] = "interleaved"
+        await ic.intercept_request(req)
+
+    async def compaction_turn():
+        req = _req(body)
+        req.ctx.extra["session_id"] = "interleaved"
+        req.headers[NEL_CALL_KIND_HEADER] = NEL_CALL_KIND_COMPACTION
+        result = await ic.intercept_request(req)
+        assert NEL_CALL_KIND_HEADER not in {k.lower() for k in result.headers}
+
+    await agent_turn()
+    await compaction_turn()
+    await agent_turn()
+    await compaction_turn()
+    await compaction_turn()
+    await agent_turn()
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "interleaved"
+    with pytest.raises(GracefulError, match="Turn budget exhausted"):
+        await ic.intercept_request(req)
+
+
+async def test_compaction_extra_headers_reach_turn_counter_like_litellm_wire(monkeypatch):
+    from nemo_evaluator.adapters.call_kind import (
+        NEL_CALL_KIND_COMPACTION,
+        NEL_CALL_KIND_HEADER,
+        merge_compaction_extra_headers,
+    )
+
+    captured: dict = {}
+
+    async def fake_acompletion(**kwargs):
+        captured.clear()
+        captured.update(kwargs)
+        raise RuntimeError("stop-after-header-capture")
+
+    import litellm
+
+    monkeypatch.setattr(litellm, "acompletion", fake_acompletion)
+    from harbor.llms.lite_llm import LiteLLM
+
+    llm = LiteLLM(model_name="openai/test-model", api_base="http://localhost:9")
+    with pytest.raises(RuntimeError, match="stop-after-header-capture"):
+        await llm.call(prompt="hi", **merge_compaction_extra_headers({}))
+
+    assert captured.get("extra_headers", {}).get(NEL_CALL_KIND_HEADER) == NEL_CALL_KIND_COMPACTION
+
+    ic = InterceptorRegistry.create("turn_counter", {"max_turns": 1})
+    wire_headers = {str(k).lower(): str(v) for k, v in (captured.get("extra_headers") or {}).items()}
+    body = {"model": "test", "messages": [{"role": "user", "content": "hi"}]}
+    for _ in range(3):
+        req = _req(body)
+        req.ctx.extra["session_id"] = "wire"
+        req.headers.update(wire_headers)
+        result = await ic.intercept_request(req)
+        assert NEL_CALL_KIND_HEADER not in {k.lower() for k in result.headers}
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "wire"
+    await ic.intercept_request(req)
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "wire"
+    with pytest.raises(GracefulError, match="Turn budget exhausted"):
+        await ic.intercept_request(req)
+
+
 async def test_turn_counter_session_isolation():
     """Repeats of the same problem get independent turn budgets when
     the proxy injects distinct session_id values."""

--- a/tests/test_adapters/test_interceptors.py
+++ b/tests/test_adapters/test_interceptors.py
@@ -262,6 +262,12 @@ async def test_turn_counter_skips_compaction_calls():
 
     req = _req(body)
     req.ctx.extra["session_id"] = "sess"
+    req.headers[NEL_CALL_KIND_HEADER] = NEL_CALL_KIND_COMPACTION
+    with pytest.raises(GracefulError, match="Skipping compaction"):
+        await ic.intercept_request(req)
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "sess"
     with pytest.raises(GracefulError, match="Turn budget exhausted"):
         await ic.intercept_request(req)
 
@@ -293,8 +299,53 @@ async def test_turn_counter_compaction_interleaved_with_agent_calls():
 
     req = _req(body)
     req.ctx.extra["session_id"] = "interleaved"
+    req.headers[NEL_CALL_KIND_HEADER] = NEL_CALL_KIND_COMPACTION
+    with pytest.raises(GracefulError, match="Skipping compaction"):
+        await ic.intercept_request(req)
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "interleaved"
     with pytest.raises(GracefulError, match="Turn budget exhausted"):
         await ic.intercept_request(req)
+
+
+async def test_turn_counter_rejects_compaction_when_no_agent_turns_remain():
+    from nemo_evaluator.adapters.call_kind import NEL_CALL_KIND_COMPACTION, NEL_CALL_KIND_HEADER
+
+    ic = InterceptorRegistry.create("turn_counter", {"max_turns": 2})
+    body = {"model": "test", "messages": [{"role": "user", "content": "hi"}]}
+
+    for _ in range(2):
+        req = _req(body)
+        req.ctx.extra["session_id"] = "exhausted"
+        await ic.intercept_request(req)
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "exhausted"
+    req.headers[NEL_CALL_KIND_HEADER] = NEL_CALL_KIND_COMPACTION
+    with pytest.raises(GracefulError, match="Skipping compaction because no further agent turns remain"):
+        await ic.intercept_request(req)
+
+
+async def test_turn_counter_allows_compaction_with_remaining_agent_turn():
+    from nemo_evaluator.adapters.call_kind import NEL_CALL_KIND_COMPACTION, NEL_CALL_KIND_HEADER
+
+    ic = InterceptorRegistry.create("turn_counter", {"max_turns": 2})
+    body = {"model": "test", "messages": [{"role": "user", "content": "hi"}]}
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "one-left"
+    await ic.intercept_request(req)
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "one-left"
+    req.headers[NEL_CALL_KIND_HEADER] = NEL_CALL_KIND_COMPACTION
+    result = await ic.intercept_request(req)
+    assert NEL_CALL_KIND_HEADER not in {k.lower() for k in result.headers}
+
+    req = _req(body)
+    req.ctx.extra["session_id"] = "one-left"
+    await ic.intercept_request(req)
 
 
 async def test_compaction_extra_headers_reach_turn_counter_like_litellm_wire(monkeypatch):

--- a/tests/test_solvers/test_compaction_logging.py
+++ b/tests/test_solvers/test_compaction_logging.py
@@ -9,7 +9,6 @@ from nemo_evaluator.solvers.compaction_logging import (
     CompactionObservationExtra,
     CompactionTokens,
     CompactionTokensIntermediate,
-    StepsCompacted,
     build_compaction_step,
     compaction_event_to_harbor_step,
     llm_call_count_for_strategy,
@@ -33,7 +32,6 @@ def _minimal_event(**overrides) -> CompactionEvent:
             free_tokens=192_000,
         ),
         llm_call_count=3,
-        steps_compacted=StepsCompacted(first_step_id=2, last_step_id=10, step_count=9),
         mechanism=CompactionMechanism(
             unwind_applied=False,
             chat_reset_applied=False,
@@ -41,7 +39,6 @@ def _minimal_event(**overrides) -> CompactionEvent:
         ),
         subagent_trajectory_ref=[
             {
-                "trajectory_path": "trajectory.summarization-1-summary.json",
                 "session_id": "sess-summarization-1-summary",
                 "extra": {"phase": "summary"},
             }
@@ -56,7 +53,7 @@ def _minimal_event(**overrides) -> CompactionEvent:
 def test_build_compaction_step_full_three_phase() -> None:
     step = build_compaction_step(_minimal_event(), step_id=11)
     assert step["source"] == "system"
-    assert step["llm_call_count"] == 3
+    assert step["extra"]["compaction"]["llm_call_count"] == 3
     assert step["extra"]["context_management"] == {"type": "compaction", "boundary": "replace"}
     assert step["extra"]["compaction"]["strategy"] == "terminus_three_phase_subagent"
     assert step["extra"]["compaction"]["tokens_before"]["prompt_tokens_approx"] == 190_000
@@ -120,9 +117,9 @@ def test_build_compaction_step_with_failed_attempts() -> None:
     assert len(attempts) == 1
     assert attempts[0]["strategy"] == "terminus_three_phase_subagent"
     assert attempts[0]["outcome"] == "failed"
-    mechanism = step["extra"]["compaction"]["mechanism"]
-    assert mechanism["unwind_applied"] is True
-    assert mechanism["messages_unwound_pairs"] == 10
+    strategy_details = step["extra"]["compaction"]["strategy_details"]
+    assert strategy_details["unwind_applied"] is True
+    assert strategy_details["messages_unwound_pairs"] == 10
     obs_extra = step["observation"]["results"][0]["extra"]
     assert obs_extra["compaction_prompt_tokens"] == 4200
 
@@ -150,19 +147,18 @@ def test_build_compaction_step_openhands_extra() -> None:
         ),
     )
     step = build_compaction_step(event, step_id=4)
-    openhands = step["extra"]["compaction"]["openhands"]
-    assert openhands["reason"] == "events"
-    assert openhands["forgotten_event_count"] == 12
-    assert openhands["max_size"] == 80
-    assert "mechanism" not in step["extra"]["compaction"]
+    strategy_details = step["extra"]["compaction"]["strategy_details"]
+    assert strategy_details["reason"] == "events"
+    assert strategy_details["forgotten_event_count"] == 12
+    assert strategy_details["max_size"] == 80
 
 
 def test_compaction_event_to_harbor_step() -> None:
-    step, llm_call_count = compaction_event_to_harbor_step(_minimal_event(), step_id=3)
-    assert llm_call_count == 3
+    step = compaction_event_to_harbor_step(_minimal_event(), step_id=3)
+    assert step.extra is not None
+    assert step.extra["compaction"]["llm_call_count"] == 3
     assert step.step_id == 3
     assert step.source == "system"
-    assert step.extra is not None
     assert step.extra["context_management"]["type"] == "compaction"
     assert step.observation is not None
     assert step.observation.results[0].content == "handoff text"

--- a/tests/test_solvers/test_compaction_logging.py
+++ b/tests/test_solvers/test_compaction_logging.py
@@ -19,7 +19,7 @@ from nemo_evaluator.solvers.compaction_logging import (
 def _minimal_event(**overrides) -> CompactionEvent:
     base = CompactionEvent(
         compaction_index=1,
-        trigger="proactive_threshold",
+        trigger="terminus_proactive_threshold",
         strategy="terminus_three_phase_subagent",
         replacement_content="handoff text",
         tokens_before=CompactionTokens(
@@ -69,7 +69,7 @@ def test_build_compaction_step_full_three_phase() -> None:
 
 def test_build_compaction_step_with_intermediate_tokens() -> None:
     event = _minimal_event(
-        trigger="context_length_exceeded",
+        trigger="terminus_context_length_exceeded",
         strategy="terminus_short_fallback",
         tokens_intermediate=CompactionTokensIntermediate(
             after_unwind=CompactionTokens(
@@ -131,6 +131,30 @@ def test_llm_call_count_for_strategy() -> None:
     assert llm_call_count_for_strategy("terminus_three_phase_subagent") == 3
     assert llm_call_count_for_strategy("terminus_short_fallback") == 1
     assert llm_call_count_for_strategy("terminus_ultimate_fallback") == 0
+
+
+def test_build_compaction_step_openhands_extra() -> None:
+    from nemo_evaluator.solvers.compaction_logging import OpenHandsCompactionExtra
+
+    event = _minimal_event(
+        trigger="openhands_condensation_events",
+        strategy="openhands_condensation",
+        llm_call_count=1,
+        subagent_trajectory_ref=None,
+        mechanism=None,
+        openhands_extra=OpenHandsCompactionExtra(
+            reason="events",
+            requirement="soft",
+            forgotten_event_count=12,
+            max_size=80,
+        ),
+    )
+    step = build_compaction_step(event, step_id=4)
+    openhands = step["extra"]["compaction"]["openhands"]
+    assert openhands["reason"] == "events"
+    assert openhands["forgotten_event_count"] == 12
+    assert openhands["max_size"] == 80
+    assert "mechanism" not in step["extra"]["compaction"]
 
 
 def test_compaction_event_to_harbor_step() -> None:

--- a/tests/test_solvers/test_compaction_logging.py
+++ b/tests/test_solvers/test_compaction_logging.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+from nemo_evaluator.solvers.compaction_logging import (
+    CompactionAttempt,
+    CompactionEvent,
+    CompactionMechanism,
+    CompactionObservationExtra,
+    CompactionTokens,
+    CompactionTokensIntermediate,
+    StepsCompacted,
+    build_compaction_step,
+    compaction_event_to_harbor_step,
+    llm_call_count_for_strategy,
+)
+
+
+def _minimal_event(**overrides) -> CompactionEvent:
+    base = CompactionEvent(
+        compaction_index=1,
+        trigger="proactive_threshold",
+        strategy="terminus_three_phase_subagent",
+        replacement_content="handoff text",
+        tokens_before=CompactionTokens(
+            prompt_tokens_approx=190_000,
+            context_limit=200_000,
+            free_tokens=10_000,
+        ),
+        tokens_after=CompactionTokens(
+            prompt_tokens_approx=8_000,
+            context_limit=200_000,
+            free_tokens=192_000,
+        ),
+        llm_call_count=3,
+        steps_compacted=StepsCompacted(first_step_id=2, last_step_id=10, step_count=9),
+        mechanism=CompactionMechanism(
+            unwind_applied=False,
+            chat_reset_applied=False,
+            messages_unwound_pairs=0,
+        ),
+        subagent_trajectory_ref=[
+            {
+                "trajectory_path": "trajectory.summarization-1-summary.json",
+                "session_id": "sess-summarization-1-summary",
+                "extra": {"phase": "summary"},
+            }
+        ],
+        timestamp="2026-06-23T02:17:14.197933+00:00",
+    )
+    for key, value in overrides.items():
+        setattr(base, key, value)
+    return base
+
+
+def test_build_compaction_step_full_three_phase() -> None:
+    step = build_compaction_step(_minimal_event(), step_id=11)
+    assert step["source"] == "system"
+    assert step["llm_call_count"] == 3
+    assert step["extra"]["context_management"] == {"type": "compaction", "boundary": "replace"}
+    assert step["extra"]["compaction"]["strategy"] == "terminus_three_phase_subagent"
+    assert step["extra"]["compaction"]["tokens_before"]["prompt_tokens_approx"] == 190_000
+    assert step["extra"]["compaction"]["tokens_after"]["prompt_tokens_approx"] == 8_000
+    assert step["observation"]["results"][0]["content"] == "handoff text"
+    refs = step["observation"]["results"][0]["subagent_trajectory_ref"]
+    assert len(refs) == 1
+    assert refs[0]["session_id"] == "sess-summarization-1-summary"
+
+
+def test_build_compaction_step_with_intermediate_tokens() -> None:
+    event = _minimal_event(
+        trigger="context_length_exceeded",
+        strategy="terminus_short_fallback",
+        tokens_intermediate=CompactionTokensIntermediate(
+            after_unwind=CompactionTokens(
+                prompt_tokens_approx=150_000,
+                context_limit=200_000,
+                free_tokens=50_000,
+            ),
+            after_chat_reset=CompactionTokens(
+                prompt_tokens_approx=12_000,
+                context_limit=200_000,
+                free_tokens=188_000,
+            ),
+        ),
+    )
+    step = build_compaction_step(event, step_id=7)
+    intermediate = step["extra"]["compaction"]["tokens_intermediate"]
+    assert intermediate["after_unwind"]["prompt_tokens_approx"] == 150_000
+    assert intermediate["after_chat_reset"]["prompt_tokens_approx"] == 12_000
+
+
+def test_build_compaction_step_with_failed_attempts() -> None:
+    event = _minimal_event(
+        strategy="terminus_short_fallback",
+        llm_call_count=1,
+        subagent_trajectory_ref=None,
+        attempts=[
+            CompactionAttempt(
+                strategy="terminus_three_phase_subagent",
+                error="timeout",
+                llm_calls=2,
+                phases_completed=["summary", "questions"],
+            )
+        ],
+        mechanism=CompactionMechanism(
+            unwind_applied=True,
+            chat_reset_applied=True,
+            messages_unwound_pairs=10,
+            unwind_target_free_tokens=4000,
+        ),
+        observation_extra=CompactionObservationExtra(
+            compaction_prompt_tokens=4200,
+            compaction_completion_tokens=180,
+            compaction_cost_usd=0.008,
+        ),
+    )
+    step = build_compaction_step(event, step_id=5)
+    attempts = step["extra"]["compaction"]["attempts"]
+    assert len(attempts) == 1
+    assert attempts[0]["strategy"] == "terminus_three_phase_subagent"
+    assert attempts[0]["outcome"] == "failed"
+    mechanism = step["extra"]["compaction"]["mechanism"]
+    assert mechanism["unwind_applied"] is True
+    assert mechanism["messages_unwound_pairs"] == 10
+    obs_extra = step["observation"]["results"][0]["extra"]
+    assert obs_extra["compaction_prompt_tokens"] == 4200
+
+
+def test_llm_call_count_for_strategy() -> None:
+    assert llm_call_count_for_strategy("terminus_three_phase_subagent") == 3
+    assert llm_call_count_for_strategy("terminus_short_fallback") == 1
+    assert llm_call_count_for_strategy("terminus_ultimate_fallback") == 0
+
+
+def test_compaction_event_to_harbor_step() -> None:
+    step, llm_call_count = compaction_event_to_harbor_step(_minimal_event(), step_id=3)
+    assert llm_call_count == 3
+    assert step.step_id == 3
+    assert step.source == "system"
+    assert step.extra is not None
+    assert step.extra["context_management"]["type"] == "compaction"
+    assert step.observation is not None
+    assert step.observation.results[0].content == "handoff text"
+    assert step.observation.results[0].subagent_trajectory_ref is not None
+    assert step.observation.results[0].subagent_trajectory_ref[0].session_id == "sess-summarization-1-summary"

--- a/tests/test_solvers/test_compaction_logging.py
+++ b/tests/test_solvers/test_compaction_logging.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 
+import json
+
 from nemo_evaluator.solvers.compaction_logging import (
     CompactionAttempt,
     CompactionEvent,
@@ -12,6 +14,7 @@ from nemo_evaluator.solvers.compaction_logging import (
     build_compaction_step,
     compaction_event_to_harbor_step,
     llm_call_count_for_strategy,
+    serialize_chat_messages,
 )
 
 
@@ -20,7 +23,14 @@ def _minimal_event(**overrides) -> CompactionEvent:
         compaction_index=1,
         trigger="terminus_proactive_threshold",
         strategy="terminus_three_phase_subagent",
-        replacement_content="handoff text",
+        replacement_content=serialize_chat_messages(
+            [
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "question prompt"},
+                {"role": "assistant", "content": "model questions"},
+                {"role": "user", "content": "handoff text"},
+            ]
+        ),
         tokens_before=CompactionTokens(
             prompt_tokens_approx=190_000,
             context_limit=200_000,
@@ -44,10 +54,24 @@ def _minimal_event(**overrides) -> CompactionEvent:
             }
         ],
         timestamp="2026-06-23T02:17:14.197933+00:00",
+        handoff_prompt="handoff text",
     )
     for key, value in overrides.items():
         setattr(base, key, value)
     return base
+
+
+def test_serialize_chat_messages_preserves_roles() -> None:
+    payload = serialize_chat_messages(
+        [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": [{"type": "text", "text": "hello"}]},
+        ]
+    )
+    assert json.loads(payload) == [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "hello"},
+    ]
 
 
 def test_build_compaction_step_full_three_phase() -> None:
@@ -58,7 +82,9 @@ def test_build_compaction_step_full_three_phase() -> None:
     assert step["extra"]["compaction"]["strategy"] == "terminus_three_phase_subagent"
     assert step["extra"]["compaction"]["tokens_before"]["prompt_tokens_approx"] == 190_000
     assert step["extra"]["compaction"]["tokens_after"]["prompt_tokens_approx"] == 8_000
-    assert step["observation"]["results"][0]["content"] == "handoff text"
+    content = json.loads(step["observation"]["results"][0]["content"])
+    assert content[-1] == {"role": "user", "content": "handoff text"}
+    assert len(content) == 4
     refs = step["observation"]["results"][0]["subagent_trajectory_ref"]
     assert len(refs) == 1
     assert refs[0]["session_id"] == "sess-summarization-1-summary"
@@ -161,6 +187,7 @@ def test_compaction_event_to_harbor_step() -> None:
     assert step.source == "system"
     assert step.extra["context_management"]["type"] == "compaction"
     assert step.observation is not None
-    assert step.observation.results[0].content == "handoff text"
+    content = json.loads(step.observation.results[0].content)
+    assert content[-1]["content"] == "handoff text"
     assert step.observation.results[0].subagent_trajectory_ref is not None
     assert step.observation.results[0].subagent_trajectory_ref[0].session_id == "sess-summarization-1-summary"

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -514,6 +514,58 @@ def main():
         assert "OH_CONDENSER_MAX_SIZE" in patched
         assert 'sys.path.insert(0, "/installed-agent/nel")' in patched
 
+    async def test_runner_patch_marks_condenser_llm_calls(self):
+        import base64
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
+
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = MagicMock(stdout="ok", stderr="", return_code=0)
+        await _patch_openhands_sdk(sandbox)
+
+        decoded_scripts = []
+        for call in sandbox.exec.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+            if "base64 -d" in cmd:
+                encoded = cmd.split("echo ", 1)[1].split(" ", 1)[0]
+                decoded_scripts.append(base64.b64decode(encoded).decode())
+
+        condenser_patch = next(
+            (s for s in decoded_scripts if "x-nel-call-kind" in s and "LLMSummarizingCondenser" in s),
+            None,
+        )
+        assert condenser_patch is not None
+        assert "model_copy" in condenser_patch
+        assert '_hdrs["x-nel-call-kind"] = "compaction"' in condenser_patch
+
+    async def test_runner_patch_skips_max_iteration_for_condensation(self):
+        import base64
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
+
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = MagicMock(stdout="ok", stderr="", return_code=0)
+        await _patch_openhands_sdk(sandbox)
+
+        decoded_scripts = []
+        for call in sandbox.exec.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+            if "base64 -d" in cmd:
+                encoded = cmd.split("echo ", 1)[1].split(" ", 1)[0]
+                decoded_scripts.append(base64.b64decode(encoded).decode())
+
+        max_iter_patch = next(
+            (
+                s
+                for s in decoded_scripts
+                if "local_conversation.py" in s and "_nel_last" in s and "isinstance(_nel_last, Condensation)" in s
+            ),
+            None,
+        )
+        assert max_iter_patch is not None
+        assert "iteration += 1" in max_iter_patch
+        assert "isinstance(_nel_last, (Condensation, CondensationRequest))" not in max_iter_patch
+
     _EVENTS_MSG_AND_ACTION = (
         'MessageEvent("agent", "partial reasoning", 1.0), ActionEvent(2.0, "call-1", "bash", \'{"command": "ls"}\')'
     )

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -537,6 +537,7 @@ def main():
         assert condenser_patch is not None
         assert "model_copy" in condenser_patch
         assert '_hdrs["x-nel-call-kind"] = "compaction"' in condenser_patch
+        assert '"usage_id": f"{llm.usage_id}-compaction"' in condenser_patch
 
     async def test_runner_patch_skips_max_iteration_for_condensation(self):
         import base64

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import tarfile
 import time
@@ -30,6 +31,7 @@ from nemo_evaluator.solvers.harbor import (
     _ensure_host_env,
     _error_from_crash_marker,
     _extract_response,
+    _flatten_atif_continuation_chain,
     _host_agent_model_url,
     _is_turn_budget_exhausted_error,
     _last_llm_error_from_marker,
@@ -2574,3 +2576,117 @@ class TestSolveZeroTokenFlag:
         )
 
         assert "final_metrics" not in result.trajectory[0]
+
+
+# ── _flatten_atif_continuation_chain ─────────────────────────────────────
+
+
+class TestFlattenAtifContinuationChain:
+    def test_single_file_renumbers_step_ids(self, tmp_path):
+        root = {
+            "session_id": "s",
+            "steps": [
+                {"step_id": 99, "source": "user", "message": "hi"},
+                {"step_id": 200, "source": "agent", "message": "done"},
+            ],
+        }
+        result = _flatten_atif_continuation_chain(root, tmp_path)
+        assert result["steps"][0]["step_id"] == 1
+        assert result["steps"][1]["step_id"] == 2
+        assert "continued_trajectory_ref" not in result
+
+    def test_two_file_chain_appends_and_renumbers(self, tmp_path):
+        cont = {
+            "steps": [{"step_id": 1, "source": "agent", "message": "done"}],
+            "final_metrics": {"total_prompt_tokens": 9, "total_completion_tokens": 5},
+        }
+        (tmp_path / "trajectory.cont-1.json").write_text(json.dumps(cont))
+        root = {
+            "session_id": "s",
+            "steps": [{"step_id": 1, "source": "user", "message": "go"}],
+            "final_metrics": {"total_prompt_tokens": 3, "total_completion_tokens": 1},
+            "continued_trajectory_ref": "trajectory.cont-1.json",
+        }
+        result = _flatten_atif_continuation_chain(root, tmp_path)
+        assert len(result["steps"]) == 2
+        assert result["steps"][0]["step_id"] == 1
+        assert result["steps"][1]["step_id"] == 2
+        assert "continued_trajectory_ref" not in result
+        assert result["final_metrics"]["total_prompt_tokens"] == 9
+
+    def test_three_file_chain(self, tmp_path):
+        (tmp_path / "trajectory.cont-2.json").write_text(
+            json.dumps({"steps": [{"step_id": 1, "source": "agent", "message": "c2"}]})
+        )
+        (tmp_path / "trajectory.cont-1.json").write_text(
+            json.dumps(
+                {
+                    "steps": [{"step_id": 1, "source": "agent", "message": "c1"}],
+                    "continued_trajectory_ref": "trajectory.cont-2.json",
+                }
+            )
+        )
+        root = {
+            "steps": [{"step_id": 1, "source": "user", "message": "root"}],
+            "continued_trajectory_ref": "trajectory.cont-1.json",
+        }
+        result = _flatten_atif_continuation_chain(root, tmp_path)
+        assert len(result["steps"]) == 3
+        assert [s["step_id"] for s in result["steps"]] == [1, 2, 3]
+
+    def test_missing_continuation_file_warns_and_stops(self, tmp_path, caplog):
+        root = {
+            "steps": [{"step_id": 1, "source": "user", "message": "x"}],
+            "continued_trajectory_ref": "trajectory.cont-1.json",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _flatten_atif_continuation_chain(root, tmp_path)
+        assert len(result["steps"]) == 1
+        assert any("missing file" in r.getMessage() for r in caplog.records)
+
+    def test_malformed_json_warns_and_stops(self, tmp_path, caplog):
+        (tmp_path / "trajectory.cont-1.json").write_text("not json {{{")
+        root = {
+            "steps": [{"step_id": 1, "source": "user", "message": "x"}],
+            "continued_trajectory_ref": "trajectory.cont-1.json",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _flatten_atif_continuation_chain(root, tmp_path)
+        assert len(result["steps"]) == 1
+        assert any("Failed to read" in r.getMessage() for r in caplog.records)
+
+    def test_cycle_breaks_with_warning(self, tmp_path, caplog):
+        (tmp_path / "trajectory.cont-2.json").write_text(
+            json.dumps(
+                {
+                    "steps": [{"step_id": 1, "source": "agent", "message": "c2"}],
+                    "continued_trajectory_ref": "trajectory.cont-1.json",
+                }
+            )
+        )
+        (tmp_path / "trajectory.cont-1.json").write_text(
+            json.dumps(
+                {
+                    "steps": [{"step_id": 1, "source": "agent", "message": "c1"}],
+                    "continued_trajectory_ref": "trajectory.cont-2.json",
+                }
+            )
+        )
+        root = {
+            "steps": [{"step_id": 1, "source": "user", "message": "root"}],
+            "continued_trajectory_ref": "trajectory.cont-1.json",
+        }
+        with caplog.at_level(logging.WARNING):
+            result = _flatten_atif_continuation_chain(root, tmp_path)
+        assert len(result["steps"]) == 3
+        assert any("Cycle detected" in r.getMessage() for r in caplog.records)
+
+    def test_does_not_mutate_original(self, tmp_path):
+        root = {
+            "steps": [{"step_id": 99, "source": "user", "message": "x"}],
+        }
+        import copy
+
+        original = copy.deepcopy(root)
+        _flatten_atif_continuation_chain(root, tmp_path)
+        assert root == original

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -216,7 +216,7 @@ class TestPatchOpenhandsSDK:
         sandbox = AsyncMock()
         sandbox.exec.return_value = MagicMock(stdout="stuck_detection disabled", stderr="", return_code=0)
         await _patch_openhands_sdk(sandbox)
-        assert sandbox.exec.call_count >= 4
+        assert sandbox.exec.call_count >= 6
 
     async def test_runner_patch_disables_visualizer(self):
         """Patch 0 must inject both stuck_detection=False AND visualizer=None.
@@ -448,6 +448,71 @@ def build_trajectory(events, llm_metrics, model_name):
             "completed_at": "2026-06-05T12:00:01.250Z",
             "duration_ms": 1250.0,
         }
+
+    async def test_runner_patch_injects_compaction_logging(self, tmp_path):
+        import base64
+
+        from nemo_evaluator.solvers.harbor import _patch_openhands_sdk
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            """\
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def build_trajectory(events_list, metrics, model, system_prompt=None, tool_definitions=None):
+    return {"steps": []}
+
+
+def main():
+    events_list = []
+    metrics = {}
+    model = "model"
+    system_prompt = None
+    tool_definitions = None
+    args = SimpleNamespace(trajectory_path="trajectory.json")
+    trajectory = build_trajectory(
+        events_list,
+        metrics,
+        model,
+        system_prompt=system_prompt,
+        tool_definitions=tool_definitions,
+    )
+
+    trajectory_path = Path(args.trajectory_path)
+"""
+        )
+
+        sandbox = AsyncMock()
+        sandbox.exec.return_value = MagicMock(stdout="ok", stderr="", return_code=0)
+        await _patch_openhands_sdk(sandbox)
+
+        decoded_scripts = []
+        for call in sandbox.exec.call_args_list:
+            cmd = call.args[0] if call.args else call.kwargs.get("cmd", "")
+            if "base64 -d" in cmd:
+                encoded = cmd.split("echo ", 1)[1].split(" ", 1)[0]
+                decoded_scripts.append(base64.b64decode(encoded).decode())
+
+        compaction_patch = next(
+            (s for s in decoded_scripts if "enrich_trajectory_with_compaction" in s),
+            None,
+        )
+        assert compaction_patch is not None, "compaction inject patch script not emitted"
+
+        compaction_patch = compaction_patch.replace(
+            "p = '/installed-agent/run_agent.py'",
+            f"p = {str(runner)!r}",
+        )
+        exec(compile(compaction_patch, "compaction_patch.py", "exec"), {})
+
+        patched = runner.read_text()
+        assert "enrich_trajectory_with_compaction" in patched
+        assert "OPENHANDS_CONDENSER_MAX_SIZE" in patched
+        assert 'sys.path.insert(0, "/installed-agent/nel")' in patched
 
     _EVENTS_MSG_AND_ACTION = (
         'MessageEvent("agent", "partial reasoning", 1.0), ActionEvent(2.0, "call-1", "bash", \'{"command": "ls"}\')'

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -511,7 +511,7 @@ def main():
 
         patched = runner.read_text()
         assert "enrich_trajectory_with_compaction" in patched
-        assert "OPENHANDS_CONDENSER_MAX_SIZE" in patched
+        assert "OH_CONDENSER_MAX_SIZE" in patched
         assert 'sys.path.insert(0, "/installed-agent/nel")' in patched
 
     _EVENTS_MSG_AND_ACTION = (

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -706,6 +706,8 @@ class TestPatchCompactionLogging:
         assert hasattr(terminus, "_nel_flush_pending_compaction")
 
     def test_flush_appends_compaction_step_without_handoff_user_step(self, patch_sandbox, tmp_path):
+        import json
+
         from nemo_evaluator.solvers.compaction_logging import CompactionTokens
 
         _patch_terminus_compaction_logging()
@@ -731,7 +733,13 @@ class TestPatchCompactionLogging:
         )
         agent._nel_stashed_tokens_intermediate = None
         agent._nel_pending_compaction = None
-        chat = SimpleNamespace()
+        chat = SimpleNamespace(
+            messages=[
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "question prompt"},
+                {"role": "assistant", "content": "model questions"},
+            ]
+        )
         from nemo_evaluator.solvers.harbor import _terminus2_nel_set_proactive_pending_compaction
 
         _terminus2_nel_set_proactive_pending_compaction(agent, chat, "handoff", None)
@@ -742,6 +750,13 @@ class TestPatchCompactionLogging:
         assert step.extra is not None
         assert step.extra["context_management"]["type"] == "compaction"
         assert step.extra["compaction"]["llm_call_count"] == 3
+        content = json.loads(step.observation.results[0].content)
+        assert content == [
+            {"role": "system", "content": "system prompt"},
+            {"role": "user", "content": "question prompt"},
+            {"role": "assistant", "content": "model questions"},
+            {"role": "user", "content": "handoff"},
+        ]
         assert agent._pending_handoff_prompt is None
 
     def test_idempotent_when_marker_present(self, patch_sandbox):

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -27,9 +27,11 @@ from nemo_evaluator.solvers.harbor import (
     _patch_harbor_lite_llm_context_length_matcher,
     _patch_terminus_api_token_anchor,
     _patch_terminus_cle_reset,
+    _patch_terminus_compaction_logging,
     _patch_terminus_unwind_min_pairs,
     _terminus2_build_local_fallback_llm_content,
     _terminus2_count_total_tokens,
+    _terminus2_nel_flush_pending_compaction,
 )
 
 # Module-level stand-ins whose *source* the patch functions inspect. Defining
@@ -55,6 +57,20 @@ _FLAGS = (
     "_TERMINUS_UNWIND_PATCHED",
     "_TERMINUS_API_ANCHOR_PATCHED",
     "_CHAT_TOKEN_ANCHOR_PATCHED",
+    "_TERMINUS_COMPACTION_PATCHED",
+)
+
+_NEL_METHODS = (
+    "_nel_ensure_compaction_state",
+    "_nel_stash_compaction_token_snapshots",
+    "_nel_token_snapshot",
+    "_nel_steps_compacted",
+    "_nel_compaction_mechanism",
+    "_nel_make_compaction_event",
+    "_nel_record_failed_compaction_attempt",
+    "_nel_set_proactive_pending_compaction",
+    "_nel_set_cle_pending_compaction",
+    "_nel_flush_pending_compaction",
 )
 
 
@@ -69,13 +85,18 @@ def patch_sandbox():
         "_query_llm": terminus._query_llm,
         "_unwind": terminus._unwind_messages_to_free_tokens,
         "_count": terminus._count_total_tokens,
+        "_run_agent_loop": terminus._run_agent_loop,
+        "_check_proactive": terminus._check_proactive_summarization,
+        "_dump": terminus._dump_trajectory_with_continuation_index,
         "chat_chat": Chat.chat,
     }
+    saved_nel = {name: terminus.__dict__.get(name) for name in _NEL_METHODS}
     had_fallback = "_build_local_fallback_llm_content" in terminus.__dict__
     fallback_val = terminus.__dict__.get("_build_local_fallback_llm_content")
     had_records = "_records_api_token_anchor" in Chat.__dict__
     records_val = Chat.__dict__.get("_records_api_token_anchor")
     saved_flags = {name: getattr(harbor, name) for name in _FLAGS}
+    saved_query_src = harbor._TERMINUS_QUERY_LLM_SRC
 
     for name in _FLAGS:
         setattr(harbor, name, False)
@@ -85,7 +106,15 @@ def patch_sandbox():
     terminus._query_llm = saved_methods["_query_llm"]
     terminus._unwind_messages_to_free_tokens = saved_methods["_unwind"]
     terminus._count_total_tokens = saved_methods["_count"]
+    terminus._run_agent_loop = saved_methods["_run_agent_loop"]
+    terminus._check_proactive_summarization = saved_methods["_check_proactive"]
+    terminus._dump_trajectory_with_continuation_index = saved_methods["_dump"]
     Chat.chat = saved_methods["chat_chat"]
+    for name, value in saved_nel.items():
+        if value is not None:
+            setattr(terminus, name, value)
+        elif name in terminus.__dict__:
+            delattr(terminus, name)
     if had_fallback:
         terminus._build_local_fallback_llm_content = fallback_val
     elif "_build_local_fallback_llm_content" in terminus.__dict__:
@@ -96,6 +125,7 @@ def patch_sandbox():
         delattr(Chat, "_records_api_token_anchor")
     for name, value in saved_flags.items():
         setattr(harbor, name, value)
+    harbor._TERMINUS_QUERY_LLM_SRC = saved_query_src
 
 
 # ── _terminus2_count_total_tokens ────────────────────────────────────────
@@ -433,7 +463,13 @@ class TestCreateAgentGating:
         from unittest.mock import MagicMock, patch
 
         solver = self._solver("terminus-2")
-        cle, unwind, anchor, ctxlim = MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        cle, unwind, anchor, ctxlim, compaction = (
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_cle_reset", cle)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_unwind_min_pairs", unwind)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_api_token_anchor", anchor)
@@ -441,6 +477,7 @@ class TestCreateAgentGating:
             "nemo_evaluator.solvers.harbor._patch_harbor_lite_llm_context_length_matcher",
             ctxlim,
         )
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_compaction_logging", compaction)
 
         sentinel = object()
         with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=sentinel):
@@ -451,12 +488,19 @@ class TestCreateAgentGating:
         unwind.assert_called_once()
         anchor.assert_called_once()
         ctxlim.assert_called_once()
+        compaction.assert_called_once()
 
     def test_non_terminus_agent_skips_patches(self, tmp_path, monkeypatch):
         from unittest.mock import MagicMock, patch
 
         solver = self._solver("openhands")
-        cle, unwind, anchor, ctxlim = MagicMock(), MagicMock(), MagicMock(), MagicMock()
+        cle, unwind, anchor, ctxlim, compaction = (
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+            MagicMock(),
+        )
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_cle_reset", cle)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_unwind_min_pairs", unwind)
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_api_token_anchor", anchor)
@@ -464,6 +508,7 @@ class TestCreateAgentGating:
             "nemo_evaluator.solvers.harbor._patch_harbor_lite_llm_context_length_matcher",
             ctxlim,
         )
+        monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_compaction_logging", compaction)
 
         with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=object()):
             solver._create_agent(tmp_path)
@@ -472,6 +517,7 @@ class TestCreateAgentGating:
         unwind.assert_not_called()
         anchor.assert_not_called()
         ctxlim.assert_not_called()
+        compaction.assert_not_called()
 
 
 # ── _patch_harbor_lite_llm_context_length_matcher ────────────────────────
@@ -625,3 +671,69 @@ class TestHarborLiteLLMContextLengthMatcher:
             result = instance._is_context_length_error(err)
         assert result is False
         assert not any("stable ctx-overflow marker" in rec.getMessage() for rec in caplog.records)
+
+
+# ── _patch_terminus_compaction_logging ───────────────────────────────────
+
+
+class TestPatchCompactionLogging:
+    def test_apply_patches_run_loop_and_query_llm(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        _patch_terminus_cle_reset()
+        _patch_terminus_unwind_min_pairs()
+        _patch_terminus_compaction_logging()
+        assert harbor._TERMINUS_COMPACTION_PATCHED is True
+        assert harbor._TERMINUS_QUERY_LLM_SRC is not None
+        assert "_nel_set_cle_pending_compaction" in harbor._TERMINUS_QUERY_LLM_SRC
+        assert hasattr(terminus, "_nel_flush_pending_compaction")
+
+    def test_flush_appends_compaction_step_without_handoff_user_step(self, patch_sandbox, tmp_path):
+        from nemo_evaluator.solvers.compaction_logging import CompactionTokens
+
+        _patch_terminus_compaction_logging()
+        terminus = patch_sandbox.terminus
+        agent = terminus(
+            logs_dir=tmp_path,
+            model_name="test-model",
+            model_info={"max_input_tokens": 1000, "max_output_tokens": 1000},
+        )
+        agent._trajectory_steps = []
+        agent._linear_history = False
+        agent._summarization_count = 1
+        agent._pending_handoff_prompt = "handoff"
+        agent._nel_stashed_tokens_before = CompactionTokens(
+            prompt_tokens_approx=190_000,
+            context_limit=200_000,
+            free_tokens=10_000,
+        )
+        agent._nel_stashed_tokens_after = CompactionTokens(
+            prompt_tokens_approx=8_000,
+            context_limit=200_000,
+            free_tokens=192_000,
+        )
+        agent._nel_stashed_tokens_intermediate = None
+        agent._nel_pending_compaction = None
+        chat = SimpleNamespace()
+        from nemo_evaluator.solvers.harbor import _terminus2_nel_set_proactive_pending_compaction
+
+        _terminus2_nel_set_proactive_pending_compaction(agent, chat, "handoff", None)
+        _terminus2_nel_flush_pending_compaction(agent, chat)
+        assert len(agent._trajectory_steps) == 1
+        step = agent._trajectory_steps[0]
+        assert step.source == "system"
+        assert step.extra is not None
+        assert step.extra["context_management"]["type"] == "compaction"
+        assert agent._pending_handoff_prompt is None
+        assert agent._nel_compaction_step_overlays[1]["llm_call_count"] == 3
+
+    def test_idempotent_when_marker_present(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+
+        async def _run_agent_loop_with_marker(self, *args, **kwargs):
+            self._nel_flush_pending_compaction(None)
+
+        terminus._run_agent_loop = _run_agent_loop_with_marker
+        original = terminus._run_agent_loop
+        _patch_terminus_compaction_logging()
+        assert harbor._TERMINUS_COMPACTION_PATCHED is True
+        assert terminus._run_agent_loop is original

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -759,6 +759,48 @@ class TestPatchCompactionLogging:
         ]
         assert agent._pending_handoff_prompt is None
 
+    def test_cle_fallback_does_not_mutate_summarization_count(self, patch_sandbox, tmp_path):
+        """Regression: NEL owns its own compaction counter and must not touch
+        Terminus's ``_summarization_count`` (which drives linear_history
+        continuation file naming). ``_summarize`` bumps that counter before it
+        can fail, so on the CLE short/ultimate fallback NEL previously
+        double-incremented it and corrupted the continuation chain."""
+        from nemo_evaluator.solvers.compaction_logging import CompactionTokens
+        from nemo_evaluator.solvers.harbor import _terminus2_nel_set_cle_pending_compaction
+
+        _patch_terminus_compaction_logging()
+        terminus = patch_sandbox.terminus
+        agent = terminus(
+            logs_dir=tmp_path,
+            model_name="test-model",
+            model_info={"max_input_tokens": 1000, "max_output_tokens": 1000},
+        )
+        agent._trajectory_steps = []
+        agent._linear_history = False
+        chat = SimpleNamespace(messages=[{"role": "system", "content": "s"}])
+
+        def _snap():
+            return CompactionTokens(prompt_tokens_approx=8_000, context_limit=200_000, free_tokens=192_000)
+
+        agent._summarization_count = 5
+
+        for expected_index in (1, 2):
+            _terminus2_nel_set_cle_pending_compaction(
+                agent,
+                chat,
+                "handoff",
+                "terminus_short_fallback",
+                [],
+                None,
+                _snap(),
+                _snap(),
+                None,
+                None,
+            )
+            assert agent._nel_pending_compaction.compaction_index == expected_index
+
+        assert agent._summarization_count == 5
+
     def test_idempotent_when_marker_present(self, patch_sandbox):
         terminus = patch_sandbox.terminus
 

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -32,6 +32,7 @@ from nemo_evaluator.solvers.harbor import (
     _patch_terminus_unwind_min_pairs,
     _terminus2_build_local_fallback_llm_content,
     _terminus2_count_total_tokens,
+    _terminus2_nel_dump_trajectory_with_continuation_index,
     _terminus2_nel_flush_pending_compaction,
 )
 
@@ -856,3 +857,99 @@ class TestPatchTerminusCompactionTurnMarker:
         assert marked["extra_headers"][NEL_CALL_KIND_HEADER] == NEL_CALL_KIND_COMPACTION
         assert agent._llm_call_kwargs == {"temperature": 0.2}
         assert "extra_headers" not in agent._llm_call_kwargs
+
+
+# ── _terminus2_nel_dump_trajectory_with_continuation_index ───────────────
+
+
+def _make_agent_for_dump(terminus_cls, tmp_path, *, linear_history=False, summarization_count=0):
+    from datetime import datetime, timezone
+    from types import SimpleNamespace
+
+    from harbor.models.trajectories.step import Step
+
+    agent = terminus_cls(
+        logs_dir=tmp_path,
+        model_name="test-model",
+        model_info={"max_input_tokens": 1000, "max_output_tokens": 1000},
+    )
+    agent._trajectory_steps = [
+        Step(
+            step_id=1,
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            source="user",
+            message="start",
+        )
+    ]
+    agent._linear_history = linear_history
+    agent._summarization_count = summarization_count
+    agent._session_id = "test-session"
+    agent._parser_name = "default"
+    agent._temperature = 0.0
+    agent._llm_kwargs = {}
+    agent._context = SimpleNamespace(
+        n_input_tokens=100,
+        n_output_tokens=50,
+        n_cache_tokens=0,
+        cost_usd=0.01,
+    )
+    return agent
+
+
+class TestDumpTrajectoryWithContinuationIndex:
+    def test_no_context_skips_write(self, patch_sandbox, tmp_path):
+        terminus = patch_sandbox.terminus
+        agent = terminus(
+            logs_dir=tmp_path,
+            model_name="test-model",
+            model_info={"max_input_tokens": 1000, "max_output_tokens": 1000},
+        )
+        agent._context = None
+        agent._trajectory_steps = []
+        agent._linear_history = False
+        agent._summarization_count = 0
+        _terminus2_nel_dump_trajectory_with_continuation_index(agent, 0)
+        assert not (tmp_path / "trajectory.json").exists()
+
+    def test_non_linear_writes_trajectory_json(self, patch_sandbox, tmp_path):
+        terminus = patch_sandbox.terminus
+        agent = _make_agent_for_dump(terminus, tmp_path, linear_history=False)
+        _terminus2_nel_dump_trajectory_with_continuation_index(agent, 0)
+        traj_path = tmp_path / "trajectory.json"
+        assert traj_path.exists()
+        data = json.loads(traj_path.read_text())
+        assert data["session_id"] == "test-session"
+        # Non-linear should not set continuation_index in agent extra
+        assert "continuation_index" not in (data.get("agent") or {}).get("extra", {})
+
+    def test_linear_continuation_index_gt_0_writes_cont_file(self, patch_sandbox, tmp_path):
+        terminus = patch_sandbox.terminus
+        agent = _make_agent_for_dump(terminus, tmp_path, linear_history=True, summarization_count=2)
+        _terminus2_nel_dump_trajectory_with_continuation_index(agent, 1)
+        cont_path = tmp_path / "trajectory.cont-1.json"
+        assert cont_path.exists()
+        data = json.loads(cont_path.read_text())
+        assert data["agent"]["extra"]["continuation_index"] == 1
+
+    def test_linear_points_to_next_continuation_when_not_last(self, patch_sandbox, tmp_path):
+        terminus = patch_sandbox.terminus
+        agent = _make_agent_for_dump(terminus, tmp_path, linear_history=True, summarization_count=3)
+        _terminus2_nel_dump_trajectory_with_continuation_index(agent, 1)
+        data = json.loads((tmp_path / "trajectory.cont-1.json").read_text())
+        assert data.get("continued_trajectory_ref") == "trajectory.cont-2.json"
+
+    def test_linear_last_segment_has_no_continued_ref(self, patch_sandbox, tmp_path):
+        terminus = patch_sandbox.terminus
+        agent = _make_agent_for_dump(terminus, tmp_path, linear_history=True, summarization_count=2)
+        _terminus2_nel_dump_trajectory_with_continuation_index(agent, 2)
+        data = json.loads((tmp_path / "trajectory.cont-2.json").read_text())
+        assert not data.get("continued_trajectory_ref")
+
+    def test_root_in_linear_chain_points_to_first_continuation(self, patch_sandbox, tmp_path):
+        terminus = patch_sandbox.terminus
+        agent = _make_agent_for_dump(terminus, tmp_path, linear_history=True, summarization_count=1)
+        _terminus2_nel_dump_trajectory_with_continuation_index(agent, 0)
+        data = json.loads((tmp_path / "trajectory.json").read_text())
+        assert data.get("continued_trajectory_ref") == "trajectory.cont-1.json"
+        # Root segment with index=0 must NOT carry continuation_index in agent extra
+        assert "continuation_index" not in data["agent"]["extra"]

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -28,6 +28,7 @@ from nemo_evaluator.solvers.harbor import (
     _patch_terminus_api_token_anchor,
     _patch_terminus_cle_reset,
     _patch_terminus_compaction_logging,
+    _patch_terminus_compaction_turn_marker,
     _patch_terminus_unwind_min_pairs,
     _terminus2_build_local_fallback_llm_content,
     _terminus2_count_total_tokens,
@@ -58,14 +59,12 @@ _FLAGS = (
     "_TERMINUS_API_ANCHOR_PATCHED",
     "_CHAT_TOKEN_ANCHOR_PATCHED",
     "_TERMINUS_COMPACTION_PATCHED",
+    "_TERMINUS_COMPACTION_TURN_MARKER_PATCHED",
 )
 
 _NEL_METHODS = (
     "_nel_ensure_compaction_state",
     "_nel_stash_compaction_token_snapshots",
-    "_nel_subagent_metrics_snapshot",
-    "_nel_summary_generation_from_subagent_delta",
-    "_nel_summary_generation_from_usage",
     "_nel_token_snapshot",
     "_nel_compaction_mechanism",
     "_nel_make_compaction_event",
@@ -73,6 +72,7 @@ _NEL_METHODS = (
     "_nel_set_proactive_pending_compaction",
     "_nel_set_cle_pending_compaction",
     "_nel_flush_pending_compaction",
+    "_nel_compaction_llm_call_kwargs",
 )
 
 
@@ -90,6 +90,8 @@ def patch_sandbox():
         "_run_agent_loop": terminus._run_agent_loop,
         "_check_proactive": terminus._check_proactive_summarization,
         "_dump": terminus._dump_trajectory_with_continuation_index,
+        "_run_subagent": terminus._run_subagent,
+        "_summarize": terminus._summarize,
         "chat_chat": Chat.chat,
     }
     saved_nel = {name: terminus.__dict__.get(name) for name in _NEL_METHODS}
@@ -111,6 +113,8 @@ def patch_sandbox():
     terminus._run_agent_loop = saved_methods["_run_agent_loop"]
     terminus._check_proactive_summarization = saved_methods["_check_proactive"]
     terminus._dump_trajectory_with_continuation_index = saved_methods["_dump"]
+    terminus._run_subagent = saved_methods["_run_subagent"]
+    terminus._summarize = saved_methods["_summarize"]
     Chat.chat = saved_methods["chat_chat"]
     for name, value in saved_nel.items():
         if value is not None:
@@ -465,7 +469,8 @@ class TestCreateAgentGating:
         from unittest.mock import MagicMock, patch
 
         solver = self._solver("terminus-2")
-        cle, unwind, anchor, ctxlim, compaction = (
+        cle, unwind, anchor, ctxlim, compaction, turn_marker = (
+            MagicMock(),
             MagicMock(),
             MagicMock(),
             MagicMock(),
@@ -480,6 +485,10 @@ class TestCreateAgentGating:
             ctxlim,
         )
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_compaction_logging", compaction)
+        monkeypatch.setattr(
+            "nemo_evaluator.solvers.harbor._patch_terminus_compaction_turn_marker",
+            turn_marker,
+        )
 
         sentinel = object()
         with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=sentinel):
@@ -491,12 +500,14 @@ class TestCreateAgentGating:
         anchor.assert_called_once()
         ctxlim.assert_called_once()
         compaction.assert_called_once()
+        turn_marker.assert_called_once()
 
     def test_non_terminus_agent_skips_patches(self, tmp_path, monkeypatch):
         from unittest.mock import MagicMock, patch
 
         solver = self._solver("openhands")
-        cle, unwind, anchor, ctxlim, compaction = (
+        cle, unwind, anchor, ctxlim, compaction, turn_marker = (
+            MagicMock(),
             MagicMock(),
             MagicMock(),
             MagicMock(),
@@ -511,6 +522,10 @@ class TestCreateAgentGating:
             ctxlim,
         )
         monkeypatch.setattr("nemo_evaluator.solvers.harbor._patch_terminus_compaction_logging", compaction)
+        monkeypatch.setattr(
+            "nemo_evaluator.solvers.harbor._patch_terminus_compaction_turn_marker",
+            turn_marker,
+        )
 
         with patch("harbor.agents.factory.AgentFactory.create_agent_from_name", return_value=object()):
             solver._create_agent(tmp_path)
@@ -520,6 +535,7 @@ class TestCreateAgentGating:
         anchor.assert_not_called()
         ctxlim.assert_not_called()
         compaction.assert_not_called()
+        turn_marker.assert_not_called()
 
 
 # ── _patch_harbor_lite_llm_context_length_matcher ────────────────────────
@@ -739,3 +755,47 @@ class TestPatchCompactionLogging:
         _patch_terminus_compaction_logging()
         assert harbor._TERMINUS_COMPACTION_PATCHED is True
         assert terminus._run_agent_loop is original
+
+
+class TestPatchTerminusCompactionTurnMarker:
+    def test_marks_summarize_subagent_calls_not_generic_subagent(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        _patch_terminus_compaction_logging()
+        _patch_terminus_compaction_turn_marker()
+        assert harbor._TERMINUS_COMPACTION_TURN_MARKER_PATCHED is True
+        assert hasattr(terminus, "_nel_compaction_llm_call_kwargs")
+        assert harbor._TERMINUS_QUERY_LLM_SRC is not None
+        assert "_nel_compaction_llm_call_kwargs()" in harbor._TERMINUS_QUERY_LLM_SRC
+        summarize_src = terminus._summarize.__code__.co_consts
+        assert (
+            any(isinstance(c, str) and "_nel_compaction_llm_call_kwargs" in c for c in summarize_src)
+            or "_nel_compaction_llm_call_kwargs" in terminus._summarize.__code__.co_names
+        )
+        assert "llm_call_kwargs" in terminus._run_subagent.__code__.co_varnames
+
+    def test_idempotent(self, patch_sandbox):
+        terminus = patch_sandbox.terminus
+        _patch_terminus_compaction_logging()
+        _patch_terminus_compaction_turn_marker()
+        first_subagent = terminus._run_subagent
+        first_summarize = terminus._summarize
+        _patch_terminus_compaction_turn_marker()
+        assert terminus._run_subagent is first_subagent
+        assert terminus._summarize is first_summarize
+
+    def test_compaction_kwargs_carry_header_default_subagent_does_not(self, patch_sandbox, tmp_path):
+        from nemo_evaluator.adapters.call_kind import NEL_CALL_KIND_COMPACTION, NEL_CALL_KIND_HEADER
+
+        terminus = patch_sandbox.terminus
+        _patch_terminus_compaction_logging()
+        _patch_terminus_compaction_turn_marker()
+        agent = terminus(
+            logs_dir=tmp_path,
+            model_name="test-model",
+            model_info={"max_input_tokens": 1000, "max_output_tokens": 1000},
+        )
+        agent._llm_call_kwargs = {"temperature": 0.2}
+        marked = agent._nel_compaction_llm_call_kwargs()
+        assert marked["extra_headers"][NEL_CALL_KIND_HEADER] == NEL_CALL_KIND_COMPACTION
+        assert agent._llm_call_kwargs == {"temperature": 0.2}
+        assert "extra_headers" not in agent._llm_call_kwargs

--- a/tests/test_solvers/test_harbor_terminus_patches.py
+++ b/tests/test_solvers/test_harbor_terminus_patches.py
@@ -63,8 +63,10 @@ _FLAGS = (
 _NEL_METHODS = (
     "_nel_ensure_compaction_state",
     "_nel_stash_compaction_token_snapshots",
+    "_nel_subagent_metrics_snapshot",
+    "_nel_summary_generation_from_subagent_delta",
+    "_nel_summary_generation_from_usage",
     "_nel_token_snapshot",
-    "_nel_steps_compacted",
     "_nel_compaction_mechanism",
     "_nel_make_compaction_event",
     "_nel_record_failed_compaction_attempt",
@@ -723,8 +725,8 @@ class TestPatchCompactionLogging:
         assert step.source == "system"
         assert step.extra is not None
         assert step.extra["context_management"]["type"] == "compaction"
+        assert step.extra["compaction"]["llm_call_count"] == 3
         assert agent._pending_handoff_prompt is None
-        assert agent._nel_compaction_step_overlays[1]["llm_call_count"] == 3
 
     def test_idempotent_when_marker_present(self, patch_sandbox):
         terminus = patch_sandbox.terminus

--- a/tests/test_solvers/test_openhands_compaction.py
+++ b/tests/test_solvers/test_openhands_compaction.py
@@ -23,7 +23,6 @@ from openhands.sdk.llm import LLM, Message, TextContent
 from nemo_evaluator.solvers.openhands_compaction import (
     build_compaction_events_from_run,
     enrich_trajectory_with_compaction,
-    event_counts_toward_max_iterations,
     infer_openhands_trigger,
     is_hard_reset,
     splice_compaction_steps_into_trajectory,
@@ -187,21 +186,89 @@ def test_splice_compaction_steps_into_trajectory(mock_count: MagicMock, mock_llm
     assert any("condensed summary" in (message.get("content") or "") for message in replacement)
 
 
-def test_event_counts_toward_max_iterations() -> None:
-    user = _user_message("task")
-    agent = _agent_message("work")
-    condensation = _condensation({user.id})
-    request = CondensationRequest()
-    assert event_counts_toward_max_iterations(None) is True
-    assert event_counts_toward_max_iterations(user) is True
-    assert event_counts_toward_max_iterations(agent) is True
-    assert event_counts_toward_max_iterations(request) is True
-    assert event_counts_toward_max_iterations(condensation) is False
-
-
 @patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[100, 20])
 def test_enrich_trajectory_no_condensation_is_noop(mock_count: MagicMock, mock_llm: LLM) -> None:
     trajectory = {"steps": [{"step_id": 1, "source": "user", "message": "hi"}]}
     result = enrich_trajectory_with_compaction(trajectory, [_user_message("hi")], mock_llm, 128_000)
     assert result is trajectory
     assert len(result["steps"]) == 1
+
+
+@patch(
+    "nemo_evaluator.solvers.openhands_compaction.get_total_token_count",
+    side_effect=[100, 50, 100, 50, 80, 30, 80, 30],
+)
+def test_multiple_condensations_produce_multiple_events(mock_count: MagicMock, mock_llm: LLM) -> None:
+    user1 = _user_message("task 1")
+    agent1 = _agent_message("reply 1")
+    cond1 = _condensation({user1.id}, summary="summary-1", response_id="resp-c1")
+    user2 = _user_message("task 2")
+    cond2 = _condensation({agent1.id}, summary="summary-2", response_id="resp-c2")
+    events = [user1, agent1, cond1, user2, cond2]
+    entries = build_compaction_events_from_run(events, mock_llm, context_limit=200_000)
+    assert len(entries) == 2
+    assert entries[0][1].compaction_index == 1
+    assert entries[1][1].compaction_index == 2
+    assert entries[0][1].strategy == "openhands_condensation"
+    assert entries[1][1].strategy == "openhands_condensation"
+
+
+def test_observation_extra_populated_from_llm_metrics(mock_llm: LLM) -> None:
+    from types import SimpleNamespace
+
+    usage = SimpleNamespace(
+        response_id="resp-c1",
+        prompt_tokens=4000,
+        completion_tokens=200,
+        cost=0.005,
+    )
+    mock_llm.metrics = SimpleNamespace(token_usages=[usage])
+
+    from nemo_evaluator.solvers.openhands_compaction import _observation_extra_for_response
+
+    obs_extra = _observation_extra_for_response(mock_llm, "resp-c1")
+    assert obs_extra is not None
+    assert obs_extra.compaction_prompt_tokens == 4000
+    assert obs_extra.compaction_completion_tokens == 200
+    assert abs(obs_extra.compaction_cost_usd - 0.005) < 1e-9
+
+
+def test_observation_extra_none_when_response_id_missing(mock_llm: LLM) -> None:
+    from nemo_evaluator.solvers.openhands_compaction import _observation_extra_for_response
+
+    assert _observation_extra_for_response(mock_llm, None) is None
+    assert _observation_extra_for_response(mock_llm, "nonexistent") is None
+
+
+@patch(
+    "nemo_evaluator.solvers.openhands_compaction.get_total_token_count",
+    side_effect=[100, 20, 100, 20],
+)
+def test_second_condensation_segment_does_not_include_first(mock_count: MagicMock, mock_llm: LLM) -> None:
+    """The second Condensation's trigger inference only looks at events since the first."""
+    user = _user_message("task")
+    cond1 = _condensation({user.id}, summary="s1")
+    request = CondensationRequest()
+    cond2 = _condensation(set(), summary="s2")
+    events = [user, cond1, request, cond2]
+    entries = build_compaction_events_from_run(events, mock_llm, context_limit=200_000)
+    assert len(entries) == 2
+    assert entries[1][1].trigger == "openhands_condensation_request"
+
+
+@patch(
+    "nemo_evaluator.solvers.openhands_compaction.get_total_token_count",
+    side_effect=[100, 20],
+)
+def test_splice_compaction_step_id_renumbered(mock_count: MagicMock, mock_llm: LLM) -> None:
+    user = _user_message("hi")
+    cond = _condensation({user.id})
+    entries = build_compaction_events_from_run([user, cond], mock_llm, context_limit=128_000)
+    trajectory = {
+        "steps": [
+            {"step_id": 5, "timestamp": user.timestamp, "source": "user", "message": "hi"},
+        ]
+    }
+    enriched = splice_compaction_steps_into_trajectory(trajectory, entries)
+    for i, step in enumerate(enriched["steps"], start=1):
+        assert step["step_id"] == i

--- a/tests/test_solvers/test_openhands_compaction.py
+++ b/tests/test_solvers/test_openhands_compaction.py
@@ -22,6 +22,7 @@ from openhands.sdk.llm import LLM, Message, TextContent
 from nemo_evaluator.solvers.openhands_compaction import (
     build_compaction_events_from_run,
     enrich_trajectory_with_compaction,
+    event_counts_toward_max_iterations,
     infer_openhands_trigger,
     is_hard_reset,
     splice_compaction_steps_into_trajectory,
@@ -175,6 +176,18 @@ def test_splice_compaction_steps_into_trajectory(mock_count: MagicMock, mock_llm
     assert compaction_step["extra"]["compaction"]["strategy_details"]["reason"] == "request"
     assert compaction_step["extra"]["compaction"]["strategy_details"]["requirement"] == "hard"
     assert compaction_step["observation"]["results"][0]["content"] == "condensed summary"
+
+
+def test_event_counts_toward_max_iterations() -> None:
+    user = _user_message("task")
+    agent = _agent_message("work")
+    condensation = _condensation({user.id})
+    request = CondensationRequest()
+    assert event_counts_toward_max_iterations(None) is True
+    assert event_counts_toward_max_iterations(user) is True
+    assert event_counts_toward_max_iterations(agent) is True
+    assert event_counts_toward_max_iterations(request) is True
+    assert event_counts_toward_max_iterations(condensation) is False
 
 
 @patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[100, 20])

--- a/tests/test_solvers/test_openhands_compaction.py
+++ b/tests/test_solvers/test_openhands_compaction.py
@@ -21,7 +21,6 @@ from openhands.sdk.llm import LLM, Message, TextContent
 
 from nemo_evaluator.solvers.openhands_compaction import (
     build_compaction_events_from_run,
-    build_event_to_step_map,
     enrich_trajectory_with_compaction,
     infer_openhands_trigger,
     is_hard_reset,
@@ -110,6 +109,7 @@ def test_build_compaction_events_proactive_events(mock_count: MagicMock, mock_ll
     assert compaction_event.replacement_content == "condensed summary"
     assert compaction_event.openhands_extra is not None
     assert compaction_event.openhands_extra.reason == "events"
+    assert compaction_event.openhands_extra.requirement == "soft"
     assert compaction_event.tokens_before.prompt_tokens_approx == 120
     assert compaction_event.tokens_after.prompt_tokens_approx == 40
 
@@ -131,6 +131,7 @@ def test_build_compaction_events_token_trigger(mock_count: MagicMock, mock_llm: 
     assert compaction_event.trigger == "openhands_condensation_tokens"
     assert compaction_event.openhands_extra is not None
     assert compaction_event.openhands_extra.reason == "tokens"
+    assert compaction_event.openhands_extra.requirement == "hard"
 
 
 @patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[50, 10, 50, 10])
@@ -145,14 +146,7 @@ def test_build_compaction_events_hard_reset(mock_count: MagicMock, mock_llm: LLM
     assert compaction_event.openhands_extra is not None
     assert compaction_event.openhands_extra.hard_reset is True
     assert compaction_event.openhands_extra.reason == "hard_reset"
-
-
-def test_build_event_to_step_map() -> None:
-    user = _user_message("u")
-    agent = _agent_message("a")
-    mapping = build_event_to_step_map([user, agent])
-    assert mapping[user.id] == 1
-    assert mapping[agent.id] == 2
+    assert compaction_event.openhands_extra.requirement == "hard"
 
 
 @patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[100, 20])
@@ -178,7 +172,8 @@ def test_splice_compaction_steps_into_trajectory(mock_count: MagicMock, mock_llm
     assert compaction_step["source"] == "system"
     assert compaction_step["extra"]["context_management"]["type"] == "compaction"
     assert compaction_step["extra"]["compaction"]["trigger"] == "openhands_condensation_request"
-    assert compaction_step["extra"]["compaction"]["openhands"]["reason"] == "request"
+    assert compaction_step["extra"]["compaction"]["strategy_details"]["reason"] == "request"
+    assert compaction_step["extra"]["compaction"]["strategy_details"]["requirement"] == "hard"
     assert compaction_step["observation"]["results"][0]["content"] == "condensed summary"
 
 

--- a/tests/test_solvers/test_openhands_compaction.py
+++ b/tests/test_solvers/test_openhands_compaction.py
@@ -1,0 +1,190 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for OpenHands SDK condensation → ATIF compaction logging.
+
+openhands-sdk is not a package dependency; the module skips when it is absent.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("openhands.sdk", reason="openhands-sdk not installed")
+
+from openhands.sdk.context.view import View
+from openhands.sdk.event.condenser import Condensation, CondensationRequest
+from openhands.sdk.event.llm_convertible.message import MessageEvent
+from openhands.sdk.llm import LLM, Message, TextContent
+
+from nemo_evaluator.solvers.openhands_compaction import (
+    build_compaction_events_from_run,
+    build_event_to_step_map,
+    enrich_trajectory_with_compaction,
+    infer_openhands_trigger,
+    is_hard_reset,
+    splice_compaction_steps_into_trajectory,
+)
+
+
+def _user_message(text: str) -> MessageEvent:
+    return MessageEvent(
+        source="user",
+        llm_message=Message(role="user", content=[TextContent(text=text)]),
+    )
+
+
+def _agent_message(text: str) -> MessageEvent:
+    return MessageEvent(
+        source="agent",
+        llm_message=Message(role="assistant", content=[TextContent(text=text)]),
+        llm_response_id="resp-agent",
+    )
+
+
+def _condensation(
+    forgotten_ids: set[str],
+    *,
+    summary: str = "condensed summary",
+    summary_offset: int = 1,
+    response_id: str = "resp-condense",
+) -> Condensation:
+    return Condensation(
+        forgotten_event_ids=forgotten_ids,
+        summary=summary,
+        summary_offset=summary_offset,
+        llm_response_id=response_id,
+    )
+
+
+@pytest.fixture
+def mock_llm() -> LLM:
+    llm = MagicMock(spec=LLM)
+    llm.metrics = SimpleNamespace(token_usages=[])
+    return llm
+
+
+def test_is_hard_reset_detects_full_view_forget() -> None:
+    user = _user_message("one")
+    agent = _agent_message("two")
+    view = View.from_events([user, agent])
+    condensation = _condensation({user.id, agent.id}, summary_offset=0)
+    assert is_hard_reset(condensation, view) is True
+
+
+def test_infer_trigger_condensation_request() -> None:
+    user = _user_message("task")
+    request = CondensationRequest()
+    condensation = _condensation({user.id})
+    events = [user, request, condensation]
+    view = View.from_events(events[:2])
+    trigger = infer_openhands_trigger(
+        events,
+        2,
+        condensation,
+        view,
+        MagicMock(spec=LLM),
+        max_size=80,
+        max_tokens=None,
+    )
+    assert trigger == "openhands_condensation_request"
+
+
+@patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[120, 40, 30, 15])
+def test_build_compaction_events_proactive_events(mock_count: MagicMock, mock_llm: LLM) -> None:
+    events = [_user_message(f"msg-{idx}") for idx in range(90)]
+    forgotten = {event.id for event in events[:40]}
+    events.append(_condensation(forgotten))
+    entries = build_compaction_events_from_run(
+        events,
+        mock_llm,
+        context_limit=200_000,
+        condenser_config={"max_size": 80},
+    )
+    assert len(entries) == 1
+    _, compaction_event = entries[0]
+    assert compaction_event.trigger == "openhands_condensation_events"
+    assert compaction_event.strategy == "openhands_condensation"
+    assert compaction_event.replacement_content == "condensed summary"
+    assert compaction_event.openhands_extra is not None
+    assert compaction_event.openhands_extra.reason == "events"
+    assert compaction_event.tokens_before.prompt_tokens_approx == 120
+    assert compaction_event.tokens_after.prompt_tokens_approx == 40
+
+
+@patch(
+    "nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[150_000, 8_000, 150_000, 8_000]
+)
+def test_build_compaction_events_token_trigger(mock_count: MagicMock, mock_llm: LLM) -> None:
+    user = _user_message("long context")
+    condensation = _condensation({user.id})
+    events = [user, condensation]
+    entries = build_compaction_events_from_run(
+        events,
+        mock_llm,
+        context_limit=200_000,
+        condenser_config={"max_size": 10_000, "max_tokens": 100_000},
+    )
+    _, compaction_event = entries[0]
+    assert compaction_event.trigger == "openhands_condensation_tokens"
+    assert compaction_event.openhands_extra is not None
+    assert compaction_event.openhands_extra.reason == "tokens"
+
+
+@patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[50, 10, 50, 10])
+def test_build_compaction_events_hard_reset(mock_count: MagicMock, mock_llm: LLM) -> None:
+    user = _user_message("task")
+    agent = _agent_message("work")
+    condensation = _condensation({user.id, agent.id}, summary_offset=0)
+    events = [user, agent, condensation]
+    entries = build_compaction_events_from_run(events, mock_llm, context_limit=128_000)
+    _, compaction_event = entries[0]
+    assert compaction_event.trigger == "openhands_condensation_hard_reset"
+    assert compaction_event.openhands_extra is not None
+    assert compaction_event.openhands_extra.hard_reset is True
+    assert compaction_event.openhands_extra.reason == "hard_reset"
+
+
+def test_build_event_to_step_map() -> None:
+    user = _user_message("u")
+    agent = _agent_message("a")
+    mapping = build_event_to_step_map([user, agent])
+    assert mapping[user.id] == 1
+    assert mapping[agent.id] == 2
+
+
+@patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[100, 20])
+def test_splice_compaction_steps_into_trajectory(mock_count: MagicMock, mock_llm: LLM) -> None:
+    user = _user_message("hello")
+    condensation = _condensation({user.id})
+    events = [user, CondensationRequest(), condensation]
+    entries = build_compaction_events_from_run(events, mock_llm, context_limit=128_000)
+    trajectory = {
+        "schema_version": "ATIF-v1.7",
+        "steps": [
+            {
+                "step_id": 1,
+                "timestamp": user.timestamp,
+                "source": "user",
+                "message": "hello",
+            }
+        ],
+    }
+    enriched = splice_compaction_steps_into_trajectory(trajectory, entries)
+    assert len(enriched["steps"]) == 2
+    compaction_step = enriched["steps"][1]
+    assert compaction_step["source"] == "system"
+    assert compaction_step["extra"]["context_management"]["type"] == "compaction"
+    assert compaction_step["extra"]["compaction"]["trigger"] == "openhands_condensation_request"
+    assert compaction_step["extra"]["compaction"]["openhands"]["reason"] == "request"
+    assert compaction_step["observation"]["results"][0]["content"] == "condensed summary"
+
+
+@patch("nemo_evaluator.solvers.openhands_compaction.get_total_token_count", side_effect=[100, 20])
+def test_enrich_trajectory_no_condensation_is_noop(mock_count: MagicMock, mock_llm: LLM) -> None:
+    trajectory = {"steps": [{"step_id": 1, "source": "user", "message": "hi"}]}
+    result = enrich_trajectory_with_compaction(trajectory, [_user_message("hi")], mock_llm, 128_000)
+    assert result is trajectory
+    assert len(result["steps"]) == 1

--- a/tests/test_solvers/test_openhands_compaction.py
+++ b/tests/test_solvers/test_openhands_compaction.py
@@ -7,6 +7,7 @@ openhands-sdk is not a package dependency; the module skips when it is absent.
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -107,7 +108,14 @@ def test_build_compaction_events_proactive_events(mock_count: MagicMock, mock_ll
     _, compaction_event = entries[0]
     assert compaction_event.trigger == "openhands_condensation_events"
     assert compaction_event.strategy == "openhands_condensation"
-    assert compaction_event.replacement_content == "condensed summary"
+    replacement = json.loads(compaction_event.replacement_content)
+    assert isinstance(replacement, list)
+    assert len(replacement) >= 1
+    joined = "\n".join(message.get("content") or "" for message in replacement)
+    assert "condensed summary" in joined
+    assert "msg-40" in joined
+    assert "msg-89" in joined
+    assert "msg-0" not in joined
     assert compaction_event.openhands_extra is not None
     assert compaction_event.openhands_extra.reason == "events"
     assert compaction_event.openhands_extra.requirement == "soft"
@@ -175,7 +183,8 @@ def test_splice_compaction_steps_into_trajectory(mock_count: MagicMock, mock_llm
     assert compaction_step["extra"]["compaction"]["trigger"] == "openhands_condensation_request"
     assert compaction_step["extra"]["compaction"]["strategy_details"]["reason"] == "request"
     assert compaction_step["extra"]["compaction"]["strategy_details"]["requirement"] == "hard"
-    assert compaction_step["observation"]["results"][0]["content"] == "condensed summary"
+    replacement = json.loads(compaction_step["observation"]["results"][0]["content"])
+    assert any("condensed summary" in (message.get("content") or "") for message in replacement)
 
 
 def test_event_counts_toward_max_iterations() -> None:

--- a/tests/test_solvers/test_openhands_compaction_pure.py
+++ b/tests/test_solvers/test_openhands_compaction_pure.py
@@ -1,0 +1,255 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for openhands_compaction.py that run without openhands-sdk installed.
+
+The module-level try/except ImportError guard means the module is importable
+and several functions are usable with plain Python objects even when openhands
+is absent.  This file covers those paths so codecov sees non-zero coverage on
+every CI run.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nemo_evaluator.solvers.compaction_logging import CompactionEvent, CompactionTokens
+from nemo_evaluator.solvers.openhands_compaction import (
+    _observation_extra_for_response,
+    _parse_timestamp,
+    _resolve_condenser_config,
+    _timestamp_sort_key,
+    splice_compaction_steps_into_trajectory,
+)
+
+
+def _make_compaction_event(
+    *,
+    timestamp: str | None = "2025-01-01T00:00:00+00:00",
+    compaction_index: int = 1,
+) -> CompactionEvent:
+    tokens = CompactionTokens(prompt_tokens_approx=1000, context_limit=128_000, free_tokens=127_000)
+    return CompactionEvent(
+        compaction_index=compaction_index,
+        trigger="unknown",
+        strategy="openhands_condensation",
+        replacement_content="[]",
+        tokens_before=tokens,
+        tokens_after=tokens,
+        llm_call_count=1,
+        timestamp=timestamp,
+    )
+
+
+class TestParseTimestamp:
+    def test_none_returns_none(self) -> None:
+        assert _parse_timestamp(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _parse_timestamp("") is None
+
+    def test_z_suffix_accepted(self) -> None:
+        result = _parse_timestamp("2025-01-15T10:00:00Z")
+        assert result is not None
+        assert result.year == 2025
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_utc_offset_accepted(self) -> None:
+        result = _parse_timestamp("2025-06-01T12:30:00+00:00")
+        assert result is not None
+        assert result.hour == 12
+        assert result.minute == 30
+
+    def test_invalid_string_returns_none(self) -> None:
+        assert _parse_timestamp("not-a-timestamp") is None
+
+    def test_non_string_value_returns_none(self) -> None:
+        assert _parse_timestamp("???") is None
+
+
+class TestTimestampSortKey:
+    def test_valid_sorts_before_none(self) -> None:
+        valid_key = _timestamp_sort_key("2025-01-01T00:00:00Z")
+        none_key = _timestamp_sort_key(None)
+        assert valid_key < none_key
+
+    def test_earlier_sorts_before_later(self) -> None:
+        earlier = _timestamp_sort_key("2025-01-01T00:00:00Z")
+        later = _timestamp_sort_key("2025-12-31T23:59:59Z")
+        assert earlier < later
+
+    def test_invalid_string_sorts_after_valid(self) -> None:
+        valid_key = _timestamp_sort_key("2025-01-01T00:00:00Z")
+        bad_key = _timestamp_sort_key("garbage")
+        assert valid_key < bad_key
+
+    def test_none_and_invalid_both_sort_last(self) -> None:
+        valid_key = _timestamp_sort_key("2025-06-01T00:00:00Z")
+        none_key = _timestamp_sort_key(None)
+        bad_key = _timestamp_sort_key("bad")
+        assert valid_key < none_key
+        assert valid_key < bad_key
+
+
+class TestResolveCondenserConfig:
+    def test_none_returns_defaults(self) -> None:
+        cfg = _resolve_condenser_config(None)
+        assert cfg["max_size"] == 80
+        assert cfg["max_tokens"] is None
+        assert cfg["keep_first"] == 4
+
+    def test_empty_dict_returns_defaults(self) -> None:
+        cfg = _resolve_condenser_config({})
+        assert cfg["max_size"] == 80
+        assert cfg["max_tokens"] is None
+        assert cfg["keep_first"] == 4
+
+    def test_max_size_override(self) -> None:
+        cfg = _resolve_condenser_config({"max_size": 50})
+        assert cfg["max_size"] == 50
+        assert cfg["max_tokens"] is None
+        assert cfg["keep_first"] == 4
+
+    def test_max_tokens_override(self) -> None:
+        cfg = _resolve_condenser_config({"max_tokens": 100_000})
+        assert cfg["max_tokens"] == 100_000
+        assert cfg["max_size"] == 80
+
+    def test_full_override(self) -> None:
+        cfg = _resolve_condenser_config({"max_size": 100, "max_tokens": 50_000, "keep_first": 2})
+        assert cfg["max_size"] == 100
+        assert cfg["max_tokens"] == 50_000
+        assert cfg["keep_first"] == 2
+
+    def test_string_values_coerced_to_int(self) -> None:
+        cfg = _resolve_condenser_config({"max_size": "60", "max_tokens": "100000", "keep_first": "3"})
+        assert cfg["max_size"] == 60
+        assert cfg["max_tokens"] == 100_000
+        assert cfg["keep_first"] == 3
+
+
+class TestObservationExtraForResponse:
+    def test_none_response_id_returns_none(self) -> None:
+        llm = SimpleNamespace(metrics=SimpleNamespace(token_usages=[]))
+        assert _observation_extra_for_response(llm, None) is None
+
+    def test_empty_string_response_id_returns_none(self) -> None:
+        llm = SimpleNamespace(metrics=SimpleNamespace(token_usages=[]))
+        assert _observation_extra_for_response(llm, "") is None
+
+    def test_no_matching_usage_returns_none(self) -> None:
+        usage = SimpleNamespace(response_id="other-id", prompt_tokens=100, completion_tokens=10, cost=0.001)
+        llm = SimpleNamespace(metrics=SimpleNamespace(token_usages=[usage]))
+        assert _observation_extra_for_response(llm, "resp-xyz") is None
+
+    def test_matching_usage_populates_extra(self) -> None:
+        usage = SimpleNamespace(response_id="resp-1", prompt_tokens=4000, completion_tokens=200, cost=0.005)
+        llm = SimpleNamespace(metrics=SimpleNamespace(token_usages=[usage]))
+        result = _observation_extra_for_response(llm, "resp-1")
+        assert result is not None
+        assert result.compaction_prompt_tokens == 4000
+        assert result.compaction_completion_tokens == 200
+        assert abs(result.compaction_cost_usd - 0.005) < 1e-9
+
+    def test_missing_metrics_attribute_returns_none(self) -> None:
+        llm = SimpleNamespace()
+        assert _observation_extra_for_response(llm, "resp-1") is None
+
+    def test_none_metrics_returns_none(self) -> None:
+        llm = SimpleNamespace(metrics=None)
+        assert _observation_extra_for_response(llm, "resp-1") is None
+
+    def test_none_token_usages_returns_none(self) -> None:
+        llm = SimpleNamespace(metrics=SimpleNamespace(token_usages=None))
+        assert _observation_extra_for_response(llm, "resp-1") is None
+
+    def test_first_match_wins_among_multiple_usages(self) -> None:
+        usage_a = SimpleNamespace(response_id="resp-1", prompt_tokens=100, completion_tokens=10, cost=0.001)
+        usage_b = SimpleNamespace(response_id="resp-1", prompt_tokens=999, completion_tokens=99, cost=0.999)
+        llm = SimpleNamespace(metrics=SimpleNamespace(token_usages=[usage_a, usage_b]))
+        result = _observation_extra_for_response(llm, "resp-1")
+        assert result is not None
+        assert result.compaction_prompt_tokens == 100
+
+
+class TestSpliceCompactionStepsIntoTrajectory:
+    def test_empty_entries_returns_same_object(self) -> None:
+        trajectory = {"steps": [{"step_id": 1, "source": "user", "message": "hi"}]}
+        result = splice_compaction_steps_into_trajectory(trajectory, [])
+        assert result is trajectory
+
+    def test_compaction_appended_after_earlier_step(self) -> None:
+        user_step = {"step_id": 1, "timestamp": "2025-01-01T00:01:00Z", "source": "user", "message": "hi"}
+        trajectory = {"steps": [user_step]}
+        event = _make_compaction_event(timestamp="2025-01-01T00:02:00Z")
+        result = splice_compaction_steps_into_trajectory(trajectory, [("2025-01-01T00:02:00Z", event)])
+        assert len(result["steps"]) == 2
+        assert result["steps"][0]["source"] == "user"
+        assert result["steps"][1]["source"] == "system"
+
+    def test_compaction_inserted_before_later_step(self) -> None:
+        user_step = {"step_id": 1, "timestamp": "2025-01-01T00:10:00Z", "source": "user", "message": "hi"}
+        trajectory = {"steps": [user_step]}
+        event = _make_compaction_event(timestamp="2025-01-01T00:05:00Z")
+        result = splice_compaction_steps_into_trajectory(trajectory, [("2025-01-01T00:05:00Z", event)])
+        assert len(result["steps"]) == 2
+        assert result["steps"][0]["source"] == "system"
+        assert result["steps"][1]["source"] == "user"
+
+    def test_step_ids_renumbered_from_one(self) -> None:
+        steps = [
+            {"step_id": 5, "timestamp": "2025-01-01T00:01:00Z", "source": "user", "message": "a"},
+            {"step_id": 10, "timestamp": "2025-01-01T00:03:00Z", "source": "agent", "message": "b"},
+        ]
+        trajectory = {"steps": steps}
+        event = _make_compaction_event(timestamp="2025-01-01T00:02:00Z")
+        result = splice_compaction_steps_into_trajectory(trajectory, [("2025-01-01T00:02:00Z", event)])
+        assert len(result["steps"]) == 3
+        for i, step in enumerate(result["steps"], start=1):
+            assert step["step_id"] == i
+
+    def test_compaction_step_has_system_source_and_compaction_extra(self) -> None:
+        trajectory = {"steps": []}
+        event = _make_compaction_event(timestamp="2025-01-01T00:01:00Z")
+        result = splice_compaction_steps_into_trajectory(trajectory, [("2025-01-01T00:01:00Z", event)])
+        assert len(result["steps"]) == 1
+        step = result["steps"][0]
+        assert step["source"] == "system"
+        assert step["extra"]["context_management"]["type"] == "compaction"
+        assert step["extra"]["compaction"]["trigger"] == "unknown"
+        assert step["extra"]["compaction"]["strategy"] == "openhands_condensation"
+
+    def test_multiple_compaction_entries_ordered_by_timestamp(self) -> None:
+        trajectory = {"steps": []}
+        event_a = _make_compaction_event(timestamp="2025-01-01T00:02:00Z", compaction_index=1)
+        event_b = _make_compaction_event(timestamp="2025-01-01T00:01:00Z", compaction_index=2)
+        entries = [
+            ("2025-01-01T00:02:00Z", event_a),
+            ("2025-01-01T00:01:00Z", event_b),
+        ]
+        result = splice_compaction_steps_into_trajectory(trajectory, entries)
+        assert len(result["steps"]) == 2
+        assert result["steps"][0]["extra"]["compaction"]["compaction_index"] == 2
+        assert result["steps"][1]["extra"]["compaction"]["compaction_index"] == 1
+
+    def test_none_timestamp_event_appended_last(self) -> None:
+        user_step = {"step_id": 1, "timestamp": "2025-01-01T00:01:00Z", "source": "user", "message": "hi"}
+        trajectory = {"steps": [user_step]}
+        event = _make_compaction_event(timestamp=None)
+        result = splice_compaction_steps_into_trajectory(trajectory, [(None, event)])
+        assert len(result["steps"]) == 2
+        assert result["steps"][-1]["source"] == "system"
+
+    @pytest.mark.parametrize(
+        "steps_value",
+        [None, []],
+        ids=["steps_none", "steps_empty"],
+    )
+    def test_missing_or_empty_steps_list(self, steps_value: list | None) -> None:
+        trajectory: dict = {"steps": steps_value}
+        event = _make_compaction_event(timestamp="2025-01-01T00:01:00Z")
+        result = splice_compaction_steps_into_trajectory(trajectory, [("2025-01-01T00:01:00Z", event)])
+        assert len(result["steps"]) == 1
+        assert result["steps"][0]["source"] == "system"


### PR DESCRIPTION
Records each compaction event as a structured system step in the exported ATIF trajectory for both Terminus-2 and the OpenHands SDK. Fixes the turn-budget accounting for compaction LLM calls and merges linear_history continuation files into a single trajectory on export.

For easier review, here is a nice HTML explainer: [compaction_pr_description.html](https://github.com/user-attachments/files/30341457/compaction_pr_description.html)


## Changes

- `compaction_logging.py` — new agent-agnostic CompactionEvent model and `build_compaction_step()` serializer shared by both agents
- `openhands_compaction.py` — reconstructs condensation events from the run log, infers trigger reason (hard-reset / request / tokens / events), snapshots before/after token counts, and splices compaction steps into the trajectory by timestamp
- Terminus-2 in-process patches — `_nel_flush_pending` appends compaction steps to the in-flight trajectory; uses a NEL-owned `_nel_compaction_count`
- `_flatten_atif_continuation_chain` — follows `continued_trajectory_ref` on disk to merge all continuation files into one trajectory on export, with cycle detection
- `call_kind.py` + `turn_counter` interceptor — tags compaction LLM calls with `x-nel-call-kind: compaction`, strips the header before it reaches the model API, skips the turn-budget decrement, and rejects compaction early when no agent turns remain
- CI: pins ruff to 0.9.9 (ruff 0.16.0 expanded defaults from 59 to 413 rules)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detailed compaction event tracking and serialization for trajectory “harbor steps,” including token/cost accounting and replacement content.
  * Enhanced OpenHands and Terminus-2 compaction/condensation instrumentation, including call tagging and trajectory enrichment.
  * Improved ATIF continued-trajectory recovery by merging chained segments and preserving final metrics.
* **Bug Fixes**
  * Prevented compaction calls from consuming normal agent turn/iteration budgets; added graceful rejection when limits are reached.
  * Added safer handling for continuation files and missing context during recovery/patching.
* **Tests**
  * Expanded unit and integration coverage for compaction logging, header propagation, splicing/enrichment, and continuation merging behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->