### PR TITLE
fix(harbor): harden OpenHands trajectory flush

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,5 @@
+sonar.projectKey=dl-joc-competitive-evaluation-nemo-evaluator-next
+sonar.projectName=nemo-evaluator-next
+sonar.sources=src
+sonar.tests=tests
+sonar.python.coverage.reportPaths=coverage.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,7 @@
-sonar.projectKey=dl-joc-competitive-evaluation-nemo-evaluator-next
-sonar.projectName=nemo-evaluator-next
-sonar.sources=src
+sonar.projectKey=EngHW_FrontierAI_Evaluator_NeMo-Evaluator-Next
+sonar.sources=src/nemo_evaluator,terraform
 sonar.tests=tests
+sonar.python.version=3.12
 sonar.python.coverage.reportPaths=coverage.xml
+sonar.terraform.provider=aws
+sonar.terraform.provider.aws.version=5.0

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -923,13 +923,12 @@ print(f'cmd_timeout_{{_MAX}}s={{ok}} at {{p}}')
 
     # -- Patch 4: flush trajectory when the runner is interrupted ----------
     # Anchor 1: wrap `conversation.send_message()` + `conversation.run()` in
-    # try/except BaseException so main() continues to the existing
+    # try/except BaseException so main() continues to the runner's existing
     # event-reconstruction + build_trajectory + save code on timeout/crash.
