### PR TITLE
fix: report unscorable MCQ samples instead of scoring them 0.0 (#1140)

### DIFF
--- a/src/nemo_evaluator/engine/comparison.py
+++ b/src/nemo_evaluator/engine/comparison.py
@@ -33,6 +33,7 @@ from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from nemo_evaluator.metrics.aggregation import _is_unscored
 from nemo_evaluator.metrics.paired_tests import (
     POWER_80_FACTOR,
     SIGNIFICANCE_THRESHOLD,
@@ -82,6 +83,9 @@ class FlipSummary:
     regression_rate: float | None = None  # n_regressions / n_paired
     improvement_rate: float | None = None
     category_breakdown: dict[str, dict[str, int]] | None = None
+    # Per *problem*, unlike the per-record ``unscored_count`` on the bundle scores.
+    n_unscored_excluded_baseline: int = 0
+    n_unscored_excluded_candidate: int = 0
 
 
 @dataclass
@@ -194,6 +198,11 @@ def compare_runs(
     b_scores = base.get("benchmark", {}).get("scores", {})
     c_scores = cand.get("benchmark", {}).get("scores", {})
     for metric in sorted(set(list(b_scores.keys()) + list(c_scores.keys()))):
+        if metric == "unscored_count":
+            # A count of skipped samples, not a score.  Rendered as a percentage
+            # delta it reads as a catastrophic regression exactly when the
+            # exclusion below is doing its job.
+            continue
         bv = b_scores.get(metric, {})
         cv = c_scores.get(metric, {})
         if not (isinstance(bv, dict) and isinstance(cv, dict)):
@@ -271,6 +280,8 @@ def compare_runs(
         if base_records and cand_records:
             base_agg = aggregate_repeats(base_records)
             cand_agg = aggregate_repeats(cand_records)
+            n_unscored_base = _n_problems_dropped(base_records, base_agg)
+            n_unscored_cand = _n_problems_dropped(cand_records, cand_agg)
 
             selected_test = test if test != "auto" else detect_test(base_agg, cand_agg)
             report.test_used = selected_test
@@ -281,6 +292,8 @@ def compare_runs(
                     base_agg,
                     cand_agg,
                     threshold=reward_threshold,
+                    n_unscored_excluded_baseline=n_unscored_base,
+                    n_unscored_excluded_candidate=n_unscored_cand,
                 )
                 report.mcnemar = mcnemar_test(
                     report.flip_report.contingency, report.flip_report.summary.n_paired, alpha=alpha
@@ -291,6 +304,8 @@ def compare_runs(
                     base_agg,
                     cand_agg,
                     threshold=reward_threshold,
+                    n_unscored_excluded_baseline=n_unscored_base,
+                    n_unscored_excluded_candidate=n_unscored_cand,
                 )
                 paired_keys = sorted(set(base_agg) & set(cand_agg))
                 paired_deltas = [
@@ -338,7 +353,13 @@ def compare_results(
     selected_test = test if test != "auto" else detect_test(base_agg, cand_agg)
     report.test_used = selected_test
 
-    flip = build_flip_report(base_agg, cand_agg, threshold=reward_threshold)
+    flip = build_flip_report(
+        base_agg,
+        cand_agg,
+        threshold=reward_threshold,
+        n_unscored_excluded_baseline=_n_problems_dropped(baseline_records, base_agg),
+        n_unscored_excluded_candidate=_n_problems_dropped(candidate_records, cand_agg),
+    )
     report.flip_report = flip
 
     if selected_test == "mcnemar":
@@ -382,8 +403,16 @@ def build_flip_report(
     base_records: dict[tuple[int, int], dict[str, Any]],
     cand_records: dict[tuple[int, int], dict[str, Any]],
     threshold: float = 0.0,
+    n_unscored_excluded_baseline: int = 0,
+    n_unscored_excluded_candidate: int = 0,
 ) -> FlipReport:
-    """Build a 2x2 contingency table and per-sample flip lists from paired results."""
+    """Build a 2x2 contingency table and per-sample flip lists from paired results.
+
+    Both records dicts are expected post-``aggregate_repeats``, where problems with
+    no scored repeat left are already gone -- so the two exclusion counts cannot be
+    derived here and must be passed in by the caller.  A direct caller that omits
+    them gets 0, not a count.
+    """
     paired_keys = sorted(set(base_records) & set(cand_records))
 
     both_correct = 0
@@ -448,6 +477,8 @@ def build_flip_report(
             regression_rate=round(baseline_only / n_paired, 4) if n_paired else None,
             improvement_rate=round(candidate_only / n_paired, 4) if n_paired else None,
             category_breakdown=cat_breakdown,
+            n_unscored_excluded_baseline=n_unscored_excluded_baseline,
+            n_unscored_excluded_candidate=n_unscored_excluded_candidate,
         ),
     )
 
@@ -459,7 +490,14 @@ def aggregate_repeats(
 
     If a problem has repeats (0, 1, 2, ...), collapse to a single entry
     keyed by (problem_idx, 0) with the mean reward. Preserves metadata
-    from the first repeat.
+    from the first surviving repeat.
+
+    Unscored repeats (see :func:`_is_unscored`) are dropped before averaging, and a
+    problem left with none is omitted entirely rather than averaged in as a zero.
+    Filtering is per arm, so a problem unscored on only one side keeps a pair whose
+    two means are taken over different repeat sets -- each unbiased over what that
+    arm actually scored.  ``_aggregated_from_repeats`` therefore counts surviving
+    repeats, not original ones.
     """
     from collections import defaultdict
 
@@ -468,14 +506,19 @@ def aggregate_repeats(
         by_problem[pid].append((rep, record))
 
     aggregated: dict[tuple[int, int], dict[str, Any]] = {}
-    for pid, entries in by_problem.items():
-        if len(entries) == 1:
+    for pid, all_entries in by_problem.items():
+        entries = [(rep, r) for rep, r in all_entries if not _is_unscored(r)]
+        if not entries:
+            continue
+        # Branch on the *original* count: a lone survivor of a repeated problem must
+        # still key to (pid, 0), or it stops pairing with the other arm's aggregate.
+        if len(all_entries) == 1:
             rep, record = entries[0]
             aggregated[(pid, rep)] = record
         else:
             rewards = [float(r.get("reward", 0)) for _, r in entries]
             mean_reward = sum(rewards) / len(rewards)
-            _, base_record = sorted(entries, key=lambda x: x[0])[0]
+            _, base_record = min(entries, key=lambda x: x[0])
             agg_record = dict(base_record)
             agg_record["reward"] = mean_reward
             agg_record["repeat"] = 0
@@ -493,6 +536,14 @@ def write_regression(report: dict[str, Any], output_path: str | Path) -> Path:
 
 
 # ── Private helpers ────────────────────────────────────────────────────
+
+
+def _n_problems_dropped(
+    raw: dict[tuple[int, int], dict[str, Any]],
+    aggregated: dict[tuple[int, int], dict[str, Any]],
+) -> int:
+    """Problems ``aggregate_repeats`` dropped because no repeat was scored."""
+    return len({pid for pid, _ in raw} - {pid for pid, _ in aggregated})
 
 
 def _load_bundle(path: str | Path) -> dict[str, Any]:
@@ -586,6 +637,15 @@ def _compute_verdict(
         n_discordant = m.n_discordant
     else:
         return "INCONCLUSIVE", ["no test result available; cannot determine regression status"]
+
+    if s.n_paired == 0:
+        return "INCONCLUSIVE", [
+            (
+                f"no paired problems available (baseline excluded {s.n_unscored_excluded_baseline}, "
+                f"candidate excluded {s.n_unscored_excluded_candidate} as unscored); "
+                "cannot determine regression status"
+            )
+        ]
 
     if p_value is None:
         return "INCONCLUSIVE", ["scipy not installed; statistical test skipped (install nemo-evaluator[stats])"]

--- a/src/nemo_evaluator/engine/eval_loop.py
+++ b/src/nemo_evaluator/engine/eval_loop.py
@@ -40,7 +40,12 @@ from nemo_evaluator.engine.step_log import (
 )
 from nemo_evaluator.environments.base import EvalEnvironment, VerifyResult
 from nemo_evaluator.errors import GracefulError, InfraError
-from nemo_evaluator.metrics.aggregation import category_breakdown, scoring_details_breakdown, summary_stats
+from nemo_evaluator.metrics.aggregation import (
+    category_breakdown,
+    scoring_details_breakdown,
+    summary_stats,
+    unscored_metrics,
+)
 from nemo_evaluator.metrics.confidence import bootstrap_ci
 from nemo_evaluator.metrics.headline import headline_score_metrics
 from nemo_evaluator.observability.collector import ArtifactCollector
@@ -294,6 +299,7 @@ async def run_evaluation(
                 "summary": summary_stats([]),
                 "runtime": ArtifactCollector().build(0.0).runtime.to_dict(),
                 "failures": ArtifactCollector().build(0.0).failures.to_dict(),
+                **unscored_metrics([]),
             },
             config=config,
             categories=None,
@@ -931,6 +937,7 @@ async def run_evaluation(
     )
 
     metrics["summary"] = summary_stats(all_rewards)
+    metrics.update(unscored_metrics(results))
 
     cats = None
     if results and "category" in results[0].get("metadata", {}):

--- a/src/nemo_evaluator/engine/sharding.py
+++ b/src/nemo_evaluator/engine/sharding.py
@@ -22,7 +22,7 @@ from typing import Any
 
 import numpy as np
 
-from nemo_evaluator.metrics.aggregation import category_breakdown, summary_stats
+from nemo_evaluator.metrics.aggregation import category_breakdown, summary_stats, unscored_metrics
 from nemo_evaluator.metrics.headline import headline_score_metrics
 
 logger = logging.getLogger(__name__)
@@ -98,6 +98,7 @@ def merge_results(shard_dirs: list[str | Path], output_dir: str | Path, n_repeat
 
     all_rewards = [r.get("reward", 0) for r in all_results]
     metrics["summary"] = summary_stats(all_rewards)
+    metrics.update(unscored_metrics(all_results))
 
     if all_runtime_stats:
         merged_rt: dict[str, Any] = {

--- a/src/nemo_evaluator/environments/vlmevalkit.py
+++ b/src/nemo_evaluator/environments/vlmevalkit.py
@@ -177,15 +177,23 @@ class VLMEvalKitEnvironment(EvalEnvironment):
     def _score_mcq(self, response: str, expected: str, choices: dict[str, str]) -> VerifyResult:
         predicted = _extract_mcq_answer(response, choices)
         correct = predicted is not None and predicted.upper() == expected.upper()
+        details: dict[str, Any] = {
+            "method": "vlmevalkit_mcq",
+            "predicted_option": predicted,
+            "expected_option": expected,
+            "exact_match": correct,
+        }
+        if predicted is None:
+            # No option could be recovered, so the reward below is "no verdict", not
+            # "wrong answer" -- VLMEvalKit's judge-based option inference is not
+            # implemented here.  Aggregation reads this flag and skips the sample
+            # instead of averaging it in as a zero.
+            details["unscored"] = True
+            details["unscored_reason"] = "empty_final_response" if not response.strip() else "format_error"
         return VerifyResult(
             reward=1.0 if correct else 0.0,
             extracted_answer=predicted or response[:200],
-            scoring_details={
-                "method": "vlmevalkit_mcq",
-                "predicted_option": predicted,
-                "expected_option": expected,
-                "exact_match": correct,
-            },
+            scoring_details=details,
         )
 
     def _score_yorn(self, response: str, expected: str) -> VerifyResult:

--- a/src/nemo_evaluator/metrics/aggregation.py
+++ b/src/nemo_evaluator/metrics/aggregation.py
@@ -112,6 +112,32 @@ def scoring_details_breakdown(
     return breakdowns
 
 
+def _is_unscored(record: dict[str, Any]) -> bool:
+    """True when the scorer produced no verdict for this sample.
+
+    ``reward`` is a plain float, so an unscorable sample and a wrong answer both
+    land on 0.0.  ``scoring_details["unscored"]`` is the only thing that tells
+    them apart; everything that averages rewards has to consult it.
+    """
+    return bool((record.get("scoring_details") or {}).get("unscored"))
+
+
+def unscored_metrics(results: list[dict[str, Any]]) -> dict[str, Any]:
+    """Per-*record* counts of samples the scorer could not score.
+
+    ``unscored_count`` is ``{"value": n}``-shaped because ``nel gate`` and the
+    report renderers only read scores of that shape; ``unscored_reasons`` is a
+    plain mapping so it is never mistaken for a gateable metric.
+    """
+    reasons: dict[str, int] = {}
+    for r in results:
+        if not _is_unscored(r):
+            continue
+        reason = (r.get("scoring_details") or {}).get("unscored_reason") or "unknown"
+        reasons[reason] = reasons.get(reason, 0) + 1
+    return {"unscored_count": {"value": sum(reasons.values())}, "unscored_reasons": reasons}
+
+
 def summary_stats(rewards: list[float]) -> dict[str, float]:
     """Compute basic summary statistics over a list of reward values."""
     if not rewards:

--- a/tests/test_engine/test_sharding.py
+++ b/tests/test_engine/test_sharding.py
@@ -96,20 +96,23 @@ def _write_shard(
     rewards_by_problem: dict[int, list[float]],
     benchmark: str = "testbench",
     repeats: int = 1,
+    unscored_by_problem: dict[int, list[bool]] | None = None,
 ) -> None:
     """Minimal on-disk shard fixture: ``results.jsonl`` + one ``eval-*.json``."""
     shard_dir.mkdir(parents=True, exist_ok=True)
     rows: list[dict] = []
     for pid, rewards in rewards_by_problem.items():
+        flags = (unscored_by_problem or {}).get(pid, [])
         for rep, reward in enumerate(rewards):
-            rows.append(
-                {
-                    "problem_idx": pid,
-                    "repeat": rep,
-                    "reward": reward,
-                    "metadata": {},
-                }
-            )
+            row = {
+                "problem_idx": pid,
+                "repeat": rep,
+                "reward": reward,
+                "metadata": {},
+            }
+            if rep < len(flags) and flags[rep]:
+                row["scoring_details"] = {"unscored": True, "unscored_reason": "format_error"}
+            rows.append(row)
     (shard_dir / "results.jsonl").write_text(
         "\n".join(json.dumps(r) for r in rows) + ("\n" if rows else ""), encoding="utf-8"
     )
@@ -226,3 +229,32 @@ class TestMergeResults:
         # Summary is binary-shaped (min=0, max=1, median=1.0 here).
         assert scores["summary"]["min"] == 0.0
         assert scores["summary"]["max"] == 1.0
+
+    def test_unscored_counts_are_summed_across_shards(self, tmp_path):
+        """Issue #1140: the merged bundle must report how many samples took the
+        unscorable path, or a sharded run hides it."""
+        s0 = tmp_path / "shard_0"
+        s1 = tmp_path / "shard_1"
+        _write_shard(
+            s0,
+            rewards_by_problem={0: [1.0, 0.0], 1: [1.0, 1.0]},
+            repeats=2,
+            unscored_by_problem={0: [False, True]},
+        )
+        _write_shard(
+            s1,
+            rewards_by_problem={2: [0.0, 0.0], 3: [1.0, 1.0]},
+            repeats=2,
+            unscored_by_problem={2: [True, True]},
+        )
+
+        scores = merge_results([s0, s1], tmp_path / "merged", n_repeats=2)["benchmark"]["scores"]
+        assert scores["unscored_count"] == {"value": 3}
+        assert scores["unscored_reasons"] == {"format_error": 3}
+
+    def test_unscored_keys_present_on_a_clean_run(self, tmp_path):
+        s0 = tmp_path / "shard_0"
+        _write_shard(s0, rewards_by_problem={0: [1.0], 1: [0.0]})
+        scores = merge_results([s0], tmp_path / "merged", n_repeats=1)["benchmark"]["scores"]
+        assert scores["unscored_count"] == {"value": 0}
+        assert scores["unscored_reasons"] == {}

--- a/tests/test_environments/test_vlmevalkit_scoring.py
+++ b/tests/test_environments/test_vlmevalkit_scoring.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""MCQ scoring must distinguish "no verdict" from "wrong answer" (issue #1140)."""
+
+import pytest
+
+from nemo_evaluator.environments.vlmevalkit import VLMEvalKitEnvironment
+
+CHOICES = {"A": "cat", "B": "dog", "C": "bird", "D": "fish"}
+
+
+def _score(response: str, expected: str = "B") -> tuple[float, bool, str | None]:
+    # ``_score_mcq`` never touches ``self``; calling it unbound keeps the test off
+    # ``__init__``, which requires the optional ``vlmeval`` package and a dataset download.
+    vr = VLMEvalKitEnvironment._score_mcq(None, response, expected, CHOICES)
+    details = vr.scoring_details
+    return vr.reward, details.get("unscored", False), details.get("unscored_reason")
+
+
+@pytest.mark.parametrize(
+    "response,reward,unscored,reason",
+    [
+        ("The answer is B", 1.0, False, None),
+        ("B", 1.0, False, None),
+        ("The answer is C", 0.0, False, None),
+        ("I cannot tell.", 0.0, True, "format_error"),
+        ("The image is too blurry to read.", 0.0, True, "format_error"),
+        ("Maybe A, or possibly C.", 0.0, True, "format_error"),
+        ("", 0.0, True, "empty_final_response"),
+        ("  \n\t ", 0.0, True, "empty_final_response"),
+    ],
+    ids=[
+        "correct_letter_in_sentence",
+        "correct_bare_letter",
+        "wrong_but_extracted",
+        "refusal_no_option",
+        "hedge_no_option",
+        "ambiguous_two_options",
+        "empty_response",
+        "whitespace_only_response",
+    ],
+)
+def test_mcq_unscored_tagging(response, reward, unscored, reason):
+    assert _score(response) == (reward, unscored, reason)
+
+
+def test_scored_samples_carry_no_unscored_keys():
+    """A scored sample must not grow the keys, or every consumer has to special-case them."""
+    details = VLMEvalKitEnvironment._score_mcq(None, "The answer is B", "B", CHOICES).scoring_details
+    assert "unscored" not in details
+    assert "unscored_reason" not in details
+
+
+def test_unscored_keeps_the_existing_details():
+    details = VLMEvalKitEnvironment._score_mcq(None, "I cannot tell.", "B", CHOICES).scoring_details
+    assert details["method"] == "vlmevalkit_mcq"
+    assert details["predicted_option"] is None
+    assert details["expected_option"] == "B"
+    assert details["exact_match"] is False

--- a/tests/test_integration/test_eval_loop_integration.py
+++ b/tests/test_integration/test_eval_loop_integration.py
@@ -945,3 +945,47 @@ class TestSidecarReset:
 
         assert not (log_dir / "trajectory_overflow").exists()
         assert not (log_dir / "capture_markers").exists()
+
+
+class _UnscorableEnv(EvalEnvironment):
+    """Second of three problems cannot be scored at all (issue #1140)."""
+
+    name = "mock_unscorable"
+
+    def __init__(self):
+        super().__init__()
+        self._dataset = [{"a": "1"}, {"a": "2"}, {"a": "3"}]
+
+    async def seed(self, idx):
+        return SeedResult(prompt=f"q{idx}", expected_answer=self._dataset[idx]["a"], metadata={"idx": idx})
+
+    async def verify(self, response, expected, **meta):
+        if expected == "2":
+            return VerifyResult(
+                reward=0.0,
+                scoring_details={"method": "mock", "unscored": True, "unscored_reason": "format_error"},
+            )
+        return VerifyResult(reward=1.0, scoring_details={"method": "mock"})
+
+
+class _EchoSolver:
+    async def solve(self, task):
+        return SolveResult(response=task.expected_answer)
+
+    async def close(self):
+        pass
+
+
+class TestUnscoredMetrics:
+    def test_unscored_count_and_reasons_reported(self):
+        bundle = asyncio.run(run_evaluation(_UnscorableEnv(), _EchoSolver(), n_repeats=2))
+        scores = bundle["benchmark"]["scores"]
+        # Per *record*, not per problem: 1 problem x 2 repeats.
+        assert scores["unscored_count"] == {"value": 2}
+        assert scores["unscored_reasons"] == {"format_error": 2}
+
+    def test_unscored_keys_present_on_a_clean_run(self):
+        bundle = asyncio.run(run_evaluation(_MockEnv(), _MockSolver(), n_repeats=1))
+        scores = bundle["benchmark"]["scores"]
+        assert scores["unscored_count"] == {"value": 0}
+        assert scores["unscored_reasons"] == {}

--- a/tests/test_scoring/test_regression.py
+++ b/tests/test_scoring/test_regression.py
@@ -65,12 +65,14 @@ def _make_paired_dirs(
     return b, c
 
 
-def _record(pid, reward, repeat=0, expected="ans", category=None, model_response=None):
+def _record(pid, reward, repeat=0, expected="ans", category=None, model_response=None, *, unscored=False):
     r = {"problem_idx": pid, "repeat": repeat, "reward": reward, "expected_answer": expected}
     if category:
         r["metadata"] = {"category": category}
     if model_response:
         r["model_response"] = model_response
+    if unscored:
+        r["scoring_details"] = {"unscored": True, "unscored_reason": "format_error"}
     return r
 
 
@@ -137,6 +139,17 @@ class TestCompareRuns:
         assert "verdict" in report
         # No results.jsonl → no paired data → INCONCLUSIVE (not PASS)
         assert report["verdict"] == "INCONCLUSIVE"
+
+    def test_unscored_count_is_not_a_score_delta(self, tmp_path):
+        """A count of skipped samples rendered as a percentage delta reads as a
+        catastrophic regression exactly when the exclusion is working."""
+        b = tmp_path / "b.json"
+        c = tmp_path / "c.json"
+        _write_bundle(b, "b", {"pass@1": {"value": 0.7}, "unscored_count": {"value": 30}})
+        _write_bundle(c, "c", {"pass@1": {"value": 0.7}, "unscored_count": {"value": 12}})
+        report = compare_runs(b, c)
+        assert "unscored_count" not in report["score_deltas"]
+        assert "pass@1" in report["score_deltas"]
 
 
 class TestPairedAnalysis:
@@ -364,6 +377,69 @@ class TestPairedAnalysis:
         assert reg.get("baseline_response") == "correct answer here"
         assert reg.get("candidate_response") == "wrong answer"
 
+    def test_fully_unscored_candidate_problems_are_excluded(self, tmp_path):
+        """Issue #1140: an unscorable sample must drop out of the pairing, not
+        count as a wrong answer and read as a regression."""
+        pytest.importorskip("scipy")
+        base = [_record(i, 1.0) for i in range(10)]
+        cand = [_record(i, 1.0) for i in range(8)] + [_record(i, 0.0, unscored=True) for i in (8, 9)]
+        b, c = _make_paired_dirs(tmp_path, base, cand)
+        report = compare_runs(b, c)
+
+        s = report["flip_report"]["summary"]
+        assert s["n_paired"] == 8
+        assert s["n_regressions"] == 0
+        assert s["n_unscored_excluded_candidate"] == 2
+        assert s["n_unscored_excluded_baseline"] == 0
+        assert report["verdict"] != "BLOCK"
+
+    def test_asymmetric_unscored_repeat_stays_paired(self, tmp_path):
+        """One arm losing a repeat must not un-pair the problem: each arm's mean is
+        taken over what that arm actually scored, so the denominators differ.
+
+        The threshold sits between the two candidate means -- 2/3 if the unscored
+        repeat is averaged in as a zero, 2/2 if it is dropped -- so a regression here
+        means the denominator was wrong."""
+        pytest.importorskip("scipy")
+        base = [_record(0, 1.0, repeat=r) for r in range(3)] + [_record(1, 0.0, repeat=r) for r in range(3)]
+        cand = [_record(0, 1.0, repeat=0), _record(0, 0.0, repeat=1, unscored=True), _record(0, 1.0, repeat=2)] + [
+            _record(1, 0.0, repeat=r) for r in range(3)
+        ]
+        b, c = _make_paired_dirs(tmp_path, base, cand)
+        report = compare_runs(b, c, reward_threshold=0.8)
+
+        s = report["flip_report"]["summary"]
+        assert s["n_paired"] == 2
+        assert s["n_unscored_excluded_candidate"] == 0
+        assert s["n_regressions"] == 0
+        assert s["n_stable_correct"] == 1
+
+    @pytest.mark.parametrize(
+        ("base_unscored", "cand_unscored", "n_excluded_baseline", "n_excluded_candidate"),
+        [
+            pytest.param(False, True, 0, 3, id="candidate-scored-nothing"),
+            pytest.param(True, False, 3, 0, id="baseline-scored-nothing"),
+            pytest.param(True, True, 3, 3, id="both-arms-scored-nothing"),
+        ],
+    )
+    def test_zero_paired_problems_is_inconclusive(
+        self, tmp_path, base_unscored, cand_unscored, n_excluded_baseline, n_excluded_candidate
+    ):
+        """Issue #1140: every problem excluded as unscored leaves nothing to compare.
+        Reporting PASS there would call a run that scored nothing a clean run."""
+        pytest.importorskip("scipy")
+        base = [_record(i, 0.0 if base_unscored else 1.0, unscored=base_unscored) for i in range(3)]
+        cand = [_record(i, 0.0 if cand_unscored else 1.0, unscored=cand_unscored) for i in range(3)]
+        b, c = _make_paired_dirs(tmp_path, base, cand)
+        report = compare_runs(b, c)
+
+        s = report["flip_report"]["summary"]
+        assert s["n_paired"] == 0
+        assert s["n_unscored_excluded_baseline"] == n_excluded_baseline
+        assert s["n_unscored_excluded_candidate"] == n_excluded_candidate
+        assert report["verdict"] == "INCONCLUSIVE"
+        assert any("no paired problems" in r for r in report["verdict_reasons"])
+
 
 class TestCompareResults:
     """Item #20: in-memory comparison API."""
@@ -377,6 +453,15 @@ class TestCompareResults:
         assert report["test_used"] == "mcnemar"
         assert "flip_report" in report
         assert report["flip_report"]["summary"]["n_paired"] == 5
+
+    def test_all_records_unscored_is_inconclusive_not_pass(self):
+        """Issue #1140: same guard on the in-memory call path (compare_results)."""
+        pytest.importorskip("scipy")
+        base = {(i, 0): {"reward": 0.0, "scoring_details": {"unscored": True}} for i in range(5)}
+        cand = {(i, 0): {"reward": 0.0, "scoring_details": {"unscored": True}} for i in range(5)}
+        report = compare_results(base, cand)
+        assert report["flip_report"]["summary"]["n_paired"] == 0
+        assert report["verdict"] == "INCONCLUSIVE"
 
 
 class TestPublicAPI:
@@ -543,6 +628,52 @@ class TestAggregateRepeats:
         # After repeat aggregation, rewards are 0.67, 0.33, etc. → non-binary → permutation
         assert report["test_used"] == "permutation"
         assert "permutation_test" in report
+
+    def test_unscored_repeat_excluded_from_mean(self):
+        from nemo_evaluator.engine.comparison import aggregate_repeats
+
+        records = {
+            (0, 0): {"reward": 1.0, "problem_idx": 0},
+            (0, 1): {"reward": 1.0, "problem_idx": 0},
+            (0, 2): {"reward": 0.0, "problem_idx": 0, "scoring_details": {"unscored": True}},
+        }
+        result = aggregate_repeats(records)
+        assert result[(0, 0)]["reward"] == 1.0
+        assert result[(0, 0)]["_aggregated_from_repeats"] == 2
+
+    def test_lone_scored_repeat_keeps_the_zero_key(self):
+        """A lone survivor of a repeated problem must still key to (pid, 0), or it
+        un-pairs from the other arm's aggregate."""
+        from nemo_evaluator.engine.comparison import aggregate_repeats
+
+        records = {
+            (0, 0): {"reward": 0.0, "problem_idx": 0, "scoring_details": {"unscored": True}},
+            (0, 1): {"reward": 0.0, "problem_idx": 0, "scoring_details": {"unscored": True}},
+            (0, 2): {"reward": 1.0, "problem_idx": 0},
+        }
+        result = aggregate_repeats(records)
+        assert list(result) == [(0, 0)]
+        assert result[(0, 0)]["reward"] == 1.0
+
+    def test_fully_unscored_problem_is_dropped(self):
+        from nemo_evaluator.engine.comparison import aggregate_repeats
+
+        records = {(0, r): {"reward": 0.0, "problem_idx": 0, "scoring_details": {"unscored": True}} for r in range(3)}
+        records[(1, 0)] = {"reward": 1.0, "problem_idx": 1}
+        result = aggregate_repeats(records)
+        assert list(result) == [(1, 0)]
+
+    def test_single_unscored_record_is_dropped(self):
+        from nemo_evaluator.engine.comparison import aggregate_repeats
+
+        records = {(0, 0): {"reward": 0.0, "problem_idx": 0, "scoring_details": {"unscored": True}}}
+        assert aggregate_repeats(records) == {}
+
+    def test_scoring_details_without_unscored_key_is_kept(self):
+        from nemo_evaluator.engine.comparison import aggregate_repeats
+
+        records = {(0, 0): {"reward": 0.0, "problem_idx": 0, "scoring_details": {"method": "exact"}}}
+        assert list(aggregate_repeats(records)) == [(0, 0)]
 
 
 class TestWriteRegression:


### PR DESCRIPTION
## Problem

Upstream issue: https://github.com/NVIDIA-NeMo/Evaluator/issues/1140

`vlmevalkit://` MCQ scoring reports an unscorable sample as a wrong answer.
`_extract_mcq_answer` returns `None` when `can_infer`, the token scan and the
answer regex all miss — VLMEvalKit resolves that case with a judge, and that
stage is not implemented here. `_score_mcq` then emits `reward=0.0`, which is
what a wrong answer gets. The only trace was `predicted_option: None`, and every
downstream read is `float(x.get("reward", 0))`, so nothing could tell the two
apart.

The consequence the reporter hit: a prompt or phrasing change that moves samples
onto the extraction-failure path shows up in a paired A/B gate as an accuracy
regression, and the gate accepts a partial score instead of failing closed.

## The fix

**Tag it at the source.** `_score_mcq` sets `scoring_details["unscored"] = True`
with an `unscored_reason` of `format_error`, or `empty_final_response` when the
response is blank — both terms the repo already uses in
`observability/collector.py`. `VerifyResult.reward` stays `float`, so no
environment and no consumer changes shape.

**Exclude it, don't zero it.** `aggregate_repeats` drops tagged repeats before
averaging and omits a problem left with no scored repeat. Because
`build_flip_report` pairs on `sorted(set(base) & set(cand))`, an omitted problem
leaves the pairing entirely rather than being counted as a zero.

One subtlety worth reviewing: the branch in `aggregate_repeats` is on the
**original** repeat count, not the surviving one. The single-entry path keys a
record by its own repeat index, so a 3-repeat problem filtered down to repeat 2
would key `(pid, 2)` against the other arm's `(pid, 0)` and silently un-pair.

**Filtering is per arm**, and that is a deliberate statistical choice.
`aggregate_repeats` runs once per run and knows nothing about the other side, so
a problem unscored on only one arm stays paired with its two means taken over
different repeat sets — each unbiased over what that arm actually scored. The
alternative (refuse to aggregate any pair containing an unscored repeat) discards
data the scored arm did produce.

**Counts, in both units.** Per *record* on the bundle scores:
`unscored_count` (`{"value": n}`) and `unscored_reasons` (`{reason: n}`), emitted
by both `run_evaluation` and `merge_results` so a sharded run reports the same
thing. Per *problem* on `FlipSummary`: `n_unscored_excluded_baseline` and
`n_unscored_excluded_candidate`. Same word, two units, deliberately.

`unscored_count` is skipped in `compare_runs`' score-delta loop. It is a count,
not a score, and `reports/regression.py` renders every entry there as a
percentage delta with a bar — 30 unscored improving to 12 would print
`3000.0% → 1200.0% (-1800.0%)` and a red `BROKE`, i.e. the fix working would be
the loudest line in the report. Gating is unaffected either way: `nel gate` reads
`benchmark.scores` through `_load_bundle_score`, and `_select_metric` only
auto-picks `mean_reward`, `pass@1`, or `scorer:*`.

## Test evidence

Full detail in the QA report; the short version:

16 tests fail on `9758d8d5` and pass after the fix. The vlmevalkit failure is the
issue's symptom, not a missing key:

```
assert (0.0, False, None) == (0.0, True, 'format_error')
```

```
$ python -m pytest tests/test_environments/test_vlmevalkit_scoring.py \
    tests/test_scoring/test_regression.py tests/test_engine/test_sharding.py \
    tests/test_integration/test_eval_loop_integration.py -q
109 passed in 125.36s (0:02:05)
```

Full suite, before and after (`-m "not network"`, `-x` dropped so pre-existing
failures do not truncate the run):

```
before:  47 failed, 2262 passed, 37 skipped, 14 deselected, 49 errors
after:   47 failed, 2284 passed, 37 skipped, 14 deselected, 49 errors
```

`+22` is exactly the tests added here, and the failing set is identical
before and after — all of it in `harbor` / terminus-solver territory, from
optional dependencies not installed locally, none in a file this touches.

```
$ uvx ruff@0.9.9 check src/ tests/
All checks passed!
```

(`v0.9.9` is the version pinned in `.pre-commit-config.yaml`.)

## Scope and known limits

- **Handled in this revision:** the exclusion above has an edge it originally
  missed — when it drops every paired problem on both arms, `n_paired` hits
  `0` and `_compute_verdict` fell through to its "no discordant pairs" branch,
  returning `PASS` on zero evidence. Both call paths (`compare_runs`,
  `compare_results`) now check `n_paired == 0` first and return `INCONCLUSIVE`,
  naming how many problems each arm excluded as unscored.
- **`nel gate`'s headline metric still counts an unscored sample as a zero**
  (`_metric_problem_values`, `metrics/headline.py`). Excluding it there changes
  the meaning of the headline number for every environment, which is a bigger
  decision than this issue; the two conditions asked for in the thread — a
  machine-readable per-sample reason and an aggregate count — are both met
  without it.
- **The auto-selected statistical test can change.** `detect_test` runs on the
  aggregated dicts and picks McNemar only when every paired reward is exactly
  0.0 or 1.0. Dropping an unscored repeat can make an arm binary again
  (`0.667` → `1.0`) and switch the test. That is the correct behaviour on the
  corrected data, but it is a visible difference between two runs of the same
  comparison.
- **Not in scope, by agreement in the issue thread:** porting VLMEvalKit's
  option-inference stage behind the judge client (explicitly opt-in, separate
  work), the unwired `needs_judge` flag, and the missing `config=` at
  `eval_loop.py:751`.
- `gate.py` / `gate_policy.py` are untouched — PR #1155 is open against them.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unscored-result metrics, including counts and categorized reasons.
  * MCQ evaluations now identify responses that cannot be scored and distinguish empty responses from formatting issues.
  * Evaluation reports and shard summaries now include unscored-result information.

* **Bug Fixes**
  * Unscored results are excluded from score comparisons and repeat aggregation.
  * Comparisons now omit problems with no scored repeats and clearly report excluded baseline and candidate results.
  * Verdict explanations provide more accurate outcomes when paired scored results are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->