### PR TITLE
fix(gate): stop counting infra-errored samples as wrong answers

### DIFF
--- a/docs/tutorials/quality-gate.mdx
+++ b/docs/tutorials/quality-gate.mdx
@@ -148,6 +148,7 @@ benchmarks:
 - **`max_drop`**: Maximum tolerated absolute regression on the 0-1 scale.  `0.01` = 1 percentage point.
 - **`max_relative_drop`**: Optional relative guardrail.  `0.02` = 2%.  Only meaningful for low-baseline benchmarks where a small absolute drop is a large relative change.
 - **`relative_guard_below`**: The relative guardrail only activates when the baseline score is below this value.  At 80% accuracy, a 1 pp drop is a 1.25% relative change (harmless).  At 10% accuracy, a 1 pp drop is a 10% relative change (significant).
+- **`excluded_error_categories`**: Samples whose `scoring_details.error_category` is one of these are left out of paired gating, because their `0.0` came from the infrastructure (a sandbox outage, a system error that exhausted its retries) rather than from the model.  Defaults to `["infra_error", "system"]`; set `[]` to gate on every sample.  The gate report records how many samples were excluded per run.
 
 **Benchmarks not listed in the policy** inherit the defaults.  If the gate discovers an eval bundle for an unlisted benchmark, it applies the default tier and threshold.  If you want to require specific benchmarks, list them explicitly -- the gate will report MISSING for any listed benchmark not found in the results.
 

--- a/src/nemo_evaluator/config/gate_policy.py
+++ b/src/nemo_evaluator/config/gate_policy.py
@@ -51,6 +51,10 @@ class BenchmarkGateDefaults(BaseModel):
     relative_guard_below: float | None = None
     metric: str | None = None
     direction: Direction = Direction.higher_is_better
+    # ``scoring_details.error_category`` values that mean the infrastructure
+    # failed rather than the model.  Samples tagged with one of these are left
+    # out of paired gating.  Set to ``[]`` to gate on every sample.
+    excluded_error_categories: list[str] = Field(default_factory=lambda: ["infra_error", "system"])
 
     @field_validator("max_drop")
     @classmethod
@@ -85,6 +89,7 @@ class BenchmarkGateEntry(BaseModel):
     relative_guard_below: float | None = Field(default=None)
     metric: str | None = None
     direction: Direction | None = None
+    excluded_error_categories: list[str] | None = None
 
     @field_validator("max_drop")
     @classmethod
@@ -119,6 +124,7 @@ class ResolvedBenchmarkPolicy(BaseModel):
     relative_guard_below: float | None
     metric: str | None
     direction: Direction
+    excluded_error_categories: list[str]
 
 
 class GatePolicy(BaseModel):
@@ -149,6 +155,7 @@ class GatePolicy(BaseModel):
                 relative_guard_below=d.relative_guard_below,
                 metric=d.metric,
                 direction=d.direction,
+                excluded_error_categories=list(d.excluded_error_categories),
             )
         return ResolvedBenchmarkPolicy(
             tier=entry.tier if entry.tier is not None else d.tier,
@@ -159,6 +166,11 @@ class GatePolicy(BaseModel):
             ),
             metric=entry.metric if entry.metric is not None else d.metric,
             direction=entry.direction if entry.direction is not None else d.direction,
+            excluded_error_categories=list(
+                entry.excluded_error_categories
+                if entry.excluded_error_categories is not None
+                else d.excluded_error_categories
+            ),
         )
 
     def required_benchmarks(self) -> set[str]:

--- a/src/nemo_evaluator/engine/gate.py
+++ b/src/nemo_evaluator/engine/gate.py
@@ -31,6 +31,7 @@ import json
 import logging
 import math
 from collections import defaultdict
+from collections.abc import Collection
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any
@@ -62,17 +63,20 @@ _SUPPORTED_GATED_METRICS = frozenset({"mean_reward", "pass@1"})
 # records with ``scoring_details.error_category`` so they can be told apart
 # from a wrong answer.  Nothing downstream read that tag, so a sandbox outage in
 # the candidate run looked to the gate like a batch of wrong answers and could