-    # SIGTERM/SIGINT are converted to a catchable BaseException so evaluator
-    # timeout cancellation gets the same flush path.  On interruption, first
-    # write a cheap partial trajectory from already-received model events.  The
-    # normal full writer below overwrites it if post-run serialization completes.
-    # Anchor 2: after the final print in main(), exit(0) cleanly so Harbor
+    # SIGTERM/SIGINT are converted to a catchable BaseException, then ignored
+    # while the already-existing post-run trajectory serialization completes.
+    # Anchor 2: add partial-run metadata and make the existing save atomic.
+    # Anchor 3: after the final print in main(), exit(0) cleanly so Harbor
     # treats the run as a normal completion and downloads the trajectory.
     _budget_flush_script = """\
 import sys
@@ -948,79 +947,34 @@ for line in c.splitlines():
     if 'Total cost:' in line and 'print' in line:
         old2 = line; break
 
+old_save = (
+    '    trajectory_path = Path(args.trajectory_path)\\n'
+    '    trajectory_path.parent.mkdir(parents=True, exist_ok=True)\\n'
+    '    with open(trajectory_path, "w") as f:\\n'
+    '        json.dump(trajectory, f, indent=2)'
+)
+
 already = '_trajectory_flush_exc' in c
-ok = old1 in c and old2 is not None and not already
+ok = old1 in c and old2 is not None and old_save in c and not already
 success = already or ok
-print(f'anchor1={repr(old1)} anchor2={repr(old2)} already={already} ok={ok}')
+print(f'anchor1={repr(old1)} anchor2={repr(old2)} save={old_save in c} already={already} ok={ok}')
 
 if ok:
-    partial = (
-        ind + 'def _trajectory_text_from_event(_event):\\n' +
-        ind + '    _msg = getattr(_event, "llm_message", None)\\n' +
-        ind + '    _raw = getattr(_msg, "content", None) if _msg is not None else None\\n' +
-        ind + '    if isinstance(_raw, list):\\n' +
-        ind + '        return chr(10).join(getattr(_c, "text", str(_c)) for _c in _raw if getattr(_c, "text", None))\\n' +
-        ind + '    return str(_raw) if _raw else ""\\n' +
-        ind + 'def _trajectory_tool_args(_event):\\n' +
-        ind + '    if getattr(_event, "tool_call", None) and hasattr(_event.tool_call, "function"):\\n' +
-        ind + '        _raw_args = getattr(_event.tool_call.function, "arguments", None)\\n' +
-        ind + '        if isinstance(_raw_args, str):\\n' +
-        ind + '            try:\\n' +
-        ind + '                return json.loads(_raw_args)\\n' +
-        ind + '            except json.JSONDecodeError:\\n' +
-        ind + '                return {"raw": _raw_args}\\n' +
-        ind + '        if isinstance(_raw_args, dict):\\n' +
-        ind + '            return _raw_args\\n' +
-        ind + '    if getattr(_event, "action", None):\\n' +
-        ind + '        try:\\n' +
-        ind + '            _ad = _event.action.model_dump() if hasattr(_event.action, "model_dump") else vars(_event.action)\\n' +
-        ind + '            return {_k: _v for _k, _v in _ad.items() if _k != "kind" and _v is not None}\\n' +
-        ind + '        except Exception:\\n' +
-        ind + '            pass\\n' +
-        ind + '    return {}\\n' +
-        ind + 'def _write_partial_trajectory(_reason):\\n' +
-        ind + '    import json, os, sys\\n' +
-        ind + '    from pathlib import Path\\n' +
-        ind + '    try:\\n' +
-        ind + '        _metric_obj = getattr(llm, "metrics", None)\\n' +
-        ind + '        _usage = getattr(_metric_obj, "accumulated_token_usage", None)\\n' +
-        ind + '        _metrics = {\\n' +
-        ind + '            "prompt_tokens": int(getattr(_usage, "prompt_tokens", 0) or 0),\\n' +
-        ind + '            "completion_tokens": int(getattr(_usage, "completion_tokens", 0) or 0),\\n' +
-        ind + '            "cached_tokens": int(getattr(_usage, "cache_read_tokens", 0) or 0),\\n' +
-        ind + '            "cost_usd": float(getattr(_metric_obj, "accumulated_cost", 0.0) or 0.0),\\n' +
-        ind + '        }\\n' +
-        ind + '        _events_list = []\\n' +
-        ind + '        for _event in list(getattr(getattr(conversation, "state", None), "events", []) or []):\\n' +
-        ind + '            if isinstance(_event, MessageEvent):\\n' +
-        ind + '                if _event.source in ("user", "agent"):\\n' +
-        ind + '                    _entry_type = "assistant_message" if _event.source == "agent" else "user_message"\\n' +
-        ind + '                    _entry = {"type": _entry_type, "content": _trajectory_text_from_event(_event), "timestamp": _event.timestamp}\\n' +
-        ind + '                    _events_list.append(_entry)\\n' +
-        ind + '            elif isinstance(_event, ActionEvent):\\n' +
-        ind + '                _events_list.append({"type": "assistant_message", "content": "", "timestamp": _event.timestamp, "llm_response_id": getattr(_event, "llm_response_id", None), "tool_calls": [{"id": _event.tool_call_id, "name": _event.tool_name, "arguments": _trajectory_tool_args(_event)}]})\\n' +
-        ind + '        _trajectory = build_trajectory(_events_list, _metrics, model)\\n' +
-        ind + '        _trajectory.setdefault("extra", {})["partial_trajectory"] = {"reason": _reason, "events": len(_events_list)}\\n' +
-        ind + '        _path = Path(args.trajectory_path)\\n' +
-        ind + '        _path.parent.mkdir(parents=True, exist_ok=True)\\n' +
-        ind + '        _tmp = _path.with_suffix(_path.suffix + ".partial")\\n' +
-        ind + '        with open(_tmp, "w") as _f:\\n' +
-        ind + '            json.dump(_trajectory, _f, indent=2)\\n' +
-        ind + '        os.replace(_tmp, _path)\\n' +
-        ind + '        print(f"trajectory flush: partial trajectory saved to {_path}", file=sys.stderr, flush=True)\\n' +
-        ind + '        return True\\n' +
-        ind + '    except Exception as _save_e:\\n' +
-        ind + '        print(f"trajectory flush: partial trajectory save failed: {type(_save_e).__name__}: {_save_e}", file=sys.stderr, flush=True)\\n' +
-        ind + '        return False\\n'
-    )
     wrap = (
         ind + '# Send instruction and run\\n' +
         ind + '_trajectory_flush_exc = None\\n' +
-        partial +
+        ind + '_trajectory_flush_reason = None\\n' +
         ind + 'class TrajectoryFlushRequested(BaseException):\\n' +
         ind + '    pass\\n' +
         ind + 'def _trajectory_timeout_handler(_signum, _frame):\\n' +
         ind + '    raise TrajectoryFlushRequested(f"signal {_signum}")\\n' +
+        ind + 'def _trajectory_ignore_interrupts():\\n' +
+        ind + '    try:\\n' +
+        ind + '        import signal as _trajectory_signal\\n' +
+        ind + '        _trajectory_signal.signal(_trajectory_signal.SIGTERM, _trajectory_signal.SIG_IGN)\\n' +
+        ind + '        _trajectory_signal.signal(_trajectory_signal.SIGINT, _trajectory_signal.SIG_IGN)\\n' +
+        ind + '    except BaseException:\\n' +
+        ind + '        pass\\n' +
         ind + 'try:\\n' +
         ind + '    import signal as _trajectory_signal\\n' +
         ind + '    _trajectory_signal.signal(_trajectory_signal.SIGTERM, _trajectory_timeout_handler)\\n' +
@@ -1032,14 +986,27 @@ if ok:
         ind + '    conversation.run()\\n' +
         ind + 'except TrajectoryFlushRequested as _e:\\n' +
         ind + '    _trajectory_flush_exc = _e\\n' +
+        ind + '    _trajectory_flush_reason = "timeout"\\n' +
         ind + '    print(f"trajectory flush: flushing after NEL timeout signal: {_e}", file=sys.stderr, flush=True)\\n' +
-        ind + '    _write_partial_trajectory("timeout")\\n' +
         ind + 'except BaseException as _e:\\n' +
         ind + '    _trajectory_flush_exc = _e\\n' +
+        ind + '    _trajectory_flush_reason = type(_e).__name__\\n' +
         ind + '    print(f"trajectory flush: flushing after {type(_e).__name__}: {_e}", file=sys.stderr, flush=True)\\n' +
-        ind + '    _write_partial_trajectory(type(_e).__name__)'
+        ind + 'finally:\\n' +
+        ind + '    _trajectory_ignore_interrupts()'
     )
     c = c.replace(old1, wrap, 1)
+    new_save = (
+        '    if _trajectory_flush_reason is not None:\\n'
+        '        trajectory.setdefault("extra", {})["partial_trajectory"] = {"reason": _trajectory_flush_reason, "events": len(events_list)}\\n'
+        '    trajectory_path = Path(args.trajectory_path)\\n'
+        '    trajectory_path.parent.mkdir(parents=True, exist_ok=True)\\n'
+        '    trajectory_tmp = trajectory_path.with_suffix(trajectory_path.suffix + ".partial")\\n'
+        '    with open(trajectory_tmp, "w") as f:\\n'
+        '        json.dump(trajectory, f, indent=2)\\n'
+        '    os.replace(trajectory_tmp, trajectory_path)'
+    )
+    c = c.replace(old_save, new_save, 1)
     exit_block = (
         ind + 'if _trajectory_flush_exc is not None:\\n' +
         ind + '    if not isinstance(_trajectory_flush_exc, TrajectoryFlushRequested):\\n' +
@@ -1098,13 +1065,28 @@ def _recover_from_logs(agent_logs_dir: Path) -> dict[str, Any]:
     }
 
     # -- 1. ATIF trajectory JSON (canonical agent output) -------------------
+    def _trajectory_file_rank(path: Path) -> tuple[int, str]:
+        name = path.name.lower()
+        if name == "trajectory.json":
+            return (0, name)
+        if name == "trajectory.partial.json":
+            return (1, name)
+        if name == "trajectory.json.partial":
+            return (2, name)
+        if name.endswith(".json"):
+            return (3, name)
+        return (4, name)
+
     traj_files = sorted(
-        (f for f in agent_logs_dir.glob("*.json") if "traj" in f.stem.lower()),
-        key=lambda p: (p.name != "trajectory.json", p.name),
+        (
+            f
+            for f in agent_logs_dir.glob("*")
+            if f.is_file()
+            and "traj" in f.name.lower()
+            and (f.name.lower().endswith(".json") or f.name.lower().endswith(".json.partial"))
+        ),
+        key=_trajectory_file_rank,
     )
-    canonical = agent_logs_dir / "trajectory.json"
-    if canonical.is_file() and canonical not in traj_files:
-        traj_files.insert(0, canonical)
 
     for tf in traj_files:
         try:

--- a/src/nemo_evaluator/solvers/harbor.py
+++ b/src/nemo_evaluator/solvers/harbor.py
@@ -927,6 +927,8 @@ print(f'cmd_timeout_{{_MAX}}s={{ok}} at {{p}}')
     # event-reconstruction + build_trajectory + save code on timeout/crash.
     # SIGTERM/SIGINT are converted to a catchable BaseException, then ignored
     # while the already-existing post-run trajectory serialization completes.
+    # A SIGKILL/OOM cannot run cleanup, so keep a structured checkpoint during
+    # conversation.run() instead of relying only on the final flush path.
     # Anchor 2: add partial-run metadata and make the existing save atomic.
     # Anchor 3: after the final print in main(), exit(0) cleanly so Harbor
     # treats the run as a normal completion and downloads the trajectory.
@@ -956,10 +958,88 @@ old_save = (
 
 already = '_trajectory_flush_exc' in c
 ok = old1 in c and old2 is not None and old_save in c and not already
-success = already or ok
-print(f'anchor1={repr(old1)} anchor2={repr(old2)} save={old_save in c} already={already} ok={ok}')
 
+events_anchor = '    # Convert SDK events to dicts for build_trajectory()\\n'
+build_anchor = '\\n    # Build and save trajectory\\n    trajectory = build_trajectory('
+main_anchor = '\\ndef main():'
+events_ok = already
 if ok:
+    events_start = c.find(events_anchor)
+    events_end = c.find(build_anchor, events_start)
+    events_ok = events_start >= 0 and events_end >= 0 and main_anchor in c
+    if events_ok:
+        events_block = c[events_start:events_end]
+        collect_helper = (
+            '\\n\\n'
+            'def _collect_trajectory_events(conversation, llm, metrics):\\n'
+            + events_block
+            + '    return events_list\\n'
+        )
+        c = c[:events_start] + '    events_list = _collect_trajectory_events(conversation, llm, metrics)' + c[events_end:]
+        c = c.replace(main_anchor, collect_helper + main_anchor, 1)
+
+success = already or (ok and events_ok)
+print(f'anchor1={repr(old1)} anchor2={repr(old2)} save={old_save in c} events={events_ok} already={already} ok={ok}')
+
+checkpoint = (
+    ind + '_trajectory_checkpoint_stop = None\\n' +
+    ind + '_trajectory_checkpoint_thread = None\\n' +
+    ind + 'def _trajectory_current_metrics():\\n' +
+    ind + '    _llm_metrics = getattr(llm, "metrics", None)\\n' +
+    ind + '    _token_usage = getattr(_llm_metrics, "accumulated_token_usage", None)\\n' +
+    ind + '    return {"prompt_tokens": getattr(_token_usage, "prompt_tokens", 0) if _token_usage else 0, "completion_tokens": getattr(_token_usage, "completion_tokens", 0) if _token_usage else 0, "cached_tokens": getattr(_token_usage, "cache_read_tokens", 0) if _token_usage else 0, "cost_usd": getattr(_llm_metrics, "accumulated_cost", 0.0) if _llm_metrics else 0.0}\\n' +
+    ind + 'def _trajectory_agent_metadata():\\n' +
+    ind + '    _system_prompt = None\\n' +
+    ind + '    _tool_definitions = []\\n' +
+    ind + '    try:\\n' +
+    ind + '        _system_prompt = agent.static_system_message\\n' +
+    ind + '    except Exception as _e:\\n' +
+    ind + '        logger.warning(f"Could not extract system prompt for checkpoint: {_e}")\\n' +
+    ind + '    try:\\n' +
+    ind + '        for _tool_name, _tool_obj in agent.tools_map.items():\\n' +
+    ind + '            _tool_definitions.append(_tool_obj.to_openai_tool())\\n' +
+    ind + '    except Exception as _e:\\n' +
+    ind + '        logger.warning(f"Could not extract tool definitions for checkpoint: {_e}")\\n' +
+    ind + '    return _system_prompt, _tool_definitions\\n' +
+    ind + 'def _trajectory_mark_partial(_trajectory, _reason, _events_count, _checkpoint=False):\\n' +
+    ind + '    _partial = {"reason": _reason, "events": _events_count}\\n' +
+    ind + '    if _checkpoint:\\n' +
+    ind + '        _partial["checkpoint"] = True\\n' +
+    ind + '    _trajectory.setdefault("extra", {})["partial_trajectory"] = _partial\\n' +
+    ind + 'def _trajectory_save(_trajectory, _path):\\n' +
+    ind + '    import os as _trajectory_os\\n' +
+    ind + '    from pathlib import Path as _TrajectoryPath\\n' +
+    ind + '    _path = _TrajectoryPath(_path)\\n' +
+    ind + '    _path.parent.mkdir(parents=True, exist_ok=True)\\n' +
+    ind + '    _tmp = _path.with_suffix(_path.suffix + ".partial")\\n' +
+    ind + '    with open(_tmp, "w") as _f:\\n' +
+    ind + '        json.dump(_trajectory, _f, indent=2, default=str)\\n' +
+    ind + '    _trajectory_os.replace(_tmp, _path)\\n' +
+    ind + 'def _trajectory_checkpoint(_reason):\\n' +
+    ind + '    try:\\n' +
+    ind + '        _metrics = _trajectory_current_metrics()\\n' +
+    ind + '        _events_list = _collect_trajectory_events(conversation, llm, _metrics)\\n' +
+    ind + '        _system_prompt, _tool_definitions = _trajectory_agent_metadata()\\n' +
+    ind + '        _trajectory = build_trajectory(_events_list, _metrics, model, system_prompt=_system_prompt, tool_definitions=_tool_definitions)\\n' +
+    ind + '        if not any(_step.get("source") == "agent" for _step in _trajectory.get("steps", [])):\\n' +
+    ind + '            return\\n' +
+    ind + '        _trajectory_mark_partial(_trajectory, _reason, len(_events_list), True)\\n' +
+    ind + '        _trajectory_save(_trajectory, args.trajectory_path)\\n' +
+    ind + '    except BaseException as _e:\\n' +
+    ind + '        print(f"trajectory checkpoint failed: {_e}", file=sys.stderr, flush=True)\\n' +
+    ind + 'def _trajectory_checkpoint_loop():\\n' +
+    ind + '    while _trajectory_checkpoint_stop is not None and not _trajectory_checkpoint_stop.wait(2.0):\\n' +
+    ind + '        _trajectory_checkpoint("checkpoint")\\n' +
+    ind + 'try:\\n' +
+    ind + '    import threading as _trajectory_threading\\n' +
+    ind + '    _trajectory_checkpoint_stop = _trajectory_threading.Event()\\n' +
+    ind + '    _trajectory_checkpoint_thread = _trajectory_threading.Thread(target=_trajectory_checkpoint_loop, daemon=True)\\n' +
+    ind + '    _trajectory_checkpoint_thread.start()\\n' +
+    ind + 'except BaseException as _e:\\n' +
+    ind + '    print(f"trajectory checkpoint thread unavailable: {_e}", file=sys.stderr, flush=True)\\n'
+)
+
+if ok and events_ok:
     wrap = (
         ind + '# Send instruction and run\\n' +
         ind + '_trajectory_flush_exc = None\\n' +
@@ -975,6 +1055,7 @@ if ok:
         ind + '        _trajectory_signal.signal(_trajectory_signal.SIGINT, _trajectory_signal.SIG_IGN)\\n' +
         ind + '    except BaseException:\\n' +
         ind + '        pass\\n' +
+        checkpoint +
         ind + 'try:\\n' +
         ind + '    import signal as _trajectory_signal\\n' +
         ind + '    _trajectory_signal.signal(_trajectory_signal.SIGTERM, _trajectory_timeout_handler)\\n' +
@@ -983,6 +1064,7 @@ if ok:
         ind + '    pass\\n' +
         ind + 'try:\\n' +
         ind + '    conversation.send_message(args.instruction)\\n' +
+        ind + '    _trajectory_checkpoint("start")\\n' +
         ind + '    conversation.run()\\n' +
         ind + 'except TrajectoryFlushRequested as _e:\\n' +
         ind + '    _trajectory_flush_exc = _e\\n' +
@@ -993,18 +1075,21 @@ if ok:
         ind + '    _trajectory_flush_reason = type(_e).__name__\\n' +
         ind + '    print(f"trajectory flush: flushing after {type(_e).__name__}: {_e}", file=sys.stderr, flush=True)\\n' +
         ind + 'finally:\\n' +
+        ind + '    try:\\n' +
+        ind + '        if _trajectory_checkpoint_stop is not None:\\n' +
+        ind + '            _trajectory_checkpoint_stop.set()\\n' +
+        ind + '        if _trajectory_checkpoint_thread is not None:\\n' +
+        ind + '            _trajectory_checkpoint_thread.join(timeout=1.0)\\n' +
+        ind + '    except BaseException:\\n' +
+        ind + '        pass\\n' +
         ind + '    _trajectory_ignore_interrupts()'
     )
     c = c.replace(old1, wrap, 1)
     new_save = (
         '    if _trajectory_flush_reason is not None:\\n'
-        '        trajectory.setdefault("extra", {})["partial_trajectory"] = {"reason": _trajectory_flush_reason, "events": len(events_list)}\\n'
-        '    trajectory_path = Path(args.trajectory_path)\\n'
-        '    trajectory_path.parent.mkdir(parents=True, exist_ok=True)\\n'
-        '    trajectory_tmp = trajectory_path.with_suffix(trajectory_path.suffix + ".partial")\\n'
-        '    with open(trajectory_tmp, "w") as f:\\n'
-        '        json.dump(trajectory, f, indent=2)\\n'
-        '    os.replace(trajectory_tmp, trajectory_path)'
+        '        _trajectory_mark_partial(trajectory, _trajectory_flush_reason, len(events_list))\\n'
+        '    _trajectory_save(trajectory, args.trajectory_path)\\n'
+        '    trajectory_path = Path(args.trajectory_path)'
     )
     c = c.replace(old_save, new_save, 1)
     exit_block = (
@@ -1073,9 +1158,7 @@ def _recover_from_logs(agent_logs_dir: Path) -> dict[str, Any]:
             return (1, name)
         if name == "trajectory.json.partial":
             return (2, name)
-        if name.endswith(".json"):
-            return (3, name)
-        return (4, name)
+        return (3, name)
 
     traj_files = sorted(
         (

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -228,6 +228,20 @@ class TestCrashMarker:
 
 
 class TestRecoverFromLogs:
+    @staticmethod
+    def _write_atif(path: Path, message: str) -> None:
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "ATIF-v1.7",
+                    "session_id": "partial",
+                    "agent": {"name": "openhands-sdk", "model_name": "model"},
+                    "steps": [{"step_id": 1, "source": "agent", "message": message}],
+                    "final_metrics": {"total_steps": 1},
+                }
+            )
+        )
+
     def test_recovers_valid_partial_trajectory_before_text_fallback(self, tmp_path):
         (tmp_path / "trajectory.json.partial").write_text(
             json.dumps(
@@ -249,6 +263,33 @@ class TestRecoverFromLogs:
         assert recovered["prompt_tokens"] == 11
         assert recovered["completion_tokens"] == 7
         assert recovered["trajectory"][0]["extra"]["partial_trajectory"]["reason"] == "timeout"
+
+    def test_prefers_canonical_trajectory_names_by_rank(self, tmp_path):
+        self._write_atif(tmp_path / "z-other-trajectory.json", "other json")
+        self._write_atif(tmp_path / "trajectory.json.partial", "json partial")
+        self._write_atif(tmp_path / "trajectory.partial.json", "partial json")
+        self._write_atif(tmp_path / "trajectory.json", "canonical")
+
+        recovered = harbor_mod._recover_from_logs(tmp_path)
+
+        assert recovered["response"] == "canonical"
+
+    def test_prefers_partial_json_before_json_partial(self, tmp_path):
+        self._write_atif(tmp_path / "z-other-trajectory.json", "other json")
+        self._write_atif(tmp_path / "trajectory.json.partial", "json partial")
+        self._write_atif(tmp_path / "trajectory.partial.json", "partial json")
+
+        recovered = harbor_mod._recover_from_logs(tmp_path)
+
+        assert recovered["response"] == "partial json"
+
+    def test_prefers_json_partial_before_other_json(self, tmp_path):
+        self._write_atif(tmp_path / "z-other-trajectory.json", "other json")
+        self._write_atif(tmp_path / "trajectory.json.partial", "json partial")
+
+        recovered = harbor_mod._recover_from_logs(tmp_path)
+
+        assert recovered["response"] == "json partial"
 
 
 class TestLastLlmErrorMarker:
@@ -970,6 +1011,9 @@ def build_trajectory(events, llm_metrics, model_name):
         return (
             module_imports
             + """
