### PR TITLE
feat(launcher): add native vLLM P/D deployment

### DIFF
--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".github/workflows/config/.secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -1086,7 +1090,7 @@
         "filename": "packages/nemo-evaluator-launcher/tests/unit_tests/test_env_vars.py",
         "hashed_secret": "cd6bd383d4886c1345a9a3ed337407c16cddcce2",
         "is_verified": false,
-        "line_number": 446
+        "line_number": 473
       }
     ],
     "packages/nemo-evaluator-launcher/tests/unit_tests/test_get_eval_factory_command.py": [
@@ -1394,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-28T15:58:57Z"
+  "generated_at": "2026-08-13T07:20:08Z"
 }

--- a/.github/workflows/config/.secrets.baseline
+++ b/.github/workflows/config/.secrets.baseline
@@ -1225,21 +1225,21 @@
         "filename": "packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py",
         "hashed_secret": "6af5a378fdb0e7d397c9f47c744e5e14195c0228",
         "is_verified": false,
-        "line_number": 1113
+        "line_number": 1189
       },
       {
         "type": "Secret Keyword",
         "filename": "packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py",
         "hashed_secret": "3a1baa793ba9d2e55a3465f9fd410de2af51e277",
         "is_verified": false,
-        "line_number": 1161
+        "line_number": 1237
       },
       {
         "type": "Secret Keyword",
         "filename": "packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py",
         "hashed_secret": "3acfb2c2b433c0ea7ff107e33df91b18e52f960f",
         "is_verified": false,
-        "line_number": 1495
+        "line_number": 1571
       }
     ],
     "packages/nemo-evaluator-launcher/tests/unit_tests/test_telemetry.py": [
@@ -1398,5 +1398,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-13T07:20:08Z"
+  "generated_at": "2026-08-13T07:53:25Z"
 }

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/api/functional.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/api/functional.py
@@ -20,6 +20,7 @@ This module provides the main functional entry points for running evaluations, q
 
 import copy
 import os
+import re
 import tempfile
 from collections import defaultdict
 from pathlib import Path
@@ -118,6 +119,109 @@ def _validate_config_sections(cfg: RunConfig) -> None:
                 f"Invalid 'execution.mounts' config:\n{e}\n"
                 f"Allowed mounts keys: {_allowed_keys(MountsModel)}"
             ) from e
