### PR TITLE
fix: extract workspace tar before pre-apply verify diagnostics

### DIFF
--- a/src/nemo_evaluator/sandbox/strategies.py
+++ b/src/nemo_evaluator/sandbox/strategies.py
@@ -331,6 +331,11 @@ class StatelessSandbox:
                 _vwd = self._ctx.verify_spec.workdir
                 diag = await self._verify_sandbox.exec(
                     f"echo '=== git HEAD ===' && cd {_vwd} && git log --oneline -1 2>/dev/null; "
+                    "_NEL_TAR=/input/workspace.tar; "
+                    '[ -n "$_NEL_EFS_SESSION" ] && [ -f "/input/$_NEL_EFS_SESSION/workspace.tar" ] && '
+                    '_NEL_TAR="/input/$_NEL_EFS_SESSION/workspace.tar"; '
+                    "mkdir -p /tmp/_nel_ws; "
+                    "if [ -f $_NEL_TAR ]; then tar xf $_NEL_TAR -C /tmp/_nel_ws 2>/dev/null; fi; "
                     "echo '=== patch stat ===' && "
                     "git apply --stat /tmp/_nel_ws/_nel_patch.diff 2>&1 | head -30; "
                     "echo '=== patch header ===' && head -40 /tmp/_nel_ws/_nel_patch.diff 2>/dev/null; "

--- a/src/nemo_evaluator/sandbox/strategies.py
+++ b/src/nemo_evaluator/sandbox/strategies.py
@@ -309,9 +309,13 @@ class StatelessSandbox:
         await self._transfer.pre_restore(self._verify_sandbox)
         # `test -s` dereferences the symlink and requires a non-empty target, so a dangling
         # link (a workspace that never transferred) exits non-zero. The trailing stat only
-        # enriches the log.
+        # enriches the log. Resolve the EFS session path first so the check matches the
+        # same tar that apply_cmd and diagnostics will use.
         check = await self._verify_sandbox.exec(
-            "test -s /input/workspace.tar && stat -L -c '%s bytes' /input/workspace.tar 2>&1",
+            "_NEL_TAR=/input/workspace.tar; "
+            '[ -n "$_NEL_EFS_SESSION" ] && [ -f "/input/$_NEL_EFS_SESSION/workspace.tar" ] && '
+            '_NEL_TAR="/input/$_NEL_EFS_SESSION/workspace.tar"; '
+            "test -s $_NEL_TAR && stat -L -c '%s bytes' $_NEL_TAR 2>&1",
             timeout_sec=10,
         )
         ws_present = check.return_code == 0
@@ -322,7 +326,7 @@ class StatelessSandbox:
         )
         if not ws_present:
             logger.error(
-                "StatelessSandbox: /input/workspace.tar MISSING in verify "
+                "StatelessSandbox: workspace.tar MISSING in verify "
                 "container — agent changes will NOT be applied! "
                 "Verify results will be against unmodified base image.",
             )

--- a/src/nemo_evaluator/sandbox/strategies.py
+++ b/src/nemo_evaluator/sandbox/strategies.py
@@ -315,7 +315,7 @@ class StatelessSandbox:
             "_NEL_TAR=/input/workspace.tar; "
             '[ -n "$_NEL_EFS_SESSION" ] && [ -f "/input/$_NEL_EFS_SESSION/workspace.tar" ] && '
             '_NEL_TAR="/input/$_NEL_EFS_SESSION/workspace.tar"; '
-            "test -s $_NEL_TAR && stat -L -c '%s bytes' $_NEL_TAR 2>&1",
+            'test -s "$_NEL_TAR" && stat -L -c \'%s bytes\' "$_NEL_TAR" 2>&1',
             timeout_sec=10,
         )
         ws_present = check.return_code == 0
@@ -339,7 +339,9 @@ class StatelessSandbox:
                     '[ -n "$_NEL_EFS_SESSION" ] && [ -f "/input/$_NEL_EFS_SESSION/workspace.tar" ] && '
                     '_NEL_TAR="/input/$_NEL_EFS_SESSION/workspace.tar"; '
                     "mkdir -p /tmp/_nel_ws; "
