### PR TITLE
fix(adapters): include full request body in cache keys

### DIFF
--- a/src/nemo_evaluator/adapters/cache/disk_cache.py
+++ b/src/nemo_evaluator/adapters/cache/disk_cache.py
@@ -67,7 +67,7 @@ class DiskCache:
     def cache_key(
         body: dict[str, Any],
         *,
-        request_path: str = "",
+        request_path: str,
         session_prefix: str = "",
     ) -> str:
         # Retain the complete incoming request body so new provider parameters

--- a/src/nemo_evaluator/adapters/cache/disk_cache.py
+++ b/src/nemo_evaluator/adapters/cache/disk_cache.py
@@ -26,7 +26,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-_RELEVANT_KEYS = ("model", "messages", "tools", "temperature", "max_tokens", "top_p", "seed")
+_CACHE_KEY_VERSION = 2
 
 _SCHEMA = """
 CREATE TABLE IF NOT EXISTS cache_v1 (
@@ -64,13 +64,19 @@ class DiskCache:
             logger.warning("Failed to initialize cache DB at %s", self._db_path, exc_info=True)
 
     @staticmethod
-    def cache_key(body: dict[str, Any], *, session_prefix: str = "") -> str:
-        canonical: dict[str, Any] = {}
-        for k in _RELEVANT_KEYS:
-            if k in body:
-                canonical[k] = body[k]
-        if "extra_body" in body and isinstance(body["extra_body"], dict):
-            canonical["extra_body"] = body["extra_body"]
+    def cache_key(
+        body: dict[str, Any],
+        *,
+        request_path: str = "",
+        session_prefix: str = "",
+    ) -> str:
+        # Retain the complete incoming request body so new provider parameters
+        # cannot silently alias an older request.
+        canonical = {
+            "version": _CACHE_KEY_VERSION,
+            "path": request_path,
+            "body": body,
+        }
         raw = json.dumps(canonical, sort_keys=True, ensure_ascii=False)
         if session_prefix:
             raw = session_prefix + "|" + raw

--- a/src/nemo_evaluator/adapters/interceptors/caching.py
+++ b/src/nemo_evaluator/adapters/interceptors/caching.py
@@ -41,7 +41,11 @@ class Interceptor(RequestToResponseInterceptor, ResponseInterceptor):
         if self._bypass:
             return req
         session_prefix = req.ctx.extra.get("session_id", "")
-        key = DiskCache.cache_key(req.body, session_prefix=session_prefix)
+        key = DiskCache.cache_key(
+            req.body,
+            request_path=req.path,
+            session_prefix=session_prefix,
+        )
         hit = await self._cache.get(key)
         if hit is not None:
             logger.debug("cache hit key=%s", key[:16])

--- a/tests/test_adapters/test_cache_keys.py
+++ b/tests/test_adapters/test_cache_keys.py
@@ -12,7 +12,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pytest
+
 from nemo_evaluator.adapters.cache.disk_cache import DiskCache
+from nemo_evaluator.adapters.interceptors.caching import Interceptor
+from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
 
 
 def _compute_key(body):
@@ -23,7 +27,7 @@ def test_golden_key_simple():
     body = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "temperature": 0.7}
     key = _compute_key(body)
     assert key == _compute_key(body)
-    assert key == "92232807c9b5c0bab68fd1abb38bc83c884fb04b0eb9b8b453c19daead7d682f"
+    assert key == "47b19779cd5d48c963c4e1d3c4a2a0266d3b3f99efb770950de1f9f71b80af13"
 
 
 def test_golden_key_with_tools():
@@ -34,19 +38,57 @@ def test_golden_key_with_tools():
     }
     key = _compute_key(body)
     assert key == _compute_key(body)
-    assert key == "ce43d524c627c96eaadbb9abdac38ad5eb60a93d15b1d26880fa1fe0f86d4c68"
+    assert key == "211169e5d6fd15019805b70d9369f704c3f103c2f603be4e7288e6f2c9f32100"
 
 
-def test_key_ignores_irrelevant_fields():
+def test_key_changes_with_stream_mode():
     base = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
     with_stream = {**base, "stream": True}
-    assert _compute_key(base) == _compute_key(with_stream)
+    assert _compute_key(base) != _compute_key(with_stream)
 
 
 def test_key_changes_with_temperature():
     body_a = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "temperature": 0.7}
     body_b = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "temperature": 0.9}
     assert _compute_key(body_a) != _compute_key(body_b)
+
+
+@pytest.mark.parametrize(
+    ("field", "value_a", "value_b"),
+    [
+        ("stop", ["END"], ["STOP"]),
+        ("response_format", {"type": "json_object"}, {"type": "text"}),
+        ("tool_choice", "auto", "none"),
+        ("parallel_tool_calls", True, False),
+        ("frequency_penalty", 0.0, 1.0),
+        ("presence_penalty", 0.0, 1.0),
+        ("logprobs", True, False),
+    ],
+)
+def test_key_changes_with_response_affecting_fields(field, value_a, value_b):
+    base = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
+    assert _compute_key({**base, field: value_a}) != _compute_key({**base, field: value_b})
+
+
+def test_key_changes_with_request_path():
+    body = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
+    chat_key = DiskCache.cache_key(body, request_path="/v1/chat/completions")
+    responses_key = DiskCache.cache_key(body, request_path="/v1/responses")
+    assert chat_key != responses_key
+
+
+def test_key_is_stable_across_mapping_order():
+    body_a = {
+        "model": "gpt-4",
+        "messages": [{"role": "user", "content": "hello"}],
+        "response_format": {"type": "json_schema", "json_schema": {"name": "answer"}},
+    }
+    body_b = {
+        "response_format": {"json_schema": {"name": "answer"}, "type": "json_schema"},
+        "messages": [{"content": "hello", "role": "user"}],
+        "model": "gpt-4",
+    }
+    assert _compute_key(body_a) == _compute_key(body_b)
 
 
 def test_key_differs_with_session_prefix():
@@ -58,3 +100,66 @@ def test_key_differs_with_session_prefix():
     assert k_none != k_a
     assert k_a != k_b
     assert k_none == DiskCache.cache_key(body, session_prefix="")
+
+
+async def test_response_affecting_field_does_not_reuse_cached_response(tmp_path):
+    interceptor = Interceptor(cache_dir=str(tmp_path))
+    base = {"model": "test", "messages": [{"role": "user", "content": "cached"}]}
+    json_request = AdapterRequest(
+        method="POST",
+        path="/chat/completions",
+        headers={},
+        body={**base, "response_format": {"type": "json_object"}},
+        ctx=InterceptorContext(),
+    )
+    assert isinstance(await interceptor.intercept_request(json_request), AdapterRequest)
+    await interceptor.intercept_response(
+        AdapterResponse(
+            status_code=200,
+            headers={},
+            body={"choices": [{"message": {"content": "{}"}}]},
+            ctx=json_request.ctx,
+        )
+    )
+
+    text_request = AdapterRequest(
+        method="POST",
+        path="/chat/completions",
+        headers={},
+        body={**base, "response_format": {"type": "text"}},
+        ctx=InterceptorContext(),
+    )
+    assert isinstance(await interceptor.intercept_request(text_request), AdapterRequest)
+
+
+async def test_stream_request_does_not_reuse_non_stream_response(tmp_path):
+    interceptor = Interceptor(cache_dir=str(tmp_path))
+    base = {"model": "test", "messages": [{"role": "user", "content": "cached"}]}
+    non_stream_request = AdapterRequest(
+        method="POST",
+        path="/chat/completions",
+        headers={},
+        body={**base, "stream": False},
+        ctx=InterceptorContext(),
+    )
+    assert isinstance(await interceptor.intercept_request(non_stream_request), AdapterRequest)
+    await interceptor.intercept_response(
+        AdapterResponse(
+            status_code=200,
+            headers={"content-type": "application/json"},
+            body={"choices": [{"message": {"content": "cached response"}}]},
+            ctx=non_stream_request.ctx,
+        )
+    )
+
+    stream_request = AdapterRequest(
+        method="POST",
+        path="/chat/completions",
+        headers={},
+        body={**base, "stream": True},
+        ctx=InterceptorContext(),
+    )
+    result = await interceptor.intercept_request(stream_request)
+
+    assert isinstance(result, AdapterRequest)
+    assert not stream_request.ctx.extra.get("cache_hit")

--- a/tests/test_adapters/test_cache_keys.py
+++ b/tests/test_adapters/test_cache_keys.py
@@ -18,16 +18,18 @@ from nemo_evaluator.adapters.cache.disk_cache import DiskCache
 from nemo_evaluator.adapters.interceptors.caching import Interceptor
 from nemo_evaluator.adapters.types import AdapterRequest, AdapterResponse, InterceptorContext
 
+_REQUEST_PATH = "/chat/completions"
+
 
 def _compute_key(body):
-    return DiskCache.cache_key(body)
+    return DiskCache.cache_key(body, request_path=_REQUEST_PATH)
 
 
 def test_golden_key_simple():
     body = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}], "temperature": 0.7}
     key = _compute_key(body)
     assert key == _compute_key(body)
-    assert key == "47b19779cd5d48c963c4e1d3c4a2a0266d3b3f99efb770950de1f9f71b80af13"
+    assert key == "a645af96c78b89c2ff7ecacf9766427df863e5bcc7a6422a57c2d3d790244200"
 
 
 def test_golden_key_with_tools():
@@ -38,7 +40,7 @@ def test_golden_key_with_tools():
     }
     key = _compute_key(body)
     assert key == _compute_key(body)
-    assert key == "211169e5d6fd15019805b70d9369f704c3f103c2f603be4e7288e6f2c9f32100"
+    assert key == "53411c91ed09778aca705d15f5f85372812fe755a0e033dcae49676d9996a5be"
 
 
 def test_key_changes_with_stream_mode():
@@ -94,12 +96,12 @@ def test_key_is_stable_across_mapping_order():
 def test_key_differs_with_session_prefix():
     """Session prefix ensures repeats of the same problem never share cache entries."""
     body = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
-    k_none = DiskCache.cache_key(body)
-    k_a = DiskCache.cache_key(body, session_prefix="repeat-0")
-    k_b = DiskCache.cache_key(body, session_prefix="repeat-1")
+    k_none = DiskCache.cache_key(body, request_path=_REQUEST_PATH)
+    k_a = DiskCache.cache_key(body, request_path=_REQUEST_PATH, session_prefix="repeat-0")
+    k_b = DiskCache.cache_key(body, request_path=_REQUEST_PATH, session_prefix="repeat-1")
     assert k_none != k_a
     assert k_a != k_b
-    assert k_none == DiskCache.cache_key(body, session_prefix="")
+    assert k_none == DiskCache.cache_key(body, request_path=_REQUEST_PATH, session_prefix="")
 
 
 async def test_response_affecting_field_does_not_reuse_cached_response(tmp_path):

--- a/tests/test_adapters/test_disk_cache.py
+++ b/tests/test_adapters/test_disk_cache.py
@@ -18,6 +18,8 @@ import pytest
 
 from nemo_evaluator.adapters.cache.disk_cache import DiskCache
 
+_REQUEST_PATH = "/chat/completions"
+
 
 @pytest.fixture
 def cache(tmp_path):
@@ -26,17 +28,21 @@ def cache(tmp_path):
 
 def test_cache_key_deterministic():
     body = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
-    assert DiskCache.cache_key(body) == DiskCache.cache_key(body)
+    assert DiskCache.cache_key(body, request_path=_REQUEST_PATH) == DiskCache.cache_key(
+        body, request_path=_REQUEST_PATH
+    )
 
 
 def test_cache_key_varies_with_model():
     base = {"model": "gpt-4", "messages": [{"role": "user", "content": "hello"}]}
     other = {**base, "model": "gpt-3.5-turbo"}
-    assert DiskCache.cache_key(base) != DiskCache.cache_key(other)
+    assert DiskCache.cache_key(base, request_path=_REQUEST_PATH) != DiskCache.cache_key(
+        other, request_path=_REQUEST_PATH
+    )
 
 
 async def test_get_set_roundtrip(cache):
-    key = DiskCache.cache_key({"model": "x", "messages": []})
+    key = DiskCache.cache_key({"model": "x", "messages": []}, request_path=_REQUEST_PATH)
     value = {"choices": [{"message": {"content": "hi"}}]}
     await cache.set(key, value)
     result = await cache.get(key)


### PR DESCRIPTION
## Summary

The adapter cache currently hashes a fixed allowlist of request fields. Requests that differ in output-affecting options such as `response_format`, `tool_choice`, `stop`, or log-probability settings can therefore share a key and reuse the wrong response.

This change versions the canonical key payload and includes the request path plus the complete incoming JSON body, including `stream`. Session prefixes keep their existing behavior. Existing cache rows naturally become misses, so no schema migration is needed.

## Testing

- Added coverage for response-affecting fields, stream-mode isolation, request-path isolation, mapping-order stability, and session prefixes.
- Added end-to-end interceptor regressions for requests that differ only by `response_format` or `stream`.
- Ran the full offline Linux suite, focused Ruff checks, and formatting checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved response caching accuracy by distinguishing requests with different paths, complete request content, response settings, and streaming modes.
  - Prevented incompatible cached responses from being reused across otherwise similar requests.
  - Ensured equivalent requests continue to produce consistent cache results regardless of field ordering.

- **Tests**
  - Added coverage for request variations, cache-key stability, and streaming/non-streaming response separation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->