+import json
+from pathlib import Path
+from typing import Any
 
 
 class MessageEvent:
@@ -988,22 +1032,35 @@ class ActionEvent:
         self.tool_call = type("TC", (), {"function": fn})()
 
 
-def build_trajectory(events, metrics, model):
+def build_trajectory(events, metrics, model, system_prompt=None, tool_definitions=None):
     steps = []
     for event in events:
-        if isinstance(event, MessageEvent):
-            steps.append({"source": event.source, "content": event.llm_message.content})
-        elif isinstance(event, ActionEvent):
+        if event["type"] == "user_message":
+            steps.append({"source": "user", "content": event["content"], "message": event["content"]})
+        elif event["type"] == "assistant_message":
+            step = {
+                "source": "agent",
+                "content": event.get("content", ""),
+                "message": event.get("content", ""),
+            }
+            if event.get("tool_calls"):
+                step["tool_calls"] = event["tool_calls"]
+            steps.append(step)
+        elif event["type"] == "tool_result":
             steps.append(
                 {
-                    "source": "agent",
-                    "content": "",
-                    "tool_calls": [{"id": event.tool_call_id, "name": event.tool_name}],
+                    "source": "system",
+                    "content": event.get("content", ""),
+                    "source_call_id": event.get("tool_call_id"),
                 }
             )