-                    "if [ -f $_NEL_TAR ]; then tar xf $_NEL_TAR -C /tmp/_nel_ws 2>/dev/null; fi; "
+                    'if [ -f "$_NEL_TAR" ]; then '
+                    'tar xf "$_NEL_TAR" -C /tmp/_nel_ws 2>&1 || echo "TAR EXTRACT FAILED: $_NEL_TAR"; '
+                    'else echo "TAR NOT FOUND: $_NEL_TAR"; fi; '
                     "echo '=== patch stat ===' && "
                     "git apply --stat /tmp/_nel_ws/_nel_patch.diff 2>&1 | head -30; "
                     "echo '=== patch header ===' && head -40 /tmp/_nel_ws/_nel_patch.diff 2>/dev/null; "

--- a/tests/test_sandbox/test_sandbox_lifecycle.py
+++ b/tests/test_sandbox/test_sandbox_lifecycle.py
@@ -174,6 +174,29 @@ class TestStatelessSandbox:
         await lc.teardown()
 
     @pytest.mark.asyncio
+    async def test_pre_apply_diagnostics_extract_tar_before_patch_checks(self):
+        """Diagnostics extract workspace.tar into /tmp/_nel_ws before reading the patch."""
+        apply_cmd = "APPLY_MARKER git apply /input/patch.diff"
+        ctx, mgr = self._make_ctx(apply_cmd=apply_cmd)
+        transfer = HostVolumeTransfer()
+        lc = StatelessSandbox(ctx, transfer)
+
+        await lc.setup()
+        await lc.get_agent_sandbox()
+        await lc.transition_to_verify("response", solver_modified=False)
+        verify_sb = await lc.get_verify_sandbox()
+
+        diag_cmds = [cmd for cmd in verify_sb._exec_log if "/tmp/_nel_ws/_nel_patch.diff" in cmd and "tar xf" in cmd]
+        assert diag_cmds, "expected a pre-apply diagnostic command that extracts the tar"
+        diag_cmd = diag_cmds[0]
+        assert "tar xf $_NEL_TAR -C /tmp/_nel_ws" in diag_cmd
+        assert diag_cmd.index("tar xf") < diag_cmd.index("git apply --stat")
+        apply_idx = verify_sb._exec_log.index(apply_cmd)
+        diag_idx = verify_sb._exec_log.index(diag_cmd)
+        assert diag_idx < apply_idx
+        await lc.teardown()
+
+    @pytest.mark.asyncio
     async def test_pre_agent_cmd_executed_after_acquire(self):
         """pre_agent_cmd runs in the agent container before the agent starts."""
         ctx, mgr = self._make_ctx(pre_agent_cmd="NEL_SCRUB_MARKER cleanup")

--- a/tests/test_sandbox/test_sandbox_lifecycle.py
+++ b/tests/test_sandbox/test_sandbox_lifecycle.py
@@ -174,6 +174,24 @@ class TestStatelessSandbox:
         await lc.teardown()
 
     @pytest.mark.asyncio
+    async def test_workspace_presence_check_resolves_efs_session_path(self):
+        """ws_present check resolves the EFS session tar path alongside the default."""
+        ctx, mgr = self._make_ctx()
+        transfer = HostVolumeTransfer()
+        lc = StatelessSandbox(ctx, transfer)
+
+        await lc.setup()
+        await lc.get_agent_sandbox()
+        await lc.transition_to_verify("response", solver_modified=False)
+        verify_sb = await lc.get_verify_sandbox()
+
+        ws_check_cmds = [cmd for cmd in verify_sb._exec_log if "_NEL_EFS_SESSION" in cmd and "test -s" in cmd]
+        assert ws_check_cmds, "workspace presence check must include EFS session path resolution"
+        assert "/input/$_NEL_EFS_SESSION/workspace.tar" in ws_check_cmds[0]
+        assert "test -s $_NEL_TAR" in ws_check_cmds[0]
+        await lc.teardown()
+
+    @pytest.mark.asyncio
     async def test_pre_apply_diagnostics_extract_tar_before_patch_checks(self):
         """Diagnostics extract workspace.tar into /tmp/_nel_ws before reading the patch."""
         apply_cmd = "APPLY_MARKER git apply /input/patch.diff"

--- a/tests/test_sandbox/test_sandbox_lifecycle.py
+++ b/tests/test_sandbox/test_sandbox_lifecycle.py
@@ -176,7 +176,7 @@ class TestStatelessSandbox:
     @pytest.mark.asyncio
     async def test_workspace_presence_check_resolves_efs_session_path(self):
         """ws_present check resolves the EFS session tar path alongside the default."""
-        ctx, mgr = self._make_ctx()
+        ctx, _ = self._make_ctx()
         transfer = HostVolumeTransfer()
         lc = StatelessSandbox(ctx, transfer)
 
