### PR TITLE
fix(interceptor): keep None content when tool_calls are present

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/endpoint_interceptor.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/endpoint_interceptor.py
@@ -104,6 +104,7 @@ class EndpointInterceptor(RequestToResponseInterceptor):
                             "message" in choice
                             and "content" in choice["message"]
                             and choice["message"]["content"] is None
+                            and not choice["message"].get("tool_calls")
                         ):
                             self.logger.warning(
                                 f"choices[{i}].message.content is None, replacing with empty string"


### PR DESCRIPTION
## Summary
- Backport of the 0.3 endpoint interceptor fix to \`main-legacy\` (0.2.8).
- Do not rewrite \`message.content: null\` to \`""\` when \`tool_calls\` is present.
## Test plan
- [ ] New unit test: None content + tool_calls stays None
- [ ] Existing None-content-without-tool-calls tests still pass