### PR TITLE
fix: fail loudly instead of silently falling back to exact match in Skills env

### DIFF
--- a/src/nemo_evaluator/environments/registry.py
+++ b/src/nemo_evaluator/environments/registry.py
@@ -131,6 +131,7 @@ def _make_skills(rest: str, **kwargs: Any) -> "EvalEnvironment":
         data_dir=kwargs.get("data_dir"),
         prompt_template=kwargs.get("prompt_template"),
         eval_type=kwargs.get("eval_type"),
+        allow_exact_match_fallback=kwargs.get("allow_exact_match_fallback", False),
     )
 
 

--- a/src/nemo_evaluator/environments/skills.py
+++ b/src/nemo_evaluator/environments/skills.py
@@ -98,12 +98,28 @@ def _load_dataset(benchmark: str, split: str | None, data_dir: str | None) -> li
     return samples
 
 
+class SkillsEvaluatorError(RuntimeError):
+    """The configured NeMo Skills evaluator is unavailable or failed.
+
+    Raised instead of silently falling back to whole-response exact string
+    matching, which measures something else entirely and turns an
+    infrastructure failure into a plausible-looking score. Pass
+    ``allow_exact_match_fallback=True`` to opt in to the old behavior.
+    """
+
+
 def _get_evaluator(eval_type: str):
     try:
         from nemo_skills.evaluation.evaluator import get_evaluator_class
 
         return get_evaluator_class(eval_type, config={})
-    except (ImportError, KeyError, ValueError, TypeError):
+    except (ImportError, KeyError, ValueError, TypeError) as e:
+        logger.warning(
+            "NeMo Skills evaluator for eval_type=%r could not be constructed: %s: %s",
+            eval_type,
+            type(e).__name__,
+            e,
+        )
         return None
 
 
@@ -131,6 +147,7 @@ class SkillsEnvironment(EvalEnvironment):
         data_dir: str | None = None,
         prompt_template: str | None = None,
         eval_type: str | None = None,
+        allow_exact_match_fallback: bool = False,
     ) -> None:
         super().__init__()
         self._benchmark = benchmark
@@ -143,9 +160,31 @@ class SkillsEnvironment(EvalEnvironment):
 
         self._eval_type = eval_type or getattr(self._module, "METRICS_TYPE", "math")
         self._evaluator = _get_evaluator(self._eval_type)
+        self._allow_exact_match_fallback = allow_exact_match_fallback
         self._prompt_template = prompt_template
 
-        logger.info("Skills: %s (%d samples, eval_type=%s)", benchmark, len(self._samples), self._eval_type)
+        if self._evaluator is None and self._eval_type not in self._score_handlers:
+            if not allow_exact_match_fallback:
+                raise SkillsEvaluatorError(
+                    f"eval_type={self._eval_type!r} for benchmark {benchmark!r} requires a "
+                    "NeMo Skills evaluator, but none could be constructed (see the warning "
+                    "above for the reason). Refusing to score by exact string matching; "
+                    "pass allow_exact_match_fallback=True to opt in to that fallback."
+                )
+            logger.warning(
+                "Skills: %s will score by EXACT STRING MATCH because no evaluator is "
+                "available for eval_type=%s (allow_exact_match_fallback=True)",
+                benchmark,
+                self._eval_type,
+            )
+
+        logger.info(
+            "Skills: %s (%d samples, eval_type=%s, evaluator=%s)",
+            benchmark,
+            len(self._samples),
+            self._eval_type,
+            "constructed" if self._evaluator is not None else "none",
+        )
 
     def __len__(self) -> int:
         return len(self._samples)
@@ -212,8 +251,19 @@ class SkillsEnvironment(EvalEnvironment):
             result = self._evaluator.eval_single(sample)
             return float(result.get("is_correct", 0)), {"method": f"skills_{self._eval_type}", **result}
         except Exception as e:
-            logger.warning("Skills evaluator failed: %s", e)
-            return self._score_exact(response, expected)
+            if self._allow_exact_match_fallback:
+                logger.warning(
+                    "Skills evaluator failed (%s: %s); scoring by exact string match "
+                    "(allow_exact_match_fallback=True)",
+                    type(e).__name__,
+                    e,
+                )
+                return self._score_exact(response, expected)
+            raise SkillsEvaluatorError(
+                f"NeMo Skills evaluator for eval_type={self._eval_type!r} failed while "
+                f"scoring; refusing to rescore by exact string matching. Pass "
+                f"allow_exact_match_fallback=True to opt in to that fallback."
+            ) from e
 
     def _score_exact(self, response: str, expected: str) -> tuple[float, dict]:
         correct = response.strip().lower() == expected.strip().lower()

--- a/tests/test_environments/test_skills_evaluator_fallback.py
+++ b/tests/test_environments/test_skills_evaluator_fallback.py
@@ -99,3 +99,21 @@ class TestScoringTimeFailure:
         reward, details = env._score("anything", "anything else", {})
         assert reward == 1.0
         assert details["method"] == "skills_code"
+
+
+class TestFactoryForwarding:
+    """The skills:// factory must forward allow_exact_match_fallback."""
+
+    def _captured_kwargs(self, **factory_kwargs):
+        from nemo_evaluator.environments import registry
+
+        with patch(f"{MOD}.SkillsEnvironment") as ctor:
+            registry._make_skills("gsm8k", **factory_kwargs)
+        return ctor.call_args.kwargs
+
+    def test_default_is_false(self):
+        assert self._captured_kwargs()["allow_exact_match_fallback"] is False
+
+    def test_explicit_optin_is_forwarded(self):
+        kwargs = self._captured_kwargs(allow_exact_match_fallback=True)
+        assert kwargs["allow_exact_match_fallback"] is True

