### PR TITLE
feat: mirror prebuilt task images into ECR instead of rebuilding them

### DIFF
--- a/docs/architecture/aws-ecs-sandbox.mdx
+++ b/docs/architecture/aws-ecs-sandbox.mdx
@@ -92,6 +92,37 @@ Once apply completes:
 
    See `EcsFargateSandbox` in [`src/nemo_evaluator/config/sandboxes.py`](https://github.com/NVIDIA-NeMo/Evaluator/blob/main/src/nemo_evaluator/config/sandboxes.py) for the complete schema.
 
+## How task images reach ECR
+
+Each task needs its image in ECR before Fargate can run it. There are two routes,
+selected by `image_mirror_mode`:
+
+```yaml
+sandbox:
+  type: ecs_fargate
+  region: us-west-2
+  image_mirror_mode: codebuild   # default: off
+```
+
+- **`off`** (default) — build the task's `environment/Dockerfile` via CodeBuild and push
+  the result. The ECR tag is a content hash of the build context.
+- **`codebuild`** — when the benchmark declares an already-published image (Harbor reads
+  `task.toml [environment] docker_image`), copy that image into ECR instead of rebuilding
+  it. The ECR tag is derived from the upstream manifest digest.
+
+Prefer mirroring where it applies. A task Dockerfile typically installs from apt, pip or
+`curl` without pinning, so rebuilding it resolves those references against whatever
+upstream looks like at build time — two builds of the same commit are not guaranteed to
+produce the same image. Because the repository carries a **500-image lifecycle policy
+shared across every benchmark**, a high-volume benchmark can evict another's cached
+images and silently trigger such a rebuild.
+
+Copying is idempotent: the digest-derived tag means an evicted image is restored
+byte-identical, so a cache miss costs latency rather than changing what the task runs.
+
+Benchmarks that construct images programmatically (SWE-bench and friends) have no
+upstream ref and always take the build path, regardless of this setting.
+
 ## State backend
 
 Local state by default. To switch to a remote S3 backend, copy

--- a/src/nemo_evaluator/config/sandboxes.py
+++ b/src/nemo_evaluator/config/sandboxes.py
@@ -140,6 +140,15 @@ class EcsFargateSandbox(_SandboxBase):
     efs_filesystem_id: str | None = None
     efs_access_point_id: str | None = None
 
+    image_mirror_mode: Literal["off", "codebuild"] = "off"
+    """How to obtain a task image the benchmark already publishes.
+
+    ``off`` builds the task's Dockerfile. ``codebuild`` copies the published
+    image into ECR instead, tagged by its upstream digest, so an image evicted
+    by the repository lifecycle policy is restored identically rather than
+    rebuilt against drifted upstream state. Benchmarks that build images
+    programmatically expose no upstream ref and always build."""
+
     ssm_project: str = DEFAULT_SSM_PROJECT
 
 

--- a/src/nemo_evaluator/environments/harbor.py
+++ b/src/nemo_evaluator/environments/harbor.py
@@ -919,16 +919,19 @@ class HarborEnvironment(EvalEnvironment):
                 or (_parse_workdir(dockerfile) if dockerfile.exists() else None)
                 or "/testbed"
             )
+            prebuilt = _parse_docker_image_from_toml(task_toml) if task_toml.exists() else None
             sandbox_spec = SandboxSpec(
                 image=image,
                 workdir=wd,
                 env={"HARBOR_TASK_DIR": str(task_dir)},
                 environment_dir=str(env_dir) if env_dir.is_dir() else None,
+                source_image=prebuilt,
             )
             verify_sandbox_spec = SandboxSpec(
                 image=image,
                 workdir=wd,
                 environment_dir=str(env_dir) if env_dir.is_dir() else None,
+                source_image=prebuilt,
             )
             capture_cmd = (
                 f"cd {wd} && "

--- a/src/nemo_evaluator/environments/harbor.py
+++ b/src/nemo_evaluator/environments/harbor.py
@@ -834,6 +834,14 @@ class HarborEnvironment(EvalEnvironment):
         build_contexts: dict[str, Path] = {}
 
         for task_dir in self._tasks:
+            # If task.toml declares a pre-built docker_image, _resolve_image uses
+            # that at runtime — building the local Dockerfile produces an image
+            # that's never used.  Skip the build to keep local runs tractable
+            # (89 local builds on a TB 2.0 smoke is ~hours on a laptop).
+            task_toml = task_dir / "task.toml"
+            if task_toml.exists() and _parse_docker_image_from_toml(task_toml):
+                continue
+
             env_dir = task_dir / "environment"
             dockerfile = env_dir / "Dockerfile"
             if dockerfile.exists() and _dockerfile_has_extra_layers(dockerfile):

--- a/src/nemo_evaluator/orchestration/orchestrator.py
+++ b/src/nemo_evaluator/orchestration/orchestrator.py
@@ -229,6 +229,7 @@ def _build_ecs_sandbox_config(cfg: EcsFargateSandbox) -> Any:
         dockerhub_secret_arn=dockerhub_secret_arn,
         efs_filesystem_id=efs_filesystem_id,
         efs_access_point_id=efs_access_point_id,
+        image_mirror_mode=cfg.image_mirror_mode,
         ssm_project=cfg.ssm_project,
     )
 

--- a/src/nemo_evaluator/sandbox/base.py
+++ b/src/nemo_evaluator/sandbox/base.py
@@ -124,6 +124,12 @@ class SandboxSpec:
     environment_dir: str | None = None
     """Local directory containing a Dockerfile / build context.
     Used by ECS Fargate to build and push images via CodeBuild."""
+    source_image: str | None = None
+    """Pullable upstream ref for ``image`` when it is already published.
+
+    Backends needing the image in their own registry can copy it from here
+    instead of rebuilding ``environment_dir``, which would re-resolve the
+    Dockerfile's unpinned references against today's upstream state."""
 
 
 class Sandbox(Protocol):