-        else:
-            steps.append(event)
-    return {"steps": steps, "final_metrics": metrics, "model_name": model}
+    return {
+        "steps": steps,
+        "final_metrics": metrics,
+        "model_name": model,
+        "system_prompt": system_prompt,
+        "tool_definitions": tool_definitions,
+    }
 
 
 class _Args:
@@ -1027,17 +1084,53 @@ def main():
     args.trajectory_path = os.environ["NEL_TEST_TRAJECTORY_PATH"]
     model = "test-model"
     llm = type("LLM", (), {"metrics": None})()
+    agent = type("Agent", (), {"static_system_message": None, "tools_map": {}})()
     conversation = _Conversation(__EVENTS_EXPR__)
 
     # Send instruction and run
     conversation.send_message(args.instruction)
     conversation.run()
 
-    import json
-    from pathlib import Path
+    metrics = {}
+    # Convert SDK events to dicts for build_trajectory()
+    events_list: list[dict[str, Any]] = []
+    for event in conversation.state.events:
+        if isinstance(event, MessageEvent):
+            content = str(event.llm_message.content) if event.llm_message else ""
+            if event.source == "user":
+                events_list.append(
+                    {
+                        "type": "user_message",
+                        "content": content,
+                        "timestamp": event.timestamp,
+                    }
+                )
+            elif event.source == "agent":
+                events_list.append(
+                    {
+                        "type": "assistant_message",
+                        "content": content,
+                        "timestamp": event.timestamp,
+                    }
+                )
+        elif isinstance(event, ActionEvent):
+            events_list.append(
+                {
+                    "type": "assistant_message",
+                    "content": "",
+                    "timestamp": event.timestamp,
+                    "tool_calls": [
+                        {
+                            "id": event.tool_call_id,
+                            "name": event.tool_name,
+                            "arguments": event.tool_call.function.arguments,
+                        }
+                    ],
+                }
+            )
 
