### PR TITLE
fix: copyright-check-summary references undefined $SKIPPING_IS_ALLOWED

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -44,15 +44,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SKIPPING_IS_ALLOWED: ${{ needs.pre-flight.outputs.docs_only == 'true' || needs.pre-flight.outputs.is_deployment_workflow == 'true' }}
         run: |
-          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
+          FAILED_JOBS=$(gh run view "$GITHUB_RUN_ID" --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
 
-          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
+          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "${SKIPPING_IS_ALLOWED:-false}" == "true" ]; then
               echo "✅ All previous jobs completed successfully"
               exit 0
           else
               echo "❌ Found $FAILED_JOBS failed job(s)"
               # Show which jobs failed
-              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              gh run view "$GITHUB_RUN_ID" --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
               exit 1
           fi

--- a/tests/test_copyright_check_workflow.py
+++ b/tests/test_copyright_check_workflow.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def test_copyright_check_summary_has_required_env():
+    workflow = Path(".github/workflows/copyright-check.yml").read_text()
+    summary = workflow.split("copyright-check-summary:", 1)[1]
+    step = summary.split("- name: Result", 1)[1].split("run: |", 1)[0]
+
+    assert "GH_TOKEN:" in step, "Result step must export GH_TOKEN for the gh CLI"
+    assert "SKIPPING_IS_ALLOWED:" in step, "Result step must define SKIPPING_IS_ALLOWED"
+
+    run = summary.split("- name: Result", 1)[1].split("run: |", 1)[1]
+    assert (
+        "${SKIPPING_IS_ALLOWED:-false}" in run or '"$SKIPPING_IS_ALLOWED"' in run
+    ), "Script should safely reference SKIPPING_IS_ALLOWED"


### PR DESCRIPTION
This PR addresses the following issue in `.github/workflows/copyright-check.yml`: copyright-check-summary references undefined $SKIPPING_IS_ALLOWED.

## Changes
- `.github/workflows/copyright-check.yml`: copyright-check-summary references undefined $SKIPPING_IS_ALLOWED.

## Details
```diff
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -1,13 +1,16 @@
-      - name: Result
-        run: |
-          FAILED_JOBS=$(gh run view $GITHUB_RUN_ID --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
-
-          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "$SKIPPING_IS_ALLOWED" == "true" ]; then
-              echo "✅ All previous jobs completed successfully"
-              exit 0
-          else
-              echo "❌ Found $FAILED_JOBS failed job(s)"
-              # Show which jobs failed
-              gh run view $GITHUB_RUN_ID --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
-              exit 1
-          fi
+      - name: Result
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SKIPPING_IS_ALLOWED: ${{ needs.pre-flight.outputs.docs_only == 'true' || needs.pre-flight.outputs.is_deployment_workflow == 'true' }}
+        run: |
+          FAILED_JOBS=$(gh run view "$GITHUB_RUN_ID" --json jobs --jq '[.jobs[] | select(.status == "completed" and .conclusion != "success")] | length') || echo 0
+
+          if [ "${FAILED_JOBS:-0}" -eq 0 ] || [ "${SKIPPING_IS_ALLOWED:-false}" == "true" ]; then
+              echo "✅ All previous jobs completed successfully"
+              exit 0
+          else
+              echo "❌ Found $FAILED_JOBS failed job(s)"
+              # Show which jobs failed
+              gh run view "$GITHUB_RUN_ID" --json jobs --jq '.jobs[] | select(.status == "completed" and .conclusion != "success") | .name'
+              exit 1
+          fi
```

## Tests
- `tests/test_copyright_check_workflow.py`

```diff
--- /dev/null
+++ b/tests/test_copyright_check_workflow.py
@@ -0,0 +1,15 @@
+from pathlib import Path
+
+
+def test_copyright_check_summary_has_required_env():
+    workflow = Path(".github/workflows/copyright-check.yml").read_text()
+    summary = workflow.split("copyright-check-summary:", 1)[1]
+    step = summary.split("- name: Result", 1)[1].split("run: |", 1)[0]
+
+    assert "GH_TOKEN:" in step, "Result step must export GH_TOKEN for the gh CLI"
+    assert "SKIPPING_IS_ALLOWED:" in step, "Result step must define SKIPPING_IS_ALLOWED"
+
+    run = summary.split("- name: Result", 1)[1].split("run: |", 1)[1]
+    assert (
+        "${SKIPPING_IS_ALLOWED:-false}" in run or '"$SKIPPING_IS_ALLOWED"' in run
+    ), "Script should safely reference SKIPPING_IS_ALLOWED"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify the copyright-check workflow configures required environment variables.
  * Confirmed optional skip behavior is referenced safely with an appropriate default or quoting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->