### PR TITLE
feat: request and capture provider token IDs in model traffic

### DIFF
--- a/src/nemo_evaluator/adapters/interceptors/endpoint.py
+++ b/src/nemo_evaluator/adapters/interceptors/endpoint.py
@@ -28,11 +28,7 @@ from nemo_evaluator.adapters.types import (
     RequestToResponseInterceptor,
 )
 from nemo_evaluator.completions_guard import enforce_text_completions_body
-from nemo_evaluator.observability.model_traffic import (
-    get_store,
-    normalize_token_ids,
-    prompt_token_ids_from_response,
-)
+from nemo_evaluator.observability.model_traffic import get_store
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +83,6 @@ class Interceptor(RequestToResponseInterceptor):
         self._retry_on_status = set(retry_on_status or [429, 502, 503, 504])
         self._max_concurrent = max_concurrent
         self._model_traffic_store = get_store(model_traffic_store_id) if model_traffic_store_id else None
-        self._tokenize_unavailable = False
         self._session: aiohttp.ClientSession | None = None
         self._lock = asyncio.Lock()
         logger.info(
@@ -122,7 +117,9 @@ class Interceptor(RequestToResponseInterceptor):
 
     @staticmethod
     def _request_stream_usage_chunks(path: str, body: dict[str, Any]) -> None:
-        if not Interceptor._is_streaming_chat_request(path, body):
+        if body.get("stream") is not True:
+            return
+        if not path.rstrip("/").endswith("/chat/completions"):
             return
 
         stream_options = body.get("stream_options")
@@ -130,62 +127,6 @@ class Interceptor(RequestToResponseInterceptor):
             body["stream_options"] = {"include_usage": True}
         elif isinstance(stream_options, dict) and "include_usage" not in stream_options:
             body["stream_options"] = {**stream_options, "include_usage": True}
-
-    @staticmethod
-    def _is_streaming_chat_request(path: str, body: dict[str, Any]) -> bool:
-        return body.get("stream") is True and path.rstrip("/").endswith("/chat/completions")
-
-    @staticmethod
-    async def _post_json(
-        session: aiohttp.ClientSession, url: str, headers: dict[str, str], body: dict[str, Any]
-    ) -> Any:
-        async with session.post(url, data=json.dumps(body), headers=headers) as resp:
-            raw = await resp.read()
-            if resp.status >= 400:
-                return None
-            try:
-                return json.loads(raw)
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                return None
-
-    async def _stream_prompt_token_ids(
-        self,
-        session: aiohttp.ClientSession,
-        url: str,
-        headers: dict[str, str],
-        body: dict[str, Any],
-    ) -> list[int] | None:
-        tokenize_body = {
-            key: body[key] for key in ("model", "messages", "tools", "chat_template_kwargs") if key in body
-        }
-        if "messages" in tokenize_body and not self._tokenize_unavailable:
-            saw_missing_route = False
-            for tokenize_url in self._tokenize_urls():
-                payload = await self._post_json(session, tokenize_url, headers, tokenize_body)
-                if isinstance(payload, dict):
-                    ids = normalize_token_ids(payload.get("tokens")) or normalize_token_ids(
-                        payload.get("prompt_token_ids")
-                    )
-                    if ids is not None:
-                        return ids
-                saw_missing_route = saw_missing_route or payload is None
-            self._tokenize_unavailable = saw_missing_route
-
-        probe = dict(body)
-        probe.pop("stream", None)
-        probe.pop("stream_options", None)
-        probe["return_token_ids"] = True
-        if "max_tokens" in probe:
-            probe["max_tokens"] = 1
-        if "max_completion_tokens" in probe:
-            probe["max_completion_tokens"] = 1
-        probe.setdefault("max_tokens", 1)
-        payload = await self._post_json(session, url, headers, probe)
-        return prompt_token_ids_from_response(payload) if payload is not None else None
-
-    def _tokenize_urls(self) -> list[str]:
-        base = self._upstream_url.rstrip("/")
-        return [*dict.fromkeys(([f"{base[:-3]}/tokenize"] if base.endswith("/v1") else []) + [f"{base}/tokenize"])]
 
     def _capture_response(self, resp: AdapterResponse) -> AdapterResponse:
         if self._model_traffic_store is not None:
@@ -258,21 +199,6 @@ class Interceptor(RequestToResponseInterceptor):
 
                     if isinstance(parsed, dict):
                         self._normalize_content(parsed)
-
-                    if (
-                        self._model_traffic_store is not None
-                        and self._model_traffic_store.capture_token_ids
-                        and 200 <= status < 400
-                        and self._is_streaming_chat_request(req.path, body)
-                        and prompt_token_ids_from_response(parsed) is None
-                    ):
-                        try:
-                            ids = await self._stream_prompt_token_ids(session, url, headers, body)
-                        except (aiohttp.ClientError, TimeoutError) as exc:
-                            logger.debug("endpoint: prompt token id fallback failed: %s", exc)
-                        else:
-                            if ids is not None:
-                                req.ctx.extra["prompt_token_ids_fallback"] = ids
 
                     return self._capture_response(
                         AdapterResponse(

--- a/src/nemo_evaluator/adapters/interceptors/endpoint.py
+++ b/src/nemo_evaluator/adapters/interceptors/endpoint.py
@@ -28,7 +28,11 @@ from nemo_evaluator.adapters.types import (
     RequestToResponseInterceptor,
 )
 from nemo_evaluator.completions_guard import enforce_text_completions_body
-from nemo_evaluator.observability.model_traffic import get_store
+from nemo_evaluator.observability.model_traffic import (
+    get_store,
+    normalize_token_ids,
+    prompt_token_ids_from_response,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +87,7 @@ class Interceptor(RequestToResponseInterceptor):
         self._retry_on_status = set(retry_on_status or [429, 502, 503, 504])
         self._max_concurrent = max_concurrent
         self._model_traffic_store = get_store(model_traffic_store_id) if model_traffic_store_id else None
+        self._tokenize_unavailable = False
         self._session: aiohttp.ClientSession | None = None
         self._lock = asyncio.Lock()
         logger.info(
@@ -117,9 +122,7 @@ class Interceptor(RequestToResponseInterceptor):
 
     @staticmethod
     def _request_stream_usage_chunks(path: str, body: dict[str, Any]) -> None:
-        if body.get("stream") is not True:
-            return
-        if not path.rstrip("/").endswith("/chat/completions"):
+        if not Interceptor._is_streaming_chat_request(path, body):
             return
 
         stream_options = body.get("stream_options")
@@ -127,6 +130,62 @@ class Interceptor(RequestToResponseInterceptor):
             body["stream_options"] = {"include_usage": True}
         elif isinstance(stream_options, dict) and "include_usage" not in stream_options:
             body["stream_options"] = {**stream_options, "include_usage": True}
+
+    @staticmethod
+    def _is_streaming_chat_request(path: str, body: dict[str, Any]) -> bool:
+        return body.get("stream") is True and path.rstrip("/").endswith("/chat/completions")
+
+    @staticmethod
+    async def _post_json(
+        session: aiohttp.ClientSession, url: str, headers: dict[str, str], body: dict[str, Any]
+    ) -> Any:
+        async with session.post(url, data=json.dumps(body), headers=headers) as resp:
+            raw = await resp.read()
+            if resp.status >= 400:
+                return None
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                return None
+
+    async def _stream_prompt_token_ids(
+        self,
+        session: aiohttp.ClientSession,
+        url: str,
+        headers: dict[str, str],
+        body: dict[str, Any],
+    ) -> list[int] | None:
+        tokenize_body = {
+            key: body[key] for key in ("model", "messages", "tools", "chat_template_kwargs") if key in body
+        }
+        if "messages" in tokenize_body and not self._tokenize_unavailable:
+            saw_missing_route = False
+            for tokenize_url in self._tokenize_urls():
+                payload = await self._post_json(session, tokenize_url, headers, tokenize_body)
+                if isinstance(payload, dict):
+                    ids = normalize_token_ids(payload.get("tokens")) or normalize_token_ids(
+                        payload.get("prompt_token_ids")
+                    )
+                    if ids is not None:
+                        return ids
+                saw_missing_route = saw_missing_route or payload is None
+            self._tokenize_unavailable = saw_missing_route
+
+        probe = dict(body)
+        probe.pop("stream", None)
+        probe.pop("stream_options", None)
+        probe["return_token_ids"] = True
+        if "max_tokens" in probe:
+            probe["max_tokens"] = 1
+        if "max_completion_tokens" in probe:
+            probe["max_completion_tokens"] = 1
+        probe.setdefault("max_tokens", 1)
+        payload = await self._post_json(session, url, headers, probe)
+        return prompt_token_ids_from_response(payload) if payload is not None else None
+
+    def _tokenize_urls(self) -> list[str]:
+        base = self._upstream_url.rstrip("/")
+        return [*dict.fromkeys(([f"{base[:-3]}/tokenize"] if base.endswith("/v1") else []) + [f"{base}/tokenize"])]
 
     def _capture_response(self, resp: AdapterResponse) -> AdapterResponse:
         if self._model_traffic_store is not None:
@@ -200,6 +259,21 @@ class Interceptor(RequestToResponseInterceptor):
                     if isinstance(parsed, dict):
                         self._normalize_content(parsed)
 
+                    if (
+                        self._model_traffic_store is not None
+                        and self._model_traffic_store.capture_token_ids
+                        and 200 <= status < 400
+                        and self._is_streaming_chat_request(req.path, body)
+                        and prompt_token_ids_from_response(parsed) is None
+                    ):
+                        try:
+                            ids = await self._stream_prompt_token_ids(session, url, headers, body)
+                        except (aiohttp.ClientError, TimeoutError) as exc:
+                            logger.debug("endpoint: prompt token id fallback failed: %s", exc)
+                        else:
+                            if ids is not None:
+                                req.ctx.extra["prompt_token_ids_fallback"] = ids
+
                     return self._capture_response(
                         AdapterResponse(
                             status_code=status,
@@ -210,7 +284,7 @@ class Interceptor(RequestToResponseInterceptor):
                         )
                     )
 
-            except asyncio.TimeoutError as exc:
+            except TimeoutError as exc:
                 latency = (time.perf_counter() - t0) * 1000
                 if attempt < self._max_retries:
                     delay = min(2**attempt, 60)

--- a/src/nemo_evaluator/config/services.py
+++ b/src/nemo_evaluator/config/services.py
@@ -75,6 +75,7 @@ class ModelTrafficCaptureConfig(BaseModel):
     capture_reasoning: bool = True  # message.reasoning_content (or SSE delta)
     capture_messages: bool = True  # message.content
     capture_request_body: bool = False  # effective upstream HTTP request body
+    capture_token_ids: bool = False
     max_content_chars: int = 0  # truncation guard for captured bodies/content; 0 = no limit
 
 

--- a/src/nemo_evaluator/engine/model_traffic_log.py
+++ b/src/nemo_evaluator/engine/model_traffic_log.py
@@ -99,7 +99,15 @@ def _iter_model_traffic_log_records(
                 row[key] = record[key]
         if record.get("request_hash"):
             row["request_hash"] = record["request_hash"]
-        for key in ("request_body", "tool_calls_full", "reasoning_content", "message_content"):
+        for key in (
+            "request_body",
+            "tool_calls_full",
+            "reasoning_content",
+            "message_content",
+            "prompt_token_ids",
+            "completion_token_ids",
+            "completion_token_ids_by_choice",
+        ):
             if key in record:
                 row[key] = record[key]
         yield row

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -109,11 +109,6 @@ def _first_token_list(data: Any, *keys: str) -> list[int] | None:
     return empty
 
 
-def normalize_token_ids(value: Any) -> list[int] | None:
-    """Return *value* as a token-id list, or ``None`` when it is not one."""
-    return _token_list(value)
-
-
 def _prefer_token_list(current: list[int] | None, candidate: list[int] | None) -> list[int] | None:
     if candidate is None:
         return current
@@ -483,19 +478,6 @@ def _summary(body: Any, **opts: Any) -> dict[str, Any]:
     return _summary_from_json(body, **opts) if isinstance(body, dict) else _summary_from_sse(body, **opts)
 
 
-def prompt_token_ids_from_response(body: Any) -> list[int] | None:
-    """Extract provider-reported prompt token IDs from JSON or SSE response bodies."""
-    summary = _summary(
-        body,
-        capture_tool_calls=False,
-        capture_reasoning=False,
-        capture_messages=False,
-        capture_token_ids=True,
-        max_content_chars=0,
-    )
-    return normalize_token_ids(summary.get("prompt_token_ids"))
-
-
 def _is_success(record: dict[str, Any]) -> bool:
     return 200 <= _int(record.get("status_code")) < 400
 
@@ -679,10 +661,6 @@ class ModelTrafficStore:
             "max_content_chars": max_content_chars,
         }
 
-    @property
-    def capture_token_ids(self) -> bool:
-        return bool(self._capture_opts["capture_token_ids"])
-
     def close(self) -> None:
         unregister_store(self.store_id)
         if self._spool_tmp is not None:
@@ -737,9 +715,6 @@ class ModelTrafficStore:
             }
 
         summary = _summary(resp.body, **self._capture_opts)
-        fallback_prompt_ids = normalize_token_ids(resp.ctx.extra.get("prompt_token_ids_fallback"))
-        if fallback_prompt_ids is not None and not summary.get("prompt_token_ids"):
-            summary["prompt_token_ids"] = fallback_prompt_ids
         success = 200 <= resp.status_code < 400
         record.update(
             {

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -10,9 +10,10 @@ import threading
 import time
 import uuid
 from collections import Counter
+from collections.abc import Iterator
 from contextlib import suppress
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterator
+from typing import TYPE_CHECKING, Any
 
 
 def _request_hash(body: Any) -> str | None:
@@ -33,14 +34,14 @@ def _request_hash(body: Any) -> str | None:
 if TYPE_CHECKING:
     from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse
 
-_REGISTRY: dict[str, "ModelTrafficStore"] = {}
+_REGISTRY: dict[str, ModelTrafficStore] = {}
 _REGISTRY_LOCK = threading.Lock()
 _USAGE_KEYS = ("prompt_tokens", "completion_tokens", "total_tokens", "reasoning_tokens", "cached_tokens")
 _PROVIDER = "provider_reported"
 _ERROR_SUMMARY_CHARS = 4000
 
 
-def register_store(store: "ModelTrafficStore") -> str:
+def register_store(store: ModelTrafficStore) -> str:
     with _REGISTRY_LOCK:
         _REGISTRY[store.store_id] = store
     return store.store_id
@@ -51,7 +52,7 @@ def unregister_store(store_id: str) -> None:
         _REGISTRY.pop(store_id, None)
 
 
-def get_store(store_id: str) -> "ModelTrafficStore":
+def get_store(store_id: str) -> ModelTrafficStore:
     with _REGISTRY_LOCK:
         store = _REGISTRY.get(store_id)
     if store is None:
@@ -106,6 +107,11 @@ def _first_token_list(data: Any, *keys: str) -> list[int] | None:
         if value is not None and empty is None:
             empty = value
     return empty
+
+
+def normalize_token_ids(value: Any) -> list[int] | None:
+    """Return *value* as a token-id list, or ``None`` when it is not one."""
+    return _token_list(value)
 
 
 def _prefer_token_list(current: list[int] | None, candidate: list[int] | None) -> list[int] | None:
@@ -381,9 +387,7 @@ def _iter_sse(body: Any) -> Iterator[dict[str, Any]]:
             continue
         if not line.startswith("data:"):
             continue
-        payload = line[5:]
-        if payload.startswith(" "):
-            payload = payload[1:]
+        payload = line[5:].removeprefix(" ")
         data_lines.append(payload)
 
     chunk = load_payload("\n".join(data_lines))
@@ -477,6 +481,19 @@ def _summary_from_sse(
 
 def _summary(body: Any, **opts: Any) -> dict[str, Any]:
     return _summary_from_json(body, **opts) if isinstance(body, dict) else _summary_from_sse(body, **opts)
+
+
+def prompt_token_ids_from_response(body: Any) -> list[int] | None:
+    """Extract provider-reported prompt token IDs from JSON or SSE response bodies."""
+    summary = _summary(
+        body,
+        capture_tool_calls=False,
+        capture_reasoning=False,
+        capture_messages=False,
+        capture_token_ids=True,
+        max_content_chars=0,
+    )
+    return normalize_token_ids(summary.get("prompt_token_ids"))
 
 
 def _is_success(record: dict[str, Any]) -> bool:
@@ -662,6 +679,10 @@ class ModelTrafficStore:
             "max_content_chars": max_content_chars,
         }
 
+    @property
+    def capture_token_ids(self) -> bool:
+        return bool(self._capture_opts["capture_token_ids"])
+
     def close(self) -> None:
         unregister_store(self.store_id)
         if self._spool_tmp is not None:
@@ -716,6 +737,9 @@ class ModelTrafficStore:
             }
 
         summary = _summary(resp.body, **self._capture_opts)
+        fallback_prompt_ids = normalize_token_ids(resp.ctx.extra.get("prompt_token_ids_fallback"))
+        if fallback_prompt_ids is not None and not summary.get("prompt_token_ids"):
+            summary["prompt_token_ids"] = fallback_prompt_ids
         success = 200 <= resp.status_code < 400
         record.update(
             {

--- a/src/nemo_evaluator/observability/model_traffic.py
+++ b/src/nemo_evaluator/observability/model_traffic.py
@@ -75,12 +75,93 @@ def _token_value(value: Any) -> int | None:
         return None
 
 
+def _token_list(value: Any) -> list[int] | None:
+    if not isinstance(value, list):
+        return None
+    out: list[int] = []
+    for item in value:
+        if isinstance(item, bool):
+            return None
+        if isinstance(item, int):
+            out.append(item)
+            continue
+        if isinstance(item, str):
+            text = item.strip()
+            digits = text[1:] if text[:1] in {"+", "-"} else text
+            if digits.isdecimal():
+                out.append(int(text))
+                continue
+        return None
+    return out
+
+
+def _first_token_list(data: Any, *keys: str) -> list[int] | None:
+    if not isinstance(data, dict):
+        return None
+    empty: list[int] | None = None
+    for key in keys:
+        value = _token_list(data.get(key))
+        if value:
+            return value
+        if value is not None and empty is None:
+            empty = value
+    return empty
+
+
+def _prefer_token_list(current: list[int] | None, candidate: list[int] | None) -> list[int] | None:
+    if candidate is None:
+        return current
+    if current is None or (candidate and not current):
+        return candidate
+    return current
+
+
+def _choice_key(choice: dict[str, Any], fallback: int) -> str:
+    value = choice.get("index")
+    if isinstance(value, bool):
+        return str(fallback)
+    try:
+        return str(int(value))
+    except (TypeError, ValueError):
+        return str(fallback)
+
+
+def _add_choice_token_ids(
+    by_choice: dict[str, list[int]], choice: dict[str, Any], fallback: int, token_ids: list[int] | None
+) -> None:
+    if token_ids:
+        by_choice.setdefault(_choice_key(choice, fallback), []).extend(token_ids)
+
+
 def _first_token(data: dict[str, Any], *keys: str) -> int | None:
     for key in keys:
         value = _token_value(data.get(key))
         if value is not None:
             return value
     return None
+
+
+def _collect_token_ids(
+    choice: dict[str, Any],
+    message: dict[str, Any],
+    prompt_token_ids: list[int] | None,
+) -> tuple[list[int] | None, list[int] | None]:
+    prompt_token_ids = _prefer_token_list(prompt_token_ids, _first_token_list(message, "prompt_token_ids"))
+    choice_token_ids = (
+        _first_token_list(choice, "token_ids", "completion_token_ids", "generation_token_ids")
+        or _first_token_list(choice.get("provider_specific_fields"), "token_ids")
+        or _first_token_list(message, "token_ids", "completion_token_ids", "generation_token_ids")
+    )
+    return prompt_token_ids, choice_token_ids
+
+
+def _add_token_id_fields(out: dict[str, Any], by_choice: dict[str, list[int]]) -> None:
+    if not by_choice:
+        return
+    ordered = dict(sorted(by_choice.items(), key=lambda item: int(item[0])))
+    out["completion_token_ids"] = [token for token_ids in ordered.values() for token in token_ids]
+    if len(ordered) > 1:
+        out["completion_token_ids_by_choice"] = ordered
 
 
 def _usage(raw: Any) -> dict[str, int]:
@@ -225,6 +306,7 @@ def _summary_from_json(
     capture_tool_calls: bool = True,
     capture_reasoning: bool = True,
     capture_messages: bool = True,
+    capture_token_ids: bool = False,
     max_content_chars: int = 100_000,
 ) -> dict[str, Any]:
     tool_names: list[str] = []
@@ -232,11 +314,16 @@ def _summary_from_json(
     full_tool_calls: list[dict[str, Any]] = []
     reasoning_parts: list[str] = []
     message_parts: list[str] = []
-    for choice in body.get("choices") or []:
+    prompt_token_ids = _first_token_list(body, "prompt_token_ids") if capture_token_ids else None
+    completion_token_ids_by_choice: dict[str, list[int]] = {}
+    for choice_idx, choice in enumerate(body.get("choices") or []):
         if not isinstance(choice, dict):
             continue
         finish_reason = str(choice.get("finish_reason") or finish_reason)
         message = choice.get("message") or choice.get("delta") or {}
+        if capture_token_ids:
+            prompt_token_ids, choice_token_ids = _collect_token_ids(choice, message, prompt_token_ids)
+            _add_choice_token_ids(completion_token_ids_by_choice, choice, choice_idx, choice_token_ids)
         if isinstance(message, dict):
             tool_names.extend(_tool_names_from_message(message))
             if capture_tool_calls:
@@ -261,6 +348,9 @@ def _summary_from_json(
         out["reasoning_content"] = _truncate("".join(reasoning_parts), max_content_chars)
     if capture_messages:
         out["message_content"] = _truncate("".join(message_parts), max_content_chars)
+    if prompt_token_ids is not None:
+        out["prompt_token_ids"] = prompt_token_ids
+    _add_token_id_fields(out, completion_token_ids_by_choice)
     return out
 
 
@@ -307,6 +397,7 @@ def _summary_from_sse(
     capture_tool_calls: bool = True,
     capture_reasoning: bool = True,
     capture_messages: bool = True,
+    capture_token_ids: bool = False,
     max_content_chars: int = 100_000,
 ) -> dict[str, Any]:
     model = ""
@@ -317,17 +408,24 @@ def _summary_from_sse(
     tool_full: dict[tuple[int, int], dict[str, Any]] = {}
     reasoning_parts: list[str] = []
     message_parts: list[str] = []
+    prompt_token_ids: list[int] | None = None
+    completion_token_ids_by_choice: dict[str, list[int]] = {}
     for chunk in _iter_sse(body):
         model = str(chunk.get("model") or model)
         if isinstance(chunk.get("usage"), dict):
             usage = _usage(chunk["usage"])
-        for choice in chunk.get("choices") or []:
+        if capture_token_ids:
+            prompt_token_ids = _prefer_token_list(prompt_token_ids, _first_token_list(chunk, "prompt_token_ids"))
+        for choice_idx, choice in enumerate(chunk.get("choices") or []):
             if not isinstance(choice, dict):
                 continue
             finish_reason = str(choice.get("finish_reason") or finish_reason)
             delta = choice.get("delta") or choice.get("message") or {}
             if not isinstance(delta, dict):
                 continue
+            if capture_token_ids:
+                prompt_token_ids, choice_token_ids = _collect_token_ids(choice, delta, prompt_token_ids)
+                _add_choice_token_ids(completion_token_ids_by_choice, choice, choice_idx, choice_token_ids)
             for raw in delta.get("tool_calls") or []:
                 if not isinstance(raw, dict):
                     continue
@@ -371,6 +469,9 @@ def _summary_from_sse(
         out["reasoning_content"] = _truncate("".join(reasoning_parts), max_content_chars)
     if capture_messages:
         out["message_content"] = _truncate("".join(message_parts), max_content_chars)
+    if prompt_token_ids is not None:
+        out["prompt_token_ids"] = prompt_token_ids
+    _add_token_id_fields(out, completion_token_ids_by_choice)
     return out
 
 
@@ -535,6 +636,7 @@ class ModelTrafficStore:
         capture_reasoning: bool = True,
         capture_messages: bool = True,
         capture_request_body: bool = False,
+        capture_token_ids: bool = False,
         max_content_chars: int = 0,
         spool_dir: str | Path | None = None,
     ) -> None:
@@ -556,6 +658,7 @@ class ModelTrafficStore:
             "capture_tool_calls": capture_tool_calls,
             "capture_reasoning": capture_reasoning,
             "capture_messages": capture_messages,
+            "capture_token_ids": capture_token_ids,
             "max_content_chars": max_content_chars,
         }
 
@@ -628,7 +731,14 @@ class ModelTrafficStore:
             record.update(_error_summary(resp.body, self._capture_opts["max_content_chars"]))
         # Persist opt-in capture fields when present (and the call succeeded).
         if success:
-            for key in ("tool_calls_full", "reasoning_content", "message_content"):
+            for key in (
+                "tool_calls_full",
+                "reasoning_content",
+                "message_content",
+                "prompt_token_ids",
+                "completion_token_ids",
+                "completion_token_ids_by_choice",
+            ):
                 if key in summary:
                     record[key] = summary[key]
         self._append_record(record)

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -788,15 +788,20 @@ def _start_proxy(
             max_concurrent_upstream=proxy_cfg.max_concurrent_upstream,
         )
 
+    capture_cfg = getattr(proxy_cfg, "model_traffic", None) if proxy_cfg is not None else None
+
+    if getattr(capture_cfg, "capture_token_ids", False):
+        proxy_kwargs["extra_body"] = {**(proxy_kwargs.get("extra_body") or {}), "return_token_ids": True}
+
     from nemo_evaluator.observability.model_traffic import ModelTrafficStore, register_store
 
-    capture_cfg = getattr(proxy_cfg, "model_traffic", None) if proxy_cfg is not None else None
     traffic_store = ModelTrafficStore(
         service_name=service_name,
         capture_tool_calls=getattr(capture_cfg, "capture_tool_calls", True),
         capture_reasoning=getattr(capture_cfg, "capture_reasoning", True),
         capture_messages=getattr(capture_cfg, "capture_messages", True),
         capture_request_body=getattr(capture_cfg, "capture_request_body", False),
+        capture_token_ids=getattr(capture_cfg, "capture_token_ids", False),
         max_content_chars=getattr(capture_cfg, "max_content_chars", 0),
     )
     register_store(traffic_store)

--- a/tests/test_adapters/test_streaming_interceptor.py
+++ b/tests/test_adapters/test_streaming_interceptor.py
@@ -18,14 +18,16 @@ import http.server
 import json
 import threading
 import urllib.request
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
 from nemo_evaluator.adapters.interceptors.streaming import Interceptor
 from nemo_evaluator.adapters.proxy import start_adapter_proxy
 from nemo_evaluator.adapters.registry import InterceptorRegistry
-from nemo_evaluator.adapters.types import AdapterResponse, InterceptorContext
+from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
+from nemo_evaluator.engine.model_traffic_log import format_model_traffic_log_records
+from nemo_evaluator.observability.model_traffic import ModelTrafficStore, register_store
 
 
 def _sse_body(chunks: list[dict[str, Any]]) -> bytes:
@@ -51,6 +53,35 @@ def _post_json(url: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
     )
     with urllib.request.urlopen(req, timeout=5) as resp:
         return resp.status, json.loads(resp.read())
+
+
+def _send_json(handler: http.server.BaseHTTPRequestHandler, status: int, body: dict[str, Any]) -> None:
+    payload = json.dumps(body).encode()
+    handler.send_response(status)
+    handler.send_header("Content-Type", "application/json")
+    handler.send_header("Content-Length", str(len(payload)))
+    handler.end_headers()
+    handler.wfile.write(payload)
+
+
+def _send_sse(handler: http.server.BaseHTTPRequestHandler, chunks: list[dict[str, Any]]) -> None:
+    payload = _sse_body(chunks)
+    handler.send_response(200)
+    handler.send_header("Content-Type", "text/event-stream")
+    handler.send_header("Content-Length", str(len(payload)))
+    handler.end_headers()
+    handler.wfile.write(payload)
+
+
+def _traffic_row(store: ModelTrafficStore, session_id: str) -> dict[str, Any]:
+    rows = format_model_traffic_log_records(
+        store.drain_session(session_id),
+        benchmark="streaming-test",
+        problem_idx=0,
+        repeat=0,
+    )
+    assert len(rows) == 1
+    return rows[0]
 
 
 @pytest.fixture
@@ -268,3 +299,95 @@ def test_start_adapter_proxy_coalesces_endpoint_streaming_response(local_server)
     assert Handler.seen_body["stream"] is True
     assert body["id"] == "cmpl-proxy"
     assert body["choices"][0]["message"]["content"] == "done"
+
+
+@pytest.mark.parametrize(
+    ("tokenize_payload", "expected_prompt_ids", "expected_paths"),
+    [
+        ({"tokens": ["10", 11, 12]}, [10, 11, 12], ["/v1/chat/completions", "/tokenize"]),
+        (
+            None,
+            [40, 41],
+            ["/v1/chat/completions", "/tokenize", "/v1/tokenize", "/v1/chat/completions"],
+        ),
+    ],
+)
+async def test_streaming_capture_fetches_prompt_token_ids(
+    local_server,
+    tokenize_payload: dict[str, Any] | None,
+    expected_prompt_ids: list[int],
+    expected_paths: list[str],
+):
+    from nemo_evaluator.adapters.interceptors.endpoint import Interceptor as EndpointInterceptor
+
+    class Handler(_QuietHandler):
+        paths: ClassVar[list[str]] = []
+        chat_bodies: ClassVar[list[dict[str, Any]]] = []
+
+        def do_POST(self):
+            Handler.paths.append(self.path)
+            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+            if self.path.endswith("/tokenize"):
+                _send_json(self, 200, tokenize_payload) if tokenize_payload else _send_json(self, 404, {})
+                return
+            assert self.path == "/v1/chat/completions"
+            Handler.chat_bodies.append(body)
+            if body.get("stream") is True:
+                _send_sse(
+                    self,
+                    [
+                        {
+                            "model": "test-model",
+                            "choices": [{"index": 0, "delta": {"content": "done"}, "token_ids": [31]}],
+                        },
+                        {
+                            "model": "test-model",
+                            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
+                        },
+                    ],
+                )
+                return
+            _send_json(self, 200, {"model": "test-model", "prompt_token_ids": ["40", 41], "choices": []})
+
+    base = local_server(Handler)
+    store = ModelTrafficStore(service_name="solver", capture_token_ids=True)
+    register_store(store)
+    ic = EndpointInterceptor(
+        upstream_url=f"{base}/v1/chat/completions",
+        extra_body={"return_token_ids": True},
+        model_traffic_store_id=store.store_id,
+    )
+    try:
+        ctx = InterceptorContext()
+        ctx.extra["session_id"] = "stream-token-ids"
+        await ic.intercept_request(
+            AdapterRequest(
+                method="POST",
+                path="/chat/completions",
+                headers={},
+                body={
+                    "model": "test-model",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                    "max_tokens": 512,
+                    "max_completion_tokens": 512,
+                },
+                ctx=ctx,
+            )
+        )
+        row = _traffic_row(store, "stream-token-ids")
+    finally:
+        await ic.close()
+        store.close()
+
+    assert Handler.paths == expected_paths
+    assert Handler.chat_bodies[0]["stream"] is True
+    if tokenize_payload is None:
+        assert Handler.chat_bodies[1]["return_token_ids"] is True
+        assert "stream" not in Handler.chat_bodies[1]
+        assert "stream_options" not in Handler.chat_bodies[1]
+        assert Handler.chat_bodies[1]["max_tokens"] == 1
+        assert Handler.chat_bodies[1]["max_completion_tokens"] == 1
+    assert row["prompt_token_ids"] == expected_prompt_ids
+    assert row["completion_token_ids"] == [31]

--- a/tests/test_adapters/test_streaming_interceptor.py
+++ b/tests/test_adapters/test_streaming_interceptor.py
@@ -18,16 +18,14 @@ import http.server
 import json
 import threading
 import urllib.request
-from typing import Any, ClassVar
+from typing import Any
 
 import pytest
 
 from nemo_evaluator.adapters.interceptors.streaming import Interceptor
 from nemo_evaluator.adapters.proxy import start_adapter_proxy
 from nemo_evaluator.adapters.registry import InterceptorRegistry
-from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
-from nemo_evaluator.engine.model_traffic_log import format_model_traffic_log_records
-from nemo_evaluator.observability.model_traffic import ModelTrafficStore, register_store
+from nemo_evaluator.adapters.types import AdapterResponse, InterceptorContext
 
 
 def _sse_body(chunks: list[dict[str, Any]]) -> bytes:
@@ -53,35 +51,6 @@ def _post_json(url: str, body: dict[str, Any]) -> tuple[int, dict[str, Any]]:
     )
     with urllib.request.urlopen(req, timeout=5) as resp:
         return resp.status, json.loads(resp.read())
-
-
-def _send_json(handler: http.server.BaseHTTPRequestHandler, status: int, body: dict[str, Any]) -> None:
-    payload = json.dumps(body).encode()
-    handler.send_response(status)
-    handler.send_header("Content-Type", "application/json")
-    handler.send_header("Content-Length", str(len(payload)))
-    handler.end_headers()
-    handler.wfile.write(payload)
-
-
-def _send_sse(handler: http.server.BaseHTTPRequestHandler, chunks: list[dict[str, Any]]) -> None:
-    payload = _sse_body(chunks)
-    handler.send_response(200)
-    handler.send_header("Content-Type", "text/event-stream")
-    handler.send_header("Content-Length", str(len(payload)))
-    handler.end_headers()
-    handler.wfile.write(payload)
-
-
-def _traffic_row(store: ModelTrafficStore, session_id: str) -> dict[str, Any]:
-    rows = format_model_traffic_log_records(
-        store.drain_session(session_id),
-        benchmark="streaming-test",
-        problem_idx=0,
-        repeat=0,
-    )
-    assert len(rows) == 1
-    return rows[0]
 
 
 @pytest.fixture
@@ -299,95 +268,3 @@ def test_start_adapter_proxy_coalesces_endpoint_streaming_response(local_server)
     assert Handler.seen_body["stream"] is True
     assert body["id"] == "cmpl-proxy"
     assert body["choices"][0]["message"]["content"] == "done"
-
-
-@pytest.mark.parametrize(
-    ("tokenize_payload", "expected_prompt_ids", "expected_paths"),
-    [
-        ({"tokens": ["10", 11, 12]}, [10, 11, 12], ["/v1/chat/completions", "/tokenize"]),
-        (
-            None,
-            [40, 41],
-            ["/v1/chat/completions", "/tokenize", "/v1/tokenize", "/v1/chat/completions"],
-        ),
-    ],
-)
-async def test_streaming_capture_fetches_prompt_token_ids(
-    local_server,
-    tokenize_payload: dict[str, Any] | None,
-    expected_prompt_ids: list[int],
-    expected_paths: list[str],
-):
-    from nemo_evaluator.adapters.interceptors.endpoint import Interceptor as EndpointInterceptor
-
-    class Handler(_QuietHandler):
-        paths: ClassVar[list[str]] = []
-        chat_bodies: ClassVar[list[dict[str, Any]]] = []
-
-        def do_POST(self):
-            Handler.paths.append(self.path)
-            body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
-            if self.path.endswith("/tokenize"):
-                _send_json(self, 200, tokenize_payload) if tokenize_payload else _send_json(self, 404, {})
-                return
-            assert self.path == "/v1/chat/completions"
-            Handler.chat_bodies.append(body)
-            if body.get("stream") is True:
-                _send_sse(
-                    self,
-                    [
-                        {
-                            "model": "test-model",
-                            "choices": [{"index": 0, "delta": {"content": "done"}, "token_ids": [31]}],
-                        },
-                        {
-                            "model": "test-model",
-                            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-                            "usage": {"prompt_tokens": 2, "completion_tokens": 1, "total_tokens": 3},
-                        },
-                    ],
-                )
-                return
-            _send_json(self, 200, {"model": "test-model", "prompt_token_ids": ["40", 41], "choices": []})
-
-    base = local_server(Handler)
-    store = ModelTrafficStore(service_name="solver", capture_token_ids=True)
-    register_store(store)
-    ic = EndpointInterceptor(
-        upstream_url=f"{base}/v1/chat/completions",
-        extra_body={"return_token_ids": True},
-        model_traffic_store_id=store.store_id,
-    )
-    try:
-        ctx = InterceptorContext()
-        ctx.extra["session_id"] = "stream-token-ids"
-        await ic.intercept_request(
-            AdapterRequest(
-                method="POST",
-                path="/chat/completions",
-                headers={},
-                body={
-                    "model": "test-model",
-                    "messages": [{"role": "user", "content": "hi"}],
-                    "stream": True,
-                    "max_tokens": 512,
-                    "max_completion_tokens": 512,
-                },
-                ctx=ctx,
-            )
-        )
-        row = _traffic_row(store, "stream-token-ids")
-    finally:
-        await ic.close()
-        store.close()
-
-    assert Handler.paths == expected_paths
-    assert Handler.chat_bodies[0]["stream"] is True
-    if tokenize_payload is None:
-        assert Handler.chat_bodies[1]["return_token_ids"] is True
-        assert "stream" not in Handler.chat_bodies[1]
-        assert "stream_options" not in Handler.chat_bodies[1]
-        assert Handler.chat_bodies[1]["max_tokens"] == 1
-        assert Handler.chat_bodies[1]["max_completion_tokens"] == 1
-    assert row["prompt_token_ids"] == expected_prompt_ids
-    assert row["completion_token_ids"] == [31]

--- a/tests/test_config/test_config_schema.py
+++ b/tests/test_config/test_config_schema.py
@@ -147,6 +147,13 @@ class TestParseEvalConfig:
                 id="model-traffic-request-body-enabled",
             ),
             pytest.param(
+                {"proxy": {"model_traffic": {"capture_token_ids": True}}},
+                {},
+                {"messages": True, "reasoning": True, "tool_calls": True, "request_body": False, "token_ids": True},
+                True,
+                id="model-traffic-token-ids-enabled",
+            ),
+            pytest.param(
                 {"proxy": {}},
                 {"trajectories": {"enrich": False}},
                 {"messages": True, "reasoning": True, "tool_calls": True, "request_body": False},
@@ -187,6 +194,7 @@ class TestParseEvalConfig:
         assert capture.capture_reasoning is expected_capture["reasoning"]
         assert capture.capture_tool_calls is expected_capture["tool_calls"]
         assert capture.capture_request_body is expected_capture["request_body"]
+        assert capture.capture_token_ids is expected_capture.get("token_ids", False)
         assert capture.max_content_chars == 0
         assert cfg.output.trajectories.enrich is expected_enrich
 

--- a/tests/test_engine/test_model_traffic_capture.py
+++ b/tests/test_engine/test_model_traffic_capture.py
@@ -393,20 +393,30 @@ async def test_append_after_consumption_fails_loud_instead_of_dropping(tmp_path:
 
 
 @pytest.mark.parametrize(
-    "capture_kwargs,expect_response_fields",
+    "capture_kwargs,expect_response_fields,expect_token_ids",
     [
-        pytest.param({}, True, id="default-capture"),
+        pytest.param({}, True, False, id="default-capture"),
         pytest.param(
             {"capture_tool_calls": False, "capture_reasoning": False, "capture_messages": False},
             False,
+            False,
             id="capture-disabled",
         ),
+        pytest.param({"capture_token_ids": True}, True, True, id="token-ids-enabled"),
     ],
 )
-def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_response_fields: bool) -> None:
+def test_format_log_record_response_capture_fields(
+    capture_kwargs: dict, expect_response_fields: bool, expect_token_ids: bool
+) -> None:
     ctx = InterceptorContext()
     ctx.extra["session_id"] = "cap-session"
     store = ModelTrafficStore(service_name="solver", **capture_kwargs)
+    body = _capture_response_body()
+    body["prompt_token_ids"] = []
+    body["choices"][0]["message"]["prompt_token_ids"] = [1, "2"]
+    body["choices"][0]["token_ids"] = [1.9]
+    body["choices"][0]["provider_specific_fields"] = {"token_ids": ["3", 4]}
+    body["choices"].append({"index": 1, "message": {}, "provider_specific_fields": {"token_ids": [5]}})
     store.start_request(
         AdapterRequest(method="POST", path="/chat/completions", headers={}, body={"model": "m"}, ctx=ctx)
     )
@@ -416,7 +426,7 @@ def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_
             headers={"content-type": "application/json"},
             latency_ms=10.0,
             ctx=ctx,
-            body=_capture_response_body(),
+            body=body,
         )
     )
     row = _format_drained(store, "cap-session")
@@ -430,6 +440,14 @@ def test_format_log_record_response_capture_fields(capture_kwargs: dict, expect_
         assert "tool_calls_full" not in row
         assert "reasoning_content" not in row
         assert "message_content" not in row
+    if expect_token_ids:
+        assert row["prompt_token_ids"] == [1, 2]
+        assert row["completion_token_ids"] == [3, 4, 5]
+        assert row["completion_token_ids_by_choice"] == {"0": [3, 4], "1": [5]}
+    else:
+        assert "prompt_token_ids" not in row
+        assert "completion_token_ids" not in row
+        assert "completion_token_ids_by_choice" not in row
 
 
 @pytest.mark.parametrize(
@@ -546,7 +564,7 @@ def test_non_success_response_forwards_compact_error_summary() -> None:
 def test_model_traffic_parses_streaming_sse_usage_and_tool_calls() -> None:
     ctx = InterceptorContext()
     ctx.extra["session_id"] = "stream-session"
-    store = ModelTrafficStore(service_name="solver")
+    store = ModelTrafficStore(service_name="solver", capture_token_ids=True)
     store.start_request(
         AdapterRequest(
             method="POST",
@@ -558,12 +576,14 @@ def test_model_traffic_parses_streaming_sse_usage_and_tool_calls() -> None:
     )
 
     body = b"""
-data: {"model":"stream-model",
-data: "choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"ba"}}]}}]}
+data: {"model":"stream-model","prompt_token_ids":[],
+data: "choices":[{"index":0,"provider_specific_fields":{"token_ids":[102]},
+data: "delta":{"tool_calls":[{"index":0,"function":{"name":"ba"}}]}}]}
 
-data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"sh"}}]}},{"index":1,"delta":{"tool_calls":[{"index":0,"function":{"name":"python"}}]}}]}
+data: {"choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"name":"sh"}}]}},
+data: {"index":1,"delta":{"tool_calls":[{"index":0,"function":{"name":"python"}}]}}]}
 
-data: {"choices":[{"index":0,"finish_reason":"tool_calls"}],
+data: {"prompt_token_ids":[100,101],"choices":[{"index":0,"finish_reason":"tool_calls","token_ids":[103]}],
 data: "usage":{"prompt_tokens":7,"completion_tokens":5,"total_tokens":12,
 data: "completion_tokens_details":{"reasoning_tokens":3}}}
 
@@ -596,6 +616,9 @@ data: [DONE]
         "reasoning_tokens": 3,
     }
     assert row["tool_calls"] == {"count": 2, "names": {"bash": 1, "python": 1}}
+    assert row["prompt_token_ids"] == [100, 101]
+    assert row["completion_token_ids"] == [102, 103]
+    assert "completion_token_ids_by_choice" not in row
     assert row["token_provenance"] == "provider_reported"
 
 

--- a/tests/test_orchestration/test_orchestrator.py
+++ b/tests/test_orchestration/test_orchestrator.py
@@ -19,6 +19,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from nemo_evaluator.config.sandboxes import NoSandbox as NoSandboxConfig
+from nemo_evaluator.config.services import InterceptorConfig, ModelTrafficCaptureConfig, ProxyConfig
+from nemo_evaluator.orchestration.orchestrator import _start_proxy
+
+
+def _token_id_proxy(**kwargs: Any) -> ProxyConfig:
+    return ProxyConfig(model_traffic=ModelTrafficCaptureConfig(capture_token_ids=True), **kwargs)
+
+
+def _svc(proxy: ProxyConfig | None = None) -> SimpleNamespace:
+    return SimpleNamespace(type="api", protocol="chat_completions", proxy=proxy, generation=None)
 
 
 class TestMakeSandboxManager:
@@ -204,7 +214,6 @@ class TestInterceptorSpecs:
 class TestStartProxyFinishReason:
     def _run(self, svc: object, config: object | None = None) -> dict[str, Any]:
         import nemo_evaluator.adapters.proxy as proxy_mod
-        from nemo_evaluator.orchestration.orchestrator import _start_proxy
 
         captured: dict[str, Any] = {}
 
@@ -240,6 +249,13 @@ class TestStartProxyFinishReason:
         names = self._names(svc)
         assert names == ["payload_modifier", "finish_reason"]
 
+    def test_proxy_token_id_request(self):
+        assert "extra_body" not in self._run(_svc())
+        assert self._run(_svc(proxy=_token_id_proxy(extra_body={"top_k": 20})))["extra_body"] == {
+            "top_k": 20,
+            "return_token_ids": True,
+        }
+
     def test_docker_sandbox_proxy_listens_on_all_interfaces(self):
         svc = MagicMock()
         svc.proxy = None
@@ -261,8 +277,6 @@ class TestStartProxyFinishReason:
         assert captured["listen_host"] == "127.0.0.1"
 
     def test_not_duplicated_when_configured(self):
-        from nemo_evaluator.config.services import InterceptorConfig, ProxyConfig
-
         svc = MagicMock()
         svc.generation = None
         svc.proxy = ProxyConfig(interceptors=[InterceptorConfig(name="finish_reason")])
@@ -270,8 +284,6 @@ class TestStartProxyFinishReason:
         assert names.count("finish_reason") == 1
 
     def test_preconfigured_finish_reason_moved_to_end(self):
-        from nemo_evaluator.config.services import InterceptorConfig, ProxyConfig
-
         svc = MagicMock()
         gen = MagicMock()
         gen.model_dump.return_value = {"max_tokens": 16}
@@ -288,8 +300,6 @@ class TestStartProxyFinishReason:
         assert names.index("finish_reason") > names.index("payload_modifier")
 
     def test_opt_out_via_proxy_flag(self):
-        from nemo_evaluator.config.services import ProxyConfig
-
         svc = MagicMock()
         svc.generation = None
         svc.proxy = ProxyConfig(finish_reason_fixup=False)
@@ -297,8 +307,6 @@ class TestStartProxyFinishReason:
         assert "finish_reason" not in names
 
     def test_opt_out_still_keeps_other_interceptors(self):
-        from nemo_evaluator.config.services import InterceptorConfig, ProxyConfig
-
         svc = MagicMock()
         svc.generation = None
         svc.proxy = ProxyConfig(


### PR DESCRIPTION
## Summary
- add opt-in `capture_token_ids` model traffic config
- add `return_token_ids: true` to proxied upstream requests only when that opt-in is enabled
- persist provider prompt/completion token ID arrays in `model_traffic.jsonl` when returned

## Tests
- `uv run --extra dev pytest tests/test_config/test_config_schema.py tests/test_engine/test_model_traffic_capture.py tests/test_orchestration -q`
- `384 passed, 1 warning` (existing walltime warning in `test_slurm_legacy_container.py`)

<!-- nel-next-real-endpoint-validation:start -->
## NEL-next Real Endpoint Validation
- Ran actual `uv run nel eval run` against `https://inference-api.nvidia.com/v1/chat/completions` with model `nvidia/openai/gpt-oss-20b` (real endpoint: inference-api, not integrate).
- Opt-in artifact root: `/tmp/nel-real-endpoint-token-ids-with-body-20260727_124321` with `proxy.model_traffic.capture_token_ids: true`, `capture_request_body: true`, and `max_tokens: 8`.
- `model_traffic.jsonl` confirmed the upstream request body included `return_token_ids: true`; the response saved `prompt_token_ids` length `153` and `completion_token_ids` length `8`; usage was `prompt_tokens=153`, `completion_tokens=8`, `total_tokens=161`, `finish_reason=length`, `status_code=200`.
- `trajectories_report.json` confirmed `wire_total=161`, `per_step_sum=161`, `final_metrics_total=161`, `all_sources_match=true`, `problems_with_more_wire_than_steps=0`, and 1:1 enrichment with no unmatched calls.
- Default/body-capture check: `/tmp/nel-real-endpoint-default-body-capture-20260727_124255` had no `return_token_ids` key in the captured request body and saved no token ID fields, confirming the flag is not sent by default.
<!-- nel-next-real-endpoint-validation:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to capture provider-reported prompt and completion token IDs in model traffic logs.
  * Token IDs can be captured for both streaming and non-streaming responses, including per-choice completion details.
  * Proxy requests automatically request token IDs when capture is enabled.

* **Bug Fixes**
  * Improved timeout handling for upstream requests while preserving retry behavior and timeout responses.

* **Tests**
  * Added coverage for token ID configuration, streaming, non-streaming, and proxy request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->