-    events_list = list(conversation.state.events)
-    trajectory = build_trajectory(events_list, {}, model)
+    # Build and save trajectory
+    trajectory = build_trajectory(events_list, metrics, model)
     trajectory_path = Path(args.trajectory_path)
     trajectory_path.parent.mkdir(parents=True, exist_ok=True)
     with open(trajectory_path, "w") as f:
@@ -1132,8 +1225,9 @@ def main():
         patched = await self._apply_flush_patch(runner)
 
         assert "_trajectory_flush_exc = None" in patched
-        assert "def _write_partial_trajectory" not in patched
-        assert "_trajectory_text_from_event" not in patched
+        assert "_trajectory_checkpoint_loop" in patched
+        assert "def _collect_trajectory_events(conversation, llm, metrics):" in patched
+        assert "_trajectory_event_text" not in patched
         assert "class TrajectoryFlushRequested" in patched
         assert 'trajectory.setdefault("extra", {})["partial_trajectory"]' in patched
         # Crash marker is written atomically (tmp + os.replace), matching the
@@ -1221,6 +1315,61 @@ def main():
         assert data["extra"]["partial_trajectory"]["reason"] == "timeout"
         assert data["extra"]["partial_trajectory"]["events"] == 2
         assert "/logs/agent" not in stderr
