### PR TITLE
fix: avoid rebuilding declared Harbor task images

### DIFF
--- a/src/nemo_evaluator/environments/harbor.py
+++ b/src/nemo_evaluator/environments/harbor.py
@@ -834,6 +834,10 @@ class HarborEnvironment(EvalEnvironment):
         build_contexts: dict[str, Path] = {}
 
         for task_dir in self._tasks:
+            task_toml = task_dir / "task.toml"
+            if task_toml.exists() and _parse_docker_image_from_toml(task_toml):
+                # Match _resolve_image: declared images take precedence over Dockerfiles.
+                continue
             env_dir = task_dir / "environment"
             dockerfile = env_dir / "Dockerfile"
             if dockerfile.exists() and _dockerfile_has_extra_layers(dockerfile):

--- a/src/nemo_evaluator/environments/harbor.py
+++ b/src/nemo_evaluator/environments/harbor.py
@@ -828,6 +828,10 @@ class HarborEnvironment(EvalEnvironment):
         return len(self._tasks)
 
     async def image_build_requests(self) -> list[Any] | None:
+        """Plan extra-layer Dockerfile builds for tasks without a declared image.
+
+        Return ``None`` when no task needs a Dockerfile build.
+        """
         from nemo_evaluator.sandbox.base import ImageBuildRequest, ImageSpec
 
         specs: list[ImageSpec] = []


### PR DESCRIPTION
Harbor tasks can declare both `[environment] docker_image` and a multi-layer `environment/Dockerfile`. Docker execution already chooses the declared image, but `image_build_requests()` still registers a separate content-hashed Dockerfile build. An unused build can therefore prevent the evaluation from starting.

This reproduced on Terminal-Bench 2.1 `qemu-alpine-ssh`: its declared `alexgshaw/qemu-alpine-ssh:20251031` image is usable, while rebuilding its Debian bullseye Dockerfile now fails because the official security repository metadata expired on September 7 after bullseye LTS ended. The error occurs during provisioning, before model trials.

Use the same existing task.toml parser and precedence in `image_build_requests()`. Tasks without a declared image retain their existing Dockerfile build path. This does not alter task data, APT validation, runtime image selection, or ECS mirroring policy.

Related: #1139 included this local Docker issue alongside a larger ECS mirror feature and was closed without merging. This change isolates the redundant-build defect.

Validation on Linux x86_64 / Python 3.12.14, using SDK 0.4.0 built from the base commit and this change:

- On the same pinned 89-task Terminal-Bench 2.1 dataset, original planning produced 83 image builds; fixed planning produced zero. All 89 seeded image/workdir pairs were identical before and after.
- Pulled `alexgshaw/qemu-alpine-ssh:20251031` and exercised native `SandboxManager.provision/acquire/exec/release`: QEMU tools and the populated Alpine ISO were available, command exit was zero, and the exact created container was absent after release. No model inference was needed for this provisioning reproduction.
- Existing Harbor/Sandbox checks: 61 passed across `test_harbor_instruction.py`, `test_harbor_verifier_setup.py`, `test_harbor_dataset_lock.py`, `test_harbor_timeouts.py`, `test_harbor_task_overlay.py`, and `test_sandbox_manager.py`.
- Required `python -m pytest tests/ -v --tb=short -m "not network" -x`: **2367 passed, 36 skipped, 14 deselected** (exit 0; 123.19 s) in a local Linux/Python 3.12.14 environment without `SLURM_JOB_ID`, with the declared `stats`, `scoring`, and `harbor` extras. All 157 frozen runtime dependency versions matched. This completed run supersedes the earlier incomplete validation in the Slurm test environment.
- Ruff on the modified file: the same 14 pre-existing findings on base and fixed source, zero new findings. Syntax and `git diff --check` passed.

No new test files are included. The source change is restricted to build planning; benchmark content, runtime image precedence, and existing fallback behavior are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Environment Docker images declared in `task.toml` are now honored without triggering unnecessary Dockerfile image builds.
  * Tasks without a declared environment image now correctly use a generated image for runtime execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

The method docstring now states the declared-image precedence and the empty build-plan result. The requested new regression cases are not included in this revision.