+
+
+def _as_integer(value: Any, field: str) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if text.lstrip("-").isdigit():
+            return int(text)
+    raise ValueError(f"vllm_pd {field} must be an integer")
+
+
+def _port(value: Any, field: str) -> int:
+    port = _as_integer(value, field)
+    if not 1 <= port <= 65535:
+        raise ValueError(f"vllm_pd {field} must be an integer between 1 and 65535")
+    return port
+
+
+def _validate_pd_deployment(cfg: RunConfig) -> None:
+    """Validate the single-instance Slurm topology required by vllm_pd."""
+    if cfg.get("deployment", {}).get("type") != "vllm_pd":
+        return
+
+    if cfg.execution.get("type") != "slurm":
+        raise ValueError("vllm_pd requires execution.type=slurm")
+
+    try:
+        num_instances = _as_integer(
+            cfg.execution.get("num_instances", 1), "execution.num_instances"
+        )
+    except ValueError as e:
+        raise ValueError("vllm_pd execution.num_instances must be 1") from e
+    if num_instances != 1:
+        raise ValueError("vllm_pd requires execution.num_instances == 1")
+
+    try:
+        prefill_nodes = _as_integer(cfg.deployment.prefill_nodes, "prefill_nodes")
+    except (AttributeError, ValueError) as e:
+        raise ValueError("vllm_pd prefill_nodes must be a positive integer") from e
+    if prefill_nodes <= 0:
+        raise ValueError("vllm_pd prefill_nodes must be a positive integer")
+
+    try:
+        decode_nodes = _as_integer(cfg.deployment.decode_nodes, "decode_nodes")
+    except (AttributeError, ValueError) as e:
+        raise ValueError("vllm_pd decode_nodes must be a positive integer") from e
+    if decode_nodes <= 0:
+        raise ValueError("vllm_pd decode_nodes must be a positive integer")
+
+    try:
+        execution_nodes = _as_integer(cfg.execution.num_nodes, "execution.num_nodes")
+    except (AttributeError, ValueError) as e:
+        raise ValueError("vllm_pd execution.num_nodes must be an integer") from e
+
+    total_nodes = prefill_nodes + decode_nodes
+    if execution_nodes != total_nodes:
+        raise ValueError(
+            "vllm_pd execution.num_nodes must equal prefill_nodes + decode_nodes "
+            f"({total_nodes}), received {execution_nodes}"
+        )
+
+    execution_deployment = cfg.execution.get("deployment") or {}
+    n_tasks = execution_deployment.get("n_tasks", cfg.execution.num_nodes)
+    try:
+        deployment_tasks = _as_integer(n_tasks, "execution.deployment.n_tasks")
+    except ValueError as e:
+        raise ValueError(
+            "vllm_pd execution.deployment.n_tasks must be an integer"
+        ) from e
+    if deployment_tasks != total_nodes:
+        raise ValueError(
+            "vllm_pd execution.deployment.n_tasks must equal prefill_nodes + "
+            f"decode_nodes ({total_nodes}), received {deployment_tasks}"
+        )
+
+    ports: dict[str, int] = {}
+    for field in (
+        "port",
+        "prefill_port",
+        "decode_port",
+        "prefill_data_parallel_rpc_port",
+        "decode_data_parallel_rpc_port",
+        "prefill_nixl_side_channel_port",
+        "decode_nixl_side_channel_port",
+    ):
+        value = cfg.deployment.get(field)
+        if value is not None:
+            ports[field] = _port(value, f"deployment.{field}")
+
+    if "port" in ports and ports["port"] == ports.get("prefill_port"):
+        raise ValueError(
+            "vllm_pd deployment.port must differ from deployment.prefill_port"
+        )
+
+    image_sha256 = cfg.deployment.get("runtime_image_sha256", "")
+    if image_sha256 and (
+        not isinstance(image_sha256, str)
+        or re.fullmatch(r"[0-9a-fA-F]{64}", image_sha256) is None
+    ):
+        raise ValueError(
+            "vllm_pd deployment.runtime_image_sha256 must be a 64-character SHA-256 digest"
+        )
 
 
 def _validate_nemo_evaluator_config_params(
@@ -307,6 +411,7 @@ def run_eval(
     # Validate that no MISSING values exist in the configuration
     _validate_no_missing_values(cfg)
     _validate_config_sections(cfg)
+    _validate_pd_deployment(cfg)
 
     if dry_run:
         print(OmegaConf.to_yaml(cfg))

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/env_vars.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/common/env_vars.py
@@ -263,15 +263,16 @@ def generate_secrets_env(
 def build_reexport_commands(group_name: str, result: SecretsEnvResult) -> str:
     """Build shell commands to re-export disambiguated vars back to original names.
 
-    For a group, generates commands like:
-        export HF_TOKEN=$HF_TOKEN_a3f1b2_TASK_A
+    The generated block preserves the caller's xtrace state while hiding the
+    assignments themselves. This keeps host-derived values out of Slurm logs
+    when the outer script uses ``set -x``.
 
     Args:
         group_name: The group to generate re-export commands for.
         result: The SecretsEnvResult from generate_secrets_env().
 
     Returns:
-        Shell command string (semicolon-separated exports), or empty string.
+        Shell command block, or empty string.
     """
     commands = []
     # Resolved vars (literal + host) first — they source from .secrets.env
@@ -287,7 +288,22 @@ def build_reexport_commands(group_name: str, result: SecretsEnvResult) -> str:
             'export %s="${%s}"'
             % (remapping.original_name, remapping.disambiguated_name)
         )
-    return " ; ".join(commands)
+    if not commands:
+        return ""
+
+    exports = "\n".join(f"    {command}" for command in commands)
+    return (
+        'case "$-" in\n'
+        "  *x*)\n"
+        "    set +x\n"
+        f"{exports}\n"
+        "    set -x\n"
+        "    ;;\n"
+        "  *)\n"
+        f"{exports}\n"
+        "    ;;\n"
+        "esac"
+    )
 
 
 def redact_secrets_env_content(

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/deployment/vllm_pd.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/deployment/vllm_pd.yaml
@@ -31,6 +31,11 @@ router_host: 0.0.0.0
 router_policy: consistent_hash
 router_request_timeout_secs: 86400
 router_extra_args: ""
+# Optional rank-zero lifecycle hook. It starts after the router and, when it
+# exits, terminates the router and controls the P/D deployment's outcome.
+# Evaluation frameworks can use it to coordinate work that must run beside the
+# router without coupling the generic P/D topology to one framework.
+router_background_command: ""
 prefill_extra_args: ""
 decode_extra_args: ""
 mount_checkpoint_to_evaluation: false
@@ -108,6 +113,10 @@ command: |
   echo "vllm_pd role=$VLLM_PD_ROLE rank=$PROC_ID prefill_nodes=$PREFILL_NODES decode_nodes=$DECODE_NODES"
 
   prefill_pid=""
+  router_pid=""
+  router_background_pid=""
+  router_background_command_file=""
+  VLLM_PD_EXEC=0
   write_role_status() {
     status_exit_code=""
     if [ -z "$ROLE_STATUS_DIR" ]; then
@@ -123,8 +132,17 @@ command: |
   }
   on_exit() {
     exit_code=$?
+    if [ -n "$router_background_pid" ] && kill -0 "$router_background_pid" 2>/dev/null; then
+      kill "$router_background_pid"
+    fi
+    if [ -n "$router_pid" ] && kill -0 "$router_pid" 2>/dev/null; then
+      kill "$router_pid"
+    fi
     if [ -n "$prefill_pid" ] && kill -0 "$prefill_pid" 2>/dev/null; then
       kill "$prefill_pid"
+    fi
+    if [ -n "$router_background_command_file" ]; then
+      rm -f "$router_background_command_file"
     fi
     if [ "$exit_code" -eq 0 ]; then
       write_role_status stopped "$exit_code"
@@ -163,6 +181,18 @@ command: |
   write_runtime_provenance
 
   run_vllm() {
+    if [ "$VLLM_PD_EXEC" = "1" ]; then
+      exec vllm serve "$MODEL" \
+        --tensor-parallel-size ${deployment.tensor_parallel_size} \
+        --pipeline-parallel-size ${deployment.pipeline_parallel_size} \
+        --trust-remote-code \
+        --served-model-name ${deployment.served_model_name} \
+        --gpu-memory-utilization ${deployment.gpu_memory_utilization} \
+        --distributed-executor-backend mp \
+        --data-parallel-backend mp \
+        --data-parallel-size-local ${deployment.data_parallel_size_local} \
+        ${deployment.extra_args} "$@"
+    fi
     vllm serve "$MODEL" \
       --tensor-parallel-size ${deployment.tensor_parallel_size} \
       --pipeline-parallel-size ${deployment.pipeline_parallel_size} \
@@ -175,7 +205,36 @@ command: |
       ${deployment.extra_args} "$@"
   }
 
+  is_background_running() {
+    jobs -pr | grep -Fxq "$1"
+  }
+
+  wait_for_router_or_background() {
+    while true; do
+      if ! is_background_running "$router_pid"; then
+        router_exit_code=0
+        wait "$router_pid" || router_exit_code=$?
+        if is_background_running "$router_background_pid"; then
+          kill "$router_background_pid" || true
+        fi
+        wait "$router_background_pid" || true
+        return "$router_exit_code"
+      fi
+      if ! is_background_running "$router_background_pid"; then
+        background_exit_code=0
+        wait "$router_background_pid" || background_exit_code=$?
+        if is_background_running "$router_pid"; then
+          kill "$router_pid" || true
+        fi
+        wait "$router_pid" || true
+        return "$background_exit_code"
+      fi
+      sleep 1
+    done
+  }
+
   if [ "$PROC_ID" -eq 0 ]; then
+    VLLM_PD_EXEC=1 \
     VLLM_NIXL_SIDE_CHANNEL_HOST="$THIS_NODE_IP" \
     VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_NIXL_PORT" \
     run_vllm \
@@ -196,7 +255,23 @@ command: |
       --host ${deployment.router_host} \
       --port ${deployment.port} \
       --intra-node-data-parallel-size ${deployment.data_parallel_size_local} \
-      --request-timeout-secs ${deployment.router_request_timeout_secs} ${deployment.router_extra_args}
+      --request-timeout-secs ${deployment.router_request_timeout_secs} ${deployment.router_extra_args} &
+    router_pid=$!
+
+    router_background_command_file=$(mktemp)
+    cat > "$router_background_command_file" <<'VLLM_PD_ROUTER_BACKGROUND_COMMAND'
+  ${deployment.router_background_command}
+  VLLM_PD_ROUTER_BACKGROUND_COMMAND
+    if grep -q '[^[:space:]]' "$router_background_command_file"; then
+      (
+        set -euo pipefail
+        source "$router_background_command_file"
+      ) &
+      router_background_pid=$!
+      wait_for_router_or_background
+    else
+      wait "$router_pid"
+    fi
   elif [ "$PROC_ID" -lt "$PREFILL_NODES" ]; then
     VLLM_NIXL_SIDE_CHANNEL_HOST="$THIS_NODE_IP" \
     VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_NIXL_PORT" \

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/deployment/vllm_pd.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/configs/deployment/vllm_pd.yaml
@@ -1,0 +1,232 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Prefill/decode-disaggregated vLLM deployment.
+#
+# A single Slurm instance launches one rank per node. Ranks [0, prefill_nodes)
+# are NIXL KV producers, the remaining ranks are consumers, and rank 0 owns the
+# vLLM router exposed through the inherited deployment port.
+defaults:
+  - vllm
+  - _self_
+
+type: vllm_pd
+
+prefill_nodes: ???
+decode_nodes: ???
+
+prefill_port: 8001
+decode_port: 8002
+prefill_data_parallel_rpc_port: 13345
+decode_data_parallel_rpc_port: 13346
+prefill_nixl_side_channel_port: 5600
+decode_nixl_side_channel_port: 5700
+
+data_parallel_size_local: 1
+api_server_count: 1
+kv_connector: NixlConnector
+kv_load_failure_policy: fail
+router_command: vllm-router
+router_host: 0.0.0.0
+router_policy: consistent_hash
+router_request_timeout_secs: 86400
+router_extra_args: ""
+prefill_extra_args: ""
+decode_extra_args: ""
+mount_checkpoint_to_evaluation: false
+role_status_dir: ""
+role_log_dir: ""
+runtime_provenance_dir: ""
+runtime_image_sha256: ""
+# The Slurm executor writes one IP per deployment node to this shared artifact
+# before launching ranks. This avoids Pyxis parsing multi-value environment
+# variables inside the deployment container.
+node_ips_file: /results/vllm_pd_node_ips.txt
+
+command: |
+  #!/bin/bash
+  set -euo pipefail
+
+  PREFILL_NODES=${deployment.prefill_nodes}
+  DECODE_NODES=${deployment.decode_nodes}
+  TOTAL_NODES=$((PREFILL_NODES + DECODE_NODES))
+  MODEL=${select_not_null:deployment.hf_model_handle,/checkpoint}
+  PREFILL_PORT=${deployment.prefill_port}
+  DECODE_PORT=${deployment.decode_port}
+  PREFILL_DP_RPC_PORT=${deployment.prefill_data_parallel_rpc_port}
+  DECODE_DP_RPC_PORT=${deployment.decode_data_parallel_rpc_port}
+  PREFILL_NIXL_PORT=${deployment.prefill_nixl_side_channel_port}
+  DECODE_NIXL_PORT=${deployment.decode_nixl_side_channel_port}
+  ROLE_STATUS_DIR="${deployment.role_status_dir}"
+  ROLE_LOG_DIR="${deployment.role_log_dir}"
+  RUNTIME_PROVENANCE_DIR="${deployment.runtime_provenance_dir}"
+  RUNTIME_IMAGE_SHA256="${deployment.runtime_image_sha256}"
+  NODE_IPS_FILE="${deployment.node_ips_file}"
+
+  if [ "$PROC_ID" -eq 0 ]; then
+    VLLM_PD_ROLE=prefill-head-router
+  elif [ "$PROC_ID" -lt "$PREFILL_NODES" ]; then
+    VLLM_PD_ROLE=prefill-worker
+  elif [ "$PROC_ID" -eq "$PREFILL_NODES" ]; then
+    VLLM_PD_ROLE=decode-head
+  else
+    VLLM_PD_ROLE=decode-worker
+  fi
+  if [ -n "$ROLE_LOG_DIR" ]; then
+    mkdir -p "$ROLE_LOG_DIR"
+    exec > >(tee -a "$ROLE_LOG_DIR/$VLLM_PD_ROLE-$PROC_ID.log") 2>&1
+  fi
+
+  if [ "$NODES_PER_INSTANCE" -ne "$TOTAL_NODES" ]; then
+    echo "vllm_pd requires $TOTAL_NODES nodes, received $NODES_PER_INSTANCE" >&2
+    exit 1
+  fi
+
+  if [ ! -r "$NODE_IPS_FILE" ]; then
+    echo "vllm_pd node IP artifact is unavailable: $NODE_IPS_FILE" >&2
+    exit 1
+  fi
+
+  NODE_COUNT=$(awk 'END { print NR }' "$NODE_IPS_FILE")
+  if [ "$NODE_COUNT" -ne "$TOTAL_NODES" ]; then
+    echo "vllm_pd expected $TOTAL_NODES node IPs, received $NODE_COUNT" >&2
+    exit 1
+  fi
+
+  PREFILL_HEAD=$(awk 'NR == 1 { print; exit }' "$NODE_IPS_FILE")
+  DECODE_HEAD=$(awk -v line=$((PREFILL_NODES + 1)) \
+    'NR == line { print; exit }' "$NODE_IPS_FILE")
+  THIS_NODE_IP=$(awk -v line=$((PROC_ID + 1)) \
+    'NR == line { print; exit }' "$NODE_IPS_FILE")
+  if [ -z "$PREFILL_HEAD" ] || [ -z "$DECODE_HEAD" ] || [ -z "$THIS_NODE_IP" ]; then
+    echo "vllm_pd node IP artifact contains an empty required address" >&2
+    exit 1
+  fi
+  PREFILL_KV_TRANSFER_CONFIG='{"kv_connector":"${deployment.kv_connector}","kv_role":"kv_producer","kv_load_failure_policy":"${deployment.kv_load_failure_policy}"}'
+  DECODE_KV_TRANSFER_CONFIG='{"kv_connector":"${deployment.kv_connector}","kv_role":"kv_consumer","kv_load_failure_policy":"${deployment.kv_load_failure_policy}"}'
+
+  echo "vllm_pd role=$VLLM_PD_ROLE rank=$PROC_ID prefill_nodes=$PREFILL_NODES decode_nodes=$DECODE_NODES"
+
+  prefill_pid=""
+  write_role_status() {
+    status_exit_code=""
+    if [ -z "$ROLE_STATUS_DIR" ]; then
+      return
+    fi
+    if [ "$#" -gt 1 ]; then
+      status_exit_code="$2"
+    fi
+    mkdir -p "$ROLE_STATUS_DIR"
+    printf 'state=%s\nrole=%s\nrank=%s\nnode_ip=%s\nexit_code=%s\n' \
+      "$1" "$VLLM_PD_ROLE" "$PROC_ID" "$THIS_NODE_IP" "$status_exit_code" \
+      > "$ROLE_STATUS_DIR/$VLLM_PD_ROLE-$PROC_ID.status"
+  }
+  on_exit() {
+    exit_code=$?
+    if [ -n "$prefill_pid" ] && kill -0 "$prefill_pid" 2>/dev/null; then
+      kill "$prefill_pid"
+    fi
+    if [ "$exit_code" -eq 0 ]; then
+      write_role_status stopped "$exit_code"
+    else
+      write_role_status failed "$exit_code"
+    fi
+    return "$exit_code"
+  }
+  trap on_exit EXIT
+  write_role_status starting
+
+  write_runtime_provenance() {
+    if [ "$PROC_ID" -ne 0 ] || [ -z "$RUNTIME_PROVENANCE_DIR" ]; then
+      return
+    fi
+    mkdir -p "$RUNTIME_PROVENANCE_DIR"
+    {
+      printf 'configured_image_sha256=%s\n' "$RUNTIME_IMAGE_SHA256"
+      printf 'router_command_version=%s\n' "$( ${deployment.router_command} --version 2>&1 || true )"
+      python3 - <<'PY'
+  from importlib.metadata import PackageNotFoundError, version
+
+  for package in ("vllm", "vllm-router", "ray", "fastokens", "instanttensor", "nixl"):
+      try:
+          print(f"{package}={version(package)}")
+      except PackageNotFoundError:
+          print(f"{package}=not-installed")
+  PY
+    } > "$RUNTIME_PROVENANCE_DIR/runtime.env"
+  }
+
+  command -v "${deployment.router_command}" >/dev/null || {
+    echo "vllm_pd requires ${deployment.router_command} in the deployment image" >&2
+    exit 1
+  }
+  write_runtime_provenance
+
+  run_vllm() {
+    vllm serve "$MODEL" \
+      --tensor-parallel-size ${deployment.tensor_parallel_size} \
+      --pipeline-parallel-size ${deployment.pipeline_parallel_size} \
+      --trust-remote-code \
+      --served-model-name ${deployment.served_model_name} \
+      --gpu-memory-utilization ${deployment.gpu_memory_utilization} \
+      --distributed-executor-backend mp \
+      --data-parallel-backend mp \
+      --data-parallel-size-local ${deployment.data_parallel_size_local} \
+      ${deployment.extra_args} "$@"
+  }
+
+  if [ "$PROC_ID" -eq 0 ]; then
+    VLLM_NIXL_SIDE_CHANNEL_HOST="$THIS_NODE_IP" \
+    VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_NIXL_PORT" \
+    run_vllm \
+      --host 0.0.0.0 \
+      --port "$PREFILL_PORT" \
+      --data-parallel-size "$PREFILL_NODES" \
+      --data-parallel-address "$PREFILL_HEAD" \
+      --data-parallel-rpc-port "$PREFILL_DP_RPC_PORT" \
+      --api-server-count ${deployment.api_server_count} \
+      --kv-transfer-config "$PREFILL_KV_TRANSFER_CONFIG" ${deployment.prefill_extra_args} &
+    prefill_pid=$!
+
+    ${deployment.router_command} \
+      --policy ${deployment.router_policy} \
+      --vllm-pd-disaggregation \
+      --prefill "http://$PREFILL_HEAD:$PREFILL_PORT" \
+      --decode "http://$DECODE_HEAD:$DECODE_PORT" \
+      --host ${deployment.router_host} \
+      --port ${deployment.port} \
+      --intra-node-data-parallel-size ${deployment.data_parallel_size_local} \
+      --request-timeout-secs ${deployment.router_request_timeout_secs} ${deployment.router_extra_args}
+  elif [ "$PROC_ID" -lt "$PREFILL_NODES" ]; then
+    VLLM_NIXL_SIDE_CHANNEL_HOST="$THIS_NODE_IP" \
+    VLLM_NIXL_SIDE_CHANNEL_PORT="$PREFILL_NIXL_PORT" \
+    run_vllm \
+      --headless \
+      --data-parallel-size "$PREFILL_NODES" \
+      --data-parallel-start-rank "$PROC_ID" \
+      --data-parallel-address "$PREFILL_HEAD" \
+      --data-parallel-rpc-port "$PREFILL_DP_RPC_PORT" \
+      --kv-transfer-config "$PREFILL_KV_TRANSFER_CONFIG" ${deployment.prefill_extra_args}
+  elif [ "$PROC_ID" -eq "$PREFILL_NODES" ]; then
+    VLLM_NIXL_SIDE_CHANNEL_HOST="$THIS_NODE_IP" \
+    VLLM_NIXL_SIDE_CHANNEL_PORT="$DECODE_NIXL_PORT" \
+    run_vllm \
+      --host 0.0.0.0 \
+      --port "$DECODE_PORT" \
+      --data-parallel-size "$DECODE_NODES" \
+      --data-parallel-address "$DECODE_HEAD" \
+      --data-parallel-rpc-port "$DECODE_DP_RPC_PORT" \
+      --api-server-count ${deployment.api_server_count} \
+      --kv-transfer-config "$DECODE_KV_TRANSFER_CONFIG" ${deployment.decode_extra_args}
+  else
+    DECODE_RANK=$((PROC_ID - PREFILL_NODES))
+    VLLM_NIXL_SIDE_CHANNEL_HOST="$THIS_NODE_IP" \
+    VLLM_NIXL_SIDE_CHANNEL_PORT="$DECODE_NIXL_PORT" \
+    run_vllm \
+      --headless \
+      --data-parallel-size "$DECODE_NODES" \
+      --data-parallel-start-rank "$DECODE_RANK" \
+      --data-parallel-address "$DECODE_HEAD" \
+      --data-parallel-rpc-port "$DECODE_DP_RPC_PORT" \
+      --kv-transfer-config "$DECODE_KV_TRANSFER_CONFIG" ${deployment.decode_extra_args}
+  fi

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/executors/slurm/executor.py
@@ -838,13 +838,10 @@ def _create_slurm_sbatch_script(
         ):
             deployment_mounts_list.append(f"{source_mnt}:{target_mnt}")
 
-        # Re-export deployment vars right before deployment srun.
-        # Bracket with `set +x`/`set -x` so xtrace doesn't expand
-        # `${HF_TOKEN_xxx}` (and similar) into the slurm log.
+        # Re-export deployment variables immediately before the deployment
+        # srun. The generated block preserves xtrace state safely.
         if deploy_reexport_cmd:
-            s += "set +x\n"
             s += f"{deploy_reexport_cmd}\n"
-            s += "set -x\n"
 
         # add deployment srun command
         deployment_srun_cmd, deployment_is_unsafe, deployment_debug = (
@@ -902,9 +899,7 @@ def _create_slurm_sbatch_script(
 
         # Re-export aux deployment vars right before aux deployment srun
         if aux.reexport_cmd:
-            s += "set +x\n"
             s += f"{aux.reexport_cmd}\n"
-            s += "set -x\n"
 
         # Add auxiliary deployment srun command
         aux_srun_cmd, aux_unsafe, aux_debug = (
@@ -954,6 +949,10 @@ def _create_slurm_sbatch_script(
     evaluation_mounts_list = [
         "{}:/results".format(remote_task_subdir / "artifacts"),
     ]
+    if (
+        checkpoint_path := cfg.deployment.get("checkpoint_path")
+    ) and cfg.deployment.get("mount_checkpoint_to_evaluation", False):
+        evaluation_mounts_list.append(f"{checkpoint_path}:/checkpoint:ro")
     for source_mnt, target_mnt in (
         cfg.execution.get("mounts", {}).get("evaluation", {}).items()
     ):
@@ -990,9 +989,7 @@ def _create_slurm_sbatch_script(
 
     # Re-export eval vars right before eval srun
     if eval_reexport_cmd:
-        s += "set +x\n"
         s += f"{eval_reexport_cmd}\n"
-        s += "set -x\n"
 
     # Export auxiliary endpoint information for evaluation containers
     aux_extra_env_names = []
@@ -1150,9 +1147,7 @@ def _generate_auto_export_section(
 
     if secrets:
         reexport_cmd = build_reexport_commands("export", secrets)
-        s += "    set +x\n"
         s += f"    {reexport_cmd}\n"
-        s += "    set -x\n"
 
     export_config = {"export": cfg.get("export", {})}
 
@@ -1901,7 +1896,19 @@ def _generate_deployment_srun_command(
 
     s += 'export NODES_IPS_ARRAY=($(for node in "${DEPLOY_NODES_ARRAY[@]}"; do srun --nodelist="$node" --ntasks=1 --nodes=1 hostname --ip-address; done))\n'
     s += 'echo "Node IPs: ${NODES_IPS_ARRAY[@]}"\n'
-    s += 'export ALL_NODE_IPS=$(IFS=,; echo "${NODES_IPS_ARRAY[*]}")\n'
+    is_vllm_pd = cfg.deployment.get("type") == "vllm_pd"
+    if is_vllm_pd:
+        # Pyxis parses container environment values as comma-separated fields and
+        # does not preserve alternative separators consistently. Share P/D node
+        # addresses through the deployment's existing /results artifact mount.
+        node_ips_file = remote_task_subdir / "artifacts" / "vllm_pd_node_ips.txt"
+        s += f"mkdir -p {shlex.quote(str(node_ips_file.parent))}\n"
+        s += (
+            'printf "%s\\n" "${NODES_IPS_ARRAY[@]}" > '
+            f"{shlex.quote(str(node_ips_file))}\n"
+        )
+    else:
+        s += 'export ALL_NODE_IPS=$(IFS=,; echo "${NODES_IPS_ARRAY[*]}")\n'
 
     num_instances = cfg.execution.get("num_instances", 1)
     nodes_per_instance = cfg.execution.num_nodes // num_instances
@@ -1925,10 +1932,15 @@ def _generate_deployment_srun_command(
     if deployment_env_var_names is None:
         deployment_env_var_names = []
 
-    # Always pass MASTER_IP and ALL_NODE_IPS into each instance container
+    # Always pass MASTER_IP into each instance container. P/D reads its node
+    # addresses from the shared artifact mount rather than a Pyxis environment.
     if "MASTER_IP" not in deployment_env_var_names:
         deployment_env_var_names.append("MASTER_IP")
-    if "ALL_NODE_IPS" not in deployment_env_var_names:
+    if is_vllm_pd:
+        deployment_env_var_names = [
+            name for name in deployment_env_var_names if name != "ALL_NODE_IPS"
+        ]
+    elif "ALL_NODE_IPS" not in deployment_env_var_names:
         deployment_env_var_names.append("ALL_NODE_IPS")
 
     # Build the command that runs inside each instance container:

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/resources/config_templates/deployment/vllm_pd.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/resources/config_templates/deployment/vllm_pd.yaml
@@ -1,0 +1,27 @@
+defaults:
+  - deployment: vllm_pd
+
+# P/D runs one Slurm instance with one rank per prefill or decode node.
+execution:
+  num_nodes: 2
+  num_instances: 1
+
+deployment:
+  env_vars:
+    HF_TOKEN: host:HF_TOKEN # Required for gated HuggingFace models
+  # Must include vllm-router and NIXL support; do not use a generic vLLM image.
+  image: ???
+  checkpoint_path: ???
+  hf_model_handle: null
+  served_model_name: ???
+  prefill_nodes: 1
+  decode_nodes: 1
+  tensor_parallel_size: 1
+  data_parallel_size_local: 1
+  mount_checkpoint_to_evaluation: true
+  role_status_dir: /results/pd-role-status
+  role_log_dir: /results/pd-role-logs
+  runtime_provenance_dir: /results/pd-runtime
+  runtime_image_sha256: ???
+  node_ips_file: /results/vllm_pd_node_ips.txt
+  extra_args: ""

--- a/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/resources/config_templates/deployment/vllm_pd.yaml
+++ b/packages/nemo-evaluator-launcher/src/nemo_evaluator_launcher/resources/config_templates/deployment/vllm_pd.yaml
@@ -24,4 +24,7 @@ deployment:
   runtime_provenance_dir: /results/pd-runtime
   runtime_image_sha256: ???
   node_ips_file: /results/vllm_pd_node_ips.txt
+  # Optional rank-zero hook that runs beside the router and controls the P/D
+  # lifecycle when it exits. Leave empty for a standalone serving deployment.
+  router_background_command: ""
   extra_args: ""

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_config_validation.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_config_validation.py
@@ -28,7 +28,10 @@ import pytest
 import yaml
 from omegaconf import OmegaConf
 
-from nemo_evaluator_launcher.api.functional import _validate_config_sections
+from nemo_evaluator_launcher.api.functional import (
+    _validate_config_sections,
+    _validate_pd_deployment,
+)
 
 # Minimal valid sections; use make_config() to build full configs.
 MINIMAL_EVALUATION: Dict[str, Any] = {
@@ -283,6 +286,162 @@ class TestStructuralValidation:
         # Then ValueError is raised naming the problematic section
         with pytest.raises(ValueError, match=expected_error):
             _validate_config_sections(cfg)
+
+
+class TestVllmPdDeploymentValidation:
+    @pytest.mark.parametrize(
+        "prefill_nodes,decode_nodes,num_nodes,num_instances,n_tasks,error",
+        [
+            (1, 1, 2, 1, 2, None),
+            (0, 1, 1, 1, 1, "prefill_nodes must be a positive integer"),
+            (1, 0, 1, 1, 1, "decode_nodes must be a positive integer"),
+            (1, 1, 3, 1, 3, r"must equal prefill_nodes \+ decode_nodes"),
+            (1, 1, 2, 2, 2, "requires execution.num_instances == 1"),
+            (1, 1, 2, 1, 1, "execution.deployment.n_tasks must equal"),
+            (1, 1, "2", "1", "2", None),
+            (1, 1, 2, 1.5, 2, "execution.num_instances must be 1"),
+            (1, 1, 2.5, 1, 2, "execution.num_nodes must be an integer"),
+            (1, 1, 2, 1, 2.5, "execution.deployment.n_tasks must be an integer"),
+        ],
+        ids=[
+            "valid",
+            "zero_prefill",
+            "zero_decode",
+            "node_count_mismatch",
+            "multiple_instances",
+            "task_count_mismatch",
+            "stringified_execution_values",
+            "fractional_instance_count",
+            "fractional_node_count",
+            "fractional_task_count",
+        ],
+    )
+    def test_topology_validation(
+        self,
+        prefill_nodes,
+        decode_nodes,
+        num_nodes,
+        num_instances,
+        n_tasks,
+        error,
+    ):
+        cfg = OmegaConf.create(
+            {
+                "deployment": {
+                    "type": "vllm_pd",
+                    "prefill_nodes": prefill_nodes,
+                    "decode_nodes": decode_nodes,
+                },
+                "execution": {
+                    "type": "slurm",
+                    "num_nodes": num_nodes,
+                    "num_instances": num_instances,
+                    "deployment": {"n_tasks": n_tasks},
+                },
+            }
+        )
+
+        if error is None:
+            _validate_pd_deployment(cfg)
+        else:
+            with pytest.raises(ValueError, match=error):
+                _validate_pd_deployment(cfg)
+
+    def test_defaults_tasks_to_nodes_when_execution_deployment_is_null(self):
+        cfg = OmegaConf.create(
+            {
+                "deployment": {
+                    "type": "vllm_pd",
+                    "prefill_nodes": 1,
+                    "decode_nodes": 1,
+                },
+                "execution": {
+                    "type": "slurm",
+                    "num_nodes": 2,
+                    "num_instances": 1,
+                    "deployment": None,
+                },
+            }
+        )
+
+        _validate_pd_deployment(cfg)
+
+    @pytest.mark.parametrize(
+        "port_config,error",
+        [
+            (
+                {"port": 8001, "prefill_port": 8001},
+                "deployment.port must differ from deployment.prefill_port",
+            ),
+            (
+                {"port": 0},
+                "deployment.port must be an integer between 1 and 65535",
+            ),
+            (
+                {"decode_nixl_side_channel_port": 65536},
+                "deployment.decode_nixl_side_channel_port must be an integer between 1 and 65535",
+            ),
+        ],
+        ids=[
+            "router_prefill_port_collision",
+            "zero_router_port",
+            "oversized_nixl_port",
+        ],
+    )
+    def test_rejects_invalid_ports(self, port_config, error):
+        cfg = OmegaConf.create(
+            {
+                "deployment": {
+                    "type": "vllm_pd",
+                    "prefill_nodes": 1,
+                    "decode_nodes": 1,
+                    **port_config,
+                },
+                "execution": {
+                    "type": "slurm",
+                    "num_nodes": 2,
+                    "num_instances": 1,
+                    "deployment": {"n_tasks": 2},
+                },
+            }
+        )
+
+        with pytest.raises(ValueError, match=error):
+            _validate_pd_deployment(cfg)
+
+    @pytest.mark.parametrize(
+        "runtime_image_sha256,error",
+        [
+            ("", None),
+            ("a" * 64, None),
+            ("sha256:" + "a" * 64, "must be a 64-character SHA-256 digest"),
+            ("not-a-digest", "must be a 64-character SHA-256 digest"),
+        ],
+        ids=["unset", "valid", "prefixed", "invalid"],
+    )
+    def test_runtime_image_digest(self, runtime_image_sha256, error):
+        cfg = OmegaConf.create(
+            {
+                "deployment": {
+                    "type": "vllm_pd",
+                    "prefill_nodes": 1,
+                    "decode_nodes": 1,
+                    "runtime_image_sha256": runtime_image_sha256,
+                },
+                "execution": {
+                    "type": "slurm",
+                    "num_nodes": 2,
+                    "num_instances": 1,
+                    "deployment": {"n_tasks": 2},
+                },
+            }
+        )
+
+        if error is None:
+            _validate_pd_deployment(cfg)
+        else:
+            with pytest.raises(ValueError, match=error):
+                _validate_pd_deployment(cfg)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_deployment_command.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_deployment_command.py
@@ -159,6 +159,74 @@ class TestVllmPdDeploymentCommand:
         )
         assert result.returncode == 0, result.stderr
 
+    def test_pd_command_supports_a_router_lifecycle_hook(self):
+        cfg = RunConfig.from_hydra(
+            hydra_overrides=[
+                "deployment=vllm_pd",
+                "deployment.served_model_name=test-model",
+                "deployment.checkpoint_path=/my/checkpoint",
+                "deployment.prefill_nodes=1",
+                "deployment.decode_nodes=1",
+                "deployment.router_background_command='echo gym-coordinator'",
+            ]
+        )
+
+        command = cfg.deployment.command
+
+        assert "VLLM_PD_ROUTER_BACKGROUND_COMMAND" in command
+        assert 'source "$router_background_command_file"' in command
+        assert "wait_for_router_or_background" in command
+        assert "echo gym-coordinator" in command
+
+        result = subprocess.run(
+            ["bash", "-n"], input=command, text=True, capture_output=True
+        )
+        assert result.returncode == 0, result.stderr
+
+    def test_pd_command_runs_router_lifecycle_hook(self, tmp_path: Path):
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        (bin_dir / "vllm").write_text("#!/bin/sh\nexec sleep 30\n")
+        (bin_dir / "vllm-router").write_text(
+            '#!/bin/sh\nif [ "${1:-}" = "--version" ]; then exit 0; fi\nexec sleep 30\n'
+        )
+        for executable in bin_dir.iterdir():
+            executable.chmod(0o755)
+
+        role_log_dir = tmp_path / "role-logs"
+        hook_marker = role_log_dir / "router-background-hook-ran"
+        node_ips_file = tmp_path / "node-ips.txt"
+        node_ips_file.write_text("10.0.0.1\n10.0.0.2\n")
+        cfg = RunConfig.from_hydra(
+            hydra_overrides=[
+                "deployment=vllm_pd",
+                "deployment.served_model_name=test-model",
+                "deployment.checkpoint_path=/my/checkpoint",
+                "deployment.prefill_nodes=1",
+                "deployment.decode_nodes=1",
+                f"deployment.node_ips_file={node_ips_file}",
+                f"deployment.role_log_dir={role_log_dir}",
+                "deployment.router_background_command='touch \"$ROLE_LOG_DIR/router-background-hook-ran\"'",
+            ]
+        )
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "NODES_PER_INSTANCE": "2",
+            "PROC_ID": "0",
+        }
+
+        result = subprocess.run(
+            ["bash", "-c", cfg.deployment.command],
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert hook_marker.exists()
+
     @pytest.mark.parametrize(
         (
             "proc_id",

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_deployment_command.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_deployment_command.py
@@ -15,6 +15,10 @@
 #
 """Tests for the select_not_null resolver and vllm deployment command construction."""
 
+import os
+import subprocess
+from pathlib import Path
+
 import pytest
 from hydra.core.global_hydra import GlobalHydra
 from omegaconf import OmegaConf
@@ -99,3 +103,142 @@ class TestVllmDeploymentCommand:
         command = cfg.deployment.command
         assert "meta-llama/Llama-3.1-8B" in command
         assert command.startswith("vllm serve meta-llama/Llama-3.1-8B")
+
+
+class TestVllmPdDeploymentCommand:
+    """Tests for the vLLM prefill/decode deployment command."""
+
+    @pytest.fixture(autouse=True)
+    def clear_hydra(self):
+        GlobalHydra.instance().clear()
+        yield
+        GlobalHydra.instance().clear()
+
+    def test_pd_command_defines_router_and_rank_roles(self):
+        cfg = RunConfig.from_hydra(
+            hydra_overrides=[
+                "deployment=vllm_pd",
+                "deployment.served_model_name=test-model",
+                "deployment.checkpoint_path=/my/checkpoint",
+                "deployment.prefill_nodes=1",
+                "deployment.decode_nodes=1",
+            ]
+        )
+
+        command = cfg.deployment.command
+
+        assert "vllm-router" in command
+        assert 'if [ "$PROC_ID" -eq 0 ]' in command
+        assert 'elif [ "$PROC_ID" -lt "$PREFILL_NODES" ]' in command
+        assert '"kv_role":"kv_producer"' in command
+        assert '"kv_role":"kv_consumer"' in command
+        assert "NODE_IPS_FILE" in command
+        assert "/results/vllm_pd_node_ips.txt" in command
+        assert "ALL_NODE_IPS" not in command
+        assert "awk 'END { print NR }'" in command
+        assert "VLLM_PD_ROLE=prefill-head-router" in command
+        assert "VLLM_PD_ROLE=decode-worker" in command
+        assert "write_role_status" in command
+        assert "$ROLE_STATUS_DIR/$VLLM_PD_ROLE-$PROC_ID.status" in command
+        assert "$ROLE_LOG_DIR/$VLLM_PD_ROLE-$PROC_ID.log" in command
+        assert "exit_code=%s" in command
+        assert "trap on_exit EXIT" in command
+        assert "write_role_status failed" in command
+        assert "write_runtime_provenance" in command
+        assert "$RUNTIME_PROVENANCE_DIR/runtime.env" in command
+        assert '"fastokens", "instanttensor", "nixl"' in command
+        assert cfg.deployment.mount_checkpoint_to_evaluation is False
+        assert cfg.deployment.role_status_dir == ""
+        assert cfg.deployment.role_log_dir == ""
+        assert cfg.deployment.runtime_provenance_dir == ""
+        assert cfg.deployment.runtime_image_sha256 == ""
+        assert cfg.deployment.node_ips_file == "/results/vllm_pd_node_ips.txt"
+
+        result = subprocess.run(
+            ["bash", "-n"], input=command, text=True, capture_output=True
+        )
+        assert result.returncode == 0, result.stderr
+
+    @pytest.mark.parametrize(
+        (
+            "proc_id",
+            "vllm_exit_code",
+            "expected_role",
+            "expected_node_ip",
+            "expected_state",
+        ),
+        [
+            (0, 0, "prefill-head-router", "10.0.0.1", "stopped"),
+            (1, 0, "decode-head", "10.0.0.2", "stopped"),
+            (1, 7, "decode-head", "10.0.0.2", "failed"),
+        ],
+    )
+    def test_pd_command_writes_terminal_role_status(
+        self,
+        tmp_path: Path,
+        proc_id: int,
+        vllm_exit_code: int,
+        expected_role: str,
+        expected_node_ip: str,
+        expected_state: str,
+    ):
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        for executable in ("vllm", "vllm-router"):
+            command = bin_dir / executable
+            command.write_text('#!/bin/sh\nexit "${FAKE_VLLM_EXIT:-0}"\n')
+            command.chmod(0o755)
+
+        status_dir = tmp_path / "role-status"
+        log_dir = tmp_path / "role-logs"
+        runtime_dir = tmp_path / "runtime"
+        node_ips_file = tmp_path / "node-ips.txt"
+        node_ips_file.write_text("10.0.0.1\n10.0.0.2\n")
+        cfg = RunConfig.from_hydra(
+            hydra_overrides=[
+                "deployment=vllm_pd",
+                "deployment.served_model_name=test-model",
+                "deployment.checkpoint_path=/my/checkpoint",
+                "deployment.prefill_nodes=1",
+                "deployment.decode_nodes=1",
+                f"deployment.role_status_dir={status_dir}",
+                f"deployment.role_log_dir={log_dir}",
+                f"deployment.runtime_provenance_dir={runtime_dir}",
+                f"deployment.runtime_image_sha256={'a' * 64}",
+                f"deployment.node_ips_file={node_ips_file}",
+            ]
+        )
+        env = {
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "FAKE_VLLM_EXIT": str(vllm_exit_code),
+            "NODES_PER_INSTANCE": "2",
+            "PROC_ID": str(proc_id),
+        }
+
+        result = subprocess.run(
+            ["bash", "-c", cfg.deployment.command],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+
+        assert result.returncode == vllm_exit_code, result.stderr
+        assert (status_dir / f"{expected_role}-{proc_id}.status").read_text() == (
+            f"state={expected_state}\n"
+            f"role={expected_role}\n"
+            f"rank={proc_id}\n"
+            f"node_ip={expected_node_ip}\n"
+            f"exit_code={vllm_exit_code}\n"
+        )
+        assert (
+            f"vllm_pd role={expected_role} rank={proc_id}"
+            in (log_dir / f"{expected_role}-{proc_id}.log").read_text()
+        )
+        if proc_id == 0:
+            provenance = (runtime_dir / "runtime.env").read_text()
+            assert f"configured_image_sha256={'a' * 64}" in provenance
+            assert "router_command_version=" in provenance
+            assert "vllm=" in provenance
+        else:
+            assert not (runtime_dir / "runtime.env").exists()

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_env_vars.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_env_vars.py
@@ -16,6 +16,7 @@
 """Tests for nemo_evaluator_launcher.common.env_vars module."""
 
 import os
+import subprocess
 from unittest import mock
 
 import pytest
@@ -221,7 +222,8 @@ class TestBuildReexportCommands:
             },
         )
         cmd = build_reexport_commands("task_a", result)
-        assert cmd == 'export HF_TOKEN="${HF_TOKEN_abc_TASK_A}"'
+        assert cmd.startswith('case "$-" in\n  *x*)\n')
+        assert cmd.count('export HF_TOKEN="${HF_TOKEN_abc_TASK_A}"') == 2
 
     def test_multiple_vars(self):
         result = SecretsEnvResult(
@@ -236,7 +238,8 @@ class TestBuildReexportCommands:
         cmd = build_reexport_commands("task_a", result)
         assert 'export HF_TOKEN="${HF_TOKEN_abc_TASK_A}"' in cmd
         assert 'export API_KEY="${API_KEY_abc_TASK_A}"' in cmd
-        assert " ; " in cmd
+        assert "set +x" in cmd
+        assert "set -x" in cmd
 
     def test_empty_group(self):
         result = SecretsEnvResult(secrets_content="")
@@ -256,6 +259,30 @@ class TestBuildReexportCommands:
         cmd = build_reexport_commands("task_a", result)
         assert 'export HF_TOKEN="${HF_TOKEN_abc_TASK_A}"' in cmd
         assert 'export API_KEY="${NGC_API_TOKEN}"' in cmd
+
+    def test_xtrace_never_prints_reexported_value(self):
+        result = SecretsEnvResult(
+            secrets_content="",
+            group_remappings={
+                "task_a": [VarRemapping("HF_TOKEN", "HF_TOKEN_abc_TASK_A")]
+            },
+        )
+        cmd = build_reexport_commands("task_a", result)
+        secret = "test-secret-value"
+
+        process = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f'export HF_TOKEN_abc_TASK_A="{secret}"\nset -x\n{cmd}\nset +x\nprintf %s "$HF_TOKEN"',
+            ],
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+        assert process.stdout == secret
+        assert secret not in process.stderr
 
 
 # --- Config collection with hierarchical merging ---

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_env_vars.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_env_vars.py
@@ -268,21 +268,21 @@ class TestBuildReexportCommands:
             },
         )
         cmd = build_reexport_commands("task_a", result)
-        secret = "test-secret-value"
+        expected_value = "sample-value"
 
         process = subprocess.run(
             [
                 "bash",
                 "-c",
-                f'export HF_TOKEN_abc_TASK_A="{secret}"\nset -x\n{cmd}\nset +x\nprintf %s "$HF_TOKEN"',
+                f'export HF_TOKEN_abc_TASK_A="{expected_value}"\nset -x\n{cmd}\nset +x\nprintf %s "$HF_TOKEN"',
             ],
             text=True,
             capture_output=True,
             check=True,
         )
 
-        assert process.stdout == secret
-        assert secret not in process.stderr
+        assert process.stdout == expected_value
+        assert expected_value not in process.stderr
 
 
 # --- Config collection with hierarchical merging ---

--- a/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
+++ b/packages/nemo-evaluator-launcher/tests/unit_tests/test_slurm_executor.py
@@ -26,6 +26,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from omegaconf import OmegaConf
 
+from nemo_evaluator_launcher.api.types import RunConfig
 from nemo_evaluator_launcher.common.env_vars import SecretsEnvResult
 from nemo_evaluator_launcher.common.execdb import ExecutionDB, JobData
 from nemo_evaluator_launcher.executors.base import ExecutionState, ExecutionStatus
@@ -245,6 +246,81 @@ class TestSlurmExecutorFeatures:
         # Check that evaluation mounts are added to evaluation container
         assert "/host/eval1:/container/eval1" in script
         assert "/host/eval2:/container/eval2" in script
+
+    def test_mount_checkpoint_to_evaluation(
+        self, base_config, mock_task, mock_dependencies
+    ):
+        """Test opt-in checkpoint visibility for evaluation-side tokenizers."""
+        base_config["deployment"]["checkpoint_path"] = "/host/model"
+        base_config["deployment"]["mount_checkpoint_to_evaluation"] = True
+
+        cfg = OmegaConf.create(base_config)
+
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+            task_idx=0,
+        ).cmd
+
+        evaluation_script = script.split("# evaluation client", maxsplit=1)[1]
+        assert "/host/model:/checkpoint:ro" in evaluation_script
+
+    def test_vllm_pd_renders_one_router_topology(self, mock_task, mock_dependencies):
+        """P/D launches all roles in one srun and waits for the rank-zero router."""
+        cfg = RunConfig.from_hydra(
+            hydra_overrides=[
+                "execution=slurm/default",
+                "execution.hostname=test-slurm-host",
+                "execution.account=test-account",
+                "execution.output_dir=/test/output",
+                "deployment=vllm_pd",
+                "deployment.served_model_name=test-model",
+                "deployment.checkpoint_path=/host/model",
+                "deployment.prefill_nodes=1",
+                "deployment.decode_nodes=1",
+                "execution.num_nodes=2",
+                "execution.num_instances=1",
+                "execution.deployment.n_tasks=2",
+                "+execution.gpus_per_node=4",
+                "execution.gres=null",
+            ]
+        )
+        cfg.evaluation = {"env_vars": {}}
+        cfg.target = {"api_endpoint": {"api_key_name": None}}
+        mock_dependencies["get_task_definition_for_job"].return_value[
+            "endpoint_type"
+        ] = "chat"
+
+        script = _create_slurm_sbatch_script(
+            cfg=cfg,
+            task=mock_task,
+            eval_image="test-eval-container:latest",
+            remote_task_subdir=Path("/test/remote"),
+            invocation_id="test123",
+            job_id="test123.0",
+            task_idx=0,
+        ).cmd
+
+        deployment_script = script.split("# evaluation client", maxsplit=1)[0]
+        assert deployment_script.count("srun --mpi pmix --overlap") == 1
+        assert "#SBATCH --gpus-per-node 4" in deployment_script
+        assert "#SBATCH --gres" not in deployment_script
+        assert (
+            '--nodelist "$INSTANCE_NODELIST" --nodes 2 --ntasks 2 ' in deployment_script
+        )
+        assert "NODES_PER_INSTANCE=2" in deployment_script
+        assert "/test/remote/artifacts/vllm_pd_node_ips.txt" in deployment_script
+        assert 'printf "%s\\n" "${NODES_IPS_ARRAY[@]}"' in deployment_script
+        assert "ALL_NODE_IPS" not in deployment_script
+        assert "/test/remote/artifacts:/results" in deployment_script
+        assert 'ROLE_STATUS_DIR=""' in deployment_script
+        assert "vllm-router" in deployment_script
+        assert 'for ip in "127.0.0.1"; do' in deployment_script
+        assert "http://$ip:8000/health" in deployment_script
 
     def test_mount_home_flag_enabled(self, base_config, mock_task, mock_dependencies):
         """Test mount_home flag when enabled (default behavior)."""


### PR DESCRIPTION
## Summary

Adds experimental native `vllm_pd` support to the maintained Launcher legacy package. It starts prefill and decode roles in one Slurm instance, exposes rank-zero router readiness at the inherited port, and shares node addresses through the artifacts mount rather than a multi-value Pyxis environment.

The deployment also provides opt-in role status, logs, and runtime provenance; mounts the checkpoint into the evaluation container for tokenizer use; and prevents secret re-exports from shell xtrace.

## Companion changes

- Native EFB recipe and Gym coordinator integration: https://gitlab-master.nvidia.com/dl/JoC/competitive_evaluation/nvidia-eval-factory-benchmarking/-/merge_requests/1098
- Separate direct-EFB service runner (no Evaluator): https://gitlab-master.nvidia.com/dl/JoC/competitive_evaluation/nvidia-eval-factory-benchmarking/-/merge_requests/1131

The native EFB recipe requires this PR to release before the normal EFB runner can compose `deployment/vllm_pd`.

## OCI HSG end-to-end validation

The native 1-prefill + 8-decode route completed on OCI HSG under `nemotron_n4_post`: Launcher invocation `5fecad0a37470beb`, Slurm `6143359`, nine four-GPU nodes, `batch` / `short`, exit `0:0` in 9m54s.

- All prefill/decode MP pools initialized NIXL.
- Rank zero's router answered the inherited port-8000 readiness check.
- The pinned Gym runtime (Python 3.13.14, Ray 2.56.1) started its local services and sent one GPQA request through the router.
- The router returned `POST /v1/chat/completions` HTTP 200; `results.yml`, metrics, and one rollout record were persisted.
- The one-sample result was correct (100% / 1 sample), with 154 input and 735 output tokens, 15.1 s response latency, and `finish_reason=stop`. This validates E2E transport and integration, not GPQA quality.

The earlier 1+1 HSG smoke also completed successfully.

## Validation

- `uv run pytest -q tests/unit_tests/test_config_validation.py tests/unit_tests/test_deployment_command.py tests/unit_tests/test_slurm_executor.py` completed successfully.
- Focused P/D validation, command/lifecycle, and rendered Slurm topology tests — 25 passed.
- Companion EFB contract, manifest, and config tests — 290 passed.
- The real EFB 1+8 leaf rendered against this PR wheel with `num_nodes: 9`, `n_tasks: 9`, node-local `/tmp/vllm` cache, the 16,384-token profile, and the router-side Gym handoff.