+
+    async def test_flush_patch_sigkill_keeps_checkpointed_trajectory(self, tmp_path, monkeypatch):
+        """SIGKILL cannot run cleanup, so the background checkpoint must preserve ATIF."""
+        traj_path = tmp_path / "trajectory" / "out.json"
+        monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            self._stub_runner(
+                "import json\nimport os\nimport sys\nimport time\nfrom pathlib import Path",
+                (
+                    '        self.state.events.append(MessageEvent("agent", "checkpointed response", 2.0))\n'
+                    '        Path(os.environ["NEL_TEST_READY_PATH"]).write_text("ready")\n'
+                    "        time.sleep(30)\n"
+                ),
+                'MessageEvent("user", "initial prompt", 1.0)',
+            )
+        )
+        patched = await self._apply_flush_patch(runner)
+        runner.write_text(f'{patched}\n\nif __name__ == "__main__":\n    main()\n')
+
+        env = os.environ.copy()
+        env["NEL_TEST_TRAJECTORY_PATH"] = str(traj_path)
+        ready_path = tmp_path / "ready"
+        env["NEL_TEST_READY_PATH"] = str(ready_path)
+        proc = subprocess.Popen(
+            [sys.executable, str(runner)],
+            env=env,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        deadline = time.monotonic() + 10
+        checkpointed = False
+        while time.monotonic() < deadline:
+            if ready_path.exists() and traj_path.exists():
+                data = json.loads(traj_path.read_text())
+                checkpointed = any(
+                    step.get("source") == "agent" and step.get("message") == "checkpointed response"
+                    for step in data.get("steps", [])
+                )
+                if checkpointed:
+                    break
+            await asyncio.sleep(0.05)
+        assert checkpointed, "background checkpoint did not write agent steps before hard kill"
+
+        proc.kill()
+        stdout, stderr = proc.communicate(timeout=10)
+
+        assert proc.returncode != 0, stdout + stderr
+        data = json.loads(traj_path.read_text())
+        assert data["extra"]["partial_trajectory"]["checkpoint"] is True
+        assert any(
+            step.get("source") == "agent" and step.get("message") == "checkpointed response" for step in data["steps"]
+        )
 
     async def test_flush_patch_ignores_reentrant_signal_while_writing_trajectory(self, tmp_path, monkeypatch):
         """A second SIGTERM during generic serialization must not abort persistence."""

--- a/tests/test_solvers/test_harbor_solver.py
+++ b/tests/test_solvers/test_harbor_solver.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import signal
+import subprocess
+import sys
 import tarfile
 import time
 from pathlib import Path
@@ -222,6 +225,30 @@ class TestCrashMarker:
 
         with pytest.raises(InfraError, match="Agent infrastructure failure: APIConnectionError: connection failed"):
             _error_from_crash_marker(tmp_path)
+
+
+class TestRecoverFromLogs:
+    def test_recovers_valid_partial_trajectory_before_text_fallback(self, tmp_path):
+        (tmp_path / "trajectory.json.partial").write_text(
+            json.dumps(
+                {
+                    "schema_version": "ATIF-v1.7",
+                    "session_id": "partial",
+                    "agent": {"name": "openhands-sdk", "model_name": "model"},
+                    "steps": [{"step_id": 1, "source": "agent", "message": "partial response"}],
+                    "final_metrics": {"total_steps": 1, "total_prompt_tokens": 11, "total_completion_tokens": 7},
+                    "extra": {"partial_trajectory": {"reason": "timeout", "events": 1}},
+                }
+            )
+        )
+        (tmp_path / "openhands_sdk.txt").write_text("text fallback")
+
+        recovered = harbor_mod._recover_from_logs(tmp_path)
+
+        assert recovered["response"] == "partial response"
+        assert recovered["prompt_tokens"] == 11
+        assert recovered["completion_tokens"] == 7
+        assert recovered["trajectory"][0]["extra"]["partial_trajectory"]["reason"] == "timeout"
 
 
 class TestLastLlmErrorMarker:
@@ -928,16 +955,17 @@ def build_trajectory(events, llm_metrics, model_name):
     )
 
     @staticmethod