-# turn a GO into a NO-GO.  These categories are excluded from paired gating;
-# model-attributable failures (graceful errors, solve timeouts) still count.
-_INFRA_ERROR_CATEGORIES = frozenset({"infra_error", "system"})
+# turn a GO into a NO-GO.  Which categories are excluded from paired gating is
+# set per benchmark by ``excluded_error_categories`` in the gate policy YAML
+# (default: ``infra_error`` and ``system``); model-attributable failures such as
+# graceful errors and solve timeouts still count.
 
 
-def _is_infra_errored(record: dict[str, Any]) -> bool:
+def _is_infra_errored(record: dict[str, Any], excluded_categories: Collection[str]) -> bool:
     """True when the record's 0.0 came from infrastructure, not the model."""
+    if not excluded_categories:
+        return False
     details = record.get("scoring_details")
     if not isinstance(details, dict):
         return False
-    return details.get("error_category") in _INFRA_ERROR_CATEGORIES
+    return details.get("error_category") in excluded_categories
 
 
 # ── Dataclasses ───────────────────────────────────────────────────────
@@ -253,15 +257,16 @@ def _evaluate_benchmark(
 
     metric = policy.metric or _select_metric(reg_report)
     result.metric = metric
-    result.n_infra_excluded_baseline = sum(1 for r in base_records.values() if _is_infra_errored(r))
-    result.n_infra_excluded_candidate = sum(1 for r in cand_records.values() if _is_infra_errored(r))
+    excluded = frozenset(policy.excluded_error_categories)
+    result.n_infra_excluded_baseline = sum(1 for r in base_records.values() if _is_infra_errored(r, excluded))
+    result.n_infra_excluded_candidate = sum(1 for r in cand_records.values() if _is_infra_errored(r, excluded))
     if result.n_infra_excluded_baseline or result.n_infra_excluded_candidate:
         result.reasons.append(
             "Excluded infra-errored samples from pairing: "
             f"{result.n_infra_excluded_baseline} baseline, {result.n_infra_excluded_candidate} candidate"
         )
-    base_values = _metric_problem_values(base_records, metric)
-    cand_values = _metric_problem_values(cand_records, metric)
+    base_values = _metric_problem_values(base_records, metric, excluded)
+    cand_values = _metric_problem_values(cand_records, metric, excluded)
     if base_values is None or cand_values is None:
         result.status = "INSUFFICIENT_EVIDENCE"
         result.reasons.append(f"Metric {metric!r} is not supported for paired gating")
@@ -274,6 +279,14 @@ def _evaluate_benchmark(
     if result.n_paired < _MIN_PAIRED_ITEMS:
         result.status = "INSUFFICIENT_EVIDENCE"
         result.reasons.append(f"Only {result.n_paired} paired items (minimum {_MIN_PAIRED_ITEMS})")
+        if result.n_infra_excluded_baseline or result.n_infra_excluded_candidate:
+            # The bundle-level scores and CIs were computed over every sample,
+            # including the ones just excluded, so falling back to them would
+            # reintroduce the infra 0.0s the exclusion removed.
+            result.reasons.append(
+                "Bundle-level scores not used as fallback: they include the excluded infra-errored samples"
+            )
+            return result
         _populate_from_bundle_scores(result, base_path, cand_path, reg_report, policy)
         return result
 
@@ -361,11 +374,16 @@ def _extract_clusters(
 def _metric_problem_values(
     records: dict[tuple[int, int], dict[str, Any]],
     metric: str,
+    excluded_categories: Collection[str] = (),
 ) -> dict[int, float] | None:
-    """Return per-problem values for a supported gated metric."""
+    """Return per-problem values for a supported gated metric.
+
+    Records whose ``scoring_details.error_category`` is in ``excluded_categories``
+    are left out before per-problem aggregation.
+    """
     by_problem: dict[int, list[dict[str, Any]]] = defaultdict(list)
     for (pid, _repeat), record in records.items():
-        if _is_infra_errored(record):
+        if _is_infra_errored(record, excluded_categories):
             continue
         by_problem[pid].append(record)
 

--- a/src/nemo_evaluator/engine/gate.py
+++ b/src/nemo_evaluator/engine/gate.py
@@ -57,6 +57,23 @@ _MIN_PAIRED_ITEMS = 10
 _GATE_REPORT_VERSION = 1
 _SUPPORTED_GATED_METRICS = frozenset({"mean_reward", "pass@1"})
 
+# The eval loop scores a sample 0.0 when the *infrastructure* failed, not the
+# model: sandbox or system errors that exhausted their retries.  It tags those
+# records with ``scoring_details.error_category`` so they can be told apart
+# from a wrong answer.  Nothing downstream read that tag, so a sandbox outage in
+# the candidate run looked to the gate like a batch of wrong answers and could
+# turn a GO into a NO-GO.  These categories are excluded from paired gating;
+# model-attributable failures (graceful errors, solve timeouts) still count.
+_INFRA_ERROR_CATEGORIES = frozenset({"infra_error", "system"})
+
+
+def _is_infra_errored(record: dict[str, Any]) -> bool:
+    """True when the record's 0.0 came from infrastructure, not the model."""
+    details = record.get("scoring_details")
+    if not isinstance(details, dict):
+        return False
+    return details.get("error_category") in _INFRA_ERROR_CATEGORIES
+
 
 # ── Dataclasses ───────────────────────────────────────────────────────
 
@@ -76,6 +93,8 @@ class BenchmarkGateResult:
     delta_ci_lower: float | None = None
     delta_ci_upper: float | None = None
     n_paired: int = 0
+    n_infra_excluded_baseline: int = 0
+    n_infra_excluded_candidate: int = 0
     max_drop_threshold: float = 0.0
     max_relative_drop_threshold: float | None = None
     direction: str = "higher_is_better"
@@ -234,7 +253,13 @@ def _evaluate_benchmark(
 
     metric = policy.metric or _select_metric(reg_report)
     result.metric = metric
-
+    result.n_infra_excluded_baseline = sum(1 for r in base_records.values() if _is_infra_errored(r))
+    result.n_infra_excluded_candidate = sum(1 for r in cand_records.values() if _is_infra_errored(r))
+    if result.n_infra_excluded_baseline or result.n_infra_excluded_candidate:
+        result.reasons.append(
+            "Excluded infra-errored samples from pairing: "
+            f"{result.n_infra_excluded_baseline} baseline, {result.n_infra_excluded_candidate} candidate"
+        )
     base_values = _metric_problem_values(base_records, metric)
     cand_values = _metric_problem_values(cand_records, metric)
     if base_values is None or cand_values is None:
@@ -340,6 +365,8 @@ def _metric_problem_values(
     """Return per-problem values for a supported gated metric."""
     by_problem: dict[int, list[dict[str, Any]]] = defaultdict(list)
     for (pid, _repeat), record in records.items():
+        if _is_infra_errored(record):
+            continue
         by_problem[pid].append(record)
 
     values: dict[int, float] = {}

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -490,24 +490,30 @@ class TestGateVerdicts:
 
     # ── TestPairedDeltaCI ─────────────────────────────────────────────────
 
-    def test_infra_errored_candidate_samples_are_excluded(self, tmp_path):
-        """A sandbox outage in the candidate run is not a regression.
-
-        The eval loop scores an exhausted infra error 0.0 and tags it
-        ``error_category: infra_error``.  Six such samples out of twenty
-        used to read as six wrong answers and turn a clean run into NO-GO.
-        """
-        base = _simple_records(20, 1.0)
-        cand = _simple_records(14, 1.0) + [
+    @staticmethod
+    def _errored_records(start, stop, category, error="sandbox unreachable"):
+        return [
             {
                 "problem_idx": i,
                 "repeat": 0,
                 "reward": 0.0,
                 "expected_answer": "ans",
-                "scoring_details": {"error": "sandbox unreachable", "error_category": "infra_error"},
+                "scoring_details": {"error": error, "error_category": category},
             }
-            for i in range(14, 20)
+            for i in range(start, stop)
         ]
+
+    @pytest.mark.parametrize("category", ["infra_error", "system"])
+    def test_infra_errored_candidate_samples_are_excluded(self, tmp_path, category):
+        """A sandbox outage in the candidate run is not a regression.
+
+        The eval loop scores an exhausted infra error 0.0 and tags it
+        ``error_category: infra_error`` (or ``system``).  Six such samples out
+        of twenty used to read as six wrong answers and turn a clean run into
+        NO-GO.
+        """
+        base = _simple_records(20, 1.0)
+        cand = _simple_records(14, 1.0) + self._errored_records(14, 20, category)
         base_dir, cand_dir = _make_gate_dirs(
             tmp_path,
             {"mmlu": (base, cand, _scores(1.0), _scores(0.7))},
@@ -525,16 +531,7 @@ class TestGateVerdicts:
     def test_model_attributable_failures_still_count(self, tmp_path):
         """Negative control: a solve timeout is the model's failure and stays a 0.0."""
         base = _simple_records(20, 1.0)
-        cand = _simple_records(14, 1.0) + [
-            {
-                "problem_idx": i,
-                "repeat": 0,
-                "reward": 0.0,
-                "expected_answer": "ans",
-                "scoring_details": {"error": "timed out", "error_category": "solve_timeout"},
-            }
-            for i in range(14, 20)
-        ]
+        cand = _simple_records(14, 1.0) + self._errored_records(14, 20, "solve_timeout", error="timed out")
         base_dir, cand_dir = _make_gate_dirs(
             tmp_path,
             {"mmlu": (base, cand, _scores(1.0), _scores(0.7))},
@@ -545,6 +542,47 @@ class TestGateVerdicts:
         assert report.verdict == "NO-GO"
         assert bench.n_paired == 20
         assert bench.n_infra_excluded_candidate == 0
+
+    def test_excluded_error_categories_is_policy_controlled(self, tmp_path):
+        """An empty ``excluded_error_categories`` gates on every sample, infra errors included."""
+        base = _simple_records(20, 1.0)
+        cand = _simple_records(14, 1.0) + self._errored_records(14, 20, "infra_error")
+        base_dir, cand_dir = _make_gate_dirs(
+            tmp_path,
+            {"mmlu": (base, cand, _scores(1.0), _scores(0.7))},
+        )
+        policy = self._policy(benchmarks={"mmlu": {"excluded_error_categories": []}})
+        report = gate_runs(base_dir, cand_dir, policy)
+        bench = report.benchmarks[0]
+        assert report.verdict == "NO-GO"
+        assert bench.n_paired == 20
+        assert bench.n_infra_excluded_candidate == 0
+
+    def test_infra_exclusion_does_not_fall_back_to_bundle_scores(self, tmp_path):
+        """Too few pairs after exclusion must not BREACH on the bundle-level CI.
+
+        The bundle scores were computed over every sample, including the
+        infra-errored ones, so using them as fallback evidence would bring the
+        excluded 0.0s straight back.
+        """
+        base = _simple_records(20, 1.0)
+        cand = _simple_records(5, 1.0) + self._errored_records(5, 20, "infra_error")
+        # Bundle CIs that would BREACH on their own: candidate 0.25 vs baseline 1.0.
+        base_scores = {"mean_reward": _score_entry(1.0, 0.95, 1.0)}
+        cand_scores = {"mean_reward": _score_entry(0.25, 0.15, 0.35)}
+        base_dir, cand_dir = _make_gate_dirs(
+            tmp_path,
+            {"mmlu": (base, cand, base_scores, cand_scores)},
+        )
+        policy = self._policy(benchmarks={"mmlu": {}})
+        report = gate_runs(base_dir, cand_dir, policy)
+        bench = report.benchmarks[0]
+        assert bench.status == "INSUFFICIENT_EVIDENCE"
+        assert report.verdict == "INCONCLUSIVE"
+        assert bench.n_paired == 5
+        assert bench.n_infra_excluded_candidate == 15
+        assert bench.candidate_score is None
+        assert any("not used as fallback" in r for r in bench.reasons)
 
 
 class TestPairedDeltaCI:

--- a/tests/test_gate.py
+++ b/tests/test_gate.py
@@ -488,8 +488,63 @@ class TestGateVerdicts:
         with pytest.raises(ValueError, match="explicit metric"):
             gate_runs(base_dir, cand_dir, policy)
 
+    # ── TestPairedDeltaCI ─────────────────────────────────────────────────
 
-# ── TestPairedDeltaCI ─────────────────────────────────────────────────
+    def test_infra_errored_candidate_samples_are_excluded(self, tmp_path):
+        """A sandbox outage in the candidate run is not a regression.
+
+        The eval loop scores an exhausted infra error 0.0 and tags it
+        ``error_category: infra_error``.  Six such samples out of twenty
+        used to read as six wrong answers and turn a clean run into NO-GO.
+        """
+        base = _simple_records(20, 1.0)
+        cand = _simple_records(14, 1.0) + [
+            {
+                "problem_idx": i,
+                "repeat": 0,
+                "reward": 0.0,
+                "expected_answer": "ans",
+                "scoring_details": {"error": "sandbox unreachable", "error_category": "infra_error"},
+            }
+            for i in range(14, 20)
+        ]
+        base_dir, cand_dir = _make_gate_dirs(
+            tmp_path,
+            {"mmlu": (base, cand, _scores(1.0), _scores(0.7))},
+        )
+        policy = self._policy(benchmarks={"mmlu": {}})
+        report = gate_runs(base_dir, cand_dir, policy)
+        bench = report.benchmarks[0]
+        assert report.verdict == "GO"
+        assert bench.status == "PASS"
+        assert bench.n_paired == 14
+        assert bench.n_infra_excluded_candidate == 6
+        assert bench.n_infra_excluded_baseline == 0
+        assert any("infra-errored" in r for r in bench.reasons)
+
+    def test_model_attributable_failures_still_count(self, tmp_path):
+        """Negative control: a solve timeout is the model's failure and stays a 0.0."""
+        base = _simple_records(20, 1.0)
+        cand = _simple_records(14, 1.0) + [
+            {
+                "problem_idx": i,
+                "repeat": 0,
+                "reward": 0.0,
+                "expected_answer": "ans",
+                "scoring_details": {"error": "timed out", "error_category": "solve_timeout"},
+            }
+            for i in range(14, 20)
+        ]
+        base_dir, cand_dir = _make_gate_dirs(
+            tmp_path,
+            {"mmlu": (base, cand, _scores(1.0), _scores(0.7))},
+        )
+        policy = self._policy(benchmarks={"mmlu": {}})
+        report = gate_runs(base_dir, cand_dir, policy)
+        bench = report.benchmarks[0]
+        assert report.verdict == "NO-GO"
+        assert bench.n_paired == 20
+        assert bench.n_infra_excluded_candidate == 0
 
 
 class TestPairedDeltaCI:


### PR DESCRIPTION
## What was wrong

The eval loop scores a sample `0.0` when a sandbox or system error exhausts its retries, and tags the record with `scoring_details.error_category` (`infra_error`, `system`) so it can be told apart from a wrong answer. Nothing downstream reads that tag. `gate.py` pairs those records like any other, so a sandbox outage on part of the candidate run reads as a batch of regressions: with the default policy, six infra-errored samples out of twenty against a clean baseline turn a GO into a NO-GO, and nothing in the report says why.

## Change

- `_metric_problem_values` skips records whose `error_category` is `infra_error` or `system`. A problem with no scored repeat left drops out of pairing on that arm, so both arms lose it.
- `BenchmarkGateResult` gains `n_infra_excluded_baseline` and `n_infra_excluded_candidate`, and a reason line is appended when either is non-zero, so the exclusion is visible in the JSON report.
- Graceful errors and solve timeouts are the model's own failures and still count as `0.0`, unchanged.

## Tests

`tests/test_gate.py`, in `TestGateVerdicts`:
- six candidate samples tagged `infra_error` out of twenty: verdict GO, `n_paired == 14`, `n_infra_excluded_candidate == 6`, reason present. Fails on `main`.
- the same six tagged `solve_timeout`: verdict stays NO-GO, nothing excluded.

`ruff check` and `ruff format` clean on both files. One pre-existing failure in this file on `main` in my environment, `TestClusteredCIIntegration::test_paired_delta_ci_with_clusters` (a width comparison), is unrelated and untouched.

## Not changed

The eval loop's own scoring of infra errors as `0.0` and the headline `pass@1` / `mean_reward` in the bundle are left as they are; this only stops the gate treating those samples as evidence of regression. If a policy-level knob is preferred over a fixed category set, happy to rework it that way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Infrastructure and system-error samples are excluded from per-problem metrics and paired regression comparisons.
  * Model-attributable failures, including solve timeouts, remain included in benchmark results.
  * Bundle-level fallback scores are no longer used when exclusions leave insufficient paired evidence.
  * Benchmark reports now show baseline and candidate exclusion counts and explanatory reasons.

* **Configuration**
  * Infrastructure-error categories can now be configured globally or overridden for individual benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->