### PR TITLE
chore: update claude review to FW-CI-templates v1.8.5

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   claude-review:
     if: github.event.issue.pull_request != null && contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v1.7.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@fe0ff3bbe10790c51273ee3c1189b3c0497bf860 # v1.8.5
     with:
       model: ${{ vars.CLAUDE_MODEL }}
       prompt: |


### PR DESCRIPTION
Bumps the pinned SHA for `_claude_review.yml` to FW-CI-templates `v1.8.5` (`fe0ff3bbe10790c51273ee3c1189b3c0497bf860`).

**What changed in v1.8.5:**
- fix: tolerate trailing whitespace in `/claude review` trigger phrase

cc @kajalj