-    def _stub_runner(module_imports: str, run_body: str, events: str) -> str:
+    def _stub_runner(module_imports: str, run_body: str, events: str, *, events_expr: str | None = None) -> str:
         """Build a minimal run_agent.py stub for the flush patch to wrap.
 
-        ``module_imports`` controls which names exist at module scope (used to
-        prove ``_write_partial_trajectory`` self-imports its dependencies).
+        ``module_imports`` controls which names exist at module scope.
         ``run_body`` is the indented body of ``_Conversation.run`` — raise to
         exercise the crash path, ``raise_signal`` to exercise the timeout path.
-        ``events`` is the comma-separated event constructor list; use message-
-        only events to keep the flush off the ``_trajectory_tool_args`` sibling
-        helper (which is not in change #5's self-sufficiency scope).
+        ``events`` is the comma-separated event constructor list; use
+        ``events_expr`` when the test needs a custom iterable.  The post-run
+        trajectory block intentionally represents the runner's existing generic
+        serialization path; the flush patch should annotate and protect this
+        block, not duplicate event-to-ATIF conversion.
         """
         return (
             module_imports
@@ -961,7 +989,21 @@ class ActionEvent:
 
 
 def build_trajectory(events, metrics, model):
-    return {"steps": events, "final_metrics": metrics, "model_name": model}
+    steps = []
+    for event in events:
+        if isinstance(event, MessageEvent):
+            steps.append({"source": event.source, "content": event.llm_message.content})
+        elif isinstance(event, ActionEvent):
+            steps.append(
+                {
+                    "source": "agent",
+                    "content": "",
+                    "tool_calls": [{"id": event.tool_call_id, "name": event.tool_name}],
+                }
+            )
+        else:
+            steps.append(event)
+    return {"steps": steps, "final_metrics": metrics, "model_name": model}
 
 
 class _Args:
@@ -985,14 +1027,25 @@ def main():
     args.trajectory_path = os.environ["NEL_TEST_TRAJECTORY_PATH"]
     model = "test-model"
     llm = type("LLM", (), {"metrics": None})()
-    conversation = _Conversation([__EVENTS__])
+    conversation = _Conversation(__EVENTS_EXPR__)
 
     # Send instruction and run
     conversation.send_message(args.instruction)
     conversation.run()
 
+    import json
+    from pathlib import Path
+
+    events_list = list(conversation.state.events)
+    trajectory = build_trajectory(events_list, {}, model)
+    trajectory_path = Path(args.trajectory_path)
+    trajectory_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(trajectory_path, "w") as f:
+        json.dump(trajectory, f, indent=2)
+
+    print(f"Agent completed. Trajectory saved to {trajectory_path}")
     print("Total cost: 0.0")
-""".replace("__EVENTS__", events)
+""".replace("__EVENTS_EXPR__", events_expr if events_expr is not None else f"[{events}]")
         )
 
     @staticmethod
@@ -1079,10 +1132,12 @@ def main():
         patched = await self._apply_flush_patch(runner)
 
         assert "_trajectory_flush_exc = None" in patched
-        assert "def _write_partial_trajectory" in patched
+        assert "def _write_partial_trajectory" not in patched
+        assert "_trajectory_text_from_event" not in patched
         assert "class TrajectoryFlushRequested" in patched
+        assert 'trajectory.setdefault("extra", {})["partial_trajectory"]' in patched
         # Crash marker is written atomically (tmp + os.replace), matching the
-        # partial-trajectory write, so a kill mid-write can't leave a truncated
+        # trajectory write, so a kill mid-write can't leave a truncated
         # marker that _error_from_crash_marker would silently drop.
         assert '_marker = "/logs/agent/agent_error.json"' in patched
         assert "_os.replace(_marker_tmp, _marker)" in patched
@@ -1125,32 +1180,83 @@ def main():
         assert data["extra"]["partial_trajectory"]["events"] == 2
         assert "/logs/agent" not in makedirs_calls, "the timeout path must not write a crash marker"
 
-    async def test_flush_patch_self_sufficient_without_module_imports(self, tmp_path, monkeypatch):
-        """_write_partial_trajectory flushes even without module-scope json/Path.
-
-        Proves change #5: the function self-imports its dependencies.  ``os``
-        and ``sys`` remain at module scope because the wrap/exit blocks (out of
-        scope for #5) still reference them there.
-        """
+    async def test_flush_patch_os_sigterm_writes_trajectory_no_marker(self, tmp_path, monkeypatch):
+        """A real SIGTERM from outside the process should flush trajectory."""
         traj_path = tmp_path / "trajectory" / "out.json"
         monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
 
         runner = tmp_path / "run_agent.py"
         runner.write_text(
             self._stub_runner(
-                "import os\nimport sys",
-                '        raise RuntimeError("simulated crash")\n',
+                "import json\nimport os\nimport sys\nimport time\nfrom pathlib import Path",
+                '        Path(os.environ["NEL_TEST_READY_PATH"]).write_text("ready")\n        time.sleep(30)\n',
                 self._EVENTS_TWO_MESSAGES,
             )
         )
         patched = await self._apply_flush_patch(runner)