@@ -188,7 +188,43 @@ class TestStatelessSandbox:
         ws_check_cmds = [cmd for cmd in verify_sb._exec_log if "_NEL_EFS_SESSION" in cmd and "test -s" in cmd]
         assert ws_check_cmds, "workspace presence check must include EFS session path resolution"
         assert "/input/$_NEL_EFS_SESSION/workspace.tar" in ws_check_cmds[0]
-        assert "test -s $_NEL_TAR" in ws_check_cmds[0]
+        assert 'test -s "$_NEL_TAR"' in ws_check_cmds[0]
+        await lc.teardown()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("marker", "description"),
+        [
+            ("test -s", "workspace presence check"),
+            ("tar xf", "pre-apply diagnostics"),
+        ],
+        ids=["presence_check", "diagnostics"],
+    )
+    async def test_efs_session_tar_resolved_consistently(self, marker, description):
+        """Both tar consumers resolve the same session path, so they cannot disagree.
+
+        The selection itself happens in the container shell against $_NEL_EFS_SESSION;
+        what is asserted here is that neither command falls back to the bare
+        /input/workspace.tar literal that caused the presence check to report MISSING
+        while a valid session archive existed.
+        """
+        ctx, _ = self._make_ctx(apply_cmd="git apply /input/patch.diff")
+        transfer = HostVolumeTransfer()
+        lc = StatelessSandbox(ctx, transfer)
+
+        await lc.setup()
+        await lc.get_agent_sandbox()
+        await lc.transition_to_verify("response", solver_modified=False)
+        verify_sb = await lc.get_verify_sandbox()
+
+        cmds = [cmd for cmd in verify_sb._exec_log if marker in cmd and "_NEL_TAR=" in cmd]
+        assert cmds, f"{description} must resolve the tar path"
+        cmd = cmds[0]
+        assert '[ -f "/input/$_NEL_EFS_SESSION/workspace.tar" ]' in cmd
+        assert '_NEL_TAR="/input/$_NEL_EFS_SESSION/workspace.tar"' in cmd
+        assert cmd.index("_NEL_EFS_SESSION") < cmd.index(marker), (
+            f"{description} must resolve the session path before using $_NEL_TAR"
+        )
         await lc.teardown()
 
     @pytest.mark.asyncio
@@ -207,8 +243,11 @@ class TestStatelessSandbox:
         diag_cmds = [cmd for cmd in verify_sb._exec_log if "/tmp/_nel_ws/_nel_patch.diff" in cmd and "tar xf" in cmd]
         assert diag_cmds, "expected a pre-apply diagnostic command that extracts the tar"
         diag_cmd = diag_cmds[0]
-        assert "tar xf $_NEL_TAR -C /tmp/_nel_ws" in diag_cmd
+        assert 'tar xf "$_NEL_TAR" -C /tmp/_nel_ws' in diag_cmd
         assert diag_cmd.index("tar xf") < diag_cmd.index("git apply --stat")
+        assert 'tar xf "$_NEL_TAR" -C /tmp/_nel_ws 2>&1' in diag_cmd
+        assert "TAR EXTRACT FAILED" in diag_cmd
+        assert "TAR NOT FOUND" in diag_cmd
         apply_idx = verify_sb._exec_log.index(apply_cmd)
         diag_idx = verify_sb._exec_log.index(diag_cmd)
         assert diag_idx < apply_idx


### PR DESCRIPTION
## Summary

- Fix pre-apply verify diagnostics in StatelessSandbox so they extract workspace.tar into /tmp/_nel_ws before reading _nel_patch.diff.
- Stops the misleading `can't open patch ... No such file or directory` log when the tar is present and apply_cmd would succeed.
- Uses the same tar path resolution as Harbor apply (/input/workspace.tar + EFS session override).

Fixes [FEA-243](https://linear.app/nvidia/issue/FEA-243/pre-apply-verify-diagnostics-run-before-workspace-tar-extract)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verify-side workspace detection by resolving the workspace tar path consistently, including session-specific tar handling when available, and ensuring it’s non-empty.
  * Updated pre-apply diagnostics to resolve the same tar path and extract it into a temporary workspace before running patch/stat/header and apply-related checks.

* **Tests**
  * Added async coverage for correct session-specific workspace tar path resolution during presence checks.
  * Added async coverage ensuring the tar extraction happens before patch/stat/header diagnostics and before the apply command.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->