### PR TITLE
feat(interceptors): allow to migrate content from  field

### DIFF
--- a/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/reasoning_interceptor.py
+++ b/packages/nemo-evaluator/src/nemo_evaluator/adapters/interceptors/reasoning_interceptor.py
@@ -363,6 +363,15 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
             ):
                 self.logger.info(**self._reasoning_stats)
 
+    @staticmethod
+    def _get_reasoning_content(msg: dict) -> Optional[str]:
+        """Return the reasoning text from msg, checking `reasoning_content`
+        then the newer `reasoning` field used by some LLM APIs."""
+        reasoning_content = msg.get("reasoning_content")
+        if reasoning_content is not None:
+            return reasoning_content
+        return msg.get("reasoning")
+
     def _process_reasoning_message(
         self, msg: dict, usage: dict = None
     ) -> tuple[dict, dict]:
@@ -382,9 +391,10 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
         updated_content_tokens = "unknown"
         reasoning_tokens = "unknown"
 
-        # Check if reasoning_content exists in the message and is not empty
-        if "reasoning_content" in msg and msg["reasoning_content"] is not None:
-            reasoning_content = msg["reasoning_content"]
+        # Check if reasoning_content (or the newer `reasoning` field) exists
+        # in the message and is not empty
+        reasoning_content = self._get_reasoning_content(msg)
+        if reasoning_content is not None:
             updated_message_content = content
             reasoning_started = (
                 True
@@ -493,12 +503,8 @@ class ResponseReasoningInterceptor(ResponseInterceptor, PostEvalHook):
     def _migrate_reasoning_content(self, msg: dict):
         """Migrate reasoning content to the content field with reasoning tokens."""
         modified_msg = msg.copy()
-        if (
-            "reasoning_content" in msg
-            and msg["reasoning_content"]
-            and msg["reasoning_content"].strip()
-        ):
-            reasoning_content = msg["reasoning_content"]
+        reasoning_content = self._get_reasoning_content(msg)
+        if reasoning_content and reasoning_content.strip():
             content = msg.get("content", "")
             updated_message_content = (
                 self.start_reasoning_token

--- a/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_reasoning.py
+++ b/packages/nemo-evaluator/tests/unit_tests/adapters/interceptors/test_reasoning.py
@@ -232,6 +232,56 @@ def test_migration(
     assert migrated_content == expected_content
 
 
+@pytest.mark.parametrize(
+    "reasoning,content,expected_content",
+    [
+        (
+            "This is my reasoning process that should be migrated",
+            "Here's my final answer.",
+            "<think>This is my reasoning process that should be migrated</think>Here's my final answer.",
+        ),
+        ("", "Here's my final answer.", "Here's my final answer."),
+        (None, "Here's my final answer.", "Here's my final answer."),
+    ],
+)
+def test_migration_reasoning_field(
+    adapter_server_migration,
+    fake_openai_endpoint,
+    reasoning,
+    content,
+    expected_content,
+):
+    """Same as test_migration, but reasoning is returned in the newer
+    `reasoning` field instead of `reasoning_content`."""
+    url = f"http://{AdapterServer.DEFAULT_ADAPTER_HOST}:{adapter_server_migration.port}"
+
+    wait_for_server("localhost", adapter_server_migration.port)
+
+    response_data = {
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": content,
+                    "reasoning": reasoning,
+                }
+            }
+        ]
+    }
+    data = {
+        "prompt": "This is a test prompt",
+        "max_tokens": 100,
+        "temperature": 0.5,
+        "fake_response": response_data,
+    }
+    response = requests.post(url, json=data)
+
+    assert response.status_code == 200
+    migrated_data = response.json()
+    migrated_content = migrated_data["choices"][0]["message"]["content"]
+    assert migrated_content == expected_content
+
+
 def test_multiple_choices(
     adapter_server,
     fake_openai_endpoint,


### PR DESCRIPTION
with newer vllm API, reasoning is in `reasoning` field instead of `reasoning_content`. This MR offers handling both