### PR TITLE
fix(interceptor): keep None content when tool_calls are present

### DIFF
--- a/src/nemo_evaluator/adapters/interceptors/endpoint.py
+++ b/src/nemo_evaluator/adapters/interceptors/endpoint.py
@@ -112,7 +112,7 @@ class Interceptor(RequestToResponseInterceptor):
     def _normalize_content(body: dict[str, Any]) -> None:
         for choice in body.get("choices", []):
             msg = choice.get("message") or choice.get("delta") or {}
-            if "content" in msg and msg["content"] is None:
+            if "content" in msg and msg["content"] is None and not msg.get("tool_calls"):
                 msg["content"] = ""
 
     @staticmethod

--- a/src/nemo_evaluator/adapters/interceptors/streaming.py
+++ b/src/nemo_evaluator/adapters/interceptors/streaming.py
@@ -29,7 +29,12 @@ def _normalize_message_content(body: dict[str, Any]) -> None:
         if not isinstance(choice, dict):
             continue
         message = choice.get("message")
-        if isinstance(message, dict) and "content" in message and message["content"] is None and not message.get("tool_calls"):
+        if (
+            isinstance(message, dict)
+            and "content" in message
+            and message["content"] is None
+            and not message.get("tool_calls")
+        ):
             message["content"] = ""
 
 

--- a/src/nemo_evaluator/adapters/interceptors/streaming.py
+++ b/src/nemo_evaluator/adapters/interceptors/streaming.py
@@ -29,7 +29,7 @@ def _normalize_message_content(body: dict[str, Any]) -> None:
         if not isinstance(choice, dict):
             continue
         message = choice.get("message")
-        if isinstance(message, dict) and "content" in message and message["content"] is None:
+        if isinstance(message, dict) and "content" in message and message["content"] is None and not message.get("tool_calls"):
             message["content"] = ""
 
 


### PR DESCRIPTION
**Bug:** `EndpointInterceptor` rewrites `content: null` → "" on tool-call turns, which breaks multi-turn tool-use benchmarks

**File:** `src/nemo_evaluator/adapters/interceptors/endpoint.py`  and `nemo_evaluator/adapters/interceptors/endpoint_interceptor.py`— the response-path block commented `# replace choices[xx].message.content=None with empty string`. (Observed in `nvcr.io/nvidia/eval-factory/tau2-bench:26.03` at `/opt/venv/lib/python3.12/site-packages/nemo_evaluator/adapters/interceptors/endpoint_interceptor.py`)
**What it does today** — unconditionally, for every choice:

```
if (
    "message" in choice
    and "content" in choice["message"]
    and choice["message"]["content"] is None
):
    self.logger.warning(f"choices[{i}].message.content is None, replacing with empty string")
    choice["message"]["content"] = ""
```

**Why it's a problem.** When a model returns a pure tool call, `content: null` + populated `tool_calls` is the correct OpenAI shape. `null` and `""` are not interchangeable there: `null` means "no text this turn", `""` is an empty text message. The interceptor runs on the response path, but multi-turn agentic harnesses replay assistant messages back into the request history — so the rewrite silently corrupts every subsequent request in the conversation. Servers that validate `content` strictly then reject the harness's own replayed history.
**Concrete failure.** `tau2_bench.tau2_bench_telecom` against a NIM serving `Qwen/Qwen3.6-35B-A3B (nvcr.io/nvstaging/nim/qwen-3.6-35b-a3b:0.2.1-spark`, profile `271fe945…`, vllm-gb10-nvfp4_fast-tp1-mtp):

• `termination_summary.json`: 333 of 342 simulations ended in `agent_error`.
• `eval_factory_metrics.json` → `status_codes: {"200": 254, "400": 10323}`.
• every 400: `litellm.BadRequestError: OpenAIException - request: Value error, Empty content is not allowed for assistant messages`.
• the count of `choices[0].message.content is None, replacing with empty string` in `client_stdout.log` (196) matches `tool_calls_count` (196) exactly.
• reported score 0.0029 — and because `skip_failed_samples: true` swallows the failures, it is emitted as a normal result rather than an error. That is the worst part: a broken run looks like a real accuracy number..
Reproduced identically on GB300 and on DGX Spark GB10, so it isn't environment-specific.
The server accepts `null` and rejects `""` — two curls, decisive:

```
for C in '""' 'null'; do echo -n "content=$C -> "; curl -s -o /dev/null -w '%{http_code}\n' localhost:8888/v1/chat/completions -H 'Content-Type: application/json' -d "{\"model\":\"Qwen/Qwen3.6-35B-A3B\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"},{\"role\":\"assistant\",\"content\":$C,\"tool_calls\":[{\"id\":\"c1\",\"type\":\"function\",\"function\":{\"name\":\"f\",\"arguments\":\"{}\"}}]},{\"role\":\"tool\",\"tool_call_id\":\"c1\",\"content\":\"ok\"}],\"max_tokens\":8}"; done
```


```
content=""   -> 400
content=null -> 200
```

The 400 comes back in ~4 ms (pre-prefill input validation); the 200 has to queue for real generation.
**Fix — one condition.** Keep the rewrite for genuine text turns, skip it when the message carries tool calls:

```
if (
    "message" in choice
    and "content" in choice["message"]
    and choice["message"]["content"] is None
    and not choice["message"].get("tool_calls")     # <-- add
):
```

**Verified.** We rebuilt `tau2-bench:26.03` locally with exactly this one-line change and re-ran the identical config: tau2 went from 0.0029 to 0.655, zero 400s, 1.85 h wall clock. For reference, the same model scored 0.5789 / 0.5848 on H200 in earlier runs, so 0.655 is a plausible real number — the rewrite was the only defect.
**Blast radius.** Single-turn benchmarks are unaffected: LiveCodeBench logs the same rewrite but never replays history, so it never sends the mutated message back. This only bites multi-turn tool-use benchmarks (tau2-bench, and presumably anything else that reconstructs conversation history), which is probably why it went unnoticed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved missing message content for tool-call messages while continuing to normalize content-less messages appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->