+        runner.write_text(f'{patched}\n\nif __name__ == "__main__":\n    main()\n')
 
-        self._run_patched_main(patched, runner, monkeypatch)
+        env = os.environ.copy()
+        env["NEL_TEST_TRAJECTORY_PATH"] = str(traj_path)
+        ready_path = tmp_path / "ready"
+        env["NEL_TEST_READY_PATH"] = str(ready_path)
+        proc = subprocess.Popen(
+            [sys.executable, str(runner)],
+            env=env,
+            stderr=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            text=True,
+        )
+        deadline = time.monotonic() + 10
+        while not ready_path.exists() and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert ready_path.exists(), "subprocess did not reach the signal-ready point"
+        proc.send_signal(signal.SIGTERM)
+        stdout, stderr = proc.communicate(timeout=10)
 
-        assert traj_path.is_file(), "flush must not depend on module-scope json/Path"
+        assert proc.returncode == 0, stdout + stderr
+        assert "trajectory flush: flushing after NEL timeout signal: signal 15" in stderr
+        assert traj_path.is_file(), "partial trajectory was not flushed on SIGTERM"
         data = json.loads(traj_path.read_text())
+        assert data["extra"]["partial_trajectory"]["reason"] == "timeout"
         assert data["extra"]["partial_trajectory"]["events"] == 2
-        assert len(data["steps"]) == 2
+        assert "/logs/agent" not in stderr
+
+    async def test_flush_patch_ignores_reentrant_signal_while_writing_trajectory(self, tmp_path, monkeypatch):
+        """A second SIGTERM during generic serialization must not abort persistence."""
+        traj_path = tmp_path / "trajectory" / "out.json"
+        monkeypatch.setenv("NEL_TEST_TRAJECTORY_PATH", str(traj_path))
+
+        runner = tmp_path / "run_agent.py"
+        runner.write_text(
+            self._stub_runner(
+                """
+import os
+import signal
+import sys
+
+
+class _EventStore:
+    def __iter__(self):
+        yield MessageEvent("agent", "before signal", 1)
+        signal.raise_signal(signal.SIGTERM)
+        yield MessageEvent("agent", "after signal", 2)
+""",
+                "        import signal as _sig\n        _sig.raise_signal(_sig.SIGINT)\n",
+                "",
+                events_expr="_EventStore()",
+            )
+        )
+        patched = await self._apply_flush_patch(runner)
+
+        makedirs_calls = self._run_patched_main(patched, runner, monkeypatch)
+
+        assert traj_path.is_file(), "reentrant signal must not abort the partial trajectory write"
+        data = json.loads(traj_path.read_text())
+        assert data["extra"]["partial_trajectory"]["reason"] == "timeout"
+        assert data["extra"]["partial_trajectory"]["events"] == 2
+        assert [step["content"] for step in data["steps"]] == ["before signal", "after signal"]
+        assert "/logs/agent" not in makedirs_calls
 
 
 class TestSandboxEnvironmentAdapter:


### PR DESCRIPTION
Hardens OpenHands trajectory preservation for interrupted SWE/Harbor runs.

Changes:
- Convert catchable SIGTERM/SIGINT interruptions in the OpenHands runner into the existing final trajectory serialization path, with nested signals ignored while the file is being written.
- Add periodic structured trajectory checkpoints during `conversation.run()` so SIGKILL/OOM-style hard exits can still leave ATIF instead of only a text log fallback.
- Reuse the runner's existing SDK-event-to-ATIF conversion helper for both final save and checkpoints; no separate ad hoc event serializer.
- Save trajectories atomically through `trajectory.json.partial` -> `trajectory.json` and prefer valid partial JSON before falling back to `openhands_sdk.txt`.

Why:
- In long SWE runs, agent processes can be hard-killed after producing tool/model activity and a workspace diff but before OpenHands writes final ATIF. That leaves rewards/verification output and model traffic present, while the trajectory has zero useful agent steps.
- Catchable signals are handled by final flush. Hard exits are handled by the new checkpoint file already on disk.

Before/after validation:
- Before the checkpoint path, SIGKILL cannot run final cleanup, so no structured trajectory is written if the process is hard-killed between model/tool activity and final save.
- After the checkpoint path, the regression test starts a patched runner, waits for a checkpoint containing an agent step, then sends SIGKILL; recovered `trajectory.json` still contains agent steps and `extra.partial_trajectory.checkpoint=true`.
- SIGTERM/SIGINT still use the final flush path and mark `extra.partial_trajectory.reason="timeout"`.

Validation:
- `.venv/bin/python -m pytest -q tests/test_solvers/test_harbor_solver.py` -> 116 passed.
- `.venv/bin/python -m ruff check src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_solver.py` -> passed.
- `.venv/bin/python -m ruff format --check src/nemo_evaluator/solvers/harbor.py tests/test_solvers/test_harbor_solver.py` -> passed.
- GitHub checks for `786a5819` -> 32 success, 6 skipped.
- Internal CI for the matching GitLab MR passed, including the Harbor image build.
