### PR TITLE
fix: create-gh-release input is forced to true

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -93,7 +93,7 @@ jobs:
       validate-only: ${{ github.event_name != 'workflow_dispatch' }}
       dry-run: ${{ inputs.dry-run || false }}
       version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
-      create-gh-release: ${{ inputs.create-gh-release || true }}
+      create-gh-release: ${{ (github.event_name != 'workflow_dispatch') || inputs.create-gh-release }}
       gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
       gh-release-from-tag: ${{ inputs.gh-release-from-tag || '' }}
       packaging: uv


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/release.yaml`: create-gh-release input is forced to true.

## Changes
- `.github/workflows/release.yaml`: create-gh-release input is forced to true.

## Details
```diff
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,3 @@
-      version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
-      create-gh-release: ${{ inputs.create-gh-release || true }}
-      gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
+      version-bump-branch: ${{ inputs.version-bump-branch || github.ref_name }}
+      create-gh-release: ${{ (github.event_name != 'workflow_dispatch') || inputs.create-gh-release }}
+      gh-release-use-changelog-builder: ${{ inputs.generate-changelog || false }}
```

## Tests
- `tests/test_release_yaml.py`

```diff
--- /dev/null
+++ tests/test_release_yaml.py
@@ -0,0 +1,42 @@
+import yaml
+
+
+def _eval_create_gh_release_expr(expr, event_name, create_gh_release):
+    expr = expr.strip()
+    assert expr.startswith("${{") and expr.endswith("}}")
+    body = expr[3:-3].strip()
+    body = body.replace("&&", " and ")
+    body = body.replace("||", " or ")
+    body = body.replace("github.event_name", "event_name")
+    body = body.replace("inputs.create-gh-release", "create_gh_release")
+    return eval(
+        body,
+        {"__builtins__": {}},
+        {"event_name": event_name, "create_gh_release": create_gh_release},
+    )
+
+
+def test_create_gh_release_respects_dispatch_input():
+    with open(".github/workflows/release.yaml") as f:
+        workflow = yaml.safe_load(f)
+
+    expr = workflow["jobs"]["release"]["with"]["create-gh-release"]
+
+    # Non-dispatch triggers must still default to true.
+    assert _eval_create_gh_release_expr(expr, "push", True) is True
+    assert _eval_create_gh_release_expr(expr, "push", False) is True
+
+    # On workflow_dispatch the caller's boolean must be honored.
+    assert _eval_create_gh_release_expr(expr, "workflow_dispatch", True) is True
+    assert _eval_create_gh_release_expr(expr, "workflow_dispatch", False) is False
```