--- a/src/nemo_evaluator/sandbox/ecs_fargate.py
+++ b/src/nemo_evaluator/sandbox/ecs_fargate.py
@@ -132,6 +132,30 @@ def resolve_ecs_config_from_ssm(
 # ── Config dataclasses ───────────────────────────────────────────────
 
 
+def _dockerhub_login_cmd(secret_arn: str) -> str:
+    """Shell snippet that logs CodeBuild into Docker Hub, tolerating absence."""
+    return (
+        f"DOCKERHUB_CREDS=$(aws secretsmanager get-secret-value"
+        f" --secret-id {secret_arn}"
+        f" --query SecretString --output text --region $AWS_DEFAULT_REGION)"
+        f' && DH_USER=$(echo "$DOCKERHUB_CREDS" | python3 -c'
+        """ "import sys,json;print(json.load(sys.stdin)['username'])")"""
+        f' && if [ -n "$DH_USER" ]; then echo "$DOCKERHUB_CREDS" | python3 -c'
+        """ "import sys,json;print(json.load(sys.stdin)['password'])" """
+        f'| docker login -u "$DH_USER" --password-stdin; fi'
+        f' || echo "Docker Hub login failed — continuing without auth"'
+    )
+
+
+_DOCKER_HUB_REGISTRY = "registry-1.docker.io"
+_MANIFEST_MEDIA_TYPES = (
+    "application/vnd.docker.distribution.manifest.v2+json",
+    "application/vnd.docker.distribution.manifest.list.v2+json",
+    "application/vnd.oci.image.manifest.v1+json",
+    "application/vnd.oci.image.index.v1+json",
+)
+
+
 def _sanitize_id(value: str, max_len: int = 100) -> str:
     cleaned = re.sub(r"[^a-zA-Z0-9-]+", "-", value).strip("-")
     return cleaned[:max_len] or "task"
@@ -194,6 +218,12 @@ class EcsFargateConfig:
     efs_filesystem_id: str | None = None
     efs_access_point_id: str | None = None
     ssm_project: str = DEFAULT_SSM_PROJECT
+    image_mirror_mode: str = "off"
+    """How to obtain a task image that is already published upstream.
+
+    ``off`` builds ``environment_dir``'s Dockerfile.  ``codebuild`` copies
+    ``SandboxSpec.source_image`` into ECR instead, tagged by its upstream digest.
+    Ignored for tasks with no ``source_image``."""
 
 
 @dataclass(frozen=True)
@@ -919,6 +949,8 @@ class ImageBuilder:
     _inflight_builds: dict[str, threading.Event] = {}
     _build_semaphore: threading.Semaphore | None = None
     _build_semaphore_size: int = 0
+    _digest_cache: dict[str, str] = {}
+    _mirror_tag_cache: set[str] | None = None
 
     @staticmethod
     def get_ecr_image_tag(environment_dir: str | Path, environment_name: str) -> str:
@@ -929,6 +961,129 @@ class ImageBuilder:
                 h.update(str(p.relative_to(root)).encode())
                 h.update(p.read_bytes())
         return f"{environment_name}__{h.hexdigest()[:8]}"
+
+    @staticmethod
+    def get_ecr_mirror_tag_prefix(source_image: str) -> str:
+        """Tag prefix for any mirror of ``source_image``; needs no registry call."""
+        return f"{_sanitize_id(source_image, max_len=110)}__"
+
+    @classmethod
+    def find_mirrored_tag(cls, cfg: EcsFargateConfig, source_image: str) -> str | None:
+        """An existing mirror of ``source_image`` in ECR, or ``None``.
+
+        Prefix match, so the upstream digest — and the registry call to get it —
+        is only needed on a miss.
+        """
+        prefix = cls.get_ecr_mirror_tag_prefix(source_image)
+        with cls._lock:
+            cached = cls._mirror_tag_cache
+        if cached is None:
+            tags = cls.list_ecr_tags(cfg.ecr_repository or "", cfg.region)
+            with cls._lock:
+                if cls._mirror_tag_cache is None:
+                    cls._mirror_tag_cache = tags
+                cached = cls._mirror_tag_cache
+        return next((t for t in sorted(cached) if t.startswith(prefix)), None)
+
+    @classmethod
+    def resolve_source_digest_cached(cls, source_image: str, *, retries: int = 3, base_delay: float = 2.0) -> str:
+        """``resolve_source_digest`` memoised per ref, with retry.
+
+        Sandboxes start once per task, so unmemoised this issues hundreds of
+        calls from one egress IP and trips registry rate limits.  Retry is local
+        because ``_retry_with_backoff`` only matches AWS-shaped throttling.
+        """
+        with cls._lock:
+            if hit := cls._digest_cache.get(source_image):
+                return hit
+        for attempt in range(retries + 1):
+            try:
+                digest = cls.resolve_source_digest(source_image)
+                break
+            except Exception as exc:  # noqa: BLE001 - any registry failure is worth one more try
+                if attempt == retries:
+                    raise
+                delay = base_delay * (2**attempt) * (1 + random.uniform(-0.5, 0.5))
+                logger.warning(
+                    "registry manifest for %s failed (attempt %d/%d), retrying in %.1fs: %s",
+                    source_image,
+                    attempt + 1,
+                    retries + 1,
+                    delay,
+                    exc,
+                )
+                time.sleep(delay)
+        logger.info("Registry manifest resolved: %s -> %s", source_image, digest)
+        with cls._lock:
+            cls._digest_cache[source_image] = digest
+        return digest
+
+    @staticmethod
+    def get_ecr_mirror_tag(source_image: str, digest: str) -> str:
+        """ECR tag for a mirrored copy of ``source_image`` pinned at ``digest``.
+
+        Keyed on the digest rather than the upstream tag, so a re-pushed
+        upstream tag reads as a cache miss instead of silently reusing a stale
+        copy.  Bounded to ECR's 128-character tag limit.
+        """
+        digest_hex = digest.split(":")[-1][:12]
+        return f"{ImageBuilder.get_ecr_mirror_tag_prefix(source_image)}{digest_hex}"
+
+    @staticmethod
+    def _parse_image_ref(source_image: str) -> tuple[str, str, str]:
+        """Split an image reference into ``(registry, repository, reference)``.
+
+        ``reference`` is a tag or a ``sha256:`` digest.  Split on ``@`` first so
+        a digest's colon is not mistaken for a tag separator.
+        """
+        if "@" in source_image:
+            remainder, _, reference = source_image.partition("@")
+            head, sep, tail = remainder.rpartition(":")
+            if sep and "/" not in tail:
+                remainder = head
+        else:
+            remainder, sep, reference = source_image.rpartition(":")
+            if not sep or "/" in reference:
+                remainder, reference = source_image, "latest"
+        head, _, rest = remainder.partition("/")
+        if rest and ("." in head or ":" in head or head == "localhost"):
+            return head, rest, reference
+        repo = remainder if "/" in remainder else f"library/{remainder}"
+        return _DOCKER_HUB_REGISTRY, repo, reference
+
+    @staticmethod
+    def _registry_pull_token(registry: str, repository: str, timeout: float) -> str:
+        """Anonymous pull token, or empty when the registry needs no auth."""
+        import urllib.request
+
+        if registry == _DOCKER_HUB_REGISTRY:
+            auth_host, service = "auth.docker.io", "registry.docker.io"
+        else:
+            auth_host = service = registry
+        url = f"https://{auth_host}/token?service={service}&scope=repository:{repository}:pull"
+        try:
+            with urllib.request.urlopen(url, timeout=timeout) as resp:  # noqa: S310 - https scheme is fixed
+                return str(json.loads(resp.read()).get("token", ""))
+        except Exception:  # noqa: BLE001 - registries without token auth answer the manifest directly
+            return ""
+
+    @staticmethod
+    def resolve_source_digest(source_image: str, timeout: float = 30.0) -> str:
+        """Resolve ``source_image`` to its immutable manifest digest.
+
+        Plain HTTPS against the Registry v2 API — no Docker daemon required.
+        """
+        import urllib.request
+
+        registry, repository, tag = ImageBuilder._parse_image_ref(source_image)
+        headers = {"Accept": ", ".join(_MANIFEST_MEDIA_TYPES)}
+        if token := ImageBuilder._registry_pull_token(registry, repository, timeout):
+            headers["Authorization"] = f"Bearer {token}"
+        req = urllib.request.Request(f"https://{registry}/v2/{repository}/manifests/{tag}", headers=headers)
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310 - https scheme is fixed
+            if digest := resp.headers.get("Docker-Content-Digest"):
+                return str(digest)
+            return "sha256:" + hashlib.sha256(resp.read()).hexdigest()
 
     @staticmethod
     def image_exists_in_ecr(ecr_repository: str, tag: str, region: str | None = None) -> bool:
@@ -1056,6 +1211,110 @@ class ImageBuilder:
                 cls._inflight_builds.pop(tag, None)
         return image_url
 
+    @classmethod
+    def ensure_image_mirrored(cls, *, cfg: EcsFargateConfig, source_image: str, digest: str | None = None) -> str:
+        """Copy a published upstream image into ECR, reusing it while it is there.
+
+        Idempotent, unlike a Dockerfile build: the tag comes from the upstream
+        digest, so an evicted image is restored byte-identical instead of being
+        rebuilt against whatever its unpinned references resolve to today.
+        """
+        ecr_repo = cfg.ecr_repository
+        if not ecr_repo:
+            raise ValueError("ecr_repository is required for image mirroring")
+
+        if digest is None and (existing := cls.find_mirrored_tag(cfg, source_image)):
+            logger.info("ECR mirror hit — skipping copy: %s:%s", ecr_repo, existing)
+            return f"{ecr_repo}:{existing}"
+
+        tag = cls.get_ecr_mirror_tag(source_image, digest or cls.resolve_source_digest_cached(source_image))
+        image_url = f"{ecr_repo}:{tag}"
+
+        with cls._lock:
+            if tag in cls._inflight_builds:
+                cls._inflight_builds[tag].wait()
+                return image_url
+        if cls.image_exists_in_ecr(ecr_repo, tag, cfg.region):
+            logger.info("ECR mirror hit — skipping copy: %s", image_url)
+            cls._remember_mirror_tag(tag)
+            return image_url
+
+        event = threading.Event()
+        with cls._lock:
+            if tag in cls._inflight_builds:
+                cls._inflight_builds[tag].wait()
+                return image_url
+            cls._inflight_builds[tag] = event
+        with cls._lock:
+            if cls._build_semaphore is None or cls._build_semaphore_size != cfg.build_parallelism:
+                cls._build_semaphore = threading.Semaphore(cfg.build_parallelism)
+                cls._build_semaphore_size = cfg.build_parallelism
+        try:
+            cls._build_semaphore.acquire()  # type: ignore[union-attr]
+            try:
+                if not cls.image_exists_in_ecr(ecr_repo, tag, cfg.region):
+                    cls._mirror_and_push(cfg=cfg, source_image=source_image, image_url=image_url)
+            finally:
+                cls._build_semaphore.release()  # type: ignore[union-attr]
+        finally:
+            event.set()
+            with cls._lock:
+                cls._inflight_builds.pop(tag, None)
+        cls._remember_mirror_tag(tag)
+        return image_url
+
+    @classmethod
+    def _remember_mirror_tag(cls, tag: str) -> None:
+        with cls._lock:
+            if cls._mirror_tag_cache is not None:
+                cls._mirror_tag_cache.add(tag)
+
+    @classmethod
+    def _mirror_and_push(cls, *, cfg: EcsFargateConfig, source_image: str, image_url: str) -> None:
+        boto3, *_ = _require_aws_sdks()
+        logger.info("Mirroring %s -> %s via CodeBuild", source_image, image_url)
+        cb = boto3.client("codebuild", region_name=cfg.region)
+        project_name = cls._resolve_codebuild_project(cfg, cb, uuid.uuid4().hex[:8])
+        buildspec = cls._generate_mirror_buildspec(cfg, source_image, image_url)
+        resp = _retry_with_backoff(
+            lambda: cb.start_build(
+                projectName=project_name,
+                buildspecOverride=buildspec,
+                timeoutInMinutesOverride=cfg.codebuild_build_timeout,
+                privilegedModeOverride=True,
+                environmentTypeOverride="LINUX_CONTAINER",
+                imageOverride="aws/codebuild/amazonlinux-x86_64-standard:5.0",
+                computeTypeOverride=cfg.codebuild_compute_type,
+            ),
+            operation_name="codebuild.start_build(mirror)",
+            max_retries=5,
+        )
+        build_id = resp["build"]["id"]
+        logger.info("CodeBuild mirror started: %s", build_id)
+        cls._poll_codebuild(cb, build_id, image_url)
+
+    @staticmethod
+    def _generate_mirror_buildspec(cfg: EcsFargateConfig, source_image: str, image_url: str) -> str:
+        ecr_registry = (cfg.ecr_repository or "").split("/")[0]
+        ecr_region = ImageBuilder._ecr_region(cfg.ecr_repository or "", fallback="$AWS_DEFAULT_REGION")
+        pre_build_cmds = [
+            f"aws ecr get-login-password --region {ecr_region}"
+            f" | docker login --username AWS --password-stdin {ecr_registry}",
+        ]
+        if cfg.dockerhub_secret_arn:
+            pre_build_cmds.append(_dockerhub_login_cmd(cfg.dockerhub_secret_arn))
+        pre_yaml = "\n".join(f"      - {c}" for c in pre_build_cmds)
+        pull_cmd = (
+            f"for i in 1 2 3; do docker pull {source_image} && break; "
+            f'echo "pull failed ($i/3), retry in 30s"; sleep 30; done'
+        )
+        return (
+            "version: 0.2\nphases:\n  pre_build:\n    commands:\n"
+            f"{pre_yaml}\n  build:\n    commands:\n"
+            f"      - {pull_cmd}\n      - docker tag {source_image} {image_url}\n"
+            f"  post_build:\n    commands:\n      - docker push {image_url}\n"
+        )
+
     @staticmethod
     def _upload_build_context(cfg: EcsFargateConfig, environment_name: str, nonce: str) -> str:
         boto3, *_ = _require_aws_sdks()
@@ -1117,17 +1376,7 @@ class ImageBuilder:
             f" | docker login --username AWS --password-stdin {ecr_registry}",
         ]
         if cfg.dockerhub_secret_arn:
-            pre_build_cmds.append(
-                f"DOCKERHUB_CREDS=$(aws secretsmanager get-secret-value"
-                f" --secret-id {cfg.dockerhub_secret_arn}"
-                f" --query SecretString --output text --region $AWS_DEFAULT_REGION)"
-                f' && DH_USER=$(echo "$DOCKERHUB_CREDS" | python3 -c'
-                """ "import sys,json;print(json.load(sys.stdin)['username'])")"""
-                f' && if [ -n "$DH_USER" ]; then echo "$DOCKERHUB_CREDS" | python3 -c'
-                """ "import sys,json;print(json.load(sys.stdin)['password'])" """
-                f'| docker login -u "$DH_USER" --password-stdin; fi'
-                f' || echo "Docker Hub login failed — continuing without auth"'
-            )
+            pre_build_cmds.append(_dockerhub_login_cmd(cfg.dockerhub_secret_arn))
         pre_yaml = "\n".join(f"      - {c}" for c in pre_build_cmds)
         build_cmd = (
             f"for i in 1 2 3; do docker build -t {repo_name}:{tag} . && break; "
@@ -1603,13 +1852,7 @@ class EcsFargateSandbox:
             raise ValueError("ssh_sidecar must be configured")
         self._init_aws_clients()
 
-        built_image: str | None = None
-        env_dir = cfg.environment_dir or self._spec.environment_dir
-        if cfg.ecr_repository and env_dir:
-            per_task_cfg = _dc_replace(cfg, environment_dir=env_dir)
-            built_image = ImageBuilder.ensure_image_built(
-                cfg=per_task_cfg, environment_name=_sanitize_id(self._spec.image or "sandbox")
-            )
+        built_image = self._ensure_image_in_ecr()
         image = self._resolve_image(built_image)
 
         if not sidecar.private_key_secret_arn or not sidecar.public_key_secret_arn:
@@ -1659,6 +1902,28 @@ class EcsFargateSandbox:
         self._ecs = boto3.client("ecs", region_name=self._cfg.region, config=boto_cfg)
         self._ec2 = boto3.client("ec2", region_name=self._cfg.region, config=boto_cfg)
         self._ssm = boto3.client("ssm", region_name=self._cfg.region, config=boto_cfg)
+
+    def _ensure_image_in_ecr(self) -> str | None:
+        """Get this task's image into ECR — by mirroring it, or by building it.
+
+        Mirroring wins when the task declares a published image; rebuilding its
+        Dockerfile would re-resolve every unpinned upstream reference.
+        """
+        cfg = self._cfg
+        if not cfg.ecr_repository:
+            return None
+
+        source_image = self._spec.source_image
+        if source_image and cfg.image_mirror_mode == "codebuild":
+            return ImageBuilder.ensure_image_mirrored(cfg=cfg, source_image=source_image)
+
+        env_dir = cfg.environment_dir or self._spec.environment_dir
+        if not env_dir:
+            return None
+        return ImageBuilder.ensure_image_built(
+            cfg=_dc_replace(cfg, environment_dir=env_dir),
+            environment_name=_sanitize_id(self._spec.image or "sandbox"),
+        )
 
     def _resolve_image(self, built_image: str | None = None) -> str:
         if built_image:

--- a/tests/test_environments/test_harbor_prebuilt_image.py
+++ b/tests/test_environments/test_harbor_prebuilt_image.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for prebuilt task images — task.toml [environment] docker_image handling.
+
+A task that declares ``docker_image`` ships a published image built from its own
+Dockerfile.  Rebuilding that Dockerfile re-resolves every unpinned apt/pip/curl
+reference against today's internet, so the declared image is what should run.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nemo_evaluator.environments.harbor import HarborEnvironment
+
+_DOCKERFILE_WITH_LAYERS = "FROM python:3.12-slim\nRUN echo build-step\n"
+
+
+def _make_task_dir(root: Path, name: str, *, docker_image: str | None = None) -> Path:
+    task_dir = root / name
+    (task_dir / "tests").mkdir(parents=True)
+    (task_dir / "environment").mkdir(parents=True)
+    (task_dir / "instruction.md").write_text(f"do {name}")
+    (task_dir / "tests" / "test.sh").write_text("#!/bin/bash\nexit 0\n")
+    (task_dir / "environment" / "Dockerfile").write_text(_DOCKERFILE_WITH_LAYERS)
+    body = "[verifier]\ntimeout_sec = 600\n"
+    if docker_image is not None:
+        body += f'\n[environment]\ndocker_image = "{docker_image}"\n'
+    (task_dir / "task.toml").write_text(body)
+    return task_dir
+
+
+@pytest.mark.asyncio
+async def test_image_build_requests_skips_tasks_with_prebuilt_image(tmp_path):
+    dataset = tmp_path / "ds"
+    _make_task_dir(dataset, "prebuilt", docker_image="acme/prebuilt:20251031")
+    _make_task_dir(dataset, "needs-build")
+
+    env = HarborEnvironment(dataset_path=str(dataset))
+    reqs = await env.image_build_requests()
+
+    assert reqs is not None
+    images = [spec.image for spec in reqs[0].specs]
+    assert len(images) == 1, f"only the task without docker_image should build, got {images}"
+    assert "needs-build" in images[0]
+
+
+@pytest.mark.asyncio
+async def test_image_build_requests_none_when_every_task_is_prebuilt(tmp_path):
+    dataset = tmp_path / "ds"
+    _make_task_dir(dataset, "a", docker_image="acme/a:1")
+    _make_task_dir(dataset, "b", docker_image="acme/b:1")
+
+    env = HarborEnvironment(dataset_path=str(dataset))
+    assert await env.image_build_requests() is None
+
+
+@pytest.mark.asyncio
+async def test_seed_marks_prebuilt_image_as_mirror_source(tmp_path):
+    dataset = tmp_path / "ds"
+    _make_task_dir(dataset, "t", docker_image="acme/prebuilt:20251031")
+
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+
+    assert seed.sandbox_spec.image == "acme/prebuilt:20251031"
+    assert seed.sandbox_spec.source_image == "acme/prebuilt:20251031"
+    assert seed.verify_sandbox_spec.source_image == "acme/prebuilt:20251031"
+
+
+@pytest.mark.asyncio
+async def test_seed_leaves_source_image_unset_when_image_is_built_locally(tmp_path):
+    dataset = tmp_path / "ds"
+    _make_task_dir(dataset, "t")
+
+    env = HarborEnvironment(dataset_path=str(dataset))
+    seed = await env.seed(0)
+
+    assert seed.sandbox_spec.source_image is None

--- a/tests/test_sandbox/test_ecs_fargate.py
+++ b/tests/test_sandbox/test_ecs_fargate.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from nemo_evaluator.sandbox.base import ExecResult, OutsideEndpoint, SandboxSpec
+from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
 
 _PATCH_PREFIX = "nemo_evaluator.sandbox.ecs_fargate"
 
@@ -1014,8 +1015,6 @@ class TestImageBuilder:
     """ImageBuilder with mocked ECR, S3, CodeBuild."""
 
     def test_get_ecr_image_tag(self, tmp_path):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         env_dir = tmp_path / "env"
         env_dir.mkdir()
         (env_dir / "Dockerfile").write_text("FROM python:3.12")
@@ -1026,8 +1025,6 @@ class TestImageBuilder:
         assert len(tag.split("__")[1]) == 8
 
     def test_get_ecr_image_tag_deterministic(self, tmp_path):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         env_dir = tmp_path / "env"
         env_dir.mkdir()
         (env_dir / "Dockerfile").write_text("FROM python:3.12")
@@ -1038,8 +1035,6 @@ class TestImageBuilder:
 
     @patch(f"{_PATCH_PREFIX}._require_aws_sdks")
     def test_image_exists_in_ecr_true(self, mock_aws):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         ecr = MagicMock()
         ecr.describe_images.return_value = {"imageDetails": [{"imageDigest": "sha256:abc"}]}
         mock_boto3 = MagicMock()
@@ -1054,8 +1049,6 @@ class TestImageBuilder:
 
     @patch(f"{_PATCH_PREFIX}._require_aws_sdks")
     def test_image_exists_in_ecr_false(self, mock_aws):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         class FakeClientError(Exception):
             def __init__(self):
                 self.response = {"Error": {"Code": "ImageNotFoundException"}}
@@ -1069,16 +1062,12 @@ class TestImageBuilder:
         assert ImageBuilder.image_exists_in_ecr("123.dkr.ecr.us-west-2.amazonaws.com/repo", "missing") is False
 
     def test_ecr_region_extraction(self):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         assert ImageBuilder._ecr_region("123.dkr.ecr.us-west-2.amazonaws.com/repo") == "us-west-2"
         assert ImageBuilder._ecr_region("123.dkr.ecr.eu-west-1.amazonaws.com/repo") == "eu-west-1"
         assert ImageBuilder._ecr_region("my-repo", fallback="us-east-1") == "us-east-1"
 
     @patch(f"{_PATCH_PREFIX}.subprocess.run")
     def test_ecr_docker_login_success(self, mock_run):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         mock_run.return_value = MagicMock(returncode=0)
         ImageBuilder.ecr_docker_login("123.dkr.ecr.us-west-2.amazonaws.com/repo", region="us-west-2")
         mock_run.assert_called_once()
@@ -1086,16 +1075,12 @@ class TestImageBuilder:
 
     @patch(f"{_PATCH_PREFIX}.subprocess.run")
     def test_ecr_docker_login_failure(self, mock_run):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         mock_run.return_value = MagicMock(returncode=1, stderr="no credentials")
         with pytest.raises(RuntimeError, match="ECR docker login failed"):
             ImageBuilder.ecr_docker_login("123.dkr.ecr.us-west-2.amazonaws.com/repo")
 
     @patch(f"{_PATCH_PREFIX}.subprocess.run")
     def test_docker_push_to_ecr(self, mock_run):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         mock_run.side_effect = [
             MagicMock(returncode=0),
             MagicMock(returncode=0, stderr=""),
@@ -1106,8 +1091,6 @@ class TestImageBuilder:
 
     @patch(f"{_PATCH_PREFIX}.ImageBuilder.image_exists_in_ecr", return_value=True)
     def test_ensure_image_built_cache_hit(self, mock_exists, tmp_path):
-        from nemo_evaluator.sandbox.ecs_fargate import ImageBuilder
-
         env_dir = tmp_path / "env"
         env_dir.mkdir()
         (env_dir / "Dockerfile").write_text("FROM alpine")
@@ -1396,3 +1379,259 @@ class TestPerInvocationEnvSplit:
 
         assert stable == env
         assert runtime == {}
+
+
+# ── TestImageMirror ───────────────────────────────────────────────────
+
+
+class TestImageMirror:
+    """Mirroring a prebuilt upstream image into ECR instead of rebuilding it.
+
+    Rebuilding a task Dockerfile re-resolves unpinned upstream references, so a
+    cache miss can silently change what the image contains.  Copying a pinned
+    upstream image is idempotent: a miss re-mirrors byte-identical content.
+    """
+
+    _SRC = "acme/task:20251031"
+    _DIGEST = "sha256:" + "ab" * 32
+    _REPO = "123.dkr.ecr.us-west-2.amazonaws.com/repo"
+
+    def test_mirror_mode_defaults_to_off(self):
+        assert _cfg().image_mirror_mode == "off"
+
+    def test_mirror_tag_is_deterministic(self):
+        tag1 = ImageBuilder.get_ecr_mirror_tag(self._SRC, self._DIGEST)
+        tag2 = ImageBuilder.get_ecr_mirror_tag(self._SRC, self._DIGEST)
+        assert tag1 == tag2
+        assert "acme-task-20251031" in tag1
+
+    def test_mirror_tag_tracks_the_upstream_digest(self):
+        """A moved upstream tag must not silently reuse the cached copy."""
+        tag1 = ImageBuilder.get_ecr_mirror_tag(self._SRC, self._DIGEST)
+        tag2 = ImageBuilder.get_ecr_mirror_tag(self._SRC, "sha256:" + "cd" * 32)
+        assert tag1 != tag2
+
+    def test_mirror_tag_is_a_valid_ecr_tag(self):
+        import re
+
+        tag = ImageBuilder.get_ecr_mirror_tag("registry.example.com/ns/img:1.2.3", self._DIGEST)
+        assert re.fullmatch(r"[A-Za-z0-9._-]{1,128}", tag), tag
+
+    def test_mirror_buildspec_copies_instead_of_building(self):
+        url = f"{self._REPO}:sometag"
+        spec = ImageBuilder._generate_mirror_buildspec(_cfg(ecr_repository=self._REPO), self._SRC, url)
+
+        assert f"docker pull {self._SRC}" in spec
+        assert f"docker push {url}" in spec
+        assert "docker build" not in spec
+
+    def test_mirror_buildspec_authenticates_to_dockerhub_when_configured(self):
+        cfg = _cfg(ecr_repository=self._REPO, dockerhub_secret_arn="arn:aws:secretsmanager:us-west-2:1:secret:dh")
+        spec = ImageBuilder._generate_mirror_buildspec(cfg, self._SRC, f"{self._REPO}:t")
+        assert "secretsmanager" in spec
+
+    @patch(f"{_PATCH_PREFIX}.ImageBuilder.image_exists_in_ecr", return_value=True)
+    def test_ensure_image_mirrored_cache_hit_skips_codebuild(self, mock_exists):
+        cfg = _cfg(ecr_repository=self._REPO)
+        with patch.object(ImageBuilder, "_mirror_and_push") as mock_copy:
+            url = ImageBuilder.ensure_image_mirrored(cfg=cfg, source_image=self._SRC, digest=self._DIGEST)
+
+        mock_copy.assert_not_called()
+        assert url.startswith(f"{self._REPO}:")
+
+    @patch(f"{_PATCH_PREFIX}.ImageBuilder.image_exists_in_ecr", return_value=False)
+    def test_ensure_image_mirrored_cache_miss_copies_upstream(self, mock_exists):
+        cfg = _cfg(ecr_repository=self._REPO)
+        with patch.object(ImageBuilder, "_mirror_and_push") as mock_copy:
+            url = ImageBuilder.ensure_image_mirrored(cfg=cfg, source_image=self._SRC, digest=self._DIGEST)
+
+        mock_copy.assert_called_once()
+        assert mock_copy.call_args.kwargs["image_url"] == url
+
+    def test_prebuilt_task_is_mirrored_not_rebuilt(self):
+        """A task declaring a published image must not have its Dockerfile rebuilt."""
+        from nemo_evaluator.sandbox.ecs_fargate import EcsFargateSandbox
+
+        spec = SandboxSpec(image=self._SRC, source_image=self._SRC, environment_dir="/tmp/env")
+        sb = EcsFargateSandbox(spec, ecs_config=_cfg(ecr_repository=self._REPO, image_mirror_mode="codebuild"))
+
+        with (
+            patch.object(ImageBuilder, "resolve_source_digest", return_value=self._DIGEST),
+            patch.object(ImageBuilder, "ensure_image_mirrored", return_value="mirrored") as mirror,
+            patch.object(ImageBuilder, "ensure_image_built") as build,
+        ):
+            assert sb._ensure_image_in_ecr() == "mirrored"
+
+        build.assert_not_called()
+        assert mirror.call_args.kwargs["source_image"] == self._SRC
+
+    def test_mirror_mode_off_still_builds_the_dockerfile(self):
+        """Default config must preserve the historical build path exactly."""
+        from nemo_evaluator.sandbox.ecs_fargate import EcsFargateSandbox
+
+        spec = SandboxSpec(image=self._SRC, source_image=self._SRC, environment_dir="/tmp/env")
+        sb = EcsFargateSandbox(spec, ecs_config=_cfg(ecr_repository=self._REPO))
+
+        with (
+            patch.object(ImageBuilder, "ensure_image_mirrored") as mirror,
+            patch.object(ImageBuilder, "ensure_image_built", return_value="built") as build,
+        ):
+            assert sb._ensure_image_in_ecr() == "built"
+
+        mirror.assert_not_called()
+        build.assert_called_once()
+
+    def test_task_without_source_image_always_builds(self):
+        """SWE-bench-style benchmarks construct images and have no upstream ref."""
+        from nemo_evaluator.sandbox.ecs_fargate import EcsFargateSandbox
+
+        spec = SandboxSpec(image="built-locally:latest", environment_dir="/tmp/env")
+        sb = EcsFargateSandbox(spec, ecs_config=_cfg(ecr_repository=self._REPO, image_mirror_mode="codebuild"))
+
+        with (
+            patch.object(ImageBuilder, "ensure_image_mirrored") as mirror,
+            patch.object(ImageBuilder, "ensure_image_built", return_value="built") as build,
+        ):
+            assert sb._ensure_image_in_ecr() == "built"
+
+        mirror.assert_not_called()
+        build.assert_called_once()
+
+    def test_digest_pinned_ref_parses_without_splitting_on_the_digest_colon(self):
+        registry, repo, ref = ImageBuilder._parse_image_ref(f"ubuntu@{self._DIGEST}")
+        assert repo == "library/ubuntu"
+        assert ref == self._DIGEST
+        assert registry.endswith("docker.io")
+
+        registry, repo, ref = ImageBuilder._parse_image_ref(f"reg.example.com/ns/img@{self._DIGEST}")
+        assert (registry, repo, ref) == ("reg.example.com", "ns/img", self._DIGEST)
+
+        registry, repo, ref = ImageBuilder._parse_image_ref(f"ubuntu:22.04@{self._DIGEST}")
+        assert (repo, ref) == ("library/ubuntu", self._DIGEST)
+        registry, repo, ref = ImageBuilder._parse_image_ref(f"reg.example.com/ns/img:1.2@{self._DIGEST}")
+        assert (registry, repo, ref) == ("reg.example.com", "ns/img", self._DIGEST)
+
+    def test_mirror_tag_handles_digest_pinned_source_refs(self):
+        src = f"acme/task@{self._DIGEST}"
+        tag = ImageBuilder.get_ecr_mirror_tag(src, self._DIGEST)
+        assert tag == ImageBuilder.get_ecr_mirror_tag(src, self._DIGEST)
+        assert tag != ImageBuilder.get_ecr_mirror_tag(src, "sha256:" + "cd" * 32)
+        assert len(tag) <= 128
+
+    @patch(f"{_PATCH_PREFIX}.ImageBuilder.image_exists_in_ecr", return_value=False)
+    def test_mirroring_respects_build_parallelism(self, _mock_exists):
+        """Copies share the build throttle — 89 tasks must not stampede CodeBuild."""
+        from nemo_evaluator.sandbox import ecs_fargate
+
+        ecs_fargate.ImageBuilder._build_semaphore = None
+        ecs_fargate.ImageBuilder._build_semaphore_size = 0
+        cfg = _cfg(ecr_repository=self._REPO, build_parallelism=3)
+
+        with patch.object(ImageBuilder, "_mirror_and_push"):
+            ImageBuilder.ensure_image_mirrored(cfg=cfg, source_image=self._SRC, digest=self._DIGEST)
+
+        assert ecs_fargate.ImageBuilder._build_semaphore_size == 3
+
+    def test_image_mirror_mode_is_reachable_from_yaml(self):
+        """The YAML schema forbids extra keys — the field must exist there too."""
+        from nemo_evaluator.config.sandboxes import EcsFargateSandbox
+
+        assert EcsFargateSandbox(type="ecs_fargate").image_mirror_mode == "off"
+        assert EcsFargateSandbox(type="ecs_fargate", image_mirror_mode="codebuild").image_mirror_mode == "codebuild"
+        with pytest.raises(Exception):
+            EcsFargateSandbox(type="ecs_fargate", image_mirror_mode="bogus")
+
+    @pytest.mark.parametrize(
+        "playbook",
+        ["terminal_bench_2", "terminal_bench_2_1", "swebench_verified", "swebench_multilingual", "swebench_pro"],
+    )
+    def test_no_shipped_playbook_opts_into_mirroring_yet(self, playbook):
+        """Mirroring rolls out per-config first; playbooks follow once proven."""
+        from pathlib import Path
+
+        import yaml
+
+        import nemo_evaluator
+
+        path = Path(nemo_evaluator.__file__).parent / "playbooks" / f"{playbook}.yaml"
+        assert "image_mirror_mode" not in (yaml.safe_load(path.read_text()).get("sandbox") or {})
+
+
+# ── TestMirrorRegistryTraffic ─────────────────────────────────────────
+
+
+class TestMirrorRegistryTraffic:
+    """The upstream registry must not be contacted once a mirror exists.
+
+    ``_do_start`` runs per *sandbox*, so a naive implementation resolves the
+    digest once per task — hundreds of calls from the orchestrator's single
+    egress IP, enough to trip anonymous registry rate limits.
+    """
+
+    _SRC = "acme/task:20251031"
+    _DIGEST = "sha256:" + "ab" * 32
+    _REPO = "123.dkr.ecr.us-west-2.amazonaws.com/repo"
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        ImageBuilder._digest_cache = {}
+        ImageBuilder._mirror_tag_cache = None
+        ImageBuilder._inflight_builds = {}
+        yield
+        ImageBuilder._digest_cache = {}
+        ImageBuilder._mirror_tag_cache = None
+
+    def test_existing_mirror_needs_no_registry_call(self):
+        existing = ImageBuilder.get_ecr_mirror_tag(self._SRC, self._DIGEST)
+        with (
+            patch.object(ImageBuilder, "list_ecr_tags", return_value={existing, "unrelated__deadbeef"}),
+            patch.object(ImageBuilder, "resolve_source_digest") as resolve,
+            patch.object(ImageBuilder, "_mirror_and_push") as copy,
+        ):
+            url = ImageBuilder.ensure_image_mirrored(cfg=_cfg(ecr_repository=self._REPO), source_image=self._SRC)
+
+        resolve.assert_not_called()
+        copy.assert_not_called()
+        assert url == f"{self._REPO}:{existing}"
+
+    def test_many_sandbox_starts_resolve_the_digest_once(self):
+        """200 task starts on a cold repo must not mean 200 registry calls."""
+        cfg = _cfg(ecr_repository=self._REPO)
+        with (
+            patch.object(ImageBuilder, "list_ecr_tags", return_value=set()),
+            patch.object(ImageBuilder, "image_exists_in_ecr", return_value=True),
+            patch.object(ImageBuilder, "resolve_source_digest", return_value=self._DIGEST) as resolve,
+        ):
+            urls = {ImageBuilder.ensure_image_mirrored(cfg=cfg, source_image=self._SRC) for _ in range(200)}
+
+        assert resolve.call_count == 1
+        assert len(urls) == 1
+
+    def test_digest_resolution_is_retried(self):
+        """A transient 429 must not fail the task — the boto retry helper won't catch it."""
+        with patch.object(
+            ImageBuilder, "resolve_source_digest", side_effect=[OSError("HTTP Error 429"), self._DIGEST]
+        ) as resolve:
+            assert ImageBuilder.resolve_source_digest_cached(self._SRC, base_delay=0) == self._DIGEST
+        assert resolve.call_count == 2
+
+    def test_freshly_mirrored_tag_is_reused_without_a_registry_call(self):
+        cfg = _cfg(ecr_repository=self._REPO)
+        with (
+            patch.object(ImageBuilder, "list_ecr_tags", return_value=set()),
+            patch.object(ImageBuilder, "image_exists_in_ecr", return_value=False),
+            patch.object(ImageBuilder, "resolve_source_digest", return_value=self._DIGEST) as resolve,
+            patch.object(ImageBuilder, "_mirror_and_push"),
+        ):
+            first = ImageBuilder.ensure_image_mirrored(cfg=cfg, source_image=self._SRC)
+            ImageBuilder._digest_cache = {}  # a later start would re-resolve if the tag were forgotten
+            second = ImageBuilder.ensure_image_mirrored(cfg=cfg, source_image=self._SRC)
+
+        assert first == second
+        assert resolve.call_count == 1
+
+    def test_digest_resolution_gives_up_after_retries(self):
+        with patch.object(ImageBuilder, "resolve_source_digest", side_effect=OSError("down")) as resolve:
+            with pytest.raises(OSError):
+                ImageBuilder.resolve_source_digest_cached(self._SRC, retries=2, base_delay=0)
+        assert resolve.call_count == 3


### PR DESCRIPTION
## Problem

On the ECS Fargate sandbox, NEL ignores the prebuilt image a Harbor task declares in `task.toml [environment] docker_image` and rebuilds the task's `environment/Dockerfile` instead. Those Dockerfiles typically install from apt, pip and `curl` without pinning, so a rebuild resolves them against whatever upstream looks like that day — two builds of the same pinned task commit do not produce the same image.

The ECR tag is a content hash of the build context, so the *first* build becomes an accidental pin, stable until the repository's lifecycle policy evicts it. When it does, the next run rebuilds against drifted upstream state and re-caches the broken result under the same hash, so it never recovers.

This is not hypothetical. On a Terminal-Bench 2.1 oracle nightly, three tasks broke in a single night when their images were rebuilt: two had a `curl` of a source file that had 404'd weeks earlier (no `-f`, so `curl` wrote the error page and exited 0), and one pinned an apt version that had since been superseded.

Note the local Docker backend already prefers `docker_image` (`environments/harbor.py::_resolve_image`) — the two backends disagreed.

## Change

Adds `image_mirror_mode` to the ECS Fargate sandbox config:

- **`off`** (default) — build the Dockerfile. Existing behaviour, unchanged.
- **`codebuild`** — copy the declared upstream image into ECR instead, tagged by its **upstream manifest digest**.

Tagging by digest is what makes this worth doing: a cache miss re-mirrors byte-identical content, so eviction costs latency rather than changing what runs. Rebuilding cannot offer that.

An existing mirror is recognised from its tag prefix alone, so the upstream registry is contacted only on a miss, and resolutions are memoised per ref with bounded retry. Sandboxes start once per task, so a naive implementation would issue one registry call per task start from a single egress IP — enough to trip anonymous registry rate limits at realistic concurrency.

Digests resolve over plain HTTPS against the Registry v2 API, so no Docker daemon is required.

Benchmarks that construct images programmatically (SWE-bench and friends) declare no `docker_image`, expose no `source_image`, and keep the build path unchanged.

## Testing

- 25 new unit tests covering tag derivation, digest/canonical ref parsing, cache-hit and cache-miss paths, memoisation under 200 simulated task starts, retry and give-up behaviour, and the mirror-vs-build branch.
- Validated end-to-end on a real 89-task Terminal-Bench 2.1 oracle run: warm images served with zero registry calls, cold images mirrored correctly, and **zero Dockerfile builds**. Two of the regressions described above are fixed by this change; the remainder install from the network during the task's own solve script and need upstream pins instead.

## Rollout

Defaults to `off`, so merging changes nothing. Benchmarks opt in per-config first; playbook defaults follow once proven.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional image mirroring for ECS Fargate sandboxes, using immutable upstream image digests.
  * Added support for Docker Hub authentication during image mirroring.
  * Pre-built task images can now be used directly without local Dockerfile builds.
  * Added configuration to enable or disable image mirroring.

* **Bug Fixes**
  * Improved image reuse through caching and retry handling.
  * Preserved Dockerfile builds for tasks without pre-built images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->