--- a/tests/test_environments/test_skills_evaluator_fallback.py
+++ b/tests/test_environments/test_skills_evaluator_fallback.py
@@ -1,0 +1,101 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SkillsEnvironment must not silently degrade to exact string matching.
+
+Regression tests for #1141: an evaluator-dependent eval_type whose evaluator
+cannot be constructed, or whose evaluator raises at scoring time, must fail
+loudly unless the exact-match fallback was explicitly opted into.
+
+No GPU, network, or nemo_skills install required: construction helpers are
+patched and scoring-time behavior is tested on a directly assembled instance.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from nemo_evaluator.environments.skills import SkillsEnvironment, SkillsEvaluatorError
+
+MOD = "nemo_evaluator.environments.skills"
+
+
+def _construct(eval_type, evaluator, **kwargs):
+    module = SimpleNamespace(METRICS_TYPE=eval_type)
+    with (
+        patch(f"{MOD}._require_skills", return_value=SimpleNamespace(get_dataset_module=lambda b: module)),
+        patch(f"{MOD}._unpack_module", return_value=(module, None)),
+        patch(f"{MOD}._load_dataset", return_value=[{"problem": "p", "expected_answer": "a"}]),
+        patch(f"{MOD}._get_evaluator", return_value=evaluator),
+    ):
+        return SkillsEnvironment(benchmark="dummy_bench", **kwargs)
+
+
+def _assembled(eval_type, evaluator, allow_fallback):
+    env = SkillsEnvironment.__new__(SkillsEnvironment)
+    env._benchmark = "dummy_bench"
+    env._eval_type = eval_type
+    env._evaluator = evaluator
+    env._allow_exact_match_fallback = allow_fallback
+    return env
+
+
+class _RaisingEvaluator:
+    def eval_single(self, sample):
+        raise ValueError("judge endpoint not configured")
+
+
+class TestConstructionGate:
+    def test_missing_evaluator_for_evaluator_eval_type_raises(self):
+        with pytest.raises(SkillsEvaluatorError, match="exact string matching"):
+            _construct("code", evaluator=None)
+
+    def test_missing_evaluator_allowed_with_optin(self):
+        env = _construct("code", evaluator=None, allow_exact_match_fallback=True)
+        reward, details = env._score("Answer", "answer", {})
+        assert reward == 1.0
+        assert details["method"] == "exact_match_fallback"
+
+    def test_handler_eval_types_do_not_require_an_evaluator(self):
+        env = _construct("multichoice", evaluator=None)
+        assert env.eval_type == "multichoice"
+
+    def test_constructed_evaluator_is_accepted(self):
+        env = _construct("code", evaluator=_RaisingEvaluator())
+        assert env._evaluator is not None
+
+
+class TestScoringTimeFailure:
+    def test_evaluator_failure_raises_without_optin(self):
+        env = _assembled("code", _RaisingEvaluator(), allow_fallback=False)
+        with pytest.raises(SkillsEvaluatorError) as excinfo:
+            env._score("def f(): return 1", "reference solution", {})
+        assert isinstance(excinfo.value.__cause__, ValueError)
+
+    def test_evaluator_failure_falls_back_with_optin(self):
+        env = _assembled("code", _RaisingEvaluator(), allow_fallback=True)
+        reward, details = env._score("def f(): return 1", "reference solution", {})
+        assert reward == 0.0
+        assert details["method"] == "exact_match_fallback"
+
+    def test_working_evaluator_unaffected(self):
+        class _Working:
+            def eval_single(self, sample):
+                return {"is_correct": True}
+
+        env = _assembled("code", _Working(), allow_fallback=False)
+        reward, details = env._score("anything", "anything else", {})
+        assert reward == 1.0
+        assert details["method"] == "skills_code"


### PR DESCRIPTION
Fixes #1141, per the Expected behavior in the issue.

Both silent-degradation paths now fail loudly by default:

- **Construction (path A):** `_get_evaluator` logs the previously swallowed exception, and `__init__` raises `SkillsEvaluatorError` when an evaluator-dependent `eval_type` (no dedicated handler) gets `None` back. The startup log line now also states whether an evaluator was constructed.
- **Scoring time (path B):** an evaluator exception raises `SkillsEvaluatorError` with the original exception chained, instead of rescoring by a different method under a warning.
- **Lenient mode is explicit opt-in:** `allow_exact_match_fallback=True` restores the old behavior, is plumbed through the `skills://` factory, logs loudly when active, and the substituted records still carry `method == "exact_match_fallback"`.

`SkillsEvaluatorError` deliberately subclasses `RuntimeError` rather than `GracefulError`/`InfraError`: both of those end in `reward=0.0`, which is exactly the indistinguishable-from-a-real-score outcome the issue is about.

Tests (`tests/test_environments/test_skills_evaluator_fallback.py`) run with no GPU, network, or nemo_skills install: construction helpers are patched for the gate tests, scoring-time behavior is tested on a directly assembled instance, and the working-evaluator path is covered to show no behavior change there. 7 pass with the fix; the construction gate and raise-on-failure cases fail on current main. Pre-existing environment-dependent failures in `test_environments_extended.py` are identical with and without this change.

Not addressed here, flagged in the issue: `predicted_answer` receives the raw unextracted response, which may itself be why some evaluators raise. That looks like a separate decision about extraction, happy to follow up if wanted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skills evaluation now reports clear errors when the configured evaluator is unavailable or fails.
  * Exact-match fallback is no longer used automatically, preventing potentially misleading evaluation results.

* **New Features**
  * Exact-match fallback can be explicitly enabled when desired.
  * Evaluator status and construction issues now provide warning details for easier diagnosis.
  * Evaluation can use configured handlers and successfully report evaluator-based scores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
